### PR TITLE
Permission fixes (SHUUP-2898)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -24,6 +24,7 @@ Localization
 Admin
 ~~~~~
 
+- Make `model_url` context function and add permission check
 - Add permission check option to `get_model_url`
 - Add permission check to toolbar button classes
 - Enable remarkable editor for service description

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -24,6 +24,7 @@ Localization
 Admin
 ~~~~~
 
+- Add permission check for dashboard blocks
 - Fix required permission issues for various modules
 - Make `model_url` context function and add permission check
 - Add permission check option to `get_model_url`

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -24,6 +24,7 @@ Localization
 Admin
 ~~~~~
 
+- Add permission check to toolbar button classes
 - Enable remarkable editor for service description
 - Add option to filter product list with manufacturer
 - Remove orderability checks from order editor

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -24,6 +24,7 @@ Localization
 Admin
 ~~~~~
 
+- Add permission check option to `get_model_url`
 - Add permission check to toolbar button classes
 - Enable remarkable editor for service description
 - Add option to filter product list with manufacturer

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -24,6 +24,7 @@ Localization
 Admin
 ~~~~~
 
+- Fix required permission issues for various modules
 - Make `model_url` context function and add permission check
 - Add permission check option to `get_model_url`
 - Add permission check to toolbar button classes

--- a/shuup/admin/modules/categories/__init__.py
+++ b/shuup/admin/modules/categories/__init__.py
@@ -8,6 +8,7 @@
 import six
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
+from filer.models import File
 
 from shuup.admin.base import AdminModule, MenuEntry, SearchResult
 from shuup.admin.utils.permissions import get_default_model_permissions
@@ -55,7 +56,7 @@ class CategoryModule(AdminModule):
                 )
 
     def get_required_permissions(self):
-        return get_default_model_permissions(Category)
+        return get_default_model_permissions(Category) | get_default_model_permissions(File)
 
     def get_model_url(self, object, kind):
         return derive_model_url(Category, "shuup_admin:category", object, kind)

--- a/shuup/admin/modules/contacts/__init__.py
+++ b/shuup/admin/modules/contacts/__init__.py
@@ -10,11 +10,9 @@ from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 
 from shuup.admin.base import AdminModule, MenuEntry, SearchResult
-from shuup.admin.utils.permissions import (
-    get_default_model_permissions, get_permissions_from_urls
-)
+from shuup.admin.utils.permissions import get_default_model_permissions
 from shuup.admin.utils.urls import admin_url, derive_model_url, get_model_url
-from shuup.core.models import Contact
+from shuup.core.models import CompanyContact, Contact, PersonContact
 
 from .dashboard import get_active_customers_block
 
@@ -71,7 +69,11 @@ class ContactModule(AdminModule):
         ]
 
     def get_required_permissions(self):
-        return get_permissions_from_urls(self.get_urls()) | get_default_model_permissions(Contact)
+        return (
+            get_default_model_permissions(CompanyContact) |
+            get_default_model_permissions(Contact) |
+            get_default_model_permissions(PersonContact)
+        )
 
     def get_search_results(self, request, query):
         minimum_query_length = 3

--- a/shuup/admin/modules/contacts/views/detail.py
+++ b/shuup/admin/modules/contacts/views/detail.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseRedirect
 from django.utils.encoding import force_text
@@ -16,6 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.generic import DetailView
 
 from shuup.admin.toolbar import PostActionButton, Toolbar, URLActionButton
+from shuup.admin.utils.permissions import get_default_model_permissions
 from shuup.core.models import CompanyContact, Contact, PersonContact
 from shuup.utils.excs import Problem
 
@@ -59,6 +61,7 @@ class ContactDetailToolbar(Toolbar):
             tooltip=_(u"Create an user for the contact."),
             icon="fa fa-star",
             extra_css_class="btn-gray btn-inverse",
+            required_permissions=get_default_model_permissions(get_user_model()),
         ))
 
     def build_new_order_button(self):

--- a/shuup/admin/modules/products/__init__.py
+++ b/shuup/admin/modules/products/__init__.py
@@ -13,6 +13,7 @@ from django.core.urlresolvers import reverse
 from django.db.models import Q
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
+from filer.models import File
 
 from shuup.admin.base import AdminModule, MenuEntry, SearchResult
 from shuup.admin.utils.permissions import (
@@ -120,7 +121,11 @@ class ProductModule(AdminModule):
                     )
 
     def get_required_permissions(self):
