### PR TITLE
Unify AppConfigs and their name usages

### DIFF
--- a/doc/provides.rst
+++ b/doc/provides.rst
@@ -24,7 +24,7 @@ the keys and lists of loading specs as values for new provides to be discovered.
 
 .. code-block:: python
 
-   class PigeonAppConfig(AppConfig):
+   class AppConfig(shoop.apps.AppConfig):
 
        provides = {
            "shipping_method_module": [

--- a/shoop/addons/__init__.py
+++ b/shoop/addons/__init__.py
@@ -4,22 +4,22 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from shoop.apps import AppConfig
+import shoop.apps
 from .manager import add_enabled_addons
 
 __all__ = ["add_enabled_addons"]
 
 
-class ShoopAddonsAppConfig(AppConfig):
-    name = "shoop.addons"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Addons"
     label = "shoop_addons"
 
     provides = {
         "admin_module": [
-            "shoop.addons.admin_module:AddonModule",
+            __name__ + ".admin_module:AddonModule",
         ]
     }
 
 
-default_app_config = "shoop.addons.ShoopAddonsAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/admin/__init__.py
+++ b/shoop/admin/__init__.py
@@ -5,34 +5,34 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from shoop.apps import AppConfig
+import shoop.apps
 from shoop.apps.settings import validate_templates_configuration
 
 
-class ShoopAdminAppConfig(AppConfig):
-    name = "shoop.admin"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Admin"
     label = "shoop_admin"
     required_installed_apps = ["bootstrap3"]
     provides = {
         "admin_module": [
-            "shoop.admin.modules.system:SystemModule",
-            "shoop.admin.modules.products:ProductModule",
-            "shoop.admin.modules.product_types:ProductTypeModule",
-            "shoop.admin.modules.media:MediaModule",
-            "shoop.admin.modules.orders:OrderModule",
-            "shoop.admin.modules.taxes:TaxModule",
-            "shoop.admin.modules.categories:CategoryModule",
-            "shoop.admin.modules.contacts:ContactModule",
-            "shoop.admin.modules.contact_groups:ContactGroupModule",
-            "shoop.admin.modules.users:UserModule",
-            "shoop.admin.modules.methods:MethodModule",
-            "shoop.admin.modules.attributes:AttributeModule",
-            "shoop.admin.modules.sales_units:SalesUnitModule",
-            "shoop.admin.modules.shops:ShopModule",
-            "shoop.admin.modules.demo:DemoModule",
-            "shoop.admin.modules.manufacturers:ManufacturerModule",
-            "shoop.admin.modules.suppliers:SupplierModule"
+            __name__ + ".modules.system:SystemModule",
+            __name__ + ".modules.products:ProductModule",
+            __name__ + ".modules.product_types:ProductTypeModule",
+            __name__ + ".modules.media:MediaModule",
+            __name__ + ".modules.orders:OrderModule",
+            __name__ + ".modules.taxes:TaxModule",
+            __name__ + ".modules.categories:CategoryModule",
+            __name__ + ".modules.contacts:ContactModule",
+            __name__ + ".modules.contact_groups:ContactGroupModule",
+            __name__ + ".modules.users:UserModule",
+            __name__ + ".modules.methods:MethodModule",
+            __name__ + ".modules.attributes:AttributeModule",
+            __name__ + ".modules.sales_units:SalesUnitModule",
+            __name__ + ".modules.shops:ShopModule",
+            __name__ + ".modules.demo:DemoModule",
+            __name__ + ".modules.manufacturers:ManufacturerModule",
+            __name__ + ".modules.suppliers:SupplierModule"
         ]
     }
 
@@ -40,4 +40,4 @@ class ShoopAdminAppConfig(AppConfig):
         validate_templates_configuration()
 
 
-default_app_config = "shoop.admin.ShoopAdminAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/api/__init__.py
+++ b/shoop/api/__init__.py
@@ -6,11 +6,12 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.core.exceptions import ImproperlyConfigured
-from shoop.apps import AppConfig
+
+import shoop.apps
 
 
-class ShoopApiAppConfig(AppConfig):
-    name = "shoop.api"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop API"
     label = "shoop_api"
     required_installed_apps = (
@@ -18,7 +19,7 @@ class ShoopApiAppConfig(AppConfig):
     )
 
     def ready(self):
-        super(ShoopApiAppConfig, self).ready()
+        super(AppConfig, self).ready()
         from django.conf import settings
         rest_framework_config = getattr(settings, "REST_FRAMEWORK", None)
         if not (rest_framework_config and rest_framework_config.get("DEFAULT_PERMISSION_CLASSES")):
@@ -28,4 +29,4 @@ class ShoopApiAppConfig(AppConfig):
             )
 
 
-default_app_config = "shoop.api.ShoopApiAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/core/__init__.py
+++ b/shoop/core/__init__.py
@@ -5,11 +5,11 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from shoop.apps import AppConfig
+import shoop.apps
 
 
-class ShoopCoreAppConfig(AppConfig):
-    name = "shoop.core"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Core"
     label = "shoop"  # Use "shoop" as app_label instead of "core"
     required_installed_apps = (
@@ -20,12 +20,12 @@ class ShoopCoreAppConfig(AppConfig):
     )
     provides = {
         "api_populator": [
-            "shoop.core.api:populate_core_api"
+            __name__ + ".api:populate_core_api"
         ],
         "pricing_module": [
-            "shoop.core.pricing.default_pricing:DefaultPricingModule"
+            __name__ + ".pricing.default_pricing:DefaultPricingModule"
         ],
     }
 
 
-default_app_config = "shoop.core.ShoopCoreAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/default_tax/__init__.py
+++ b/shoop/default_tax/__init__.py
@@ -16,8 +16,8 @@ class AppConfig(shoop.apps.AppConfig):
     label = "default_tax"
 
     provides = {
-        "tax_module": ["shoop.default_tax.module:DefaultTaxModule"],
-        "admin_module": ["shoop.default_tax.admin_module:TaxRulesAdminModule"],
+        "tax_module": [__name__ + ".module:DefaultTaxModule"],
+        "admin_module": [__name__ + ".admin_module:TaxRulesAdminModule"],
     }
 
 

--- a/shoop/discount_pricing/__init__.py
+++ b/shoop/discount_pricing/__init__.py
@@ -5,21 +5,21 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from shoop.apps import AppConfig
+import shoop.apps
 
 
-class DiscountPricingAppConfig(AppConfig):
-    name = "shoop.discount_pricing"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Discount Pricing"
     label = "discount_pricing"
     provides = {
         "pricing_module": [
-            "shoop.discount_pricing.module:DiscountPricingModule"
+            __name__ + ".module:DiscountPricingModule"
         ],
         "admin_product_form_part": [
-            "shoop.discount_pricing.admin_form_part:DiscountPricingFormPart"
+            __name__ + ".admin_form_part:DiscountPricingFormPart"
         ],
     }
 
 
-default_app_config = "shoop.discount_pricing.DiscountPricingAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/front/__init__.py
+++ b/shoop/front/__init__.py
@@ -6,21 +6,22 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.conf import settings
-from shoop.apps import AppConfig
+
+import shoop.apps
 from shoop.apps.settings import validate_templates_configuration
 
 
-class ShoopFrontAppConfig(AppConfig):
-    name = "shoop.front"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Frontend"
     label = "shoop_front"
 
     provides = {
         "admin_module": [
-            "shoop.front.admin_module.BasketAdminModule",
+            __name__ + ".admin_module.BasketAdminModule",
         ],
         "notify_event": [
-            "shoop.front.notify_events:OrderReceived"
+            __name__ + ".notify_events:OrderReceived"
         ]
     }
 
@@ -32,4 +33,4 @@ class ShoopFrontAppConfig(AppConfig):
             install_error_handlers()
 
 
-default_app_config = "shoop.front.ShoopFrontAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/front/apps/auth/__init__.py
+++ b/shoop/front/apps/auth/__init__.py
@@ -4,19 +4,19 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from shoop.apps import AppConfig
+import shoop.apps
 
 
-class AuthAppConfig(AppConfig):
-    name = "shoop.front.apps.auth"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Frontend - User Authentication"
     label = "shoop_front.auth"
 
     provides = {
         "front_urls": [
-            "shoop.front.apps.auth.urls:urlpatterns"
+            __name__ + ".urls:urlpatterns"
         ],
     }
 
 
-default_app_config = "shoop.front.apps.auth.AuthAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/front/apps/customer_information/__init__.py
+++ b/shoop/front/apps/customer_information/__init__.py
@@ -5,7 +5,9 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
+
 from django.utils.translation import ugettext_lazy as _
+
 import shoop.apps
 
 
@@ -15,8 +17,8 @@ class AppConfig(shoop.apps.AppConfig):
     label = 'shoop_front.customer_information'
 
     provides = {
-        'front_urls': [__name__ + '.urls:urlpatterns'],
+        'front_urls': [__name__ + ".urls:urlpatterns"],
     }
 
 
-default_app_config = __name__ + '.AppConfig'
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/front/apps/personal_order_history/__init__.py
+++ b/shoop/front/apps/personal_order_history/__init__.py
@@ -5,7 +5,9 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
+
 from django.utils.translation import ugettext_lazy as _
+
 import shoop.apps
 
 
@@ -15,8 +17,8 @@ class AppConfig(shoop.apps.AppConfig):
     label = 'shoop_front.personal_order_history'
 
     provides = {
-        'front_urls': [__name__ + '.urls:urlpatterns'],
+        'front_urls': [__name__ + ".urls:urlpatterns"],
     }
 
 
-default_app_config = __name__ + '.AppConfig'
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/front/apps/registration/__init__.py
+++ b/shoop/front/apps/registration/__init__.py
@@ -30,11 +30,12 @@ URL names
 
 import django.conf
 from registration.signals import user_activated, login_user
-from shoop.apps import AppConfig
+
+import shoop.apps
 
 
-class RegistrationAppConfig(AppConfig):
-    name = "shoop.front.apps.registration"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Frontend - User Registration"
     label = "shoop_front.registration"
 
@@ -44,7 +45,7 @@ class RegistrationAppConfig(AppConfig):
 
     provides = {
         "front_urls": [
-            "shoop.front.apps.registration.urls:urlpatterns"
+            __name__ + ".urls:urlpatterns"
         ],
     }
 
@@ -71,4 +72,4 @@ class RegistrationAppConfig(AppConfig):
             # false for HTML mails.
             django.conf.settings.REGISTRATION_EMAIL_HTML = False
 
-default_app_config = "shoop.front.apps.registration.RegistrationAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/front/apps/simple_order_notification/__init__.py
+++ b/shoop/front/apps/simple_order_notification/__init__.py
@@ -6,14 +6,18 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
+
 import logging
+
 from django.core.mail.message import EmailMessage
+from django.template import engines
 from django.template.utils import InvalidTemplateEngineError
 from django.utils import translation
-from shoop.apps import AppConfig
+
+import shoop.apps
 from shoop.utils.analog import LogEntryKind
+
 from .templates import MESSAGE_BODY_TEMPLATE, MESSAGE_SUBJECT_TEMPLATE
-from django.template import engines
 
 LOG = logging.getLogger("shoop.simple_order_notification")
 NOTIFICATION_SUCCESS_LOG_IDENTIFIER = "simple_order_notification_ok"
@@ -57,14 +61,14 @@ def send_simple_order_notification(sender, order, request, **kwargs):
             kind=LogEntryKind.ERROR)
 
 
