### PR TITLE
Add cash payment method (SHUUP-2723)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add cash payment method
 - Add rounding behavior component
 - Add contact group availability behavior component
 - Fix bug: Do not display decimal values in scientific notation

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add rounding behavior component
 - Add contact group availability behavior component
 - Fix bug: Do not display decimal values in scientific notation
 - Fix bug: Taxes of child order lines are filled incorrectly

--- a/shoop/admin/__init__.py
+++ b/shoop/admin/__init__.py
@@ -45,6 +45,7 @@ class ShoopAdminAppConfig(AppConfig):
             "shoop.admin.modules.services.forms:WaivingCostBehaviorComponentForm",
             "shoop.admin.modules.services.forms:WeightLimitsBehaviorComponentForm",
             "shoop.admin.modules.services.forms:GroupAvailabilityBehaviorComponentForm",
+            "shoop.admin.modules.services.forms:RoundingBehaviorComponentForm",
         ],
         "service_behavior_component_form_part": [
             "shoop.admin.modules.services.weight_based_pricing.WeightBasedPricingFormPart"

--- a/shoop/admin/__init__.py
+++ b/shoop/admin/__init__.py
@@ -58,6 +58,10 @@ class ShoopAdminAppConfig(AppConfig):
     }
 
     def ready(self):
+        from shoop.core.order_creator.signals import order_creator_finished
+        from shoop.admin.modules.orders.receivers import handle_custom_payment_return_requests
+
+        order_creator_finished.connect(handle_custom_payment_return_requests, dispatch_uid='shoop.admin.order_create')
         validate_templates_configuration()
 
 

--- a/shoop/admin/modules/orders/receivers.py
+++ b/shoop/admin/modules/orders/receivers.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.timezone import now
+
+from shoop.core.models import CustomPaymentProcessor
+
+
+# TEMPORARY until we get admin orders also calling service methods
+
+
+def _create_cash_payment_for_order(order):
+    if not order.is_paid():
+        order.create_payment(
+            order.taxful_total_price,
+            payment_identifier="Cash-%s" % now().isoformat(),
+            description="Cash Payment"
+        )
+
+
+def handle_custom_payment_return_requests(sender, order, *args, **kwargs):
+    payment_processor = order.payment_method.payment_processor if order.payment_method else None
+    if isinstance(payment_processor, CustomPaymentProcessor):
+        service = order.payment_method.choice_identifier
+        if service == "cash":
+            _create_cash_payment_for_order(order)

--- a/shoop/admin/modules/services/forms.py
+++ b/shoop/admin/modules/services/forms.py
@@ -14,7 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 from shoop.admin.forms import ShoopAdminForm
 from shoop.core.models import (
     FixedCostBehaviorComponent, GroupAvailabilityBehaviorComponent,
-    PaymentMethod, ServiceProvider, ShippingMethod,
+    PaymentMethod, RoundingBehaviorComponent, ServiceProvider, ShippingMethod,
     WaivingCostBehaviorComponent, WeightLimitsBehaviorComponent
 )
 
@@ -66,7 +66,6 @@ class BaseMethodForm(ShoopAdminForm):
         service_data = self._get_cleaned_data_without_translations()
         provider = service_data.pop(self.service_provider_attr)
         choice_identifier = service_data.pop("choice_identifier")
-
         return provider.create_service(choice_identifier, **service_data)
 
 
@@ -127,4 +126,10 @@ class WeightLimitsBehaviorComponentForm(forms.ModelForm):
 class GroupAvailabilityBehaviorComponentForm(forms.ModelForm):
     class Meta:
         model = GroupAvailabilityBehaviorComponent
+        exclude = ["identifier"]
+
+
+class RoundingBehaviorComponentForm(forms.ModelForm):
+    class Meta:
+        model = RoundingBehaviorComponent
         exclude = ["identifier"]

--- a/shoop/core/locale/en/LC_MESSAGES/django.po
+++ b/shoop/core/locale/en/LC_MESSAGES/django.po
@@ -1079,6 +1079,9 @@ msgstr ""
 msgid "Manually processed payment"
 msgstr ""
 
+msgid "Cash payment"
+msgstr ""
+
 msgid "carrier"
 msgstr ""
 

