### PR TITLE
Simple CMS: Enable Page plugin for all visible pages (SHUUP-2931)

### DIFF
--- a/shuup/simple_cms/plugins.py
+++ b/shuup/simple_cms/plugins.py
@@ -30,7 +30,7 @@ class PageLinksConfigForm(GenericPluginForm):
                 value.initial = self.plugin.config.get(name, value.initial)
                 self.fields[name] = value
         self.fields["pages"] = forms.ModelMultipleChoiceField(
-            queryset=Page.objects.filter(visible_in_menu=True),
+            queryset=Page.objects.visible(),
             required=False,
             initial=self.plugin.config.get("pages", None),
         )
@@ -78,7 +78,7 @@ class PageLinksPlugin(TemplatedPlugin):
         show_all_pages = self.config.get("show_all_pages", True)
         hide_expired = self.config.get("hide_expired", False)
 
-        pages_qs = Page.objects.filter(visible_in_menu=True)
+        pages_qs = Page.objects.filter()
         if hide_expired:
             pages_qs = pages_qs.visible()
 

--- a/shuup_tests/simple_cms/test_plugins.py
+++ b/shuup_tests/simple_cms/test_plugins.py
@@ -13,22 +13,6 @@ from .utils import create_page
 
 
 @pytest.mark.django_db
-def test_page_links_plugin_visible_in_menu():
-    """
-    Make sure plugin correctly filters out pages that are not set to be
-    visible in menus
-    """
-    context = get_jinja_context()
-    page = create_page(eternal=True, visible_in_menu=True)
-    plugin = PageLinksPlugin({"pages": [page.pk]})
-    assert page in plugin.get_context_data(context)["pages"]
-
-    page.visible_in_menu = False
-    page.save()
-    assert page not in plugin.get_context_data(context)["pages"]
-
-
-@pytest.mark.django_db
 @pytest.mark.parametrize("show_all_pages", [True, False])
 def test_page_links_plugin_hide_expired(show_all_pages):
     """


### PR DESCRIPTION
Instead of allowing only pages visible in menu allow all visible pages
for merchant to set in page plugin.