-class SimpleOrderNotificationAppConfig(AppConfig):
-    name = "shoop.front.apps.simple_order_notification"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Frontend - Simple Order Notification"
     label = "shoop_front.simple_order_notification"
 
     provides = {
         "admin_module": [
-            "shoop.front.apps.simple_order_notification.admin_module:SimpleOrderNotificationModule",
+            __name__ + ".admin_module:SimpleOrderNotificationModule",
         ]
     }
 
@@ -76,4 +80,4 @@ class SimpleOrderNotificationAppConfig(AppConfig):
             dispatch_uid="simple_order_notification.send_simple_order_notification")
 
 
-default_app_config = "shoop.front.apps.simple_order_notification.SimpleOrderNotificationAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/front/apps/simple_search/__init__.py
+++ b/shoop/front/apps/simple_search/__init__.py
@@ -6,22 +6,23 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
-from shoop.apps import AppConfig
+
+import shoop.apps
 
 
-class SimpleSearchAppConfig(AppConfig):
-    name = "shoop.front.apps.simple_search"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Frontend - Simple Search"
     label = "shoop_front.simple_search"
 
     provides = {
         "front_urls": [
-            "shoop.front.apps.simple_search.urls:urlpatterns"
+            __name__ + ".urls:urlpatterns"
         ],
         "front_template_helper_namespace": [
-            "shoop.front.apps.simple_search.template_helpers:TemplateHelpers"
+            __name__ + ".template_helpers:TemplateHelpers"
         ]
     }
 
 
