### PR TITLE
Buy X get Y campaign (SHUUP-2733)

### DIFF
--- a/doc/api/shoop.admin.modules.orders.rst
+++ b/doc/api/shoop.admin.modules.orders.rst
@@ -27,6 +27,14 @@ shoop.admin.modules.orders.json_order_creator module
     :undoc-members:
     :show-inheritance:
 
+shoop.admin.modules.orders.sections module
+------------------------------------------
+
+.. automodule:: shoop.admin.modules.orders.sections
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/doc/api/shoop.admin.modules.product_types.views.rst
+++ b/doc/api/shoop.admin.modules.product_types.views.rst
@@ -4,6 +4,14 @@ shoop.admin.modules.product_types.views package
 Submodules
 ----------
 
+shoop.admin.modules.product_types.views.ajax module
+---------------------------------------------------
+
+.. automodule:: shoop.admin.modules.product_types.views.ajax
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 shoop.admin.modules.product_types.views.edit module
 ---------------------------------------------------
 

--- a/doc/api/shoop.campaigns.models.rst
+++ b/doc/api/shoop.campaigns.models.rst
@@ -12,6 +12,22 @@ shoop.campaigns.models.basket_conditions module
     :undoc-members:
     :show-inheritance:
 
+shoop.campaigns.models.basket_effects module
+--------------------------------------------
+
+.. automodule:: shoop.campaigns.models.basket_effects
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+shoop.campaigns.models.basket_line_effects module
+-------------------------------------------------
+
+.. automodule:: shoop.campaigns.models.basket_line_effects
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 shoop.campaigns.models.campaigns module
 ---------------------------------------
 
@@ -40,6 +56,14 @@ shoop.campaigns.models.context_conditions module
 ------------------------------------------------
 
 .. automodule:: shoop.campaigns.models.context_conditions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+shoop.campaigns.models.product_effects module
+---------------------------------------------
+
+.. automodule:: shoop.campaigns.models.product_effects
     :members:
     :undoc-members:
     :show-inheritance:

