### PR TITLE
Add `custom_css` field to theme configuration

### DIFF
--- a/shoop/themes/classic_gray/__init__.py
+++ b/shoop/themes/classic_gray/__init__.py
@@ -14,6 +14,12 @@ from shoop.apps import AppConfig
 from shoop.xtheme.theme import Theme
 
 
+CUSTOM_CSS_HELP = _("""This field can be used to customize your theme to match your branding.
+The contents of this field will be rendered inside 'style'
+tag in the template header so use only plain CSS here.""")
+FOOTER_LINKS_HELP = _("One line per link in format 'http://example.com Example Link'")
+
+
 class ClassicGrayTheme(Theme):
     identifier = "shoop.themes.classic_gray"
     name = "Shoop Classic Gray Theme"
@@ -22,9 +28,11 @@ class ClassicGrayTheme(Theme):
 
     fields = [
         ("show_welcome_text", forms.BooleanField(required=False, initial=True, label=_("Show Frontpage Welcome Text"))),
+        ("custom_css", forms.CharField(required=False, label=_("Custom CSS"), widget=forms.Textarea,
+                                       help_text=CUSTOM_CSS_HELP)),
         ("footer_html", forms.CharField(required=False, label=_("Footer custom HTML"), widget=forms.Textarea)),
         ("footer_links", forms.CharField(required=False, label=_("Footer links"), widget=forms.Textarea,
-                                         help_text=_("One line per link in format 'http://example.com Example Link'"))),
+                                         help_text=FOOTER_LINKS_HELP)),
         ("footer_column_order", forms.ChoiceField(required=False, initial="", label=_("Footer column order"))),
     ]
 

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/base.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/base.jinja
@@ -14,6 +14,9 @@
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,700' rel='stylesheet' type='text/css'>
     {# Include Styles #}
     <link rel="stylesheet" href="{{ STATIC_URL }}classic_gray/css/style.css">
+    <style>
+    {{ xtheme.get("custom_css")|default("", True)|safe }}
+    </style>
 </head>
 <body>
     {% if request.shop.maintenance_mode %}


### PR DESCRIPTION
This would allow some theme customization until proper tools are implemented. Currently customers are using the `Footer HTML` field for this purpose

Refs no ref