-default_app_config = "shoop.front.apps.simple_search.SimpleSearchAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/notify/__init__.py
+++ b/shoop/notify/__init__.py
@@ -6,7 +6,8 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 
-from shoop.apps import AppConfig
+import shoop.apps
+
 from .base import Condition, Action, Event, Variable, Binding
 from .enums import ConstantUse, TemplateUse
 from .script import Context
@@ -23,30 +24,30 @@ __all__ = (
 )
 
 
-class ShoopNotifyAppConfig(AppConfig):
-    name = "shoop.notify"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Notification Framework"
     label = "shoop_notify"
     provides = {
         "notify_condition": [
-            "shoop.notify.conditions:LanguageEqual",
-            "shoop.notify.conditions:BooleanEqual",
-            "shoop.notify.conditions:IntegerEqual",
-            "shoop.notify.conditions:TextEqual",
-            "shoop.notify.conditions:Empty",
-            "shoop.notify.conditions:NonEmpty",
+            __name__ + ".conditions:LanguageEqual",
+            __name__ + ".conditions:BooleanEqual",
+            __name__ + ".conditions:IntegerEqual",
+            __name__ + ".conditions:TextEqual",
+            __name__ + ".conditions:Empty",
+            __name__ + ".conditions:NonEmpty",
         ],
         "notify_action": [
-            "shoop.notify.actions:SetDebugFlag",
-            "shoop.notify.actions:AddOrderLogEntry",
-            "shoop.notify.actions:SendEmail",
-            "shoop.notify.actions:AddNotification",
+            __name__ + ".actions:SetDebugFlag",
+            __name__ + ".actions:AddOrderLogEntry",
+            __name__ + ".actions:SendEmail",
+            __name__ + ".actions:AddNotification",
         ],
         "notify_event": [],
         "admin_module": [
-            "shoop.notify.admin_module:NotifyAdminModule",
+            __name__ + ".admin_module:NotifyAdminModule",
         ]
     }
 
 