--- a/shoop/core/locale/en/LC_MESSAGES/django.po
+++ b/shoop/core/locale/en/LC_MESSAGES/django.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-17 19:37+0000\n"
+"POT-Creation-Date: 2016-06-21 17:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
@@ -1035,6 +1035,36 @@ msgid "Customer does not belong to any group."
 msgstr ""
 
 msgid "Service is not available for any of the customers groups."
+msgstr ""
+
+msgid "round to nearest with ties going away from zero"
+msgstr ""
+
+msgid "round to nearest with ties going towards zero"
+msgstr ""
+
+msgid "round away from zero"
+msgstr ""
+
+msgid "round towards zero"
+msgstr ""
+
+msgid "Rounding"
+msgstr ""
+
+msgid "Round total order price to the nearest quant."
+msgstr ""
+
+msgid "rounding quant"
+msgstr ""
+
+msgid "rounding mode"
+msgstr ""
+
+msgid "rounding"
+msgstr ""
+
+msgid "Only administrators can process cash payments"
 msgstr ""
 
 msgid "payment processor"

--- a/shoop/core/migrations/0028_roundingbehaviorcomponent.py
+++ b/shoop/core/migrations/0028_roundingbehaviorcomponent.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from decimal import Decimal
+import shoop.core.models
+import enumfields.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop', '0027_contact_group_behavior'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RoundingBehaviorComponent',
+            fields=[
+                ('servicebehaviorcomponent_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='shoop.ServiceBehaviorComponent')),
+                ('quant', models.DecimalField(default=Decimal('0.05'), verbose_name='rounding quant', max_digits=36, decimal_places=9)),
+                ('mode', enumfields.fields.EnumField(default=b'ROUND_HALF_UP', max_length=10, verbose_name='rounding mode', enum=shoop.core.models.RoundingMode)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('shoop.servicebehaviorcomponent',),
+        ),
+    ]

--- a/shoop/core/models/__init__.py
+++ b/shoop/core/models/__init__.py
@@ -47,8 +47,9 @@ from ._service_base import (
 )
 from ._service_behavior import (
     FixedCostBehaviorComponent, GroupAvailabilityBehaviorComponent,
-    WaivingCostBehaviorComponent, WeightBasedPriceRange,
-    WeightBasedPricingBehaviorComponent, WeightLimitsBehaviorComponent
+    RoundingBehaviorComponent, RoundingMode, WaivingCostBehaviorComponent,
+    WeightBasedPriceRange, WeightBasedPricingBehaviorComponent,
+    WeightLimitsBehaviorComponent
 )
 from ._service_payment import (
     CustomPaymentProcessor, PaymentMethod, PaymentProcessor, PaymentUrls
@@ -118,6 +119,8 @@ __all__ = [
     "ProductVariationVariable",
     "ProductVariationVariableValue",
     "ProductVisibility",
+    "RoundingMode",
+    "RoundingBehaviorComponent",
     "SalesUnit",
     "SavedAddress",
     "SavedAddressRole",

--- a/shoop_tests/admin/test_service_behavior_components.py
+++ b/shoop_tests/admin/test_service_behavior_components.py
@@ -6,6 +6,8 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 
+import decimal
+
 import pytest
 from django.test import override_settings
 
@@ -13,12 +15,13 @@ from shoop.admin.modules.services.views import (
     PaymentMethodEditView, ShippingMethodEditView
 )
 from shoop.core.models import (
-    FixedCostBehaviorComponent, PaymentMethod, ShippingMethod,
-    WaivingCostBehaviorComponent, GroupAvailabilityBehaviorComponent,
-    WeightLimitsBehaviorComponent
+    FixedCostBehaviorComponent, GroupAvailabilityBehaviorComponent,
+    PaymentMethod, RoundingBehaviorComponent, RoundingMode, ShippingMethod,
+    WaivingCostBehaviorComponent, WeightLimitsBehaviorComponent
 )
 from shoop.testing.factories import (
-    get_default_payment_method, get_default_shipping_method, get_default_shop, get_default_customer_group
+    get_default_customer_group, get_default_payment_method,
+    get_default_shipping_method, get_default_shop
 )
 from shoop.testing.utils import apply_request_middleware
 
@@ -50,6 +53,10 @@ def get_default_behavior_settings():
         },
         GroupAvailabilityBehaviorComponent.__name__.lower(): {
             "groups": [get_default_customer_group().pk]
+        },
+        RoundingBehaviorComponent.__name__.lower(): {
+            "mode": RoundingMode.ROUND_UP.value,
+            "quant": decimal.Decimal('0.05')
         }
     }
 

--- a/shoop_tests/core/test_custom_payment_processor.py
+++ b/shoop_tests/core/test_custom_payment_processor.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from decimal import Decimal
+
+import pytest
+
+from shoop.core.models import (
+    CustomPaymentProcessor, PaymentMethod, PaymentStatus, PaymentUrls
+)
+from shoop.core.pricing import TaxfulPrice
+from shoop.testing.factories import (
+    create_order_with_product, get_default_product, get_default_shop,
+    get_default_supplier, get_default_tax_class
+)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('choice_identifier, expected_payment_status', [
+    ('cash', PaymentStatus.FULLY_PAID),
+    ('manual', PaymentStatus.DEFERRED)
+])
+def test_custom_payment_processor_cash_service(choice_identifier, expected_payment_status):
+    shop = get_default_shop()
+    product = get_default_product()
+    supplier = get_default_supplier()
+    processor = CustomPaymentProcessor.objects.create()
+    payment_method = PaymentMethod.objects.create(
+        shop=shop,
+        payment_processor=processor,
+        choice_identifier=choice_identifier,
+        tax_class=get_default_tax_class())
+    order = create_order_with_product(
+        product=product,
+        supplier=supplier,
+        quantity=1,
+        taxless_base_unit_price=Decimal('5.55'),
+        shop=shop)
+    order.taxful_total_price = TaxfulPrice(Decimal('5.55'), u'EUR')
+    order.payment_method = payment_method
+    order.save()
+
+    assert order.payment_status == PaymentStatus.NOT_PAID
+    processor.process_payment_return_request(choice_identifier, order, None)
+    assert order.payment_status == expected_payment_status
+    processor.process_payment_return_request(choice_identifier, order, None)
+    assert order.payment_status == expected_payment_status

--- a/shoop_tests/core/test_rounding_behavior_component.py
+++ b/shoop_tests/core/test_rounding_behavior_component.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from decimal import Decimal
+
+import pytest
+
+from shoop.core.models import RoundingMode, RoundingBehaviorComponent
+from shoop.core.order_creator import OrderSource
+from shoop.testing.factories import get_default_shop
+from shoop_tests.utils.fixtures import regular_user
+
+regular_user = regular_user  # noqa
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('price, cost, mode', [
+    ('2.32', '-0.02', RoundingMode.ROUND_DOWN),
+    ('2.35', '0.00', RoundingMode.ROUND_DOWN),
+    ('2.38', '-0.03', RoundingMode.ROUND_DOWN),
+    ('2.32', '0.03', RoundingMode.ROUND_UP),
+    ('2.35', '0.00', RoundingMode.ROUND_UP),
+    ('2.38', '0.02', RoundingMode.ROUND_UP),
+    ('2.32', '-0.02', RoundingMode.ROUND_HALF_DOWN),
+    ('2.35', '0.00', RoundingMode.ROUND_HALF_DOWN),
+    ('2.38', '0.02', RoundingMode.ROUND_HALF_DOWN),
+    ('2.32', '-0.02', RoundingMode.ROUND_HALF_UP),
+    ('2.35', '0.00', RoundingMode.ROUND_HALF_UP),
+    ('2.38', '0.02', RoundingMode.ROUND_HALF_UP)
+])
+def test_rounding_costs(price, cost, mode):
+    shop = get_default_shop()
+    source = OrderSource(shop)
+    source.total_price_of_products = source.create_price(price)
+    behavior = RoundingBehaviorComponent.objects.create(mode=mode)
+    costs = list(behavior.get_costs(None, source))
+
+    assert len(costs) == 1
+    assert costs[0].price.value == Decimal(cost)
+
+
+@pytest.mark.django_db
+def test_unavailability_reasons(admin_user, regular_user):
+    shop = get_default_shop()
+    source = OrderSource(shop)
+    source.creator = admin_user
+    behavior = RoundingBehaviorComponent.objects.create()
+    reasons = list(behavior.get_unavailability_reasons(None, source))
+
+    assert len(reasons) == 0
+
+    source.creator = regular_user
+    reasons = list(behavior.get_unavailability_reasons(None, source))
+
+    assert len(reasons) == 1


### PR DESCRIPTION
Add cash payments to the custom payment processor which sets created orders
to fully paid on creation. Also add rounding behavior component to round
order totals to the nearest 0.05.

Refs SHUUP-2723