### PR TITLE
Tune order editor/creator prices (SHUUP-2853, SHUUP-2640)

### DIFF
--- a/shoop/admin/modules/orders/static_src/create/reducers/lines.js
+++ b/shoop/admin/modules/orders/static_src/create/reducers/lines.js
@@ -45,7 +45,7 @@ function getFormattedStockCounts(line) {
     return {
         physicalCount: physicalCount.toFixed(line.salesDecimals) + ' ' + line.salesUnit,
         logicalCount: logicalCount.toFixed(line.salesDecimals) + ' ' + line.salesUnit
-    }
+    };
 }
 
 function getDiscountsAndTotal(quantity, baseUnitPrice, unitPrice, updateUnitPrice=false) {
@@ -55,7 +55,7 @@ function getDiscountsAndTotal(quantity, baseUnitPrice, unitPrice, updateUnitPric
         updates.unitPrice = unitPrice;
     }
     var totalBeforeDiscount = baseUnitPrice * quantity;
-    var total = +(unitPrice * quantity).toFixed(2);
+    var total = +(unitPrice * quantity);
     updates.total = total;
     if (baseUnitPrice < unitPrice || unitPrice < 0) {
         updates.discountPercent = 0;
@@ -85,13 +85,15 @@ function updateLineFromProduct(state, {payload}) {
         return setLineProperties(state, id, updates);
     }
 
+    const baseUnitPrice = ensureNumericValue(product.baseUnitPrice.value);
+    const unitPrice = ensureNumericValue(product.unitPrice.value);
     updates = getDiscountsAndTotal(
         ensureNumericValue(product.quantity),
-        ensureNumericValue(product.baseUnitPrice.value),
-        ensureNumericValue(product.unitPrice.value)
+        baseUnitPrice,
+        unitPrice
     );
-    updates.baseUnitPrice = ensureNumericValue(product.baseUnitPrice.value);
-    updates.unitPrice = ensureNumericValue(product.unitPrice.value);
+    updates.baseUnitPrice = baseUnitPrice;
+    updates.unitPrice = unitPrice;
     updates.unitPriceIncludesTax = product.unitPrice.includesTax;
     updates.sku = product.sku;
     updates.text = product.name;
@@ -170,7 +172,7 @@ function setLineProperty(state, {payload}) {
             case "total":
                 const calculatedTotal = line.quantity * line.baseUnitPrice;
                 // TODO: change the hardcoded rounding when doing SHOOP-1912
-                const total = +ensureNumericValue(value, calculatedTotal).toFixed(2);
+                const total = +ensureNumericValue(value, calculatedTotal);
                 updates = getDiscountsAndTotal(
                     line.quantity,
                     line.baseUnitPrice,

--- a/shoop/admin/modules/orders/views/edit.py
+++ b/shoop/admin/modules/orders/views/edit.py
@@ -180,7 +180,7 @@ class OrderEditView(CreateOrUpdateView):
             "shop": encode_shop(order.shop),
             "lines": [
                 get_line_data_for_edit(order.shop, line) for line in order.lines.filter(
-                    type__in=[OrderLineType.PRODUCT, OrderLineType.OTHER]
+                    type__in=[OrderLineType.PRODUCT, OrderLineType.OTHER], parent_line_id=None
                 )
             ],
             "shippingMethodId": (encode_method(order.shipping_method) if order.shipping_method else None),

--- a/shoop/admin/modules/orders/views/edit.py
+++ b/shoop/admin/modules/orders/views/edit.py
@@ -266,12 +266,12 @@ class OrderEditView(CreateOrUpdateView):
                 "name": force_text(product.tax_class),
             },
             "baseUnitPrice": {
-                "value": price_info.base_price.value,
-                "includesTax": price_info.base_price.includes_tax
+                "value": price_info.base_unit_price.value,
+                "includesTax": price_info.base_unit_price.includes_tax
             },
             "unitPrice": {
-                "value": price_info.price.value,
-                "includesTax": price_info.price.includes_tax
+                "value": price_info.discounted_unit_price.value,
+                "includesTax": price_info.base_unit_price.includes_tax
             }
         }
 


### PR DESCRIPTION
* Admin order creator: Return unit prices when fetching product data
* Admin order creator: Reduce discount amount precision to two decimals
* Admin order edit: Do not preserve lines with parent