-default_app_config = "shoop.notify.ShoopNotifyAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/simple_cms/__init__.py
+++ b/shoop/simple_cms/__init__.py
@@ -5,7 +5,9 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
+
 from django.utils.translation import ugettext_lazy as _
+
 import shoop.apps
 
 
@@ -17,10 +19,10 @@ class AppConfig(shoop.apps.AppConfig):
     provides = {
         "front_urls_post": [__name__ + ".urls:urlpatterns"],
         "admin_module": [
-            "shoop.simple_cms.admin_module:SimpleCMSAdminModule"
+            __name__ + ".admin_module:SimpleCMSAdminModule"
         ],
         "front_template_helper_namespace": [
-            "shoop.simple_cms.template_helpers:SimpleCMSTemplateHelpers"
+            __name__ + ".template_helpers:SimpleCMSTemplateHelpers"
         ]
     }
 

--- a/shoop/simple_pricing/__init__.py
+++ b/shoop/simple_pricing/__init__.py
@@ -5,25 +5,25 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from shoop.apps import AppConfig
+import shoop.apps
 
 
 # TODO: Document how to create custom pricing modules (Refs SHOOP-514)
-class ShoopSimplePricingAppConfig(AppConfig):
-    name = "shoop.simple_pricing"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Simple Pricing"
     label = "simple_pricing"
     provides = {
         "pricing_module": [
-            "shoop.simple_pricing.module:SimplePricingModule"
+            __name__ + ".module:SimplePricingModule"
         ],
         "admin_product_form_part": [
-            "shoop.simple_pricing.admin_form_part:SimplePricingFormPart"
+            __name__ + ".admin_form_part:SimplePricingFormPart"
         ],
         "api_populator": [
-            "shoop.simple_pricing.api:populate_simple_pricing_api"
+            __name__ + ".api:populate_simple_pricing_api"
         ]
     }
 
 
