### PR TITLE
Admin: Add purchase orders (SHUUP-2699)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -77,7 +77,8 @@ Localization
 Admin
 ~~~~~
 
-- Add customer detail view to order creator 
+- Add purchase orders on manufacturers
+- Add customer detail view to order creator
 - Define module-level permissions for all admin modules
 - Enable adding of permission groups from `Users` admin
 - Add admin module for managing Django permission groups

--- a/shoop/admin/locale/en/LC_MESSAGES/django.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-16 00:45+0000\n"
+"POT-Creation-Date: 2016-06-26 05:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -235,6 +235,12 @@ msgstr ""
 msgid "Manufacturers"
 msgstr ""
 
+msgid "Create Purchase Order"
+msgstr ""
+
+msgid "Create an order for the manufacturer."
+msgstr ""
+
 msgid "Media"
 msgstr ""
 
@@ -276,7 +282,16 @@ msgstr ""
 msgid "Orders"
 msgstr ""
 
-msgid "Show orders"
+msgid "Sales Orders"
+msgstr ""
+
+msgid "Show sales orders"
+msgstr ""
+
+msgid "Purchase Orders"
+msgstr ""
+
+msgid "Show purchase orders"
 msgstr ""
 
 msgid "Outstanding Orders"
@@ -332,10 +347,6 @@ msgstr ""
 msgid "Product %(product)s is not available in the %(shop)s shop."
 msgstr ""
 
-#, python-format
-msgid "Product %(product)s is not orderable: %(error)s"
-msgstr ""
-
 msgid "Please add lines to the order."
 msgstr ""
 
@@ -352,6 +363,9 @@ msgid "Please select shipping method."
 msgstr ""
 
 msgid "Please select payment method."
+msgstr ""
+
+msgid "Please select manufacturer."
 msgstr ""
 
 msgid "Payments"
@@ -404,10 +418,6 @@ msgid "Create Order"
 msgstr ""
 
 #, python-format
-msgid "Contact %s does not exist."
-msgstr ""
-
-#, python-format
 msgid "Order %(identifier)s updated."
 msgstr ""
 
@@ -419,6 +429,10 @@ msgid "Could not proceed with order:"
 msgstr ""
 
 msgid "Could not finalize order:"
+msgstr ""
+
+#, python-format
+msgid "Contact %s does not exist."
 msgstr ""
 
 msgid "Order"

--- a/shoop/admin/locale/en/LC_MESSAGES/django.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-26 05:43+0000\n"
+"POT-Creation-Date: 2016-06-26 05:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -405,6 +405,12 @@ msgid "Edit order"
 msgstr ""
 
 msgid "This order cannot modified at this point"
+msgstr ""
+
+msgid "Mark as Arrived"
+msgstr ""
+
+msgid "This order can not be marked as arrived at this point"
 msgstr ""
 
 msgid "Unable to set order as completed at this point"

--- a/shoop/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-20 19:23+0000\n"
+"POT-Creation-Date: 2016-06-26 05:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -175,6 +175,11 @@ msgid "Recent Orders"
 msgstr ""
 
 msgid "Close"
+
+msgid "Back"
+msgstr ""
+
+msgid "Confirm"
 msgstr ""
 
 msgid "A new customer will be created based on billing address."
@@ -207,13 +212,15 @@ msgstr ""
 msgid "Shipping Address"
 msgstr ""
 
-msgid "Back"
-msgstr ""
-
-msgid "Confirm"
-msgstr ""
-
 msgid "Discard Changes"
+msgstr ""
+
+msgid ""
+"Method rules, taxes and possible extra discounts are calculated after "
+"proceeding."
+msgstr ""
+
+msgid "Proceed"
 msgstr ""
 
 msgid "Select Shop"
@@ -231,12 +238,25 @@ msgstr ""
 msgid "Payment Method"
 msgstr ""
 
-msgid ""
-"Method rules, taxes and possible extra discounts are calculated after "
-"proceeding."
+msgid "Manufacturer Details"
 msgstr ""
 
-msgid "Proceed"
+msgid "Qty"
+msgstr ""
+
+msgid "Base Unit Price"
+msgstr ""
+
+msgid "Line Total"
+msgstr ""
+
+msgid "Discounted Unit Price"
+msgstr ""
+
+msgid "Discount Percent"
+msgstr ""
+
+msgid "Total Discount Amount"
 msgstr ""
 
 msgid "Logical Count"
@@ -251,25 +271,7 @@ msgstr ""
 msgid "Text/Comment"
 msgstr ""
 
-msgid "Qty"
-msgstr ""
-
 msgid "Total Price"
-msgstr ""
-
-msgid "Base Unit Price"
-msgstr ""
-
-msgid "Discounted Unit Price"
-msgstr ""
-
-msgid "Discount Percent"
-msgstr ""
-
-msgid "Total Discount Amount"
-msgstr ""
-
-msgid "Line Total"
 msgstr ""
 
 msgid "Orderline type"
@@ -291,6 +293,9 @@ msgid "Taxes not included."
 msgstr ""
 
 msgid "Add new line"
+msgstr ""
+
+msgid "Manufacturer"
 msgstr ""
 
 msgid "No shipping method"

--- a/shoop/admin/modules/manufacturers/views/edit.py
+++ b/shoop/admin/modules/manufacturers/views/edit.py
@@ -7,8 +7,11 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 
+from django.core.urlresolvers import reverse
 from django.forms.models import ModelForm
+from django.utils.translation import ugettext as _
 
+from shoop.admin.toolbar import URLActionButton
 from shoop.admin.utils.views import CreateOrUpdateView
 from shoop.core.models import Manufacturer
 
@@ -24,3 +27,17 @@ class ManufacturerEditView(CreateOrUpdateView):
     form_class = ManufacturerForm
     template_name = "shoop/admin/manufacturers/edit.jinja"
     context_object_name = "manufacturer"
+
+    def get_toolbar(self):
+        toolbar = super(ManufacturerEditView, self).get_toolbar()
+        if self.object.pk:
+            toolbar.append(
+                URLActionButton(
+                    text=_("Create Purchase Order"),
+                    icon="fa fa-plus",
+                    url=reverse("shoop_admin:purchase_order.new") + "?manufacturer_id=%s" % self.object.pk,
+                    tooltip=_(u"Create an order for the manufacturer."),
+                    extra_css_class="btn-success"
+                )
+            )
+        return toolbar

--- a/shoop/admin/modules/orders/__init__.py
+++ b/shoop/admin/modules/orders/__init__.py
@@ -92,6 +92,11 @@ class OrderModule(CurrencyBound, AdminModule):
                 "shoop.admin.modules.orders.views.PurchaseOrderListView",
                 name="purchase_order.list"
             ),
+            admin_url(
+                "^purchase-orders/(?P<pk>\d+)/set-arrived/$",
+                "shoop.admin.modules.orders.views.PurchaseOrderSetArrivedView",
+                name="purchase_order.set-arrived"
+            ),
         ]
 
     def get_menu_category_icons(self):

--- a/shoop/admin/modules/orders/__init__.py
+++ b/shoop/admin/modules/orders/__init__.py
@@ -18,12 +18,13 @@ from shoop.admin.utils.permissions import (
     get_default_model_permissions, get_permissions_from_urls
 )
 from shoop.admin.utils.urls import admin_url, derive_model_url, get_model_url
-from shoop.core.models import Contact, Order, OrderStatusRole, Product
+from shoop.core.models import (
+    Contact, Order, OrderStatusRole, Product, PurchaseOrder
+)
 
 
 class OrderModule(CurrencyBound, AdminModule):
     name = _("Orders")
-    breadcrumbs_menu_entry = MenuEntry(name, url="shoop_admin:order.list")
 
     def get_urls(self):
         return [
@@ -76,6 +77,21 @@ class OrderModule(CurrencyBound, AdminModule):
                 permissions=get_default_model_permissions(Order),
 
             ),
+            admin_url(
+                "^purchase-orders/(?P<pk>\d+)/$",
+                "shoop.admin.modules.orders.views.PurchaseOrderDetailView",
+                name="purchase_order.detail"
+            ),
+            admin_url(
+                "^purchase-orders/new/$",
+                "shoop.admin.modules.orders.views.PurchaseOrderEditView",
+                name="purchase_order.new"
+            ),
+            admin_url(
+                "^purchase-orders/$",
+                "shoop.admin.modules.orders.views.PurchaseOrderListView",
+                name="purchase_order.list"
+            ),
         ]
 
     def get_menu_category_icons(self):
@@ -85,11 +101,18 @@ class OrderModule(CurrencyBound, AdminModule):
         category = _("Orders")
         return [
             MenuEntry(
-                text=_("Orders"),
+                text=_("Sales Orders"),
                 icon="fa fa-inbox",
                 url="shoop_admin:order.list",
                 category=category,
-                aliases=[_("Show orders")]
+                aliases=[_("Show sales orders")]
+            ),
+            MenuEntry(
+                text=_("Purchase Orders"),
+                icon="fa fa-inbox",
+                url="shoop_admin:purchase_order.list",
+                category=category,
+                aliases=[_("Show purchase orders")]
             ),
         ]
 
@@ -145,4 +168,7 @@ class OrderModule(CurrencyBound, AdminModule):
             )
 
     def get_model_url(self, object, kind):
-        return derive_model_url(Order, "shoop_admin:order", object, kind)
+        return (
+            derive_model_url(PurchaseOrder, "shoop_admin:purchase_order", object, kind) or
+            derive_model_url(Order, "shoop_admin:order", object, kind)
+        )

--- a/shoop/admin/modules/orders/dashboard.py
+++ b/shoop/admin/modules/orders/dashboard.py
@@ -24,7 +24,7 @@ from shoop.utils.numbers import bankers_round
 
 
 def get_orders_by_currency(currency):
-    return Order.objects.filter(currency=currency)
+    return Order.objects.sales_orders().filter(currency=currency)
 
 
 class OrderValueChartDashboardBlock(DashboardChartBlock):
@@ -107,7 +107,7 @@ def get_avg_purchase_size_block(request, currency):
 
     # Average size of purchase with amount of orders it is calculated from
     average_purchase_size = (
-        Order.objects.all()
+        Order.objects.sales_orders().all()
         .aggregate(count=Count("id"), sum=Avg("taxful_total_price_value")))
     return DashboardMoneyBlock(
         id="average_purchase_sum",

--- a/shoop/admin/modules/orders/json_order_creator.py
+++ b/shoop/admin/modules/orders/json_order_creator.py
@@ -13,10 +13,13 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.utils.translation import ugettext as _
 
 from shoop.core.models import (
-    CompanyContact, Contact, MutableAddress, OrderLineType, OrderStatus,
-    PaymentMethod, PersonContact, Product, ShippingMethod, Shop
+    CompanyContact, Contact, Manufacturer, MutableAddress, OrderLineType,
+    OrderStatus, PaymentMethod, PersonContact, Product, ShippingMethod, Shop
 )
-from shoop.core.order_creator import OrderCreator, OrderModifier, OrderSource
+from shoop.core.order_creator import (
+    OrderCreator, OrderModifier, OrderSource, PurchaseOrderCreator,
+    PurchaseOrderSource
+)
 from shoop.utils.analog import LogEntryKind
 from shoop.utils.numbers import parse_decimal_string
 
@@ -99,17 +102,6 @@ class JsonOrderCreator(object):
             }), code="no_shop_product"))
             return False
         supplier = shop_product.suppliers.first()  # TODO: Allow setting a supplier?
-        is_orderable = True
-        for message in shop_product.get_orderability_errors(
-                supplier=supplier, quantity=sl_kwargs["quantity"], customer=source.customer):
-            self.add_error(ValidationError((_("Product %(product)s is not orderable: %(error)s") % {
-                "product": product,
-                "error": str(message.args[0])
-            }), code=str(message.args[1])))
-            is_orderable = False
-
-        if not is_orderable:
-            return False
 
         sl_kwargs["product"] = product
         sl_kwargs["supplier"] = supplier
@@ -175,17 +167,132 @@ class JsonOrderCreator(object):
             customer = PersonContact(**fields)
         return customer
 
-    def _initialize_source_from_state(self, state, creator, ip_address, save, order_to_update=None):
+    def initialize_source_from_state(self, state, creator, ip_address, save, order_to_update=None):
         shop_data = state.pop("shop", None).get("selected", {})
         shop = self.safe_get_first(Shop, pk=shop_data.pop("id", None))
         if not shop:
             self.add_error(ValidationError(_("Please choose a valid shop."), code="no_shop"))
             return None
-
-        source = OrderSource(shop=shop)
+        source = self.source(shop=shop)
         if order_to_update:
             source.update_from_order(order_to_update)
+        return source
 
