### PR TITLE
Core: Fix RoundingBehaviorComponent.mode length (SHUUP-2913)

### DIFF
--- a/shoop/core/migrations/0028_roundingbehaviorcomponent.py
+++ b/shoop/core/migrations/0028_roundingbehaviorcomponent.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('servicebehaviorcomponent_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='shoop.ServiceBehaviorComponent')),
                 ('quant', models.DecimalField(default=Decimal('0.05'), verbose_name='rounding quant', max_digits=36, decimal_places=9)),
-                ('mode', enumfields.fields.EnumField(default='ROUND_HALF_UP', max_length=10, verbose_name='rounding mode', enum=shoop.core.models.RoundingMode)),
+                ('mode', enumfields.fields.EnumField(default='ROUND_HALF_UP', max_length=50, verbose_name='rounding mode', enum=shoop.core.models.RoundingMode)),
             ],
             options={
                 'abstract': False,

--- a/shoop/core/models/_service_behavior.py
+++ b/shoop/core/models/_service_behavior.py
@@ -204,7 +204,7 @@ class RoundingBehaviorComponent(ServiceBehaviorComponent):
         max_digits=36, decimal_places=9, default=decimal.Decimal('0.05'),
         verbose_name=_("rounding quant"))
     mode = EnumField(
-        RoundingMode,
+        RoundingMode, max_length=50,
         default=RoundingMode.ROUND_HALF_UP,
         verbose_name=_("rounding mode"))
 


### PR DESCRIPTION
Length of the mode column should be enough to hold the string values of
the decimal rounding constants.  Currently longest of them
"ROUND_HALF_DOWN", which is 15 characters.  Update the length of the
column from 10 to 50 to make all values fit (and leave some space for
possibly longer values in the future).