### PR TITLE
Guide: Fix admin search for invalid API URL settings

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -61,6 +61,8 @@ Default Tax
 Guide
 ~~~~~
 
+- Fix admin search for invalid API URL settings
+
 General/miscellaneous
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/shuup/guide/admin_module.py
+++ b/shuup/guide/admin_module.py
@@ -24,18 +24,19 @@ class GuideAdminModule(AdminModule):
                     settings.SHUUP_GUIDE_API_URL, timeout=settings.SHUUP_GUIDE_TIMEOUT_LIMIT, params={"q": query}
                 )
                 json = response.json()
-                results = json["results"]["hits"]["hits"]
-                for result in results:
-                    title = result["fields"]["title"][0]
-                    link = result["fields"]["link"] + ".html"
-                    url = manipulate_query_string(link, highlight=query)
-                    yield SearchResult(
-                        text=_("Guide: %s") % title,
-                        url=url,
-                        is_action=True,
-                        relevance=0,
-                        target="_blank",
-                    )
+                if "results" in json:
+                    results = json["results"]["hits"]["hits"]
+                    for result in results:
+                        title = result["fields"]["title"][0]
+                        link = result["fields"]["link"] + ".html"
+                        url = manipulate_query_string(link, highlight=query)
+                        yield SearchResult(
+                            text=_("Guide: %s") % title,
+                            url=url,
+                            is_action=True,
+                            relevance=0,
+                            target="_blank",
+                        )
             except RequestException:
                 # Catch timeout or network errors so as not to break the search
                 pass

--- a/shuup/guide/settings.py
+++ b/shuup/guide/settings.py
@@ -8,13 +8,13 @@
 #: ReadtheDocs API URL
 #:
 #: URL for fetching search results via ReadtheDocs API.
-SHUUP_GUIDE_API_URL = "https://readthedocs.org/api/v2/search/?project=shuup-guide&version=latest&"
+SHUUP_GUIDE_API_URL = "https://readthedocs.org/api/v2/search/?project=shoop-guide&version=latest&"
 
 #: ReadtheDocs link URL
 #:
 #: URL for manually linking search query link. Query parameters are
 #: added to end of URL when constructing link.
-SHUUP_GUIDE_LINK_URL = "http://shuup-guide.readthedocs.io/en/latest/search.html?check_keywords=yes&area=default&"
+SHUUP_GUIDE_LINK_URL = "http://shoop-guide.readthedocs.io/en/latest/search.html?check_keywords=yes&area=default&"
 
 #: Whether or not to fetch search results from ReadtheDocs
 #:


### PR DESCRIPTION
Fix admin search when Shuup Guide URL settings result in invalid
response.

Additionally, temporarily fix default Shuup Guide URL settings.

Refs SHUUP-2938