### PR TITLE
Tune details of inactive contact checks (SHUUP-2845)

### DIFF
--- a/shoop/front/apps/auth/forms.py
+++ b/shoop/front/apps/auth/forms.py
@@ -17,6 +17,8 @@ from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 from django.utils.translation import ugettext as _
 
+from shoop.core.models import get_person_contact
+
 
 class EmailAuthenticationForm(AuthenticationForm):
 
@@ -53,10 +55,9 @@ class EmailAuthenticationForm(AuthenticationForm):
 
     def confirm_login_allowed(self, user):
         """
-        If a user has a contact that has been disabled by admin, do not let
-        user login.
+        Do not let user with inactive person contact to login.
         """
-        if hasattr(user, "contact") and not user.contact.is_active:
+        if not get_person_contact(user).is_active:
             raise forms.ValidationError(
                 self.error_messages['inactive'],
                 code='inactive',

--- a/shoop/front/middleware.py
+++ b/shoop/front/middleware.py
@@ -83,6 +83,10 @@ class ShoopFrontMiddleware(object):
         if not request.person.is_active:
             messages.add_message(request, messages.INFO, _("Logged out since this account is inactive."))
             logout(request)
+            # Usually logout is connected to the `refresh_on_logout`
+            # method via a signal and that already sets request.person
+            # to anonymous, but set it explicitly too, just to be sure
+            request.person = get_person_contact(None)
 
     def _set_customer(self, request):
         company = get_company_contact(request.user)

--- a/shoop_tests/core/test_contacts.py
+++ b/shoop_tests/core/test_contacts.py
@@ -44,18 +44,20 @@ def test_anonymous_contact():
     a2 = AnonymousContact()
 
     # Basic Contact stuff
+    assert a1.is_anonymous, "AnonymousContact is anonymous"
+    assert not a1.is_all_seeing, "AnonymousContact is not all seeing"
     assert a1.identifier is None
-    assert a1.is_active
+    assert a1.is_active, "AnonymousContact is active"
     assert a1.language == ''
     assert a1.marketing_permission
     assert a1.phone == ''
     assert a1.www == ''
     assert a1.timezone is None
     assert a1.prefix == ''
-    assert a1.name == ''
+    assert a1.name == '', "AnonymousContact has no name"
     assert a1.suffix == ''
     assert a1.name_ext == ''
-    assert a1.email == ''
+    assert a1.email == '', "AnonymousContact has no email"
     assert str(a1) == ''
 
     # Primary key / id


### PR DESCRIPTION
* Front: Authentication form: Use get_person_contact
 * Front: Middleware: Explicitly change inactive person to anonymous
 * Document AnonymousContact tests a bit