### PR TITLE
Admin: Only allow permissions for named modules

### DIFF
--- a/shoop/admin/modules/permission_groups/views/edit.py
+++ b/shoop/admin/modules/permission_groups/views/edit.py
@@ -45,7 +45,7 @@ class PermissionGroupForm(forms.ModelForm):
         self.fields["members"] = members_field
 
     def _get_module_choices(self):
-        return set((force_text(module.name), force_text(module.name)) for module in get_modules())
+        return set((force_text(m.name), force_text(m.name)) for m in get_modules() if m.name != "_Base_")
 
     def _get_initial_members(self):
         if self.instance.pk:


### PR DESCRIPTION
If admin modules do not have names set, do not allow as choices in
the `PermissionGroup` admin since there is no way to differentiate
modules when selecting modules to grant permissions.

Refs SHUUP-2901