-default_app_config = "shoop.simple_pricing.ShoopSimplePricingAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/simple_supplier/__init__.py
+++ b/shoop/simple_supplier/__init__.py
@@ -5,18 +5,18 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from shoop.apps import AppConfig
+import shoop.apps
 
 
-class ShoopSimpleSupplierAppConfig(AppConfig):
-    name = "shoop.simple_supplier"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Simple Supplier"
     label = "simple_supplier"
     provides = {
         "supplier_module": [
-            "shoop.simple_supplier.module:SimpleSupplierModule"
+            __name__ + ".module:SimpleSupplierModule"
         ]
     }
 
 
-default_app_config = "shoop.simple_supplier.ShoopSimpleSupplierAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/testing/__init__.py
+++ b/shoop/testing/__init__.py
@@ -5,21 +5,21 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from shoop.apps import AppConfig
+import shoop.apps
 
 
-class ShoopTestingAppConfig(AppConfig):
-    name = "shoop.testing"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Testing & Demo Utilities"
     label = "shoop_testing"
     provides = {
         "admin_module": [
-            "shoop.testing.admin_module:TestingAdminModule"
+            __name__ + ".admin_module:TestingAdminModule"
         ],
         "payment_method_module": [
-            "shoop.testing.pseudo_payment:PseudoPaymentMethodModule",
+            __name__ + ".pseudo_payment:PseudoPaymentMethodModule",
         ]
     }
 
 
-default_app_config = "shoop.testing.ShoopTestingAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/themes/classic_gray/__init__.py
+++ b/shoop/themes/classic_gray/__init__.py
@@ -10,11 +10,11 @@ from django.conf import settings
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
-from shoop.apps import AppConfig
-from shoop.xtheme.theme import Theme
+import shoop.apps
+import shoop.xtheme
 
 
-class ClassicGrayTheme(Theme):
+class Theme(shoop.xtheme.Theme):
     identifier = "shoop.themes.classic_gray"
     name = "Shoop Classic Gray Theme"
     author = "Juha Kujala"
@@ -65,16 +65,16 @@ class ClassicGrayTheme(Theme):
         return self._format_cms_links(id__in=page_ids)
 
 
-class ClassicGrayThemeAppConfig(AppConfig):
-    name = "shoop.themes.classic_gray"
-    verbose_name = ClassicGrayTheme.name
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
+    verbose_name = Theme.name
     label = "shoop.themes.classic_gray"
     provides = {
-        "xtheme": "shoop.themes.classic_gray:ClassicGrayTheme",
+        "xtheme": __name__ + ":Theme",
         "xtheme_plugin": [
-            "shoop.themes.classic_gray.plugins:ProductHighlightPlugin",
+            __name__ + ".plugins:ProductHighlightPlugin",
         ]
     }
 
 
