### PR TITLE
Admin: Show stock on order creation (SHUUP-2730)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -73,6 +73,7 @@ Localization
 Admin
 ~~~~~
 
+- Show stock in order creator
 - Fix bug: Fix decimal precision issues on order creation
 - Enable order creation for contact from contact detail view
 - Fix bug: Refresh order lines when customer is changed during order creation

--- a/shoop/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-01 12:18+0000\n"
+"POT-Creation-Date: 2016-06-13 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -171,10 +171,10 @@ msgstr ""
 msgid "Select Shop"
 msgstr ""
 
-msgid "Order Contents"
+msgid "Customer Details"
 msgstr ""
 
-msgid "Customer Details"
+msgid "Order Contents"
 msgstr ""
 
 msgid "Shipping Method"
@@ -189,6 +189,12 @@ msgid ""
 msgstr ""
 
 msgid "Proceed"
+msgstr ""
+
+msgid "Logical Count"
+msgstr ""
+
+msgid "Physical Count"
 msgstr ""
 
 msgid "Select product"

--- a/shoop/admin/modules/orders/static_src/create/reducers/lines.js
+++ b/shoop/admin/modules/orders/static_src/create/reducers/lines.js
@@ -38,6 +38,16 @@ function setLineProperties(linesState, lineId, props) {
     });
 }
 
+function getFormattedStockCounts(line) {
+    const physicalCount = ensureNumericValue(line.physicalCount);
+    const logicalCount = ensureNumericValue(line.logicalCount);
+
+    return {
+        physicalCount: physicalCount.toFixed(line.salesDecimals) + ' ' + line.salesUnit,
+        logicalCount: logicalCount.toFixed(line.salesDecimals) + ' ' + line.salesUnit
+    }
+}
+
 function getDiscountsAndTotal(quantity, baseUnitPrice, unitPrice, updateUnitPrice=false) {
     const updates = {};
 
@@ -88,6 +98,7 @@ function updateLineFromProduct(state, {payload}) {
     updates.quantity = product.quantity;
     updates.step = product.purchaseMultiple;
     updates.errors = product.errors;
+    updates = _.merge(updates, getFormattedStockCounts(product));
     return setLineProperties(state, id, updates);
 }
 
@@ -177,6 +188,7 @@ function setLines(state, {payload}) {
     _.map(payload, (line) => {
         _.merge(
             line,
+            getFormattedStockCounts(line),
             getDiscountsAndTotal(
                 ensureNumericValue(line.quantity),
                 ensureNumericValue(line.baseUnitPrice),

--- a/shoop/admin/modules/orders/static_src/create/view/lines.js
+++ b/shoop/admin/modules/orders/static_src/create/view/lines.js
@@ -48,8 +48,12 @@ export function renderOrderLines(store, shop, lines) {
                             }
                         });
                     }
-                }, (line.product ?
-                    [line.product.text, m("br"), m("small", "(" + line.sku + ")")] : gettext("Select product"))
+                }, (line.product ? [
+                    line.product.text, m("br"),
+                    m("small", "(" + line.sku + ")"), m("br"),
+                    m("small", gettext("Logical Count") + ": " + line.logicalCount), m("br"),
+                    m("small", gettext("Physical Count") + ": " + line.physicalCount)
+                ] : gettext("Select product"))
             );
             canEditPrice = (line.product && line.product.id);
         } else {

--- a/shoop_tests/admin/test_order_creator.py
+++ b/shoop_tests/admin/test_order_creator.py
@@ -179,6 +179,10 @@ def test_order_creator_product_data(rf, admin_user):
     assert_contains(response, "taxClass")
     assert_contains(response, "sku")
     assert_contains(response, product.sku)
+    assert_contains(response, "logicalCount")
+    assert_contains(response, "physicalCount")
+    assert_contains(response, "salesDecimals")
+    assert_contains(response, "salesUnit")
 
 
 def test_order_creator_customer_data(rf, admin_user):


### PR DESCRIPTION
Show physical and logical stock counts to merchant when he is creating
an order.

Refs SHUUP-2730