### PR TITLE
Update product prices when customer is changed (SHUUP-2719, SHUUP-2721)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -73,6 +73,7 @@ Localization
 Admin
 ~~~~~
 
+- Fix bug: Refresh order lines when customer is changed during order creation
 - Add default ``is_active`` filter to Contact and User admins
 - Enable default values for ``ChoiceFilter``
 - Enable contact activation/deactivation

--- a/shoop/admin/modules/orders/static_src/create/actions/index.js
+++ b/shoop/admin/modules/orders/static_src/create/actions/index.js
@@ -80,6 +80,7 @@ export const retrieveCustomerData = function({id}) {
             }
             dispatch(receiveCustomerData({id, data}));
             dispatch(setCustomer(data));
+            dispatch(updateLines());
         });
     };
 };

--- a/shoop/admin/modules/orders/static_src/create/reducers/lines.js
+++ b/shoop/admin/modules/orders/static_src/create/reducers/lines.js
@@ -75,12 +75,10 @@ function updateLineFromProduct(state, {payload}) {
         updates.errors = product.errors;
         return setLineProperties(state, id, updates);
     }
-    if (line.unitPrice === 0) {
-        updates = getDiscountsAndTotal(product.quantity, product.baseUnitPrice.value, product.unitPrice.value);
-        updates.baseUnitPrice = product.baseUnitPrice.value;
-        updates.unitPrice = product.unitPrice.value;
-        updates.unitPriceIncludesTax = product.unitPrice.includesTax;
-    }
+    updates = getDiscountsAndTotal(product.quantity, product.baseUnitPrice.value, product.unitPrice.value);
+    updates.baseUnitPrice = product.baseUnitPrice.value;
+    updates.unitPrice = product.unitPrice.value;
+    updates.unitPriceIncludesTax = product.unitPrice.includesTax;
     updates.sku = product.sku;
     updates.text = product.name;
     updates.quantity = product.quantity;

--- a/shoop/admin/modules/orders/views/edit.py
+++ b/shoop/admin/modules/orders/views/edit.py
@@ -132,7 +132,7 @@ def get_price_info(shop, customer, product, quantity):
         shop=shop,
         customer=(customer or AnonymousContact()),
     )
-    return pricing_mod.get_price_info(pricing_ctx, product, quantity=quantity)
+    return product.get_price_info(pricing_ctx, quantity=quantity)
 
 
 class OrderEditView(CreateOrUpdateView):


### PR DESCRIPTION
Fix line item pricing to reflect customer/campaign discounts for admin
order editor. Use `product.get_price_info` to get prices.

Refs SHUUP-2721, SHUUP-2719