--- a/shoop/campaigns/apps.py
+++ b/shoop/campaigns/apps.py
@@ -42,6 +42,7 @@ class CampaignAppConfig(AppConfig):
         "basket_campaign_effect": [
             "shoop.campaigns.models.basket_effects:BasketDiscountAmount",
             "shoop.campaigns.models.basket_effects:BasketDiscountPercentage",
+            "shoop.campaigns.models.basket_line_effects:FreeProductLine",
         ],
         "campaign_context_condition": [
             "shoop.campaigns.models.context_conditions:ContactGroupCondition",

--- a/shoop/campaigns/locale/en/LC_MESSAGES/django.po
+++ b/shoop/campaigns/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-14 00:17+0000\n"
+"POT-Creation-Date: 2016-06-14 21:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -216,6 +216,15 @@ msgstr ""
 msgid "Give percentage discount."
 msgstr ""
 
+msgid "Free Product(s)"
+msgstr ""
+
+msgid "product"
+msgstr ""
+
+msgid "Select product(s) to give free."
+msgstr ""
+
 msgid "shop"
 msgstr ""
 
@@ -299,9 +308,6 @@ msgid "Limit the campaign to selected product types."
 msgstr ""
 
 msgid "Product"
-msgstr ""
-
-msgid "product"
 msgstr ""
 
 msgid "Limit the campaign to selected products."

--- a/shoop/campaigns/migrations/0007_freeproductline.py
+++ b/shoop/campaigns/migrations/0007_freeproductline.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop', '0025_add_codes_for_order'),
+        ('campaigns', '0006_effects'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='FreeProductLine',
+            fields=[
+                ('basketdiscounteffect_ptr', models.OneToOneField(primary_key=True, serialize=False, auto_created=True, to='campaigns.BasketDiscountEffect', parent_link=True)),
+                ('products', models.ManyToManyField(verbose_name='product', to='shoop.Product')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('campaigns.basketdiscounteffect',),
+        ),
+    ]

--- a/shoop/campaigns/models/__init__.py
+++ b/shoop/campaigns/models/__init__.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 from .basket_conditions import BasketCondition
 from .basket_effects import BasketDiscountEffect
+from .basket_line_effects import BasketLineEffect
 from .campaigns import BasketCampaign, Campaign, CatalogCampaign, Coupon
 from .catalog_filters import CatalogFilter
 from .contact_group_sales_ranges import ContactGroupSalesRange
@@ -16,6 +17,7 @@ __all__ = [
     'BasketCampaign',
     'BasketDiscountEffect',
     'BasketCondition',
+    'BasketLineEffect',
     'Campaign',
     'ProductDiscountEffect',
     'CatalogCampaign',

--- a/shoop/campaigns/models/basket_line_effects.py
+++ b/shoop/campaigns/models/basket_line_effects.py
@@ -1,0 +1,74 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import random
+
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+from shoop.campaigns.models import BasketDiscountEffect
+from shoop.core.models import OrderLineType, Product
+from shoop.core.order_creator._source import LineSource
+
+
+class BasketLineEffect(BasketDiscountEffect):
+
+    class Meta:
+        abstract = True
+
+    def get_discount_lines(self, order_source, original_lines):
+        """
+        Applies the effect based on given `order_source`
+
+        :return: amount of discount to accumulate for the product
+        :rtype: Iterable[shoop.core.order_creator.SourceLine]
+        """
+        raise NotImplementedError("Not implemented!")
+
+
+class FreeProductLine(BasketLineEffect):
+    identifier = "free_product_line_effect"
+    model = Product
+    yields = True
+    name = _("Free Product(s)")
+
+    products = models.ManyToManyField(Product, verbose_name=_("product"))
+
+    @property
+    def description(self):
+        return _("Select product(s) to give free.")
+
+    @property
+    def values(self):
+        return self.products
+
+    @values.setter
+    def values(self, values):
+        self.products = values
+
+    def get_discount_lines(self, order_source, original_lines):
+        lines = []
+        shop = order_source.shop
+        for product in self.products.all():
+            shop_product = product.get_shop_instance(shop)
+            supplier = shop_product.suppliers.first()
+            if not shop_product.is_orderable(
+                    supplier=supplier, customer=order_source.customer, quantity=1):
+                continue
+            line_data = dict(
+                line_id="free_product_%s" % str(random.randint(0, 0x7FFFFFFF)),
+                type=OrderLineType.PRODUCT,
+                quantity=1,
+                shop=shop,
+                text=("%s (%s)" % (product.name, self.campaign.public_name)),
+                base_unit_price=shop.create_price(0),
+                product=product,
+                sku=product.sku,
+                supplier=supplier,
+                line_source=LineSource.DISCOUNT_MODULE
+            )
+            lines.append(order_source.create_line(**line_data))
+        return lines

--- a/shoop/core/order_creator/_source.py
+++ b/shoop/core/order_creator/_source.py
@@ -14,6 +14,7 @@ from django.core.exceptions import ValidationError
 from django.utils.encoding import force_text
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
+from enumfields import Enum
 from six import iteritems
 
 from shoop.core import taxing
@@ -501,6 +502,13 @@ def _collect_lines_from_signal(signal_results):
                 yield line
 
 
+class LineSource(Enum):
+    CUSTOMER = 1
+    SELLER = 2
+    ADMIN = 3
+    DISCOUNT_MODULE = 4
+
+
 class SourceLine(TaxableItem, Priceful):
     """
     Line of OrderSource.
@@ -559,6 +567,8 @@ class SourceLine(TaxableItem, Priceful):
         self.text = kwargs.pop("text", "")
         self.require_verification = kwargs.pop("require_verification", False)
         self.accounting_identifier = kwargs.pop("accounting_identifier", "")
+
+        self.line_source = kwargs.pop("line_source", LineSource.CUSTOMER)
 
         self._taxes = None
 

--- a/shoop/front/basket/objects.py
+++ b/shoop/front/basket/objects.py
@@ -18,6 +18,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from shoop.core.models import OrderLineType, PaymentMethod, ShippingMethod
 from shoop.core.order_creator import OrderSource, SourceLine
+from shoop.core.order_creator._source import LineSource
 from shoop.front.basket.storage import BasketCompatibilityError, get_storage
 from shoop.utils.numbers import parse_decimal_string
 from shoop.utils.objects import compare_partial_dicts
@@ -76,11 +77,11 @@ class BasketLine(SourceLine):
 
     @property
     def can_delete(self):
-        return (self.type == OrderLineType.PRODUCT)
+        return (self.type == OrderLineType.PRODUCT and self.line_source != LineSource.DISCOUNT_MODULE)
 
     @property
     def can_change_quantity(self):
-        return (self.type == OrderLineType.PRODUCT)
+        return (self.type == OrderLineType.PRODUCT and self.line_source != LineSource.DISCOUNT_MODULE)
 
 
 class BaseBasket(OrderSource):

--- a/shoop_tests/campaigns/test_basket_campaigns.py
+++ b/shoop_tests/campaigns/test_basket_campaigns.py
@@ -7,26 +7,30 @@
 from decimal import Decimal
 
 import pytest
-
 from django.db import IntegrityError
 
 from shoop.campaigns.forms import BasketCampaignForm
 from shoop.campaigns.models.basket_conditions import (
-    BasketTotalProductAmountCondition, BasketTotalAmountCondition
+    BasketTotalAmountCondition, BasketTotalProductAmountCondition
 )
-from shoop.campaigns.models.basket_effects import BasketDiscountAmount, BasketDiscountPercentage
-from shoop.campaigns.models.campaigns import BasketCampaign, Coupon, CouponUsage
+from shoop.campaigns.models.basket_effects import (
+    BasketDiscountAmount, BasketDiscountPercentage
+)
+from shoop.campaigns.models.campaigns import (
+    BasketCampaign, Coupon, CouponUsage
+)
 from shoop.core.models import OrderLineType
 from shoop.core.order_creator import OrderCreator
 from shoop.front.basket import get_basket
 from shoop.front.basket.commands import handle_add_campaign_code
 from shoop.testing.factories import (
-    create_product, get_default_supplier, get_default_tax_class,
-    get_default_product, get_shipping_method
+    create_product, get_default_product, get_default_supplier,
+    get_shipping_method
 )
 from shoop_tests.campaigns import initialize_test
 from shoop_tests.core.test_order_creator import seed_source
 from shoop_tests.utils import printable_gibberish
+
 
 """
 These tests provides proof for following requirements:

--- a/shoop_tests/campaigns/test_effects.py
+++ b/shoop_tests/campaigns/test_effects.py
@@ -1,0 +1,107 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from shoop.campaigns.models import BasketCampaign, Coupon
+from shoop.campaigns.models.basket_conditions import BasketTotalProductAmountCondition
+from shoop.campaigns.models.basket_line_effects import FreeProductLine
+from shoop.core.models import OrderLineType
+from shoop.core.order_creator._source import LineSource
+from shoop.front.basket import get_basket
+from shoop.testing.factories import create_product, get_default_supplier
+from shoop_tests.campaigns import initialize_test
+from shoop_tests.utils import printable_gibberish
+
+
+@pytest.mark.django_db
+def test_basket_free_product(rf):
+    request, shop, group = initialize_test(rf, False)
+    price = shop.create_price
+
+    basket = get_basket(request)
+    supplier = get_default_supplier()
+
+    single_product_price = "50"
+    discount_amount_value = "10"
+
+     # create basket rule that requires 2 products in basket
+    product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=single_product_price)
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+    basket.save()
+
+    second_product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=single_product_price)
+
+    rule = BasketTotalProductAmountCondition.objects.create(value="2")
+
+    campaign = BasketCampaign.objects.create(active=True, shop=shop, name="test", public_name="test")
+    campaign.conditions.add(rule)
+
+    effect = FreeProductLine.objects.create(campaign=campaign)
+    effect.products.add(second_product)
+
+
+    basket.uncache()
+    final_lines = basket.get_final_lines()
+
+    assert len(final_lines) == 2
+
+    line_types = [l.type for l in final_lines]
+    assert OrderLineType.DISCOUNT not in line_types
+
+    for line in basket.get_final_lines():
+        assert line.type == OrderLineType.PRODUCT
+        if line.product != product:
+            assert line.product == second_product
+            assert line.line_source == LineSource.DISCOUNT_MODULE
+        else:
+            assert line.line_source == LineSource.CUSTOMER
+
+
+@pytest.mark.django_db
+def test_basket_free_product_coupon(rf):
+    request, shop, group = initialize_test(rf, False)
+    price = shop.create_price
+
+    basket = get_basket(request)
+    supplier = get_default_supplier()
+
+    single_product_price = "50"
+    discount_amount_value = "10"
+
+     # create basket rule that requires 2 products in basket
+    product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=single_product_price)
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+    basket.save()
+
+    second_product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=single_product_price)
+
+    rule = BasketTotalProductAmountCondition.objects.create(value="2")
+    coupon = Coupon.objects.create(code="TEST", active=True)
+
+    campaign = BasketCampaign.objects.create(active=True, shop=shop, name="test", public_name="test", coupon=coupon)
+    campaign.conditions.add(rule)
+
+    effect = FreeProductLine.objects.create(campaign=campaign)
+    effect.products.add(second_product)
+
+    basket.add_code(coupon.code)
+
+    basket.uncache()
+    final_lines = basket.get_final_lines()
+
+    assert len(final_lines) == 2
+
+    line_types = [l.type for l in final_lines]
+    assert OrderLineType.DISCOUNT not in line_types
+
+    for line in basket.get_final_lines():
+        assert line.type == OrderLineType.PRODUCT
+
+        if line.product != product:
+            assert line.product == second_product


### PR DESCRIPTION
Included:
* Core: Add `line_source` to `SourceLine`
* Core: Add `Enum` `LineSource` that contains four different identifiers.
* Core: Add `SourceLine.line_source` to identify lines.
* Modify `can_delete()` and `can_change_quantity()` to take `LineSource` into account in `BasketLine`
* Campaigns: Add Buy X get Y campaign

Refs SHUUP-2733