### PR TITLE
Campaigns: Make catalog filters faster

### DIFF
--- a/shuup/campaigns/models/catalog_filters.py
+++ b/shuup/campaigns/models/catalog_filters.py
@@ -54,7 +54,7 @@ class ProductFilter(CatalogFilter):
     products = models.ManyToManyField(Product, verbose_name=_("product"))
 
     def filter_queryset(self, queryset):
-        return queryset.filter(product__in=self.products.all())
+        return queryset.filter(product_id__in=self.products.all().values_list("id", flat=True))
 
     @property
     def description(self):


### PR DESCRIPTION
Filter with product_id instead of products. This will make the queryset much
faster since only id's is fetched for products and extra joins is avoided.