### PR TITLE
Cash payment fixes and improvements (SHUUP-2888)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add staff only behavior component
 - Add refund-related methods to ``Order``
 - Add `OrderLineType.REFUND` enum type
 - Update order phone max length to 64 characters
@@ -80,7 +81,7 @@ Admin
 ~~~~~
 
 - Add refund creator to `Order` admin
-- Add customer detail view to order creator 
+- Add customer detail view to order creator
 - Add purchase orders on manufacturers
 - Add customer detail view to order creator
 - Define module-level permissions for all admin modules

--- a/shoop/admin/__init__.py
+++ b/shoop/admin/__init__.py
@@ -46,6 +46,7 @@ class ShoopAdminAppConfig(AppConfig):
             "shoop.admin.modules.services.forms:WaivingCostBehaviorComponentForm",
             "shoop.admin.modules.services.forms:WeightLimitsBehaviorComponentForm",
             "shoop.admin.modules.services.forms:GroupAvailabilityBehaviorComponentForm",
+            "shoop.admin.modules.services.forms.StaffOnlyBehaviorComponentForm",
             "shoop.admin.modules.services.forms:RoundingBehaviorComponentForm",
         ],
         "service_behavior_component_form_part": [

--- a/shoop/admin/__init__.py
+++ b/shoop/admin/__init__.py
@@ -63,7 +63,8 @@ class ShoopAdminAppConfig(AppConfig):
         from shoop.core.order_creator.signals import order_creator_finished
         from shoop.admin.modules.orders.receivers import handle_custom_payment_return_requests
 
-        order_creator_finished.connect(handle_custom_payment_return_requests, dispatch_uid='shoop.admin.order_create')
+        order_creator_finished.connect(handle_custom_payment_return_requests,
+                                       dispatch_uid='shoop.admin.handle_cash_payments')
         validate_templates_configuration()
 
 

--- a/shoop/admin/modules/services/forms.py
+++ b/shoop/admin/modules/services/forms.py
@@ -15,7 +15,8 @@ from shoop.admin.forms import ShoopAdminForm
 from shoop.core.models import (
     FixedCostBehaviorComponent, GroupAvailabilityBehaviorComponent,
     PaymentMethod, RoundingBehaviorComponent, ServiceProvider, ShippingMethod,
-    WaivingCostBehaviorComponent, WeightLimitsBehaviorComponent
+    StaffOnlyBehaviorComponent, WaivingCostBehaviorComponent,
+    WeightLimitsBehaviorComponent
 )
 
 
@@ -76,6 +77,16 @@ def _get_service_choices(service_provider):
     return [(sc.identifier, sc.name) for sc in service_choices]
 
 
+class AlwaysChangedModelForm(forms.ModelForm):
+    """
+    ModelForm that can be saved if it is empty or has unchanged lines on creation
+    """
+    def has_changed(self, *args, **kwargs):
+        if self.instance.pk is None:
+            return True
+        return super(AlwaysChangedModelForm, self).has_changed(*args, **kwargs)
+
+
 class ShippingMethodForm(BaseMethodForm):
     service_provider_attr = "carrier"
 
@@ -129,7 +140,13 @@ class GroupAvailabilityBehaviorComponentForm(forms.ModelForm):
         exclude = ["identifier"]
 
 
-class RoundingBehaviorComponentForm(forms.ModelForm):
+class StaffOnlyBehaviorComponentForm(AlwaysChangedModelForm):
+    class Meta:
+        model = StaffOnlyBehaviorComponent
+        exclude = ["identifier"]
+
+
+class RoundingBehaviorComponentForm(AlwaysChangedModelForm):
     class Meta:
         model = RoundingBehaviorComponent
         exclude = ["identifier"]

--- a/shoop/core/locale/en/LC_MESSAGES/django.po
+++ b/shoop/core/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-27 22:04+0000\n"
+"POT-Creation-Date: 2016-06-28 04:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -1060,6 +1060,15 @@ msgstr ""
 msgid "Service is not available for any of the customers groups."
 msgstr ""
 
+msgid "Staff only availability"
+msgstr ""
+
+msgid "Limit service availability to staff only"
+msgstr ""
+
+msgid "Service is only available for staff"
+msgstr ""
+
 msgid "round to nearest with ties going away from zero"
 msgstr ""
 
@@ -1085,9 +1094,6 @@ msgid "rounding mode"
 msgstr ""
 
 msgid "rounding"
-msgstr ""
-
-msgid "Only administrators can process cash payments"
 msgstr ""
 
 msgid "payment processor"

--- a/shoop/core/migrations/0031_staffonlybehaviorcomponent.py
+++ b/shoop/core/migrations/0031_staffonlybehaviorcomponent.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop', '0030_purchaseorder'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='StaffOnlyBehaviorComponent',
+            fields=[
+                ('servicebehaviorcomponent_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='shoop.ServiceBehaviorComponent')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('shoop.servicebehaviorcomponent',),
+        ),
+    ]

--- a/shoop/core/models/__init__.py
+++ b/shoop/core/models/__init__.py
@@ -47,9 +47,9 @@ from ._service_base import (
 )
 from ._service_behavior import (
     FixedCostBehaviorComponent, GroupAvailabilityBehaviorComponent,
-    RoundingBehaviorComponent, RoundingMode, WaivingCostBehaviorComponent,
-    WeightBasedPriceRange, WeightBasedPricingBehaviorComponent,
-    WeightLimitsBehaviorComponent
+    RoundingBehaviorComponent, RoundingMode, StaffOnlyBehaviorComponent,
+    WaivingCostBehaviorComponent, WeightBasedPriceRange,
+    WeightBasedPricingBehaviorComponent, WeightLimitsBehaviorComponent
 )
 from ._service_payment import (
     CustomPaymentProcessor, PaymentMethod, PaymentProcessor, PaymentUrls
@@ -140,6 +140,7 @@ __all__ = [
     "Shop",
     "ShopProduct",
     "ShopStatus",
+    "StaffOnlyBehaviorComponent",
     "StockBehavior",
     "SuppliedProduct",
     "Supplier",

--- a/shoop/core/models/_service_behavior.py
+++ b/shoop/core/models/_service_behavior.py
@@ -174,6 +174,15 @@ class GroupAvailabilityBehaviorComponent(ServiceBehaviorComponent):
             yield ValidationError(_("Service is not available for any of the customers groups."))
 
 
+class StaffOnlyBehaviorComponent(ServiceBehaviorComponent):
+    name = _("Staff only availability")
+    help_text = _("Limit service availability to staff only")
+
+    def get_unavailability_reasons(self, service, source):
+        if not source.creator or not source.creator.is_staff:
+            yield ValidationError(_("Service is only available for staff"))
+
+
 class RoundingMode(Enum):
     ROUND_HALF_UP = decimal.ROUND_HALF_UP
     ROUND_HALF_DOWN = decimal.ROUND_HALF_DOWN
@@ -204,7 +213,3 @@ class RoundingBehaviorComponent(ServiceBehaviorComponent):
         rounded = nickel_round(total_price, self.quant, self.mode.value)
         remainder = rounded - total_price
         yield ServiceCost(remainder, _("rounding"))
-
-    def get_unavailability_reasons(self, service, source):
-        if not source.creator or not(source.creator.is_superuser or source.creator.is_staff):
-            yield ValidationError(_("Only administrators can process cash payments"))

--- a/shoop/core/models/_service_payment.py
+++ b/shoop/core/models/_service_payment.py
@@ -16,6 +16,9 @@ from parler.models import TranslatedFields
 from ._order_lines import OrderLineType
 from ._orders import Order, PaymentStatus
 from ._service_base import Service, ServiceChoice, ServiceProvider
+from ._service_behavior import (
+    RoundingBehaviorComponent, StaffOnlyBehaviorComponent
+)
 
 
 class PaymentMethod(Service):
@@ -134,6 +137,16 @@ class CustomPaymentProcessor(PaymentProcessor):
             ServiceChoice('manual', _("Manually processed payment")),
             ServiceChoice('cash', _("Cash payment"))
         ]
+
+    def _create_service(self, choice_identifier, **kwargs):
+        service = super(CustomPaymentProcessor, self)._create_service(
+            choice_identifier, **kwargs)
+        if choice_identifier == 'cash':
+            service.behavior_components.add(
+                RoundingBehaviorComponent.objects.create())
+            service.behavior_components.add(
+                StaffOnlyBehaviorComponent.objects.create())
+        return service
 
     def process_payment_return_request(self, service, order, request):
         if service == 'cash':

--- a/shoop_tests/admin/test_service_behavior_components.py
+++ b/shoop_tests/admin/test_service_behavior_components.py
@@ -17,7 +17,8 @@ from shoop.admin.modules.services.views import (
 from shoop.core.models import (
     FixedCostBehaviorComponent, GroupAvailabilityBehaviorComponent,
     PaymentMethod, RoundingBehaviorComponent, RoundingMode, ShippingMethod,
-    WaivingCostBehaviorComponent, WeightLimitsBehaviorComponent
+    StaffOnlyBehaviorComponent, WaivingCostBehaviorComponent,
+    WeightLimitsBehaviorComponent
 )
 from shoop.testing.factories import (
     get_default_customer_group, get_default_payment_method,
@@ -57,7 +58,8 @@ def get_default_behavior_settings():
         RoundingBehaviorComponent.__name__.lower(): {
             "mode": RoundingMode.ROUND_UP.value,
             "quant": decimal.Decimal('0.05')
-        }
+        },
+        StaffOnlyBehaviorComponent.__name__.lower(): {}
     }
 
 

--- a/shoop_tests/core/test_rounding_behavior_component.py
+++ b/shoop_tests/core/test_rounding_behavior_component.py
@@ -43,18 +43,3 @@ def test_rounding_costs(price, cost, mode):
     assert len(costs) == 1
     assert costs[0].price.value == Decimal(cost)
 
-
-@pytest.mark.django_db
-def test_unavailability_reasons(admin_user, regular_user):
-    shop = get_default_shop()
-    source = OrderSource(shop)
-    source.creator = admin_user
-    behavior = RoundingBehaviorComponent.objects.create()
-    reasons = list(behavior.get_unavailability_reasons(None, source))
-
-    assert len(reasons) == 0
-
-    source.creator = regular_user
-    reasons = list(behavior.get_unavailability_reasons(None, source))
-
-    assert len(reasons) == 1

--- a/shoop_tests/core/test_staff_only_behavior.py
+++ b/shoop_tests/core/test_staff_only_behavior.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from shoop.core.models import StaffOnlyBehaviorComponent
+from shoop.testing.factories import (
+    get_default_payment_method, get_default_shop
+)
+from shoop_tests.utils.basketish_order_source import BasketishOrderSource
+from shoop_tests.utils.fixtures import regular_user
+
+regular_user = regular_user # noqa
+
+
+@pytest.mark.django_db
+def test_staff_only_behavior(admin_user, regular_user):
+    payment_method = get_default_payment_method()
+    component = StaffOnlyBehaviorComponent.objects.create()
+    payment_method.behavior_components.add(component)
+    source = BasketishOrderSource(get_default_shop())
+
+    # anonymous user
+    unavailability_reasons = list(payment_method.get_unavailability_reasons(source))
+    assert len(unavailability_reasons) == 1
+
+    # regular user
+    source.creator = regular_user
+    unavailability_reasons = list(payment_method.get_unavailability_reasons(source))
+    assert len(unavailability_reasons) == 1
+
+    # admin
+    source.creator = admin_user
+    unavailability_reasons = list(payment_method.get_unavailability_reasons(source))
+    assert len(unavailability_reasons) == 0


### PR DESCRIPTION
* Add staff only behavior component
* Add fix to support empty forms and forms with initial values
* Update `CustomPaymentProcessor` to use `RoundingBehaviorComponent` and
  `StaffOnlyBehaviorComponent` by default when service is "cash"
* Remove `get_unavailability_reasons` from `RoundingBehaviorComponent`
* Use better dispatch_uid for order created signal

Refs SHUUP-2888