+    def _get_customer(self, customer_data, billing_address_data, is_company, save):
+        customer = self.safe_get_first(Contact, pk=customer_data.get("id")) if customer_data else None
+        if not customer:
+            customer = self._create_contact_from_address(billing_address_data, is_company)
+            if not customer:
+                return
+            if save:
+                customer.save()
+        return customer
+
+    def _postprocess_order(self, order, state):
+        comment = (state.pop("comment", None) or "")
+        if comment:
+            order.add_log_entry(comment, kind=LogEntryKind.NOTE, user=order.creator)
+
+    def create_source_from_state(self, state, creator=None, ip_address=None, save=False, order_to_update=None):
+        """
+        Create an order source from a state dict unserialized from JSON.
+
+        :param state: State dictionary
+        :type state: dict
+        :param creator: Creator user
+        :type creator: django.contrib.auth.models.User|None
+        :param save: Flag whether order customer and addresses is saved to database
+        :type save: boolean
+        :param order_to_update: Order object to edit
+        :type order_to_update: shoop.core.models.Order|None
+        :return: The created order source, or None if something failed along the way
+        :rtype: OrderSource|None
+        """
+        if not self.is_valid:  # pragma: no cover
+            raise ValueError("Create a new JsonOrderCreator for each order.")
+        # We'll be mutating the state to make it easier to track we've done everything,
+        # so it's nice to deepcopy things first.
+        state = deepcopy(state)
+
+        # First, initialize an OrderSource.
+        source = self.initialize_source_from_state(
+            state, creator=creator, ip_address=ip_address, save=save, order_to_update=order_to_update)
+        if not source:
+            return None
+
+        # Then, copy some lines into it.
+        self._process_lines(source, state)
+
+        if not self.is_valid:  # If we encountered any errors thus far, don't bother going forward
+            return None
+
+        for error in source.get_validation_errors():
+            self.add_error(error)
+
+        if not self.is_valid:
+            return None
+
+        if order_to_update:
+            for code in order_to_update.codes:
+                source.add_code(code)
+        return source
+
+    def create_order_from_state(self, state, creator=None, ip_address=None):
+        """
+        Create an order from a state dict unserialized from JSON.
+
+        :param state: State dictionary
+        :type state: dict
+        :param creator: Creator user
+        :type creator: django.contrib.auth.models.User|None
+        :param ip_address: Remote IP address (IPv4 or IPv6)
+        :type ip_address: str
+        :return: The created order, or None if something failed along the way
+        :rtype: Order|None
+        """
+        source = self.create_source_from_state(
+            state, creator=creator, ip_address=ip_address, save=True)
+        # Then create an OrderCreator and try to get things done!
+        creator = self.creator()
+        try:
+            order = creator.create_order(order_source=source)
+            self._postprocess_order(order, state)
+            return order
+        except Exception as exc:  # pragma: no cover
+            self.add_error(exc)
+            return
+
+    def update_order_from_state(self, state, order_to_update, modified_by=None):
+        """
+        Update an order from a state dict unserialized from JSON.
+
+        :param state: State dictionary
+        :type state: dict
+        :param order_to_update: Order object to edit
+        :type order_to_update: shoop.core.models.Order
+        :return: The created order, or None if something failed along the way
+        :rtype: Order|None
+        """
+        source = self.create_source_from_state(state, order_to_update=order_to_update, save=True)
+        if source:
+            source.modified_by = modified_by
+        modifier = OrderModifier()
+        try:
+            order = modifier.update_order_from_source(order_source=source, order=order_to_update)
+            self._postprocess_order(order, state)
+            return order
+        except Exception as exc:
+            self.add_error(exc)
+            return
+
+
+class JsonSalesOrderCreator(JsonOrderCreator):
+    source = OrderSource
+    creator = OrderCreator
+
+    def initialize_source_from_state(self, state, creator, ip_address, save, order_to_update=None):
+        source = super(JsonSalesOrderCreator, self).initialize_source_from_state(
+            state, creator, ip_address, save, order_to_update)
         customer_data = state.pop("customer", None)
         billing_address_data = customer_data.pop("billingAddress", {})
         shipping_address_data = (
@@ -229,113 +336,35 @@ class JsonOrderCreator(object):
             shipping_address=shipping_address,
             status=OrderStatus.objects.get_default_initial(),
             shipping_method=self.safe_get_first(ShippingMethod, pk=shipping_method.get("id")),
-            payment_method=self.safe_get_first(PaymentMethod, pk=payment_method.get("id")),
+            payment_method=self.safe_get_first(PaymentMethod, pk=payment_method.get("id"))
         )
         return source
 
-    def _get_customer(self, customer_data, billing_address_data, is_company, save):
-        customer = self.safe_get_first(Contact, pk=customer_data.get("id")) if customer_data else None
+
+class JsonPurchaseOrderCreator(JsonOrderCreator):
+    source = PurchaseOrderSource
+    creator = PurchaseOrderCreator
+
+    def initialize_source_from_state(self, state, creator, ip_address, save, order_to_update=None):
+        source = super(JsonPurchaseOrderCreator, self).initialize_source_from_state(
+            state, creator, ip_address, save, order_to_update)
+        customer = PersonContact.objects.get(user=creator)
         if not customer:
-            customer = self._create_contact_from_address(billing_address_data, is_company)
-            if not customer:
-                return
-            if save:
-                customer.save()
-        return customer
+            return
 
-    def _postprocess_order(self, order, state):
-        comment = (state.pop("comment", None) or "")
-        if comment:
-            order.add_log_entry(comment, kind=LogEntryKind.NOTE, user=order.creator)
+        selected_manufacturer = state.pop("manufacturer", {}).get("selected", None)
+        manufacturer = self.safe_get_first(Manufacturer, pk=selected_manufacturer)
+        if not manufacturer:
+            self.add_error(ValidationError(_("Please select manufacturer."), code="no_manufacturer"))
 
-    def create_source_from_state(self, state, creator=None, ip_address=None, save=False, order_to_update=None):
-        """
-        Create an order source from a state dict unserialized from JSON.
+        if self.errors:
+            return
 
-        :param state: State dictionary
-        :type state: dict
-        :param creator: Creator user
-        :type creator: django.contrib.auth.models.User|None
-        :param save: Flag whether order customer and addresses is saved to database
-        :type save: boolean
-        :param order_to_update: Order object to edit
-        :type order_to_update: shoop.core.models.Order|None
-        :return: The created order source, or None if something failed along the way
-        :rtype: OrderSource|None
-        """
-        if not self.is_valid:  # pragma: no cover
-            raise ValueError("Create a new JsonOrderCreator for each order.")
-        # We'll be mutating the state to make it easier to track we've done everything,
-        # so it's nice to deepcopy things first.
-        state = deepcopy(state)
-
-        # First, initialize an OrderSource.
-        source = self._initialize_source_from_state(
-            state, creator=creator, ip_address=ip_address, save=save, order_to_update=order_to_update)
-        if not source:
-            return None
-
-        # Then, copy some lines into it.
-        self._process_lines(source, state)
-        if not self.is_valid:  # If we encountered any errors thus far, don't bother going forward
-            return None
-
-        for error in source.get_validation_errors():
-            self.add_error(error)
-
-        if not self.is_valid:
-            return None
-
-        if order_to_update:
-            for code in order_to_update.codes:
-                source.add_code(code)
+        source.update(
+            creator=creator,
+            ip_address=ip_address,
+            customer=customer,
+            manufacturer=manufacturer,
+            status=OrderStatus.objects.get_default_initial()
+        )
         return source
-
-    def create_order_from_state(self, state, creator=None, ip_address=None):
-        """
-        Create an order from a state dict unserialized from JSON.
-
-        :param state: State dictionary
-        :type state: dict
-        :param creator: Creator user
-        :type creator: django.contrib.auth.models.User|None
-        :param ip_address: Remote IP address (IPv4 or IPv6)
-        :type ip_address: str
-        :return: The created order, or None if something failed along the way
-        :rtype: Order|None
-        """
-        source = self.create_source_from_state(
-            state, creator=creator, ip_address=ip_address, save=True)
-
-        # Then create an OrderCreator and try to get things done!
-        creator = OrderCreator()
-        try:
-            order = creator.create_order(order_source=source)
-            self._postprocess_order(order, state)
-            return order
-        except Exception as exc:  # pragma: no cover
-            self.add_error(exc)
-            return
-
-    def update_order_from_state(self, state, order_to_update, modified_by=None):
-        """
-        Update an order from a state dict unserialized from JSON.
-
-        :param state: State dictionary
-        :type state: dict
-        :param order_to_update: Order object to edit
-        :type order_to_update: shoop.core.models.Order
-        :return: The created order, or None if something failed along the way
-        :rtype: Order|None
-        """
-        source = self.create_source_from_state(state, order_to_update=order_to_update, save=True)
-        if source:
-            source.modified_by = modified_by
-        modifier = OrderModifier()
-        try:
-            order = modifier.update_order_from_source(order_source=source, order=order_to_update)
-            self._postprocess_order(order, state)
-            return order
-        except Exception as exc:
-            self.add_error(exc)
-            return

--- a/shoop/admin/modules/orders/static_src/create/actions/index.js
+++ b/shoop/admin/modules/orders/static_src/create/actions/index.js
@@ -28,6 +28,9 @@ export const setShipToBillingAddress = createAction("setShipToBillingAddress");
 export const setIsCompany = createAction("setIsCompany");
 export const setCustomer = createAction("setCustomer");
 export const showCustomerModal = createAction("showCustomerModal");
+// Manufacturer actions
+export const setSelectedManufacturer = createAction("setSelectedManufacturer");
+export const setManufacturers = createAction("setManufacturers");
 // Methods actions
 export const setShippingMethodChoices = createAction("setShippingMethodChoices");
 export const setShippingMethod = createAction("setShippingMethod");
@@ -37,13 +40,14 @@ export const setPaymentMethod = createAction("setPaymentMethod");
 export const updateTotals = createAction("updateTotals");
 export const setOrderSource = createAction("setOrderSource");
 export const clearOrderSourceData = createAction("clearOrderSourceData");
