### PR TITLE
Core: Prevent duplicate categories from all_visible-filter

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Fix bug: Prevent duplicate categories from all_visible-filter
 - Add support for using pricing templatetags for services
 - Make refund creation atomic
 - Allow refund only for non editable orders

--- a/shuup/core/models/_categories.py
+++ b/shuup/core/models/_categories.py
@@ -66,7 +66,7 @@ class CategoryManager(TranslatableManager, TreeManager):
             else:
                 qs = qs.filter(visibility=CategoryVisibility.VISIBLE_TO_ALL)
 
-        return qs.order_by("tree_id", "lft")
+        return qs.distinct()
 
     def all_except_deleted(self, language=None):
         return (self.language(language) if language else self).exclude(status=CategoryStatus.DELETED)


### PR DESCRIPTION
Remove duplicates in case category have multiple visibility groups set.

Remove order_by from all_visible-filter as unnecessary. The category
meta already defines the default ordering.