### PR TITLE
Core: Add ordering for Category model (SHUUP-2671)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Fix bug: Category model is missing MPTT ordering options
 - Add staff only behavior component
 - Add refund-related methods to ``Order``
 - Add `OrderLineType.REFUND` enum type

--- a/shoop/core/migrations/0001_initial.py
+++ b/shoop/core/migrations/0001_initial.py
@@ -131,6 +131,7 @@ class Migration(migrations.Migration):
                 ('parent', mptt.fields.TreeForeignKey(to='shoop.Category', verbose_name='parent category', blank=True, related_name='children', null=True)),
             ],
             options={
+                'ordering': ('tree_id', 'lft'),
                 'verbose_name_plural': 'categories',
                 'verbose_name': 'category',
             },

--- a/shoop/core/models/_categories.py
+++ b/shoop/core/models/_categories.py
@@ -99,6 +99,7 @@ class Category(MPTTModel, TranslatableModel):
     objects = CategoryManager()
 
     class Meta:
+        ordering = ('tree_id', 'lft')
         verbose_name = _('category')
         verbose_name_plural = _('categories')
 


### PR DESCRIPTION
Since Category is a MPTT model, it should be ordered appropriately when
doing queries.  Make that happen by adding correct ordering specifier
to Category classes meta attributes.

This should fix ValueErrors like this for Category query sets:

    Node <class 'parler.managers.TranslatableQuerySet'> not in
    depth-first order