+export const setOrderType = createAction("setOrderType");
 export const setOrderId = createAction("setOrderId");
 // Comment action
 export const setComment = createAction("setComment");
 
 export const retrieveProductData = function ({id, forLine, quantity}) {
     return (dispatch, getState) => {
-        const {customer, lines, shop} = getState();
+        const {customer, lines, shop, orderType} = getState();
         const prodsAlreadyInLinesQty = _.reduce(lines, function(sum, line) {
             if (line.id !== forLine && line.product && line.product.id === id) {
                 return sum + parseFloat(line.quantity);
@@ -63,7 +67,7 @@ export const retrieveProductData = function ({id, forLine, quantity}) {
             }
             dispatch(receiveProductData({id, data}));
             if (forLine) {
-                dispatch(updateLineFromProduct({id: forLine, product: data}));
+                dispatch(updateLineFromProduct({id: forLine, orderType, product: data}));
                 dispatch(updateTotals(getState));
             }
         });
@@ -103,6 +107,7 @@ export const retrieveCustomerDetails = function({id}) {
 export const retrieveOrderSourceData = function () {
     return (dispatch, getState) => {
         const state = getState();
+        console.log(state);
         post("source_data", {state}).then((data) => {
             dispatch(receiveOrderSourceData({data}));
             dispatch(setOrderSource(data));
@@ -159,7 +164,7 @@ function handleFinalizeResponse(dispatch, data) {
 
 export const beginFinalizingOrder = function () {
     return (dispatch, getState) => {
-        const state = _.assign({}, getState(), {productData: null, order: null}); // We don't care about that substate
+        const state = _.assign({}, getState(), {order: {type: getState().order.type}}, {productData: null}); // We don't care about that substate
         post("finalize", {state}).then((data) => {
             handleFinalizeResponse(dispatch, data);
         }, (data) => {  // error handler

--- a/shoop/admin/modules/orders/static_src/create/index.js
+++ b/shoop/admin/modules/orders/static_src/create/index.js
@@ -10,6 +10,7 @@
 import _ from "lodash";
 import m from "mithril";
 import view from "./view";
+import purchaseOrderView from "./view";
 import {persistStore} from "redux-persist";
 import store from "./store";
 import {
@@ -19,11 +20,15 @@ import {
     setShippingMethodChoices,
     setPaymentMethodChoices,
     setCustomer,
+    setSelectedManufacturer,
+    setManufacturers,
     setShippingMethod,
     setPaymentMethod,
     setLines,
     setOrderId,
-    updateTotals
+    setOrderType,
+    updateTotals,
+    clearOrderSourceData
 } from "./actions";
 
 var controller = null;
@@ -32,14 +37,19 @@ export function init(config = {}) {
     if (controller !== null) {
         return;
     }
+
+    store.dispatch(setOrderType(config.orderType));
     store.dispatch(setShopChoices(config.shops || []));
     store.dispatch(setShop(config.shops[0] || []));
     store.dispatch(setCountries(config.countries || []));
+    store.dispatch(setManufacturers(config.manufacturers || []));
     store.dispatch(setShippingMethodChoices(config.shippingMethods || []));
     store.dispatch(setPaymentMethodChoices(config.paymentMethods || []));
+
     const orderId = config.orderId;
     store.dispatch(setOrderId(orderId));
     const customerData = config.customerData;
+    const manufacturer = config.manufacturer;
 
     const persistor = persistStore(store);
     persistor.purge(["customerDetails"]);
@@ -55,9 +65,18 @@ export function init(config = {}) {
         }
     }
 
-    if (customerData) { // contact -> New Order
+    if (savedOrder && savedOrder.type !== config.orderType) { // sales <-> purchase order
+        persistor.purgeAll();
+    }
+
+    if (customerData) { // contact -> New Sales Order
         persistor.purgeAll();
         store.dispatch(setCustomer(customerData));
+    }
+
+    if (manufacturer) { // manufacturer -> New Purchase Order
+        persistor.purgeAll();
+        store.dispatch(setSelectedManufacturer(manufacturer));
     }
 
     if (orderId) { // Edit mode

--- a/shoop/admin/modules/orders/static_src/create/reducers/index.js
+++ b/shoop/admin/modules/orders/static_src/create/reducers/index.js
@@ -13,6 +13,7 @@ import shop from "./shop";
 import customer from "./customer";
 import customerData from "./customerData";
 import customerDetails from "./customerDetails";
+import manufacturer from "./manufacturer";
 import methods from "./methods";
 import order from "./order";
 import comment from "./comment";
@@ -24,10 +25,12 @@ const childReducer = combineReducers({
     customer,
     customerData,
     customerDetails,
+    manufacturer,
     methods,
     order,
     comment
 });
+
 
 export default function(state, action) {
     if(action.type === "_replaceState") { // For debugging purposes.

--- a/shoop/admin/modules/orders/static_src/create/reducers/lines.js
+++ b/shoop/admin/modules/orders/static_src/create/reducers/lines.js
@@ -20,6 +20,7 @@ function newLine() {
         quantity: 1,
         step: "",
         baseUnitPrice: 0,
+        purchasePrice: 0,
         unitPrice: 0,
         unitPriceIncludesTax: false,
         discountPercent: 0,
@@ -73,7 +74,8 @@ function getDiscountsAndTotal(quantity, baseUnitPrice, unitPrice, updateUnitPric
 }
 
 function updateLineFromProduct(state, {payload}) {
-    const {id, product} = payload;
+    const {id, product, orderType} = payload;
+
     const line = _.detect(state, (sLine) => sLine.id === id);
     if (!line) {
         return state;
@@ -87,11 +89,13 @@ function updateLineFromProduct(state, {payload}) {
 
     const baseUnitPrice = ensureNumericValue(product.baseUnitPrice.value);
     const unitPrice = ensureNumericValue(product.unitPrice.value);
+
     updates = getDiscountsAndTotal(
         ensureNumericValue(product.quantity),
         baseUnitPrice,
         unitPrice
     );
+
     updates.baseUnitPrice = baseUnitPrice;
     updates.unitPrice = unitPrice;
     updates.unitPriceIncludesTax = product.unitPrice.includesTax;
@@ -152,6 +156,15 @@ function setLineProperty(state, {payload}) {
                     ensureNumericValue(value, line.baseUnitPrice),
                     true
                 );
+                break;
+            case "baseUnitPrice":
+                const baseUnitPrice = ensureNumericValue(value, line.baseUnitPrice)
+                updates = getDiscountsAndTotal(
+                    line.quantity,
+                    baseUnitPrice,
+                    baseUnitPrice
+                );
+                updates.baseUnitPrice = baseUnitPrice;
                 break;
             case "discountPercent":
                 const discountPercent = Math.min(100, Math.max(0, ensureNumericValue(value)));

--- a/shoop/admin/modules/orders/static_src/create/reducers/manufacturer.js
+++ b/shoop/admin/modules/orders/static_src/create/reducers/manufacturer.js
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {handleActions} from "redux-actions";
+import _ from "lodash";
+
+export default handleActions({
+    setManufacturers: (state, {payload}) => {
+        var updates = {};
+        if(payload && payload.length > 0) {
+            updates["all"] = payload;
+            updates["selected"] = payload[0].id;
+        }
+        return _.assign({}, state, updates)
+    },
+    setSelectedManufacturer: (state, {payload}) => _.assign({}, state, {"selected": payload})
+}, {
+    all: [],
+    selected: 0
+});

--- a/shoop/admin/modules/orders/static_src/create/reducers/order.js
+++ b/shoop/admin/modules/orders/static_src/create/reducers/order.js
@@ -24,10 +24,12 @@ export default handleActions({
     beginCreatingOrder: ((state) => _.assign(state, {creating: true})),
     endCreatingOrder:  ((state) => _.assign(state, {creating: false})),
     updateTotals,
+    setOrderType: ((state, {payload}) => _.assign(state, {type: payload})),
     setOrderId: ((state, {payload}) => _.assign(state, {id: payload})),
     setOrderSource: ((state, {payload}) => _.assign(state, {source: payload})),
     clearOrderSourceData: ((state) => _.assign(state, {source: null}))
 }, {
+    type: null,
     id: null,
     creating: false,
     source: null,

--- a/shoop/admin/modules/orders/static_src/create/view/confirm.js
+++ b/shoop/admin/modules/orders/static_src/create/view/confirm.js
@@ -6,47 +6,8 @@
  * This source code is licensed under the AGPLv3 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
-function renderHeaders() {
-    return  m("tr", [
-        m("th", gettext("SKU")),
-        m("th", gettext("Text")),
-        m("th", gettext("Quantity")),
-        m("th", gettext("Unit Price")),
-        m("th", gettext("Discount amount")),
-        m("th", gettext("Total (excluding taxes)")),
-        m("th", gettext("Tax percent")),
-        m("th", gettext("Total"))
-    ]);
-}
-
-function renderLines(lines) {
-    return _(lines).map((line) => {
-        return m("tr", [
-            m("td", line.sku),
-            m("td", line.text),
-            m("td", line.quantity),
-            m("td", line.unitPrice),
-            m("td", line.discountAmount),
-            m("td", line.taxlessTotal),
-            m("td", line.taxPercentage),
-            m("td", line.taxfulTotal)
-        ]);
-    }).value();
-}
-
-function renderTotals(source) {
-    return m("tr", [
-        m("td", ""),
-        m("td", ""),
-        m("td", ""),
-        m("td", ""),
-        m("td", source.totalDiscountAmount),
-        m("td", source.taxlessTotal),
-        m("td", ""),
-        m("td", source.taxfulTotal)
-    ]);
-}
+import {table} from "./utils";
+import {beginFinalizingOrder, clearOrderSourceData} from "../actions";
 
 function renderAddress(address) {
     return _(address).map((line, index) => {
@@ -75,20 +36,61 @@ function renderAddressBlock(title, address){
     );
 }
 
-export function confirmView(source) {
-    return [
+function renderLinesTable(store) {
+    const {type, source} = store.getState().order;
+    var columns = [
+        {key: "sku", label: gettext("SKU")},
+        {key: "text", label: gettext("Text")},
+        {key: "quantity", label: gettext("Quantity")},
+        {key: "unitPrice", label: gettext("Unit Price")}
+    ];
+    if(type === 'sales'){
+        columns.push({key: "discountAmount", label: gettext("Discount amount")});
+    }
+    columns = columns.concat([
+        {key: "taxlessTotal", label: gettext("Total (excluding taxes)")},
+        {key: "taxPercentage", label: gettext("Tax percent")},
+        {key: "taxfulTotal", label: gettext("Total")}
+    ]);
+    const data = [
+        ...source.orderLines, {
+            discountAmount: source.totalDiscountAmount,
+            taxlessTotal: source.taxlessTotal,
+            taxfulTotal: source.taxfulTotal
+        }
+    ];
+
+    return table({
+        tableClass: "table-striped",
+        columns,
+        data
+    })
+}
+
+export function confirmView(store) {
+    const {type, creating, source} = store.getState().order;
+    return m("div.container-fluid",
         m("div.table-responsive",
-            m("table.table.table-striped", [
-                m("thead", renderHeaders()),
-                m("tbody", [
-                    renderLines(source.orderLines),
-                    renderTotals(source)
-                ])
-            ])
+            renderLinesTable(store)
         ),
+        type === 'sales'?
         m("div.row", [
             m("div.col-md-6", renderAddressBlock(gettext("Billing address"), source.billingAddress)),
             m("div.col-md-6", renderAddressBlock(gettext("Shipping address"), source.shippingAddress))
+        ]): null,
+        m("div", [
+            m("button.btn.btn-danger.btn-lg" + (creating ? ".disabled" : ""), {
+                disabled: creating,
+                onclick: () => {
+                    store.dispatch(clearOrderSourceData());
+                }
+            }, m("i.fa.fa-close"), " " + gettext("Back")),
+            m("button.btn.btn-success.btn-lg.pull-right" + (creating ? ".disabled" : ""), {
+                disabled: creating,
+                onclick: () => {
+                    store.dispatch(beginFinalizingOrder());
+                }
+            }, m("i.fa.fa-check"), " " + gettext("Confirm"))
         ])
-    ];
+    );
 }

--- a/shoop/admin/modules/orders/static_src/create/view/index.js
+++ b/shoop/admin/modules/orders/static_src/create/view/index.js
@@ -10,67 +10,84 @@ import m from "mithril";
 import {shopSelectView} from "./shops";
 import {orderLinesView} from "./lines";
 import {customerSelectView} from "./customers";
+import {manufacturerSelectView} from "./manufacturers";
 import {shipmentMethodSelectView, paymentMethodSelectView} from "./methods";
 import {confirmView} from "./confirm";
 import {contentBlock} from "./utils";
 import {beginFinalizingOrder, clearOrderSourceData, retrieveOrderSourceData} from "../actions";
 import store from "../store";
 
-export default function view() {
+function discardChangesButton() {
+    return (
+        m("div.container-fluid",
+            m("button.btn.btn-gray.btn-inverse.pull-right", {
+                onclick: () => {
+                    window.localStorage.setItem("resetSavedOrder", "true");
+                    window.location.reload();
+                }
+            }, m("i.fa.fa-undo"), " " + gettext("Discard Changes"))
+        )
+    );
+}
+
+function footer() {
     const {creating, source, total} = store.getState().order;
-    const {choices, selected} = store.getState().shop;
-    if (source) {
-        return m("div.container-fluid",
-            confirmView(source),
-            m("div", [
-                m("button.btn.btn-danger.btn-lg" + (creating ? ".disabled" : ""), {
+    const {selected} = store.getState().shop;
+
+    return (
+        m("div.order-footer",
+            m("div.text", m(
+                "small",
+                gettext("Method rules, taxes and possible extra discounts are calculated after proceeding."))
+            ),
+            m("div.text", m("h2", m("small", gettext("Total") + ": "), total + " " + selected.currency)),
+            m("div.proceed-button", [
+                m("button.btn.btn-success.btn-block" + (creating ? ".disabled" : ""), {
                     disabled: creating,
                     onclick: () => {
-                        store.dispatch(clearOrderSourceData());
+                        if(!source) {
+                            store.dispatch(retrieveOrderSourceData());
+                        }
                     }
-                }, m("i.fa.fa-close"), " " + gettext("Back")),
-                m("button.btn.btn-success.btn-lg.pull-right" + (creating ? ".disabled" : ""), {
-                    disabled: creating,
-                    onclick: () => {
-                        store.dispatch(beginFinalizingOrder());
-                    }
-                }, m("i.fa.fa-check"), " " + gettext("Confirm"))
+                }, m("i.fa.fa-check"), " " + gettext("Proceed"))
             ])
-        );
+        )
+    );
+}
+
+function salesOrderView() {
+    const {creating} = store.getState().order;
+    const {choices} = store.getState().shop;
+
+    return [
+        (choices.length > 1 ? contentBlock("i.fa.fa-building", gettext("Select Shop"), shopSelectView(store)) : null),
+        contentBlock("i.fa.fa-user", gettext("Customer Details"), customerSelectView(store)),
+        contentBlock("i.fa.fa-cubes", gettext("Order Contents"), orderLinesView(store, creating)),
+        contentBlock("i.fa.fa-truck", gettext("Shipping Method"), shipmentMethodSelectView(store)),
+        contentBlock("i.fa.fa-credit-card", gettext("Payment Method"), paymentMethodSelectView(store))
+    ];
+}
+
+function purchaseOrderView() {
+    const {creating} = store.getState().order;
+    const {choices} = store.getState().shop;
+
+    return [
+        (choices.length > 1 ? contentBlock("i.fa.fa-building", gettext("Select Shop"), shopSelectView(store)) : null),
+        contentBlock("i.fa.fa-user", gettext("Manufacturer Details"), manufacturerSelectView(store)),
+        contentBlock("i.fa.fa-cubes", gettext("Order Contents"), orderLinesView(store, creating))
+    ];
+}
+
+export default function view() {
+    const {source, type} = store.getState().order;
+    if (source) {
+        return confirmView(store);
     } else {
         return [
-            m("div.container-fluid",
-                m("button.btn.btn-gray.btn-inverse.pull-right", {
-                    onclick: () => {
-                        window.localStorage.setItem("resetSavedOrder", "true");
-                        window.location.reload();
-                    }
-                }, m("i.fa.fa-undo"), " " + gettext("Discard Changes"))
-            ),
-            m("div.container-fluid",
-                (choices.length > 1 ? contentBlock("i.fa.fa-building", gettext("Select Shop"), shopSelectView(store)) : null),
-                contentBlock("i.fa.fa-user", gettext("Customer Details"), customerSelectView(store)),
-                contentBlock("i.fa.fa-cubes", gettext("Order Contents"), orderLinesView(store, creating)),
-                contentBlock("i.fa.fa-truck", gettext("Shipping Method"), shipmentMethodSelectView(store)),
-                contentBlock("i.fa.fa-credit-card", gettext("Payment Method"), paymentMethodSelectView(store)),
-                m("div.order-footer",
-                    m("div.text", m(
-                        "small",
-                        gettext("Method rules, taxes and possible extra discounts are calculated after proceeding."))
-                    ),
-                    m("div.text", m("h2", m("small", gettext("Total") + ": "), total + " " + selected.currency)),
-                    m("div.proceed-button", [
-                        m("button.btn.btn-success.btn-block" + (creating ? ".disabled" : ""), {
-                            disabled: creating,
-                            onclick: () => {
-                                if(!source) {
-                                    store.dispatch(retrieveOrderSourceData());
-                                }
-                            }
-                        }, m("i.fa.fa-check"), " " + gettext("Proceed"))
-                    ])
-                )
-            )
-        ]
+            discardChangesButton(),
+            m("div.container-fluid", type === "sales"? salesOrderView() : purchaseOrderView()),
+            footer()
+        ];
     }
 }

--- a/shoop/admin/modules/orders/static_src/create/view/manufacturers.js
+++ b/shoop/admin/modules/orders/static_src/create/view/manufacturers.js
@@ -1,0 +1,20 @@
+/**
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {setSelectedManufacturer} from "../actions";
+import {selectBox} from "./utils";
+
+export function manufacturerSelectView(store) {
+    const {manufacturer} = store.getState();
+    return m("div.form-group.required-field", [
+        m("label.control-label", gettext("Manufacturer")),
+        selectBox(manufacturer.selected, function(){
+            store.dispatch(setSelectedManufacturer(this.value));
+        }, manufacturer.all)
+    ]);
+}

--- a/shoop/admin/modules/orders/views/__init__.py
+++ b/shoop/admin/modules/orders/views/__init__.py
@@ -6,14 +6,17 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .detail import OrderDetailView, OrderSetStatusView
-from .edit import OrderEditView
-from .list import OrderListView
+from .detail import (
+    OrderDetailView, OrderSetStatusView, PurchaseOrderDetailView
+)
+from .edit import OrderEditView, PurchaseOrderEditView
+from .list import OrderListView, PurchaseOrderListView
 from .log import NewLogEntryView
 from .payment import OrderCreatePaymentView
 from .shipment import OrderCreateShipmentView
 
 __all__ = [
     "NewLogEntryView", "OrderDetailView", "OrderEditView", "OrderListView",
-    "OrderCreatePaymentView", "OrderCreateShipmentView", "OrderSetStatusView"
+    "OrderCreatePaymentView", "OrderCreateShipmentView", "OrderSetStatusView",
+    "PurchaseOrderEditView", "PurchaseOrderDetailView", "PurchaseOrderListView"
 ]

--- a/shoop/admin/modules/orders/views/__init__.py
+++ b/shoop/admin/modules/orders/views/__init__.py
@@ -7,7 +7,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from .detail import (
-    OrderDetailView, OrderSetStatusView, PurchaseOrderDetailView
+    OrderDetailView, OrderSetStatusView, PurchaseOrderDetailView,
+    PurchaseOrderSetArrivedView
 )
 from .edit import OrderEditView, PurchaseOrderEditView
 from .list import OrderListView, PurchaseOrderListView
@@ -18,5 +19,6 @@ from .shipment import OrderCreateShipmentView
 __all__ = [
     "NewLogEntryView", "OrderDetailView", "OrderEditView", "OrderListView",
     "OrderCreatePaymentView", "OrderCreateShipmentView", "OrderSetStatusView",
-    "PurchaseOrderEditView", "PurchaseOrderDetailView", "PurchaseOrderListView"
+    "PurchaseOrderEditView", "PurchaseOrderDetailView", "PurchaseOrderListView",
+    "PurchaseOrderSetArrivedView"
 ]

--- a/shoop/admin/modules/orders/views/edit.py
+++ b/shoop/admin/modules/orders/views/edit.py
@@ -14,7 +14,6 @@ from babel.numbers import format_currency, format_decimal
 from django.contrib import messages
 from django.core import serializers
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import Sum
 from django.http.response import HttpResponse, JsonResponse
@@ -22,12 +21,17 @@ from django.utils.encoding import force_text
 from django.utils.translation import ugettext as _
 from django_countries import countries
 
-from shoop.admin.modules.orders.json_order_creator import JsonOrderCreator
+from shoop.admin.base import MenuEntry
+from shoop.admin.modules.orders.json_order_creator import (
+    JsonPurchaseOrderCreator, JsonSalesOrderCreator
+)
 from shoop.admin.toolbar import Toolbar
+from shoop.admin.utils.urls import get_model_url
 from shoop.admin.utils.views import CreateOrUpdateView
 from shoop.core.models import (
-    AnonymousContact, CompanyContact, Contact, Order, OrderLineType,
-    PaymentMethod, PersonContact, Product, ShippingMethod, Shop, ShopStatus
+    AnonymousContact, CompanyContact, Contact, Manufacturer, Order,
+    OrderLineType, PaymentMethod, PersonContact, Product, PurchaseOrder,
+    ShippingMethod, Shop, ShopStatus
 )
 from shoop.core.pricing import get_pricing_module
 from shoop.utils.i18n import (
@@ -36,8 +40,15 @@ from shoop.utils.i18n import (
 )
 
 
+def get_order_creator_for_type(type):
+    if type == "sales":
+        return JsonSalesOrderCreator()
+    else:
+        return JsonPurchaseOrderCreator()
+
+
 def create_order_from_state(state, **kwargs):
-    joc = JsonOrderCreator()
+    joc = get_order_creator_for_type(state["order"]["type"])
     order = joc.create_order_from_state(state, **kwargs)
     if not order:
         raise ValidationError(list(joc.errors))
@@ -45,7 +56,7 @@ def create_order_from_state(state, **kwargs):
 
 
 def update_order_from_state(state, order_to_update, **kwargs):
-    joc = JsonOrderCreator()
+    joc = get_order_creator_for_type(state["order"]["type"])
     order = joc.update_order_from_state(state, order_to_update, **kwargs)
     if not order:
         raise ValidationError(list(joc.errors))
@@ -53,7 +64,7 @@ def update_order_from_state(state, order_to_update, **kwargs):
 
 
 def create_source_from_state(state, **kwargs):
-    joc = JsonOrderCreator()
+    joc = get_order_creator_for_type(state["order"]["type"])
     source = joc.create_source_from_state(state, **kwargs)
     if not source:
         raise ValidationError(list(joc.errors))
@@ -93,7 +104,44 @@ def encode_line(line):
     }
 
 
-def get_line_data_for_edit(shop, line):
+def encode_manufacturer_data(manufacturer):
+    return {
+        "id": manufacturer.id,
+        "name": manufacturer.name
+    }
+
+
+def encode_customer_data(customer):
+    return {
+        "id": customer.id,
+        "name": customer.name,
+        "isCompany": bool(isinstance(customer, CompanyContact)),
+        "billingAddress": encode_address(customer.default_billing_address),
+        "shippingAddress": encode_address(customer.default_shipping_address)
+    }
+
+
+def encode_order_data_for_edit(order):
+    return {
+        "shop": encode_shop(order.shop),
+        "lines": [
+            encode_line_data_for_edit(order.shop, line) for line in order.lines.filter(
+                type__in=[OrderLineType.PRODUCT, OrderLineType.OTHER], parent_line_id=None
+            )
+        ],
+        "shippingMethodId": (encode_method(order.shipping_method) if order.shipping_method else None),
+        "paymentMethodId": (encode_method(order.payment_method) if order.payment_method else None),
+        "customer": {
+            "id": order.customer.id,
+            "name": order.customer.name,
+            "isCompany": bool(isinstance(order.customer, CompanyContact)),
+            "billingAddress": encode_address(order.billing_address),
+            "shippingAddress": encode_address(order.shipping_address)
+        }
+    }
+
+
+def encode_line_data_for_edit(shop, line):
     total_price = line.taxful_price.value if shop.prices_include_tax else line.taxless_price.value
     base_data = {
         "id": line.id,
@@ -143,77 +191,111 @@ def get_price_info(shop, customer, product, quantity):
     return product.get_price_info(pricing_ctx, quantity=quantity)
 
 
-class OrderEditView(CreateOrUpdateView):
-    model = Order
+def get_product_data(request, for_purchase_order=False):
+    product_id = request.GET["id"]
+    shop_id = request.GET["shop_id"]
+    customer_id = request.GET.get("customer_id")
+    quantity = decimal.Decimal(request.GET.get("quantity", 1))
+    already_in_lines_qty = decimal.Decimal(request.GET.get("already_in_lines_qty", 0))
+    product = Product.objects.filter(pk=product_id).first()
+    errors = None
+    price_dict = None
+    if not product:
+        return {"errorText": _("Product %s does not exist.") % product_id}
+    shop = Shop.objects.get(pk=shop_id)
+    try:
+        shop_product = product.get_shop_instance(shop)
+    except ObjectDoesNotExist:
+        return {
+            "errorText": _("Product %(product)s is not available in the %(shop)s shop.") %
+            {"product": product.name, "shop": shop.name}
+        }
+
+    min_quantity = shop_product.minimum_purchase_quantity
+    # Make quantity to be at least minimum quantity
+    quantity = (min_quantity if quantity < min_quantity else quantity)
+    customer = Contact.objects.filter(pk=customer_id).first() if customer_id else None
+    # TODO: Allow setting a supplier?
+    supplier = shop_product.suppliers.filter().first()
+    stock_status = supplier.get_stock_status(product.pk) if supplier else None
+    if not for_purchase_order:
+        errors = " ".join(
+            [str(message.args[0]) for message in shop_product.get_orderability_errors(
+                supplier=supplier, quantity=(quantity + already_in_lines_qty), customer=customer, ignore_minimum=True)])
+    product_data = {
+        "id": product.id,
+        "sku": product.sku,
+        "name": product.name,
+        "quantity": quantity,
+        "logicalCount": stock_status.logical_count if stock_status else 0,
+        "physicalCount": stock_status.physical_count if stock_status else 0,
+        "salesDecimals": product.sales_unit.decimals if product.sales_unit else 0,
+        "salesUnit": product.sales_unit.short_name if product.sales_unit else "",
+        "purchaseMultiple": shop_product.purchase_multiple,
+        "errors": errors,
+        "taxClass": {
+            "id": product.tax_class.id,
+            "name": force_text(product.tax_class),
+        }
+    }
+
+    if for_purchase_order:
+        purchase_price = supplier.get_latest_purchase_price(product.id) if supplier else None
+        if purchase_price:
+            price_dict = {
+                "baseUnitPrice": {
+                    "value": purchase_price.value,
+                    "includesTax": purchase_price.includes_tax
+                }
+            }
+            price_dict["unitPrice"] = price_dict["baseUnitPrice"]
+
+    if not price_dict:
+        price_info = get_price_info(shop, customer, product, quantity)
+        price_dict = {
+            "baseUnitPrice": {
+                "value": price_info.base_unit_price.value,
+                "includesTax": price_info.base_unit_price.includes_tax
+            },
+            "unitPrice": {
+                "value": price_info.discounted_unit_price.value,
+                "includesTax": price_info.base_unit_price.includes_tax
+            }
+        }
+    product_data.update(price_dict)
+    return product_data
+
+
+class BaseOrderEditView(CreateOrUpdateView):
     template_name = "shoop/admin/orders/create.jinja"
     context_object_name = "order"
     title = _("Create Order")
     fields = []
 
+    def get_breadcrumb_parents(self):
+        return [
+            MenuEntry(
+                text=self.object._meta.verbose_name_plural.title(),
+                url=get_model_url(self.object, kind="list")
+            )
+        ]
+
     def get_context_data(self, **kwargs):
-        context = super(OrderEditView, self).get_context_data(**kwargs)
-        context["config"] = self.get_config()
+        context = super(BaseOrderEditView, self).get_context_data(**kwargs)
+        context["config"] = {
+            "shops": [encode_shop(shop) for shop in Shop.objects.filter(status=ShopStatus.ENABLED)],
+            "orderId": self.object.pk,
+            "orderData": encode_order_data_for_edit(self.object) if self.object.pk else {}
+        }
         return context
 
     def get_toolbar(self):
         return Toolbar([])
 
-    def get_config(self):
-        order = self.object
-        shops = [encode_shop(shop) for shop in Shop.objects.filter(status=ShopStatus.ENABLED)]
-        customer_id = self.request.GET.get("contact_id")
-        shipping_methods = ShippingMethod.objects.enabled()
-        payment_methods = PaymentMethod.objects.enabled()
-        return {
-            "shops": shops,
-            "countries": [{"id": code, "name": name} for code, name in list(countries)],
-            "shippingMethods": [encode_method(sm) for sm in shipping_methods],
-            "paymentMethods": [encode_method(pm) for pm in payment_methods],
-            "orderId": order.pk,
-            "orderData": self.get_initial_order_data(),
-            "customerData": self.get_customer_data(customer_id) if customer_id else None
-        }
-
-    def get_initial_order_data(self):
-        order = self.object
-        if not order.pk:
-            return {}
-        return {
-            "shop": encode_shop(order.shop),
-            "lines": [
-                get_line_data_for_edit(order.shop, line) for line in order.lines.filter(
-                    type__in=[OrderLineType.PRODUCT, OrderLineType.OTHER], parent_line_id=None
-                )
-            ],
-            "shippingMethodId": (encode_method(order.shipping_method) if order.shipping_method else None),
-            "paymentMethodId": (encode_method(order.payment_method) if order.payment_method else None),
-            "customer": {
-                "id": order.customer.id,
-                "name": order.customer.name,
-                "isCompany": bool(isinstance(order.customer, CompanyContact)),
-                "billingAddress": encode_address(order.billing_address),
-                "shippingAddress": encode_address(order.shipping_address)
-            }
-        }
-
-    def get_customer_data(self, customer_id):
-        customer = Contact.objects.filter(pk=customer_id).first()
-        if not customer:
-            return JsonResponse(
-                {"success": False, "errorMessage": _("Contact %s does not exist.") % customer_id}, status=400
-            )
-        return {
-            "id": customer.id,
-            "name": customer.name,
-            "isCompany": bool(isinstance(customer, CompanyContact)),
-            "billingAddress": encode_address(customer.default_billing_address),
-            "shippingAddress": encode_address(customer.default_shipping_address)
-        }
-
     def dispatch(self, request, *args, **kwargs):
         if request.GET.get("command"):
             return self.dispatch_command(request)
-        return super(OrderEditView, self).dispatch(request, *args, **kwargs)
+        return super(BaseOrderEditView, self).dispatch(request, *args, **kwargs)
 
     def dispatch_command(self, request):
         handler = getattr(self, "handle_%s" % request.GET.get("command"), None)
@@ -225,102 +307,7 @@ class OrderEditView(CreateOrUpdateView):
         return retval
 
     def handle_product_data(self, request):
-        product_id = request.GET["id"]
-        shop_id = request.GET["shop_id"]
-        customer_id = request.GET.get("customer_id")
-        quantity = decimal.Decimal(request.GET.get("quantity", 1))
-        already_in_lines_qty = decimal.Decimal(request.GET.get("already_in_lines_qty", 0))
-        product = Product.objects.filter(pk=product_id).first()
-        if not product:
-            return {"errorText": _("Product %s does not exist.") % product_id}
-        shop = Shop.objects.get(pk=shop_id)
-        try:
-            shop_product = product.get_shop_instance(shop)
-        except ObjectDoesNotExist:
-            return {
-                "errorText": _("Product %(product)s is not available in the %(shop)s shop.") %
-                {"product": product.name, "shop": shop.name}
-            }
-
-        min_quantity = shop_product.minimum_purchase_quantity
-        # Make quantity to be at least minimum quantity
-        quantity = (min_quantity if quantity < min_quantity else quantity)
-        customer = Contact.objects.filter(pk=customer_id).first() if customer_id else None
-        price_info = get_price_info(shop, customer, product, quantity)
-        supplier = shop_product.suppliers.first()  # TODO: Allow setting a supplier?
-        stock_status = supplier.get_stock_status(product.pk) if supplier else None
-        errors = " ".join(
-            [str(message.args[0]) for message in shop_product.get_orderability_errors(
-                supplier=supplier, quantity=(quantity + already_in_lines_qty), customer=customer, ignore_minimum=True)])
-        return {
-            "id": product.id,
-            "sku": product.sku,
-            "name": product.name,
-            "quantity": quantity,
-            "logicalCount": stock_status.logical_count if stock_status else 0,
-            "physicalCount": stock_status.physical_count if stock_status else 0,
-            "salesDecimals": product.sales_unit.decimals if product.sales_unit else 0,
-            "salesUnit": product.sales_unit.short_name if product.sales_unit else "",
-            "purchaseMultiple": shop_product.purchase_multiple,
-            "errors": errors,
-            "taxClass": {
-                "id": product.tax_class.id,
-                "name": force_text(product.tax_class),
-            },
-            "baseUnitPrice": {
-                "value": price_info.base_unit_price.value,
-                "includesTax": price_info.base_unit_price.includes_tax
-            },
-            "unitPrice": {
-                "value": price_info.discounted_unit_price.value,
-                "includesTax": price_info.base_unit_price.includes_tax
-            }
-        }
-
-    def handle_customer_data(self, request):
-        customer_id = request.GET["id"]
-        return self.get_customer_data(customer_id)
-
-    def handle_customer_details(self, request):
-        customer_id = request.GET["id"]
-        customer = Contact.objects.get(pk=customer_id)
-        companies = []
-        if isinstance(customer, PersonContact):
-            companies = sorted(customer.company_memberships.all(), key=(lambda x: force_text(x)))
-        recent_orders = customer.customer_orders.order_by('-id')[:10]
-
-        order_summary = []
-        for dt in customer.customer_orders.datetimes('order_date', 'year'):
-            summary = customer.customer_orders.filter(order_date__year=dt.year).aggregate(
-                total=Sum('taxful_total_price_value')
-            )
-            order_summary.append({
-                'year': dt.year,
-                'total': format_currency(
-                    summary['total'], currency=recent_orders[0].currency, locale=get_current_babel_locale()
-                )
-            })
-
-        return {
-            "customer_info": {
-                "name": customer.full_name,
-                "phone_no": customer.phone,
-                "email": customer.email,
-                "companies": companies if len(companies) else None,
-                "groups": [force_text(group) for group in customer.groups.all()],
-                "merchant_notes": customer.merchant_notes
-            },
-            "order_summary": order_summary,
-            "recent_orders": [
-                {
-                    "order_date": get_locally_formatted_datetime(order.order_date),
-                    "total": format_money(order.taxful_total_price),
-                    "status": order.get_status_display(),
-                    "payment_status": force_text(order.payment_status.label),
-                    "shipment_status": force_text(order.shipping_status.label)
-                } for order in recent_orders
-            ]
-        }
+        return {}
 
     @transaction.atomic
     def _handle_source_data(self, request):
@@ -365,7 +352,7 @@ class OrderEditView(CreateOrUpdateView):
         return JsonResponse({
             "success": True,
             "orderIdentifier": order.identifier,
-            "url": reverse("shoop_admin:order.list")
+            "url": get_model_url(self.object, kind="list")
         })
 
     def handle_source_data(self, request):
@@ -373,6 +360,99 @@ class OrderEditView(CreateOrUpdateView):
 
     def handle_finalize(self, request):
         return _handle_or_return_error(self._handle_finalize, request, _("Could not finalize order:"))
+
+
+class OrderEditView(BaseOrderEditView):
+    model = Order
+
+    def get_queryset(self):
+        return Order.objects.sales_orders()
+
+    def get_context_data(self, **kwargs):
+        context = super(OrderEditView, self).get_context_data(**kwargs)
+        customer_id = self.request.GET.get("contact_id")
+        customer = Contact.objects.filter(pk=customer_id).first()
+        shipping_methods = ShippingMethod.objects.enabled()
+        payment_methods = PaymentMethod.objects.enabled()
+        context["config"].update({
+            "orderType": "sales",
+            "countries": [{"id": code, "name": name} for code, name in list(countries)],
+            "shippingMethods": [encode_method(sm) for sm in shipping_methods],
+            "paymentMethods": [encode_method(pm) for pm in payment_methods],
+            "customerData": encode_customer_data(customer) if customer else None
+        })
+        return context
+
+    def handle_customer_data(self, request):
+        customer_id = request.GET["id"]
+        customer = Contact.objects.filter(pk=customer_id).first()
+        if not customer:
+            return JsonResponse(
+                {"success": False, "errorMessage": _("Contact %s does not exist.") % customer_id}, status=400
+            )
+        return encode_customer_data(customer)
+
+    def handle_customer_details(self, request):
+        customer_id = request.GET["id"]
+        customer = Contact.objects.get(pk=customer_id)
+        companies = []
+        if isinstance(customer, PersonContact):
+            companies = sorted(customer.company_memberships.all(), key=(lambda x: force_text(x)))
+        customer_sales_orders = customer.customer_orders.filter(purchaseorder__isnull=True)
+        recent_orders = customer_sales_orders.order_by('-id')[:10]
+
+        order_summary = []
+        for dt in customer_sales_orders.datetimes('order_date', 'year'):
+            summary = customer_sales_orders.filter(order_date__year=dt.year).aggregate(
+                total=Sum('taxful_total_price_value')
+            )
+            order_summary.append({
+                'year': dt.year,
+                'total': format_currency(
+                    summary['total'], currency=recent_orders[0].currency, locale=get_current_babel_locale()
+                )
+            })
+
+        return {
+            "customer_info": {
+                "name": customer.full_name,
+                "phone_no": customer.phone,
+                "email": customer.email,
+                "companies": companies if len(companies) else None,
+                "groups": [force_text(group) for group in customer.groups.all()],
+                "merchant_notes": customer.merchant_notes
+            },
+            "order_summary": order_summary,
+            "recent_orders": [
+                {
+                    "order_date": get_locally_formatted_datetime(order.order_date),
+                    "total": format_money(order.taxful_total_price),
+                    "status": order.get_status_display(),
+                    "payment_status": force_text(order.payment_status.label),
+                    "shipment_status": force_text(order.shipping_status.label)
+                } for order in recent_orders
+            ]
+        }
+
+    def handle_product_data(self, request):
+        return get_product_data(request)
+
+
+class PurchaseOrderEditView(BaseOrderEditView):
+    model = PurchaseOrder
+
+    def get_context_data(self, **kwargs):
+        context = super(PurchaseOrderEditView, self).get_context_data(**kwargs)
+        manufacturer_id = self.request.GET.get("manufacturer_id")
+        context["config"].update({
+            "orderType": "purchase",
+            "manufacturers": [encode_manufacturer_data(manufacturer) for manufacturer in Manufacturer.objects.all()],
+            "manufacturer": manufacturer_id
+        })
+        return context
+
+    def handle_product_data(self, request):
+        return get_product_data(request, for_purchase_order=True)
 
 
 def _handle_or_return_error(func, request, error_message):

--- a/shoop/admin/modules/orders/views/list.py
+++ b/shoop/admin/modules/orders/views/list.py
@@ -15,7 +15,9 @@ from shoop.admin.utils.picotable import (
     TextFilter
 )
 from shoop.admin.utils.views import PicotableListView
-from shoop.core.models import Order, OrderStatus, PaymentStatus, ShippingStatus
+from shoop.core.models import (
+    Order, OrderStatus, PaymentStatus, PurchaseOrder, ShippingStatus
+)
 from shoop.utils.i18n import format_money, get_locally_formatted_datetime
 
 
@@ -39,7 +41,7 @@ class OrderListView(PicotableListView):
     ]
 
     def get_queryset(self):
-        return super(OrderListView, self).get_queryset().exclude(deleted=True)
+        return super(OrderListView, self).get_queryset().sales_orders().exclude(deleted=True)
 
     def format_order_date(self, instance, *args, **kwargs):
         return get_locally_formatted_datetime(instance.order_date)
@@ -53,3 +55,20 @@ class OrderListView(PicotableListView):
             {"title": _(u"Total"), "text": item["taxful_total_price"]},
             {"title": _(u"Status"), "text": item["status"]}
         ]
+
+
+class PurchaseOrderListView(OrderListView):
+    model = PurchaseOrder
+    columns = [
+        Column("identifier", _(u"Order"), linked=True, filter_config=TextFilter(operator="startswith")),
+        Column("order_date", _(u"Order Date"), display="format_order_date", filter_config=DateRangeFilter()),
+        Column("status", _(u"Status"), filter_config=ChoicesFilter(choices=OrderStatus.objects.all())),
+        Column(
+            "taxful_total_price", _(u"Total"), sort_field="taxful_total_price_value",
+            display="format_taxful_total_price", class_name="text-right",
+            filter_config=RangeFilter(field_type="number", filter_field="order__taxful_total_price_value")
+        ),
+    ]
+
+    def get_queryset(self):
+        return super(OrderListView, self).get_queryset().exclude(deleted=True)

--- a/shoop/admin/modules/products/views/list.py
+++ b/shoop/admin/modules/products/views/list.py
@@ -32,6 +32,7 @@ class ProductListView(PicotableListView):
     def get_queryset(self):
         filter = self.get_filter()
         shop_id = filter.get("shop")
+        manufacturer_id = filter.get("manufacturer")
         qs = Product.objects.all_except_deleted()
         q = Q()
         for mode in filter.get("modes", []):
@@ -39,6 +40,8 @@ class ProductListView(PicotableListView):
         qs = qs.filter(q)
         if shop_id:
             qs = qs.filter(shop_products__shop_id=int(shop_id))
+        if manufacturer_id:
+            qs = qs.filter(manufacturer_id=manufacturer_id)
         return qs
 
     def get_object_abstract(self, instance, item):

--- a/shoop/core/locale/en/LC_MESSAGES/django.po
+++ b/shoop/core/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-21 17:57+0000\n"
+"POT-Creation-Date: 2016-06-26 02:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -599,6 +599,12 @@ msgid "All rows requiring verification have been verified."
 msgstr ""
 
 msgid "All products have been shipped. Fully Shipped status set."
+msgstr ""
+
+msgid "purchase order"
+msgstr ""
+
+msgid "purchase orders"
 msgstr ""
 
 msgid "gateway ID"
@@ -1242,6 +1248,13 @@ msgstr ""
 
 #, python-format
 msgid "%s not available in this shop"
+msgstr ""
+
+msgid "Only staff can create purchase orders"
+msgstr ""
+
+#, python-format
+msgid "%(product)s not manufactured by %(manufacturer)s"
 msgstr ""
 
 msgid "Default Pricing"

--- a/shoop/core/locale/en/LC_MESSAGES/django.po
+++ b/shoop/core/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-26 02:32+0000\n"
+"POT-Creation-Date: 2016-06-26 05:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -605,6 +605,13 @@ msgid "purchase order"
 msgstr ""
 
 msgid "purchase orders"
+msgstr ""
+
+msgid "Purchase order cannot be marked as arrived"
+msgstr ""
+
+#, python-format
+msgid "All products have arrived. Order status set to %s."
 msgstr ""
 
 msgid "gateway ID"

--- a/shoop/core/migrations/0030_purchaseorder.py
+++ b/shoop/core/migrations/0030_purchaseorder.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop', '0029_update_order_phone_max_length'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PurchaseOrder',
+            fields=[
+                ('order_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='shoop.Order')),
+                ('manufacturer', models.ForeignKey(related_name='purchase_orders', on_delete=django.db.models.deletion.PROTECT, verbose_name='manufacturer', to='shoop.Manufacturer')),
+            ],
+            options={
+                'ordering': ('-id',),
+                'verbose_name': 'purchase order',
+                'verbose_name_plural': 'purchase orders',
+            },
+            bases=('shoop.order',),
+        ),
+    ]

--- a/shoop/core/models/__init__.py
+++ b/shoop/core/models/__init__.py
@@ -26,7 +26,7 @@ from ._manufacturers import Manufacturer
 from ._order_lines import OrderLine, OrderLineTax, OrderLineType
 from ._orders import (
     Order, OrderLogEntry, OrderStatus, OrderStatusRole, PaymentStatus,
-    ShippingStatus
+    PurchaseOrder, ShippingStatus
 )
 from ._payments import Payment
 from ._persistent_cache import PersistentCacheEntry
@@ -121,6 +121,7 @@ __all__ = [
     "ProductVisibility",
     "RoundingMode",
     "RoundingBehaviorComponent",
+    "PurchaseOrder",
     "SalesUnit",
     "SavedAddress",
     "SavedAddressRole",

--- a/shoop/core/models/_orders.py
+++ b/shoop/core/models/_orders.py
@@ -156,6 +156,9 @@ class OrderQuerySet(models.QuerySet):
             )
         )
 
+    def sales_orders(self):
+        return self.filter(purchaseorder__isnull=True)
+
 
 @python_2_unicode_compatible
 class Order(MoneyPropped, models.Model):
@@ -682,6 +685,20 @@ class Order(MoneyPropped, models.Model):
 
 
 OrderLogEntry = define_log_model(Order)
+
+
+@python_2_unicode_compatible
+class PurchaseOrder(Order):
+    manufacturer = models.ForeignKey(
+        "Manufacturer", on_delete=models.PROTECT, related_name="purchase_orders", verbose_name=_('manufacturer'))
+
+    class Meta:
+        ordering = ("-id",)
+        verbose_name = _('purchase order')
+        verbose_name_plural = _('purchase orders')
+
+    def __str__(self):  # pragma: no cover
+        return "Purchase Order %s (%s)" % (self.identifier, self.manufacturer.name)
 
 
 def _round_price(value):

--- a/shoop/core/models/_orders.py
+++ b/shoop/core/models/_orders.py
@@ -700,11 +700,35 @@ class PurchaseOrder(Order):
     def __str__(self):  # pragma: no cover
         return "Purchase Order %s (%s)" % (self.identifier, self.manufacturer.name)
 
-    def get_payment_status_display(self): # pragma: no cover
+    def get_payment_status_display(self):  # pragma: no cover
         return None
 
-    def get_shipping_status_display(self): # pragma: no cover
+    def get_shipping_status_display(self):  # pragma: no cover
         return None
+
+    @atomic
+    def mark_as_arrived(self, user):
+        if not self.can_set_complete():
+            raise ValidationError(_("Purchase order cannot be marked as arrived"))
+        lines = (
+            self.lines
+            .filter(type=OrderLineType.PRODUCT)
+            .values("supplier_id", "product_id", "quantity", "base_unit_price_value"))
+        for line in lines:
+            supplier = Supplier.objects.get(id=line["supplier_id"])
+            supplier.adjust_stock(
+                line['product_id'],
+                delta=line['quantity'],
+                purchase_price=line['base_unit_price_value'],
+                created_by=user
+            )
+        self.status = OrderStatus.objects.get_default_complete()
+        message = _(u"All products have arrived. Order status set to %s." % self.status)
+        self.add_log_entry(message=message, user=user)
+        self.save(update_fields=("status",))
+
+    def can_set_complete(self):
+        return not self.is_complete() and not self.is_canceled()
 
 
 def _round_price(value):

--- a/shoop/core/models/_orders.py
+++ b/shoop/core/models/_orders.py
@@ -700,6 +700,12 @@ class PurchaseOrder(Order):
     def __str__(self):  # pragma: no cover
         return "Purchase Order %s (%s)" % (self.identifier, self.manufacturer.name)
 
+    def get_payment_status_display(self): # pragma: no cover
+        return None
+
+    def get_shipping_status_display(self): # pragma: no cover
+        return None
+
 
 def _round_price(value):
     return bankers_round(value, 2)  # TODO: To be fixed in SHOOP-1912

--- a/shoop/core/models/_suppliers.py
+++ b/shoop/core/models/_suppliers.py
@@ -92,3 +92,6 @@ class Supplier(ModuleInterface, ShoopModel):
 
     def update_stocks(self, product_ids):
         return self.module.update_stocks(product_ids)
+
+    def get_latest_purchase_price(self, product_id):
+        return self.module.get_latest_purchase_price(product_id)

--- a/shoop/core/models/_suppliers.py
+++ b/shoop/core/models/_suppliers.py
@@ -84,8 +84,8 @@ class Supplier(ModuleInterface, ShoopModel):
             if shop_product.is_orderable(self, customer, shop_product.minimum_purchase_quantity)
         ]
 
-    def adjust_stock(self, product_id, delta, created_by=None):
-        return self.module.adjust_stock(product_id, delta, created_by=created_by)
+    def adjust_stock(self, product_id, delta, purchase_price=0, created_by=None):
+        return self.module.adjust_stock(product_id, delta, purchase_price=purchase_price, created_by=created_by)
 
     def update_stock(self, product_id):
         return self.module.update_stock(product_id)

--- a/shoop/core/order_creator/__init__.py
+++ b/shoop/core/order_creator/__init__.py
@@ -8,9 +8,11 @@
 
 from shoop.utils import update_module_attributes
 
-from ._creator import OrderCreator
+from ._creator import OrderCreator, PurchaseOrderCreator
 from ._modifier import OrderModifier
-from ._source import OrderSource, SourceLine, TaxesNotCalculated
+from ._source import (
+    OrderSource, PurchaseOrderSource, SourceLine, TaxesNotCalculated
+)
 from ._source_modifier import (
     get_order_source_modifier_modules, is_code_usable,
     OrderSourceModifierModule
@@ -23,6 +25,8 @@ __all__ = [
     "OrderModifier",
     "OrderSource",
     "OrderSourceModifierModule",
+    "PurchaseOrderCreator",
+    "PurchaseOrderSource",
     "SourceLine",
     "TaxesNotCalculated"
 ]

--- a/shoop/core/suppliers/base.py
+++ b/shoop/core/suppliers/base.py
@@ -9,6 +9,8 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
 from shoop.core.models import StockBehavior
+from shoop.core.pricing import TaxlessPrice
+from shoop.core.settings import SHOOP_HOME_CURRENCY
 from shoop.core.stocks import ProductStockStatus
 
 
@@ -74,3 +76,6 @@ class BaseSupplierModule(object):
         # Naive default implementation; smarter modules can do something better
         for product_id in product_ids:
             self.update_stock(product_id)
+
+    def get_latest_purchase_price(self, product_id):
+        return TaxlessPrice("0.00", SHOOP_HOME_CURRENCY)

--- a/shoop/core/suppliers/base.py
+++ b/shoop/core/suppliers/base.py
@@ -66,7 +66,7 @@ class BaseSupplierModule(object):
             if quantity > stock_status.logical_count:
                 yield ValidationError(stock_status.message or _(u"Insufficient stock"), code="stock_insufficient")
 
-    def adjust_stock(self, product_id, delta, created_by=None):
+    def adjust_stock(self, product_id, delta, purchase_price=0, created_by=None):
         raise NotImplementedError("Not implemented in BaseSupplierModule")
 
     def update_stock(self, product_id):

--- a/shoop/simple_supplier/module.py
+++ b/shoop/simple_supplier/module.py
@@ -53,8 +53,14 @@ class SimpleSupplierModule(BaseSupplierModule):
         sv, _ = StockCount.objects.get_or_create(supplier_id=supplier_id, product_id=product_id)
         sv.logical_count = values["logical_count"]
         sv.physical_count = values["physical_count"]
-        latest_event = StockAdjustment.objects.filter(
-            supplier=supplier_id, product=product_id).order_by("-created_on").first()
-        if latest_event:
-            sv.stock_value_value = latest_event.purchase_price_value * sv.logical_count
+        latest_purchase_price = self.get_latest_purchase_price(product_id)
+        if latest_purchase_price:
+            sv.stock_value_value = latest_purchase_price.value * sv.logical_count
         sv.save(update_fields=("logical_count", "physical_count", "stock_value_value"))
+
+    def get_latest_purchase_price(self, product_id):
+        sa = StockAdjustment.objects.filter(
+            product_id=product_id, supplier=self.supplier).order_by("-created_on").first()
+        if sa:
+            return sa.purchase_price
+        return super(SimpleSupplierModule, self).get_latest_purchase_price(product_id)

--- a/shoop/simple_supplier/utils.py
+++ b/shoop/simple_supplier/utils.py
@@ -5,10 +5,9 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from decimal import Decimal
 from math import pow
 
-from django.db.models import Sum
+from django.db.models import Q, Sum
 from django.template.loader import render_to_string
 
 from shoop.core.models import OrderLine, OrderStatusRole, ShipmentProduct
@@ -20,10 +19,8 @@ def get_current_stock_value(supplier_id, product_id):
     """
     Count stock values for supplier and product combination
 
-    Logical count is events minus orders bought (not cancelled)
-    describing how many products is currently orderable
-    Physical count is events minus orders actually sent
-    describing how many products is currently in stock
+    Logical count describes how many products are currently orderable
+    Physical count describes how many products are currently in stock
 
     :param supplier_id: supplier_id to count stock values for
     :param product_id: product_id to count stock values for
@@ -35,9 +32,16 @@ def get_current_stock_value(supplier_id, product_id):
         StockAdjustment.objects
         .filter(supplier_id=supplier_id, product_id=product_id)
         .aggregate(total=Sum("delta"))["total"] or 0)
+
+    pending_purchase_orders = (
+        OrderLine.objects
+        .filter(supplier_id=supplier_id, product_id=product_id, order__purchaseorder__isnull=False)
+        .exclude(Q(order__status__role=OrderStatusRole.COMPLETE) | Q(order__status__role=OrderStatusRole.CANCELED))
+        .aggregate(total=Sum("quantity"))["total"] or 0)
+
     orders_bought = (
         OrderLine.objects
-        .filter(supplier_id=supplier_id, product_id=product_id)
+        .filter(supplier_id=supplier_id, product_id=product_id, order__purchaseorder__isnull=True)
         .exclude(order__status__role=OrderStatusRole.CANCELED)
         .aggregate(total=Sum("quantity"))["total"] or 0)
     orders_sent = (
@@ -45,7 +49,7 @@ def get_current_stock_value(supplier_id, product_id):
         .filter(shipment__supplier=supplier_id, product_id=product_id)
         .aggregate(total=Sum("quantity"))["total"] or 0)
     return {
-        "logical_count": events - orders_bought,
+        "logical_count": events + pending_purchase_orders - orders_bought,
         "physical_count": events - orders_sent
     }
 
@@ -90,9 +94,7 @@ def get_stock_adjustment_div(request, supplier, product):
     :return: html div as a string
     :rtype: str
     """
-    latest_adjustment = StockAdjustment.objects.filter(
-        product=product, supplier=supplier).order_by("-created_on").first()
-    purchase_price = (latest_adjustment.purchase_price_value if latest_adjustment else Decimal("0.00"))
+    purchase_price = supplier.get_latest_purchase_price(product.pk)
     context = {
         "product": product,
         "supplier": supplier,

--- a/shoop/testing/factories.py
+++ b/shoop/testing/factories.py
@@ -31,11 +31,12 @@ from shoop.core.defaults.order_statuses import create_default_order_statuses
 from shoop.core.models import (
     AnonymousContact, Attribute, AttributeType, Category, CategoryStatus,
     CompanyContact, Contact, ContactGroup, CustomCarrier,
-    CustomPaymentProcessor, FixedCostBehaviorComponent, MutableAddress, Order,
-    OrderLine, OrderLineTax, OrderLineType, OrderStatus, PaymentMethod,
-    PersonContact, Product, ProductMedia, ProductMediaKind, ProductType,
-    SalesUnit, ShippingMethod, Shop, ShopProduct, ShopStatus, StockBehavior,
-    Supplier, SupplierType, Tax, TaxClass, WaivingCostBehaviorComponent
+    CustomPaymentProcessor, FixedCostBehaviorComponent, Manufacturer,
+    MutableAddress, Order, OrderLine, OrderLineTax, OrderLineType, OrderStatus,
+    PaymentMethod, PersonContact, Product, ProductMedia, ProductMediaKind,
+    ProductType, SalesUnit, ShippingMethod, Shop, ShopProduct, ShopStatus,
+    StockBehavior, Supplier, SupplierType, Tax, TaxClass,
+    WaivingCostBehaviorComponent
 )
 from shoop.core.order_creator import OrderCreator, OrderSource
 from shoop.core.pricing import get_pricing_module
@@ -407,6 +408,11 @@ def get_shop(prices_include_tax, currency="EUR"):
     return shop
 
 
+def get_default_manufacturer():
+    manufacturer, _ = Manufacturer.objects.get_or_create(name=DEFAULT_NAME)
+    return manufacturer
+
+
 def get_default_product():
     product = Product.objects.filter(sku=DEFAULT_IDENTIFIER).first()
     if not product:
@@ -471,6 +477,7 @@ def create_product(sku, shop=None, supplier=None, default_price=None, **attrs):
     product_attrs = dict(
         type=get_default_product_type(),
         tax_class=get_default_tax_class(),
+        manufacturer=get_default_manufacturer(),
         sku=sku,
         name=sku.title(),
         width=100,

--- a/shoop_tests/admin/test_order_creator.py
+++ b/shoop_tests/admin/test_order_creator.py
@@ -15,28 +15,34 @@ from django.test import RequestFactory
 from django.utils import translation
 
 from shoop.admin.modules.orders.views.edit import (
-    encode_address, encode_method,OrderEditView
+    encode_address, encode_method, OrderEditView, PurchaseOrderEditView
 )
-from shoop.core.models import Order, OrderLineType, Tax, TaxClass
+from shoop.core.models import (
+    get_person_contact, Manufacturer, Order, OrderLineType, Tax, TaxClass
+)
 from shoop.default_tax.models import TaxRule
 from shoop.testing.factories import (
-    create_empty_order, create_product, create_random_company, create_random_person,
-    get_default_payment_method, get_default_shipping_method, get_default_shop,
-    get_default_supplier, get_initial_order_status, UserFactory
+    create_empty_order, create_product, create_random_company,
+    create_random_person, get_default_manufacturer, get_default_payment_method,
+    get_default_shipping_method, get_default_shop, get_default_supplier,
+    get_initial_order_status, UserFactory
 )
 from shoop.testing.utils import apply_request_middleware
+from shoop.utils.iterables import first
+from shoop_tests.simple_supplier.utils import get_simple_supplier
 from shoop_tests.utils import assert_contains, printable_gibberish
 
 TEST_COMMENT = "Hello. Is it me you're looking for?"
 
 
-def get_frontend_order_state(contact, valid_lines=True):
+def get_frontend_order_state(type="sales", contact=None, valid_lines=True):
     """
     Get a dict structure mirroring what the frontend JavaScript would submit.
     :type contact: Contact|None
     """
     translation.activate("en")
     shop = get_default_shop()
+    manufacturer = get_default_manufacturer()
     tax = Tax.objects.create(code="test_code", rate=decimal.Decimal("0.20"), name="Default")
     tax_class = TaxClass.objects.create(identifier="test_tax_class", name="Default")
     rule = TaxRule.objects.create(tax=tax)
@@ -44,8 +50,9 @@ def get_frontend_order_state(contact, valid_lines=True):
     rule.save()
     product = create_product(
         sku=printable_gibberish(),
-        supplier=get_default_supplier(),
-        shop=shop
+        supplier=get_simple_supplier(),
+        shop=shop,
+        manufacturer=manufacturer
     )
     product.tax_class = tax_class
     product.save()
@@ -70,16 +77,12 @@ def get_frontend_order_state(contact, valid_lines=True):
             {"id": "x", "type": "product", "product": {"id": unshopped_product.id}},  # not in this shop?
             {"id": "y", "type": "product", "product": {"id": -product.id}},  # invalid product?
             {"id": "z", "type": "other", "quantity": 1, "unitPrice": "q"},  # what's that price?
-            {"id": "rr", "type": "product", "quantity": 1, "product": {"id": not_visible_product.id}}  # not visible
+            {"id": "rr", "type": "product", "quantity": 1, "baseUnitPrice": 50, "product": {"id": not_visible_product.id}}  # not visible
         ]
 
     state = {
-        "customer": {"id": contact.id if contact else None},
         "lines": lines,
-        "methods": {
-            "shippingMethod": {"id": get_default_shipping_method().id},
-            "paymentMethod": {"id": get_default_payment_method().id},
-        },
+        "order": {"type": type},
         "shop": {
             "selected": {
                 "id": shop.id,
@@ -89,6 +92,19 @@ def get_frontend_order_state(contact, valid_lines=True):
             }
         }
     }
+
+    if type == 'sales':
+        state.update({
+            "customer": {"id": contact.id if contact else None},
+            "methods": {
+                "shippingMethod": {"id": get_default_shipping_method().id},
+                "paymentMethod": {"id": get_default_payment_method().id},
+            }
+        })
+    elif type == 'purchase':
+        state.update({
+            "manufacturer": {"selected": manufacturer.id}
+        })
     return state
 
 
@@ -102,9 +118,9 @@ def get_frontend_request_for_command(state, command, user):
     ), user=user)
 
 
-def get_order_from_state(state, admin_user):
+def get_order_from_state(state, admin_user, view_class=OrderEditView):
     request = get_frontend_request_for_command(state, "finalize", admin_user)
-    response =OrderEditView.as_view()(request)
+    response = view_class.as_view()(request)
     assert_contains(response, "orderIdentifier")  # this checks for status codes as a side effect
     data = json.loads(response.content.decode("utf8"))
     return Order.objects.get(identifier=data["orderIdentifier"])
@@ -113,7 +129,7 @@ def get_order_from_state(state, admin_user):
 def test_order_creator_valid(rf, admin_user):
     get_initial_order_status()  # Needed for the API
     contact = create_random_person(locale="en_US", minimum_name_comp_len=5)
-    order = get_order_from_state(get_frontend_order_state(contact), admin_user)
+    order = get_order_from_state(get_frontend_order_state(contact=contact), admin_user)
     assert order.lines.count() == 5  # 3 submitted, two for the shipping and payment method
     assert order.creator == admin_user
     assert order.customer == contact
@@ -125,6 +141,26 @@ def test_order_creator_valid(rf, admin_user):
             assert line.taxful_price.amount > line.taxless_price.amount
 
 
+def test_purchase_order_creator_valid(rf, admin_user):
+    get_initial_order_status()  # Needed for the API
+    contact = get_person_contact(admin_user)
+    supplier = get_simple_supplier()
+    state = get_frontend_order_state(type="purchase")
+    order = get_order_from_state(
+        state,
+        admin_user,
+        PurchaseOrderEditView
+    )
+    product_line = first(filter(lambda line: line["type"] == "product", state["lines"]))
+    stock = supplier.get_stock_status(product_line["product"]["id"])
+    assert order.lines.count() == 3 # 3 submitted, none for shipping/payment methods
+    assert order.customer == contact
+    assert hasattr(order, "purchaseorder")
+    assert order.purchaseorder.manufacturer.pk == state["manufacturer"]["selected"]
+    assert stock.logical_count == decimal.Decimal(product_line["quantity"])
+    assert stock.physical_count == 0
+
+
 def test_order_creator_invalid_base_data(rf, admin_user):
     get_initial_order_status()  # Needed for the API
     state = get_frontend_order_state(contact=None)
@@ -132,7 +168,17 @@ def test_order_creator_invalid_base_data(rf, admin_user):
     state["customer"]["id"] = None
     state["shop"]["selected"]["id"] = None
     request = get_frontend_request_for_command(state, "finalize", admin_user)
-    response =OrderEditView.as_view()(request)
+    response = OrderEditView.as_view()(request)
+    assert_contains(response, "errorMessage", status_code=400)
+
+
+def test_purchase_order_creator_invalid_base_data(rf, admin_user):
+    get_initial_order_status()  # Needed for the API
+    contact = get_person_contact(admin_user)
+    state = get_frontend_order_state(type="purchase")
+    state["manufacturer"]["selected"] = None
+    request = get_frontend_request_for_command(state, "finalize", admin_user)
+    response = PurchaseOrderEditView.as_view()(request)
     assert_contains(response, "errorMessage", status_code=400)
 
 
@@ -148,21 +194,54 @@ def test_order_creator_invalid_line_data(rf, admin_user):
     assert_contains(response, "is not available", status_code=400)
     assert_contains(response, "The price", status_code=400)
     assert_contains(response, "The quantity", status_code=400)
+
+
+def test_order_creator_orderability_errors(rf, admin_user):
+    get_initial_order_status()  # Needed for the API
+    contact = create_random_person(locale="en_US", minimum_name_comp_len=5)
+    shop = get_default_shop()
+    not_visible_product = create_product(
+        sku=printable_gibberish(),
+        supplier=get_default_supplier(),
+        shop=shop
+    )
+    not_visible_shop_product = not_visible_product.get_shop_instance(shop)
+    not_visible_shop_product.visible = False
+    not_visible_shop_product.save()
+    state = get_frontend_order_state(contact=contact)
+    state['lines'] = [
+        {"id": "rr", "type": "product", "quantity": 1, "baseUnitPrice": 50, "product": {"id": not_visible_product.id}}
+    ]
+    request = get_frontend_request_for_command(state, "finalize", admin_user)
+    response =OrderEditView.as_view()(request)
     assert_contains(response, "not visible", status_code=400)
 
 
 def test_order_creator_view_GET(rf, admin_user):
     get_default_shop()
     request = apply_request_middleware(rf.get("/"), user=admin_user)
-    response =OrderEditView.as_view()(request)
+    response = OrderEditView.as_view()(request)
     assert_contains(response, "shippingMethods")  # in the config
+    assert_contains(response, "shops")  # in the config
+
+
+def test_purchase_order_creator_view_GET(rf, admin_user):
+    get_default_shop()
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
+    response = PurchaseOrderEditView.as_view()(request)
+    assert_contains(response, "manufacturer")  # in the config
     assert_contains(response, "shops")  # in the config
 
 
 def test_order_creator_view_invalid_command(rf, admin_user):
     get_default_shop()
-    request = apply_request_middleware(rf.get("/", {"command": printable_gibberish()}), user=admin_user)
-    response = OrderEditView.as_view()(request)
+    response = OrderEditView.as_view()(get_frontend_request_for_command({}, printable_gibberish(), admin_user))
+    assert_contains(response, "unknown command", status_code=400)
+
+
+def test_purchase_order_creator_view_invalid_command(rf, admin_user):
+    get_default_shop()
+    response = PurchaseOrderEditView.as_view()(get_frontend_request_for_command({}, printable_gibberish(), admin_user))
     assert_contains(response, "unknown command", status_code=400)
 
 
@@ -175,7 +254,7 @@ def test_order_creator_product_data(rf, admin_user):
         "id": product.id,
         "quantity": 42
     }), user=admin_user)
-    response =OrderEditView.as_view()(request)
+    response = OrderEditView.as_view()(request)
     assert_contains(response, "taxClass")
     assert_contains(response, "sku")
     assert_contains(response, product.sku)
@@ -185,6 +264,28 @@ def test_order_creator_product_data(rf, admin_user):
     assert_contains(response, "salesUnit")
 
 
+def test_purchase_order_creator_product_data(rf, admin_user):
+    shop = get_default_shop()
+    supplier = get_simple_supplier()
+    purchase_price = "10.000000000"
+    product = create_product(sku=printable_gibberish(), supplier=supplier, shop=shop)
+    supplier.module.adjust_stock(
+        product.id,
+        delta=1,
+        purchase_price=decimal.Decimal(purchase_price),
+        created_by=admin_user
+    )
+    request = apply_request_middleware(rf.get("/", {
+        "command": "product_data",
+        "shop_id": shop.id,
+        "id": product.id,
+        "quantity": 42
+    }), user=admin_user)
+    response = PurchaseOrderEditView.as_view()(request)
+    data = json.loads(response.content.decode("utf8"))
+    assert data['baseUnitPrice']['value'] == purchase_price
+
+
 def test_order_creator_customer_data(rf, admin_user):
     get_default_shop()
     contact = create_random_person(locale="en_US", minimum_name_comp_len=5)
@@ -192,7 +293,7 @@ def test_order_creator_customer_data(rf, admin_user):
         "command": "customer_data",
         "id": contact.id
     }), user=admin_user)
-    response =OrderEditView.as_view()(request)
+    response = OrderEditView.as_view()(request)
     assert_contains(response, "name")
     assert_contains(response, contact.name)
 
@@ -200,10 +301,23 @@ def test_order_creator_customer_data(rf, admin_user):
 def test_order_creator_source_data(rf, admin_user):
     get_initial_order_status()  # Needed for the API
     contact = create_random_person(locale="en_US", minimum_name_comp_len=5)
-    request = get_frontend_request_for_command(get_frontend_order_state(contact), "source_data", admin_user)
-    response =OrderEditView.as_view()(request)
+    request = get_frontend_request_for_command(get_frontend_order_state(contact=contact), "source_data", admin_user)
+    response = OrderEditView.as_view()(request)
     data = json.loads(response.content.decode("utf8"))
     assert len(data.get("orderLines")) == 5
+
+
+def test_purchase_order_creator_source_data(rf, admin_user):
+    get_initial_order_status()  # Needed for the API
+    contact = get_person_contact(admin_user)
+    request = get_frontend_request_for_command(
+        get_frontend_order_state(type="purchase"), "source_data", admin_user
+    )
+    response = PurchaseOrderEditView.as_view()(request)
+    data = json.loads(response.content.decode("utf8"))
+    assert len(data.get("orderLines")) == 3
+    assert data.get("shippingAddress") is None
+    assert data.get("billingAddress") is None
 
 
 @pytest.mark.django_db
@@ -321,6 +435,15 @@ def test_order_creator_view_for_customer(rf, admin_user):
     response = OrderEditView.as_view()(request)
     assert_contains(response, "customerData")  # in the config
     assert_contains(response, "isCompany")  # in the config
+
+
+def test_purchase_order_creator_for_manufacturer(rf, admin_user):
+    get_default_shop()
+    manufacturer = get_default_manufacturer()
+    request = apply_request_middleware(rf.get("/", {"manufacturer_id": manufacturer.id}), user=admin_user)
+    response = PurchaseOrderEditView.as_view()(request)
+    assert_contains(response, "manufacturer")  # in the config
+    assert_contains(response, "name")  # in the config
 
 
 def test_order_creator_customer_details(rf, admin_user):

--- a/shoop_tests/core/test_order_creator.py
+++ b/shoop_tests/core/test_order_creator.py
@@ -8,15 +8,22 @@
 
 import pytest
 
-from shoop.core.models import get_person_contact, Order, OrderLineType, Shop
-from shoop.core.order_creator import OrderCreator, OrderSource, SourceLine
+from shoop.core.models import (
+    get_person_contact, Manufacturer, Order, OrderLineType, PurchaseOrder,
+    Shop
+)
+from shoop.core.order_creator import (
+    OrderCreator, OrderSource, PurchaseOrderCreator, PurchaseOrderSource,
+    SourceLine
+)
 from shoop.testing.factories import (
-    get_address, get_default_payment_method, get_default_product,
-    get_default_shipping_method, get_default_shop, get_default_supplier,
-    get_initial_order_status
+    get_address, get_default_manufacturer, get_default_payment_method,
+    get_default_product, get_default_shipping_method, get_default_shop,
+    get_default_supplier, get_initial_order_status
 )
 from shoop.utils.models import get_data_dict
 from shoop_tests.utils.basketish_order_source import BasketishOrderSource
+from shoop_tests.utils.fixtures import regular_user
 
 
 def test_invalid_order_source_updating():
@@ -68,6 +75,15 @@ def seed_source(user):
     source.shipping_method = get_default_shipping_method()
     assert source.payment_method_id == get_default_payment_method().id
     assert source.shipping_method_id == get_default_shipping_method().id
+    return source
+
+
+def get_purchase_order_source(user):
+    source = PurchaseOrderSource(get_default_shop())
+    source.status = get_initial_order_status()
+    source.customer = get_person_contact(user)
+    source.creator = user
+    source.manufacturer = get_default_manufacturer()
     return source
 
 
@@ -139,3 +155,44 @@ def test_order_source_parentage(rf, admin_user):
     kid_line = order.lines.filter(sku="KIDKIDKID").first()
     assert kid_line
     assert kid_line.parent_line.product_id == product.pk
+
+
+@pytest.mark.django_db
+def test_purchase_order_creator(rf, admin_user):
+    source = get_purchase_order_source(admin_user)
+    product = get_default_product()
+    source.add_line(
+        type=OrderLineType.PRODUCT,
+        product=product,
+        supplier=get_default_supplier(),
+        quantity=1,
+        base_unit_price=source.create_price(10),
+        line_id="main"
+    )
+    creator = PurchaseOrderCreator()
+    purchase_order = PurchaseOrder.objects.get(pk=creator.create_order(source).pk)
+    assert purchase_order
+
+
+@pytest.mark.django_db
+def test_purchase_order_creator_validation_errors(rf, admin_user, regular_user):
+    source = get_purchase_order_source(admin_user)
+    product = get_default_product()
+    source.add_line(
+        type=OrderLineType.PRODUCT,
+        product=product,
+        supplier=get_default_supplier(),
+        quantity=1,
+        base_unit_price=source.create_price(10),
+        line_id="main"
+    )
+    creator = PurchaseOrderCreator()
+    source.creator = regular_user
+    with pytest.raises(Exception):
+        creator.create_order(source)  # invalid user
+
+    product.manufacturer = Manufacturer.objects.create(name='foo')
+    product.save()
+    source.creator = admin_user
+    with pytest.raises(Exception):
+        creator.create_order(source)  # invalid manufacturer

--- a/shoop_tests/core/test_orders.py
+++ b/shoop_tests/core/test_orders.py
@@ -17,8 +17,8 @@ from shoop.core.excs import (
     NoPaymentToCreateException, NoProductsToShipException
 )
 from shoop.core.models import (
-    Order, OrderLine, OrderLineTax, OrderLineType, OrderStatus,
-    OrderStatusRole, PaymentStatus, ShippingStatus
+    Order, OrderLine, OrderLineTax, OrderLineType, OrderStatus, PaymentStatus,
+    ShippingStatus
 )
 from shoop.core.pricing import TaxfulPrice, TaxlessPrice
 from shoop.testing.factories import (

--- a/shoop_tests/functional/test_order_edit_with_coupons.py
+++ b/shoop_tests/functional/test_order_edit_with_coupons.py
@@ -9,20 +9,25 @@ from __future__ import unicode_literals
 
 import decimal
 import json
+
 import pytest
 
 from shoop.admin.modules.orders.views.edit import OrderEditView
-from shoop.campaigns.models import Coupon, BasketCampaign
-from shoop.campaigns.models.basket_conditions import BasketTotalProductAmountCondition
+from shoop.campaigns.models import BasketCampaign, Coupon
+from shoop.campaigns.models.basket_conditions import \
+    BasketTotalProductAmountCondition
 from shoop.campaigns.models.basket_effects import BasketDiscountAmount
-from shoop.core.order_creator import OrderCreator
 from shoop.core.models import Order, OrderLineType, Tax, TaxClass
+from shoop.core.order_creator import OrderCreator
 from shoop.default_tax.models import TaxRule
 from shoop.front.basket import get_basket
 from shoop.testing.factories import (
-   create_product, get_payment_method, get_shipping_method, get_default_supplier, get_initial_order_status, create_random_person, UserFactory
+    create_product, create_random_person, get_default_supplier,
+    get_initial_order_status, get_payment_method, get_shipping_method,
+    UserFactory
 )
-from shoop_tests.admin.test_order_creator import get_frontend_request_for_command
+from shoop_tests.admin.test_order_creator import \
+    get_frontend_request_for_command
 from shoop_tests.campaigns import initialize_test
 from shoop_tests.utils import assert_contains, printable_gibberish
 
@@ -130,6 +135,7 @@ def _get_frontend_order_state(shop, contact):
     ]
 
     state = {
+        "order": {"type": "sales"},
         "customer": {"id": contact.id if contact else None},
         "lines": lines,
         "methods": {

--- a/shoop_tests/functional/test_order_stock_calculations.py
+++ b/shoop_tests/functional/test_order_stock_calculations.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from shoop.core.models import PurchaseOrder
+from shoop.simple_supplier.models import StockCount
+from shoop.testing.factories import (
+    create_order_with_product, create_product, get_default_product,
+    get_default_shop, get_default_supplier
+)
+from shoop_tests.simple_supplier.utils import get_simple_supplier
+
+
+@pytest.mark.django_db
+def test_purchase_order_mark_as_arrived(rf, admin_user):
+    shop = get_default_shop()
+    supplier = get_default_supplier()
+    product = get_default_product()
+    order = create_order_with_product(product, supplier, 1, 200, shop=shop)
+    purchase_order = PurchaseOrder(order_ptr_id=order.pk, manufacturer=product.manufacturer)
+    purchase_order.__dict__.update(order.__dict__)
+    purchase_order.save()
+
+    with pytest.raises(NotImplementedError):
+        purchase_order.mark_as_arrived(admin_user)  # base supplier module stock adjustment is not implemented
+
+    supplier = get_simple_supplier()
+    product = create_product("simple-test-product", shop, supplier)
+    order = create_order_with_product(product, supplier, 1, 200, shop=shop)
+    purchase_order = PurchaseOrder(order_ptr=order, manufacturer=product.manufacturer)
+    purchase_order.__dict__.update(order.__dict__)
+    purchase_order.save()
+    stock = StockCount.objects.get(supplier=supplier, product=product)
+    assert not purchase_order.is_complete()
+    assert stock.logical_count == 1
+    assert stock.physical_count == 0
+
+    purchase_order.mark_as_arrived(admin_user)
+
+    stock = StockCount.objects.get(supplier=supplier, product=product)
+    assert purchase_order.is_complete()
+    assert stock.logical_count == 1
+    assert stock.physical_count == 1


### PR DESCRIPTION
Add the ability to create purchase orders on manufacturers.
    * Add purchase order model
    * refactor client-side admin order creator
    * refactor admin `JsonOrderCreator` and `OrderEditorView`
    * Add purchase order list, create, and detail views
    * Add "create purchase order" button to manufacturer detail view

Refs SHUUP-2699