### PR TITLE
Admin: Remove orderability checks from admin order editor (SHUUP-2934)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -21,6 +21,7 @@ Localization
 Admin
 ~~~~~
 
+- Remove orderability checks from order editor
 - Replace buttons with dropdown in Orders admin
 
 Addons

--- a/shuup/admin/modules/orders/views/edit.py
+++ b/shuup/admin/modules/orders/views/edit.py
@@ -229,7 +229,6 @@ class OrderEditView(CreateOrUpdateView):
         shop_id = request.GET["shop_id"]
         customer_id = request.GET.get("customer_id")
         quantity = decimal.Decimal(request.GET.get("quantity", 1))
-        already_in_lines_qty = decimal.Decimal(request.GET.get("already_in_lines_qty", 0))
         product = Product.objects.filter(pk=product_id).first()
         if not product:
             return {"errorText": _("Product %s does not exist.") % product_id}
@@ -249,9 +248,6 @@ class OrderEditView(CreateOrUpdateView):
         price_info = get_price_info(shop, customer, product, quantity)
         supplier = shop_product.suppliers.first()  # TODO: Allow setting a supplier?
         stock_status = supplier.get_stock_status(product.pk) if supplier else None
-        errors = " ".join(
-            [str(message.args[0]) for message in shop_product.get_orderability_errors(
-                supplier=supplier, quantity=(quantity + already_in_lines_qty), customer=customer, ignore_minimum=True)])
         return {
             "id": product.id,
             "sku": product.sku,
@@ -262,7 +258,6 @@ class OrderEditView(CreateOrUpdateView):
             "salesDecimals": product.sales_unit.decimals if product.sales_unit else 0,
             "salesUnit": product.sales_unit.short_name if product.sales_unit else "",
             "purchaseMultiple": shop_product.purchase_multiple,
-            "errors": errors,
             "taxClass": {
                 "id": product.tax_class.id,
                 "name": force_text(product.tax_class),

--- a/shuup_tests/admin/test_order_creator.py
+++ b/shuup_tests/admin/test_order_creator.py
@@ -141,14 +141,12 @@ def test_order_creator_invalid_line_data(rf, admin_user):
     contact = create_random_person(locale="en_US", minimum_name_comp_len=5)
     state = get_frontend_order_state(contact=contact, valid_lines=False)
     request = get_frontend_request_for_command(state, "finalize", admin_user)
-    response =OrderEditView.as_view()(request)
+    response = OrderEditView.as_view()(request)
     # Let's see that we get a cornucopia of trouble:
     assert_contains(response, "does not exist", status_code=400)
     assert_contains(response, "does not have a product", status_code=400)
-    assert_contains(response, "is not available", status_code=400)
     assert_contains(response, "The price", status_code=400)
     assert_contains(response, "The quantity", status_code=400)
-    assert_contains(response, "not visible", status_code=400)
 
 
 def test_order_creator_view_GET(rf, admin_user):


### PR DESCRIPTION
* Remove orderability checks while fetching product data
* Add ``AdminOrderSource`` to skip validation
* Add ``AdminOrderCreator`` and ``AdminOrderModifier`` to skip
orderability checks