-        return get_permissions_from_urls(self.get_urls()) | get_default_model_permissions(Product)
+        return (
+            get_permissions_from_urls(self.get_urls()) |
+            get_default_model_permissions(Product) |
+            get_default_model_permissions(File)
+        )
 
     def get_model_url(self, object, kind):
         return derive_model_url(Product, "shuup_admin:product", object, kind)

--- a/shuup/admin/modules/shops/__init__.py
+++ b/shuup/admin/modules/shops/__init__.py
@@ -8,6 +8,7 @@
 from __future__ import unicode_literals
 
 from django.utils.translation import ugettext_lazy as _
+from filer.models import File
 
 from shuup.admin.base import AdminModule, MenuEntry
 from shuup.admin.utils.permissions import get_default_model_permissions
@@ -39,7 +40,7 @@ class ShopModule(AdminModule):
         ]
 
     def get_required_permissions(self):
-        return get_default_model_permissions(Shop)
+        return get_default_model_permissions(Shop) | get_default_model_permissions(File)
 
     def get_model_url(self, object, kind):
         return derive_model_url(Shop, "shuup_admin:shop", object, kind)

--- a/shuup/admin/template_helpers/shuup_admin.py
+++ b/shuup/admin/template_helpers/shuup_admin.py
@@ -94,23 +94,24 @@ def get_breadcrumbs(context):
     return breadcrumbs
 
 
-def model_url(model, kind="detail", default=None):
+@contextfunction
+def model_url(context, model, kind="detail", default=None):
     """
     Get a model URL of the given kind for a model (instance or class).
 
+    :param context: Jinja rendering context
+    :type context: jinja2.runtime.Context
     :param model: The model instance or class.
     :type model: django.db.Model
     :param kind: The URL kind to retrieve. See `get_model_url`.
     :type kind: str
-    :param default: Default value to return if model URL retrieval fails. If None,
-                    the `NoModelUrl` exception is (re)raised.
-    :type default: str|None
+    :param default: Default value to return if model URL retrieval fails.
+    :type default: str
     :return: URL string.
     :rtype: str
     """
+    user = context.get("user")
     try:
-        return get_model_url(model, kind)
+        return get_model_url(model, kind=kind, user=user)
     except NoModelUrl:
-        if default is None:
-            raise
         return default

--- a/shuup/admin/templates/shuup/admin/contacts/detail.jinja
+++ b/shuup/admin/templates/shuup/admin/contacts/detail.jinja
@@ -68,7 +68,8 @@
                     <tbody>
                         {% for member in contact.members.all() %}
                             <tr>
-                                <td><a href="{{ shuup_admin.model_url(member) }}">{{ member.name }}</a></td>
+                                {% set url = shuup_admin.model_url(member) %}
+                                <td>{% if url %}<a href="{{ url }}">{% endif %}{{ member.name }}{% if url %}</a>{% endif %}</td>
                                 <td>{{ member.email }}</td>
                             </tr>
                         {% endfor %}
@@ -89,7 +90,8 @@
 {%- endmacro -%}
 
 {%- macro render_object(obj) -%}
-    <a href="{{ shuup_admin.model_url(obj) }}">
+    {% set url = shuup_admin.model_url(obj) %}
+    {% if url %}<a href="{{ url }}">{% endif %}
         {{- obj -}}
-    </a>
+    {% if url %}</a>{% endif %}
 {%- endmacro -%}

--- a/shuup/admin/templates/shuup/admin/macros/order_view.jinja
+++ b/shuup/admin/templates/shuup/admin/macros/order_view.jinja
@@ -14,14 +14,15 @@
             </thead>
             <tbody>
             {% for order in orders %}
+                {% set url = shuup_admin.model_url(order) %}
                 <tr>
-                    <td><a href="{{ shuup_admin.model_url(order) }}">{{ order.identifier }}</a></td>
+                    <td>{% if url %}<a href="{{ url }}">{% endif %}{{ order.identifier }}{% if url %}</a>{% endif %}</td>
                     <td>{{ order.order_date|datetime(format="short") }}</td>
                     <td class="text-right">{{ order.taxful_total_price|money }}</td>
                     <td>{{ order.get_status_display() }}</td>
                     <td>{{ order.get_shipping_status_display() }}</td>
                     <td>{{ order.get_payment_status_display() }}</td>
