### PR TITLE
Core: fix rounding component to use taxful total (SHUUP-2920)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add support for service behavior costs on post-tax totals
 - Create separate refund lines for quantities and amounts
 - Fix handling of refunds for discounted lines
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Fix rounding behavior component to create service cost on post-tax totals
 - Add support for service behavior costs on post-tax totals
 - Create separate refund lines for quantities and amounts
 - Fix handling of refunds for discounted lines

--- a/shuup/core/models/_service_base.py
+++ b/shuup/core/models/_service_base.py
@@ -1,6 +1,6 @@
 # This file is part of Shuup.
 #
-# Copyright (c) 2012-2016, Shuup Ltd. All rights reserved.
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
@@ -321,11 +321,12 @@ class Service(TranslatableShuupModel):
         :type source: shuup.core.order_creator.OrderSource
         :rtype: Iterable[shuup.core.order_creator.SourceLine]
         """
-        for (num, line_data) in enumerate(self._get_line_data(source, self.get_post_tax_costs), 1):
+        for (num, line_data) in enumerate(
+                self._get_line_data(source, self.get_post_tax_costs, include_empty_cost=False), 1):
             (price_info, tax_class, text) = line_data
             yield self._create_line(source, num, price_info, tax_class, text)
 
-    def _get_line_data(self, source, cost_getter):
+    def _get_line_data(self, source, cost_getter, include_empty_cost=True):
         # Split to costs with and without description
         costs_with_description = []
         costs_without_description = []
@@ -335,7 +336,7 @@ class Service(TranslatableShuupModel):
             else:
                 assert cost.tax_class is None
                 costs_without_description.append(cost)
-        if not (costs_with_description or costs_without_description):
+        if include_empty_cost and not (costs_with_description or costs_without_description):
             costs_without_description = [ServiceCost(source.create_price(0))]
 
         effective_name = self.get_effective_name(source)

--- a/shuup/core/models/_service_base.py
+++ b/shuup/core/models/_service_base.py
@@ -1,6 +1,6 @@
 # This file is part of Shuup.
 #
-# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+# Copyright (c) 2012-2016, Shuup Ltd. All rights reserved.
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
@@ -285,6 +285,18 @@ class Service(TranslatableShuupModel):
             for cost in component.get_costs(self, source):
                 yield cost
 
+    def get_post_tax_costs(self, source):
+        """
+        Get post tax costs of this service for items in given source.
+
+        :type source: shuup.core.order_creator.OrderSource
+        :return: description, price and tax class of the costs
+        :rtype: Iterable[ServiceCost]
+        """
+        for component in self.behavior_components.all():
+            for cost in component.get_post_tax_costs(self, source):
+                yield cost
+
     def get_lines(self, source):
         """
         Get lines for given source.
@@ -295,26 +307,38 @@ class Service(TranslatableShuupModel):
         :type source: shuup.core.order_creator.OrderSource
         :rtype: Iterable[shuup.core.order_creator.SourceLine]
         """
-        for (num, line_data) in enumerate(self._get_line_data(source), 1):
+        for (num, line_data) in enumerate(self._get_line_data(source, self.get_costs), 1):
             (price_info, tax_class, text) = line_data
             yield self._create_line(source, num, price_info, tax_class, text)
 
-    def _get_line_data(self, source):
+    def get_post_tax_lines(self, source):
+        """
+        Get post tax lines for given source.
+
+        Lines are created based on costs.  Costs without description are
+        combined to single line.
+
+        :type source: shuup.core.order_creator.OrderSource
+        :rtype: Iterable[shuup.core.order_creator.SourceLine]
+        """
+        for (num, line_data) in enumerate(self._get_line_data(source, self.get_post_tax_costs), 1):
+            (price_info, tax_class, text) = line_data
+            yield self._create_line(source, num, price_info, tax_class, text)
+
+    def _get_line_data(self, source, cost_getter):
         # Split to costs with and without description
         costs_with_description = []
         costs_without_description = []
-        for cost in self.get_costs(source):
+        for cost in cost_getter(source):
             if cost.description:
                 costs_with_description.append(cost)
             else:
                 assert cost.tax_class is None
                 costs_without_description.append(cost)
-
         if not (costs_with_description or costs_without_description):
             costs_without_description = [ServiceCost(source.create_price(0))]
 
         effective_name = self.get_effective_name(source)
-
         # Yield the combined cost first
         if costs_without_description:
             combined_price_info = _sum_costs(costs_without_description, source)
@@ -430,6 +454,19 @@ class ServiceBehaviorComponent(PolymorphicShuupModel):
         Return costs for for this object. This should be implemented
         in subclass. This method is used to calculate price for
         ``ShippingMethod`` and ``PaymentMethod`` objects.
+
+        :type service: Service
+        :type source: shuup.core.order_creator.OrderSource
+        :rtype: Iterable[ServiceCost]
+        """
+        return ()
+
+    def get_post_tax_costs(self, service, source):
+        """
+        Return post tax costs for for this object. This should be
+        implemented in subclass. This method is used to calculate
+        post tax costs for ``ShippingMethod`` and ``PaymentMethod``
+        objects.
 
         :type service: Service
         :type source: shuup.core.order_creator.OrderSource

--- a/shuup/core/models/_service_behavior.py
+++ b/shuup/core/models/_service_behavior.py
@@ -1,6 +1,6 @@
 # This file is part of Shuup.
 #
-# Copyright (c) 2012-2016, Shuup Ltd. All rights reserved.
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.

--- a/shuup/core/models/_service_behavior.py
+++ b/shuup/core/models/_service_behavior.py
@@ -1,6 +1,6 @@
 # This file is part of Shuup.
 #
-# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+# Copyright (c) 2012-2016, Shuup Ltd. All rights reserved.
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
@@ -208,8 +208,8 @@ class RoundingBehaviorComponent(ServiceBehaviorComponent):
         default=RoundingMode.ROUND_HALF_UP,
         verbose_name=_("rounding mode"))
 
-    def get_costs(self, service, source):
-        total_price = source.total_price_of_products
+    def get_post_tax_costs(self, service, source):
+        total_price = source.taxful_total_price.amount
         rounded = nickel_round(total_price, self.quant, self.mode.value)
         remainder = rounded - total_price
-        yield ServiceCost(remainder, _("rounding"))
+        yield ServiceCost(source.shop.create_price(remainder), _("rounding"))

--- a/shuup_tests/core/test_rounding_behavior_component.py
+++ b/shuup_tests/core/test_rounding_behavior_component.py
@@ -36,9 +36,9 @@ regular_user = regular_user  # noqa
 def test_rounding_costs(price, cost, mode):
     shop = get_default_shop()
     source = OrderSource(shop)
-    source.total_price_of_products = source.create_price(price)
+    source.taxful_total_price = source.create_price(price)
     behavior = RoundingBehaviorComponent.objects.create(mode=mode)
-    costs = list(behavior.get_costs(None, source))
+    costs = list(behavior.get_post_tax_costs(None, source))
 
     assert len(costs) == 1
     assert costs[0].price.value == Decimal(cost)


### PR DESCRIPTION
* Add `get_post_tax_costs` method to `Service` which can be used to add order
lines after taxes have been calculated.
* Fix the rounding behavior component to calculate cost based on taxful amount.