-default_app_config = "shoop.themes.classic_gray.ClassicGrayThemeAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop/xtheme/__init__.py
+++ b/shoop/xtheme/__init__.py
@@ -4,27 +4,28 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from shoop.apps import AppConfig
+import shoop.apps
+
 from .theme import Theme
 from .plugins.base import Plugin, templated_plugin_factory
 
 __all__ = ["Theme", "Plugin", "templated_plugin_factory"]
 
 
-class XThemeAppConfig(AppConfig):
-    name = "shoop.xtheme"
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     verbose_name = "Shoop Extensible Theme Engine"
     label = "shoop_xtheme"
 
     provides = {
         "front_urls_pre": [__name__ + ".urls:urlpatterns"],
         "xtheme_plugin": [
-            "shoop.xtheme.plugins.text:TextPlugin"
+            __name__ + ".plugins.text:TextPlugin"
         ],
         "admin_module": [
-            "shoop.xtheme.admin_module:XthemeAdminModule"
+            __name__ + ".admin_module:XthemeAdminModule"
         ]
     }
 
 
-default_app_config = "shoop.xtheme.XThemeAppConfig"
+default_app_config = __name__ + ".AppConfig"

--- a/shoop_tests/admin/test_modules.py
+++ b/shoop_tests/admin/test_modules.py
@@ -13,7 +13,7 @@ from django.http import HttpResponseRedirect
 from django.test.utils import override_settings
 from django.utils.timezone import now
 import os
-from shoop.admin import ShoopAdminAppConfig
+import shoop.admin
 from shoop.admin.base import AdminModule
 from shoop.admin.dashboard import DashboardContentBlock, get_activity
 from shoop.admin.menu import get_menu_entry_categories
@@ -54,7 +54,7 @@ def test_modules_in_core_admin_work(rf, admin_user):
     request = rf.get("/")
     apply_request_middleware(request, user=admin_user)
     request = apply_request_middleware(rf.get("/"), user=admin_user)
-    with replace_modules(ShoopAdminAppConfig.provides["admin_module"]):
+    with replace_modules(shoop.admin.AppConfig.provides["admin_module"]):
         assert all(get_module_urls())
         assert get_menu_entry_categories(request)
 

--- a/shoop_tests/core/__init__.py
+++ b/shoop_tests/core/__init__.py
@@ -5,19 +5,19 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from shoop.apps import AppConfig
+import shoop.apps
 
 
-class AppConfig(AppConfig):
-    name = 'shoop_tests.core'
+class AppConfig(shoop.apps.AppConfig):
+    name = __name__
     label = 'shoop_tests_core'
 
     provides = {
         "module_test_module": [
-            "shoop_tests.core.module_test_module:ModuleTestModule",
-            "shoop_tests.core.module_test_module:AnotherModuleTestModule",
+            __name__ + ".module_test_module:ModuleTestModule",
+            __name__ + ".module_test_module:AnotherModuleTestModule",
         ]
     }
 
 
-default_app_config = 'shoop_tests.core.AppConfig'
+default_app_config = __name__ + ".AppConfig"

--- a/shoop_tests/themes/classic_gray/test_footer_links.py
+++ b/shoop_tests/themes/classic_gray/test_footer_links.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from shoop.themes.classic_gray import ClassicGrayTheme
+import shoop.themes.classic_gray
 
 
-class DatabaseNaiveClassicGrayTheme(ClassicGrayTheme):
+class DatabaseNaiveClassicGrayTheme(shoop.themes.classic_gray.Theme):
     def __init__(self, test_settings):
         self.test_settings = test_settings
         super(DatabaseNaiveClassicGrayTheme, self).__init__()


### PR DESCRIPTION
Rename all `*AppConfig` classes in `__init__.py` files to just
`AppConfig` and make use of `__name__` when specifying strings in
`__init__.py` files that refer to names in the current package or in its
submodules.