-                    <td><a href="{{ shuup_admin.model_url(order) }}"><i class="fa fa-arrow-right"></i></a></td>
+                    <td>{% if url %}<a href="url }}">{% endif %}<i class="fa fa-arrow-right"></i>{% if url %}</a>{% endif %}</td>
                 </tr>
             {% endfor %}
             </tbody>
@@ -30,12 +31,13 @@
     <div class="visible-xs mobile-list-group">
         <ul class="list-group">
             {% for order in orders %}
+                {% set url = shuup_admin.model_url(order) %}
                 <li class="list-group-item">
-                    <a href="{{ shuup_admin.model_url(order) }}">
+                    {% if url %}<a href="{{ url }}">{% endif %}
                         <h4 class="list-group-item-heading">
                             <strong>{% trans %}Order{% endtrans %} {{ order.identifier }}</strong> ({{ order.order_date|datetime(format="short") }})
                         </h4>
-                    </a>
+                    {% if url %}</a>{% endif %}
                     <p class="list-group-item-text">
                         {{ order.get_status_display() }},
                         {{ order.get_shipping_status_display() }},

--- a/shuup/admin/utils/picotable.py
+++ b/shuup/admin/utils/picotable.py
@@ -381,7 +381,7 @@ class PicotableViewMixin(object):
 
     def get_object_url(self, instance):
         try:
-            return get_model_url(instance)
+            return get_model_url(instance, user=self.request.user)
         except NoModelUrl:
             pass
         return None

--- a/shuup/admin/views/dashboard.py
+++ b/shuup/admin/views/dashboard.py
@@ -10,6 +10,7 @@ from django.views.generic.base import TemplateView
 import shuup
 from shuup.admin.dashboard import get_activity
 from shuup.admin.module_registry import get_modules
+from shuup.admin.utils.permissions import get_missing_permissions
 from shuup.core.telemetry import try_send_telemetry
 
 
@@ -22,8 +23,9 @@ class DashboardView(TemplateView):
         context["notifications"] = notifications = []
         context["blocks"] = blocks = []
         for module in get_modules():
-            notifications.extend(module.get_notifications(request=self.request))
-            blocks.extend(module.get_dashboard_blocks(request=self.request))
+            if not get_missing_permissions(self.request.user, module.get_required_permissions()):
+                notifications.extend(module.get_notifications(request=self.request))
+                blocks.extend(module.get_dashboard_blocks(request=self.request))
         context["activity"] = get_activity(request=self.request)
         return context
 

--- a/shuup_tests/admin/test_urls.py
+++ b/shuup_tests/admin/test_urls.py
@@ -13,6 +13,7 @@ from django.core.exceptions import ImproperlyConfigured
 from shuup.admin.utils.urls import admin_url, get_model_url, NoModelUrl
 from shuup.core.models import Product
 from shuup_tests.admin.utils import admin_only_urls
+from shuup_tests.utils.faux_users import StaffUser
 
 
 def test_model_url():
@@ -22,6 +23,30 @@ def test_model_url():
         p = Product()
         p.pk = 3
         assert get_model_url(p)
+
+
+def test_model_url_with_permissions():
+    permissions = set(["shuup.add_product", "shuup.delete_product", "shuup.change_product"])
+    p = Product()
+    p.pk = 3
+
+    # If no user is given, don't check for permissions
+    assert get_model_url(p)
+
+    # If a user is given and no permissions are provided, check for default model permissions
+    user = StaffUser()
+    with pytest.raises(NoModelUrl):
+        assert get_model_url(p, user=user)
+
+    # If a user is given and permissions are provided, check for those permissions
+    assert get_model_url(p, user=user, required_permissions=())
+    with pytest.raises(NoModelUrl):
+        assert get_model_url(p, user=user, required_permissions=["shuup.add_product"])
+
+    # Confirm that url is returned with correct permissions
+    user.permissions = permissions
+    assert get_model_url(p, user=user)
+    assert get_model_url(p, user=user, required_permissions=permissions)
 
 
 def test_invalid_admin_url():


### PR DESCRIPTION
Add permission checks for:
- Toolbar buttons
- shuup.admin.utils.url.get_model_url
- shuup.admin.template_helpers.shuup_admin.model_url
- Dashboard blocks
- Fixes for various modules

Refs SHUUP--2898