### PR TITLE
Make contact views extendable

### DIFF
--- a/doc/api/shuup.admin.modules.contacts.rst
+++ b/doc/api/shuup.admin.modules.contacts.rst
@@ -8,6 +8,26 @@ Subpackages
 
     shuup.admin.modules.contacts.views
 
+Submodules
+----------
+
+shuup.admin.modules.contacts.dashboard module
+---------------------------------------------
+
+.. automodule:: shuup.admin.modules.contacts.dashboard
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+shuup.admin.modules.contacts.sections module
+--------------------------------------------
+
+.. automodule:: shuup.admin.modules.contacts.sections
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Module contents
 ---------------
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -31,6 +31,8 @@ Localization
 Admin
 ~~~~~
 
+- Make contact views extendable
+- Make generic Section object for detail view sections
 - Display shipment form errors as messages
 - Populate tax number from contact for admin order creator
 - Move various dashboard blocks to own admin modules

--- a/doc/provides.rst
+++ b/doc/provides.rst
@@ -99,7 +99,7 @@ Core
     Subclass init should take current order as a parameter.
 
 ``admin_order_section``
-    Additional ``OrderSection`` subclasses for Order detail sections.
+    Additional ``Section`` subclasses for Order detail sections.
 
 ``front_urls``
     Lists of frontend URLs to be appended to the usual frontend URLs.

--- a/doc/provides.rst
+++ b/doc/provides.rst
@@ -64,6 +64,17 @@ Core
 ``admin_contact_group_form_part``
     Additional ``FormPart`` classes for ContactGroup editing
 
+``admin_contact_toolbar_button``
+    Additional ``BaseActionButton`` subclasses for Contact detail.
+    Subclass init should take current contact as a parameter.
+
+``admin_contact_edit_toolbar_button``
+    Additional ``BaseActionButton`` subclasses for Contact edit.
+    Subclass init should take current contact as a parameter.
+
+``admin_contact_section``
+    Additional ``Section`` subclasses for Contact detail sections.
+
 ``admin_extend_create_shipment_form``
     Allows providing extension for shipment creation in admin.
     Should implement the

--- a/shuup/admin/__init__.py
+++ b/shuup/admin/__init__.py
@@ -57,6 +57,12 @@ class ShuupAdminAppConfig(AppConfig):
             "shuup.admin.modules.orders.sections:ContentsOrderSection",
             "shuup.admin.modules.orders.sections:PaymentOrderSection",
             "shuup.admin.modules.orders.sections:LogEntriesOrderSection",
+        ],
+        "admin_contact_section": [
+            "shuup.admin.modules.contacts.sections:BasicInfoContactSection",
+            "shuup.admin.modules.contacts.sections:AddressesContactSection",
+            "shuup.admin.modules.contacts.sections:OrdersContactSection",
+            "shuup.admin.modules.contacts.sections:MembersContactSection",
         ]
     }
 

--- a/shuup/admin/base.py
+++ b/shuup/admin/base.py
@@ -8,10 +8,9 @@
 from __future__ import unicode_literals
 
 import hashlib
-
-import six
 import warnings
 
+import six
 from django.core.urlresolvers import reverse
 from django.utils.encoding import force_bytes, force_text
 
@@ -197,8 +196,8 @@ class Activity(Resolvable):
 
 class Section(object):
     """
-    Subclass this and add the class to the admin_*_section provide list 
-    (e.g. `admin_order_section`) to show a custom section on the specified 
+    Subclass this and add the class to the admin_*_section provide list
+    (e.g. `admin_order_section`) to show a custom section on the specified
     model object's admin detail page.
 
     `identifier` must be unique
@@ -232,8 +231,8 @@ class Section(object):
         Returns additional information to be used in the template
 
         To fetch this data in the template, you must first add it to your request's context
-       
-        e.g. `context[admin_order_section.identifier] = 
+
+        e.g. `context[admin_order_section.identifier] =
                 admin_order_section.get_context_data(self.object)`
 
 
@@ -249,7 +248,7 @@ class OrderSection(Section):
     Deprecated use Section instead
     """
     def __new__(cls):
-        warnings.error("OrderSection in shuup.admin.base is deprecated, use Section instead ", DeprecationWarning)
+        warnings.warn("OrderSection in shuup.admin.base is deprecated, use Section instead ", DeprecationWarning)
         return super(OrderSection, cls).__new__(cls)
 
     @classmethod

--- a/shuup/admin/modules/contacts/sections.py
+++ b/shuup/admin/modules/contacts/sections.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django.utils.encoding import force_text
+from django.utils.translation import ugettext as _
+
+from shuup.admin.base import Section
+from shuup.core.models import PersonContact
+
+
+class BasicInfoContactSection(Section):
+    identifier = "contact_basic_info"
+    name = _("Basic Information")
+    icon = "fa-info-circle"
+    template = "shuup/admin/contacts/_contact_basic_info.jinja"
+    order = 1
+
+    @staticmethod
+    def visible_for_object(contact):
+        return True
+
+    @staticmethod
+    def get_context_data(contact):
+        context = {}
+
+        context['groups'] = sorted(
+            contact.groups.all(),
+            key=(lambda x: force_text(x))
+        )
+
+        context["companies"] = []
+        if isinstance(contact, PersonContact):
+            context["companies"] = sorted(
+                contact.company_memberships.all(),
+                key=(lambda x: force_text(x))
+            )
+
+        return context
+
+
+class AddressesContactSection(Section):
+    identifier = "contact_addresses"
+    name = _("Addresses")
+    icon = "fa-map-marker"
+    template = "shuup/admin/contacts/_contact_addresses.jinja"
+    order = 2
+
+    @staticmethod
+    def visible_for_object(contact):
+        return (contact.default_shipping_address_id or
+                contact.default_billing_address_id)
+
+    @staticmethod
+    def get_context_data(contact):
+        return None
+
+
+class OrdersContactSection(Section):
+    identifier = "contact_orders"
+    name = _("Orders")
+    icon = "fa-inbox"
+    template = "shuup/admin/contacts/_contact_orders.jinja"
+    order = 3
+
+    @staticmethod
+    def visible_for_object(contact):
+        return (contact.default_shipping_address_id or
+                contact.default_billing_address_id)
+
+    @staticmethod
+    def get_context_data(contact):
+        return contact.customer_orders.order_by("-id")
+
+
+class MembersContactSection(Section):
+    identifier = "contact_members"
+    name = _("Members")
+    icon = "fa-user"
+    template = "shuup/admin/contacts/_contact_members.jinja"
+    order = 4
+
+    @staticmethod
+    def visible_for_object(contact):
+        return hasattr(contact, 'members')
+
+    @staticmethod
+    def get_context_data(contact):
+        if contact.members:
+            return contact.members.all()
+
+        return None

--- a/shuup/admin/modules/contacts/views/edit.py
+++ b/shuup/admin/modules/contacts/views/edit.py
@@ -24,6 +24,7 @@ from shuup.admin.forms.widgets import PersonContactChoiceWidget
 from shuup.admin.toolbar import get_default_edit_toolbar
 from shuup.admin.utils.urls import get_model_url
 from shuup.admin.utils.views import CreateOrUpdateView
+from shuup.apps.provides import get_provide_objects
 from shuup.core.models import (
     CompanyContact, Contact, ContactGroup, ImmutableAddress, MutableAddress,
     PersonContact
@@ -239,5 +240,8 @@ class ContactEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView
             self.get_save_form_id(),
             discard_url=(get_model_url(self.object) if self.object.pk else None)
         )
-        # TODO: Add extensibility
+
+        for button in get_provide_objects("admin_contact_edit_toolbar_button"):
+            toolbar.append(button(self.object))
+
         return toolbar

--- a/shuup/admin/modules/orders/sections.py
+++ b/shuup/admin/modules/orders/sections.py
@@ -9,11 +9,11 @@ from __future__ import unicode_literals
 
 from django.utils.translation import ugettext as _
 
-from shuup.admin.base import OrderSection
+from shuup.admin.base import Section
 from shuup.core.models._orders import OrderLogEntry
 
 
-class PaymentOrderSection(OrderSection):
+class PaymentOrderSection(Section):
     identifier = "payments"
     name = _("Payments")
     icon = "fa-dollar"
@@ -29,7 +29,7 @@ class PaymentOrderSection(OrderSection):
         return order.payments.all()
 
 
-class ContentsOrderSection(OrderSection):
+class ContentsOrderSection(Section):
     identifier = "contents"
     name = _("Order Contents")
     icon = "fa-file-text"
@@ -37,7 +37,7 @@ class ContentsOrderSection(OrderSection):
     order = 2
 
     @staticmethod
-    def visible_for_order(order):
+    def visible_for_object(order):
         return True
 
     @staticmethod
@@ -45,7 +45,7 @@ class ContentsOrderSection(OrderSection):
         return None
 
 
-class LogEntriesOrderSection(OrderSection):
+class LogEntriesOrderSection(Section):
     identifier = "log_entries"
     name = _("Log Entries")
     icon = "fa-pencil"
@@ -54,7 +54,7 @@ class LogEntriesOrderSection(OrderSection):
     order = 3
 
     @staticmethod
-    def visible_for_order(order):
+    def visible_for_object(order):
         return True
 
     @staticmethod

--- a/shuup/admin/modules/orders/views/detail.py
+++ b/shuup/admin/modules/orders/views/detail.py
@@ -114,8 +114,8 @@ class OrderDetailView(DetailView):
 
         order_sections_provides = sorted(get_provide_objects("admin_order_section"), key=lambda x: x.order)
         for admin_order_section in order_sections_provides:
-            # Check whether the OrderSection should be visible for the current object
-            if admin_order_section.visible_for_order(self.object):
+            # Check whether the Section should be visible for the current object
+            if admin_order_section.visible_for_object(self.object):
                 context["order_sections"].append(admin_order_section)
                 # add additional context data where the key is the order_section identifier
                 context[admin_order_section.identifier] = admin_order_section.get_context_data(self.object)

--- a/shuup/admin/templates/shuup/admin/contacts/_contact_addresses.jinja
+++ b/shuup/admin/templates/shuup/admin/contacts/_contact_addresses.jinja
@@ -1,0 +1,18 @@
+<div class="row contact-addresses">
+    <div class="col-md-6 shipping-address">
+        <h4 class="underline"><i class="fa fa-truck"></i> {% trans %}Shipping address{% endtrans %}</h4>
+        {% for line in contact.default_shipping_address or [] %}
+            <p>{{ line }}</p>
+        {% else %}
+            <i class="fa fa-warning text-warning"></i> {% trans %}No shipping address defined.{% endtrans %}
+        {% endfor %}
+    </div>
+    <div class="col-md-6 billing-address">
+        <h4 class="underline"><i class="fa fa-file-text"></i> {% trans %}Billing address{% endtrans %}</h4>
+        {% for line in contact.default_billing_address or [] %}
+            <p>{{ line }}</p>
+        {% else %}
+            <i class="fa fa-warning text-warning"></i> {% trans %}No billing address defined.{% endtrans %}
+        {% endfor %}
+    </div>
+</div>

--- a/shuup/admin/templates/shuup/admin/contacts/_contact_basic_info.jinja
+++ b/shuup/admin/templates/shuup/admin/contacts/_contact_basic_info.jinja
@@ -1,0 +1,20 @@
+{% from "shuup/admin/macros/general.jinja" import info_row, render_objects %}
+
+<dl class="dl-horizontal">
+    {{ info_row(_("Full Name"), contact.full_name) }}
+    {{ info_row(_("Phone"), contact.phone, "tel:" ~ contact.phone) }}
+    {{ info_row(_("Email"), contact.email, "mailto:" ~ contact.email) }}
+    {% set groups = render_objects(contact_basic_info.groups) %}
+    {{ info_row(_("Groups"), groups|default(_("No groups"), True)) }}
+    {{ info_row(_("Bound User"), contact.user, shuup_admin.model_url(contact.user) if contact.user else None) }}
+    {% if contact_basic_info.companies %}
+        {% set rendered_companies = render_objects(contact_basic_info.companies) %}
+        {{ info_row(_("Companies"), rendered_companies) }}
+    {% endif %}
+    {{ info_row(
+        _("Account Manager"),
+        contact.account_manager,
+        shuup_admin.model_url(contact.account_manager) if contact.account_manager else None) }}
+    {{ info_row(_("Merchant Notes"), contact.merchant_notes) }}
+    </tbody>
+</dl>

--- a/shuup/admin/templates/shuup/admin/contacts/_contact_members.jinja
+++ b/shuup/admin/templates/shuup/admin/contacts/_contact_members.jinja
@@ -1,0 +1,22 @@
+{% if not contact_members.count() %}
+    {{ _("No members.") }}
+
+{% else %}
+<table class="table table-condensed table-striped">
+<thead>
+    <tr>
+        <th>{{ _("Name") }}</th>
+        <th>{{ _("Email") }}</th>
+    </tr>
+</thead>
+<tbody>
+    {% for member in contact_members %}
+        <tr>
+            {% set url = shuup_admin.model_url(member) %}
+            <td>{% if url %}<a href="{{ url }}">{% endif %}{{ member.name }}{% if url %}</a>{% endif %}</td>
+            <td>{{ member.email }}</td>
+        </tr>
+    {% endfor %}
+</tbody>
+</table>
+{% endif %}

--- a/shuup/admin/templates/shuup/admin/contacts/_contact_orders.jinja
+++ b/shuup/admin/templates/shuup/admin/contacts/_contact_orders.jinja
@@ -1,0 +1,2 @@
+{% from "shuup/admin/macros/order_view.jinja" import order_view with context %}
+{{ order_view(contact_orders) }}

--- a/shuup/admin/templates/shuup/admin/contacts/detail.jinja
+++ b/shuup/admin/templates/shuup/admin/contacts/detail.jinja
@@ -4,94 +4,19 @@
 {% block content %}
     {% call content_with_sidebar(content_id="contact_details") %}
         <div id="contact_details">
-            {% call content_block(_("Basic Information"), "fa-info-circle") %}
-                <dl class="dl-horizontal">
-                    {{ info_row(_("Full Name"), contact.full_name) }}
-                    {{ info_row(_("Phone"), contact.phone, "tel:" ~ contact.phone) }}
-                    {{ info_row(_("Email"), contact.email, "mailto:" ~ contact.email) }}
-                    {% set groups = render_objects(contact_groups) %}
-                    {{ info_row(_("Groups"), groups|default(_("No groups"), True)) }}
-                    {{ info_row(_("Bound User"), contact.user, shuup_admin.model_url(contact.user) if contact.user else None) }}
-                    {% if companies %}
-                        {% set rendered_companies = render_objects(companies) %}
-                        {{ info_row(_("Companies"), rendered_companies) }}
-                    {% endif %}
-                    {{ info_row(
-                        _("Account Manager"),
-                        contact.account_manager,
-                        shuup_admin.model_url(contact.account_manager) if contact.account_manager else None) }}
-                    {{ info_row(_("Merchant Notes"), contact.merchant_notes) }}
-                    </tbody>
-                </dl>
-            {% endcall %}
-
-            {% if contact.default_shipping_address_id or contact.default_billing_address_id %}
-                {% call content_block(_("Addresses"), "fa-map-marker") %}
-                    <div class="row contact-addresses">
-                        <div class="col-md-6 shipping-address">
-                            <h4 class="underline"><i class="fa fa-truck"></i> {% trans %}Shipping address{% endtrans %}</h4>
-                            {% for line in contact.default_shipping_address or [] %}
-                                <p>{{ line }}</p>
-                            {% else %}
-                                <i class="fa fa-warning text-warning"></i> {% trans %}No shipping address defined.{% endtrans %}
-                            {% endfor %}
-                        </div>
-                        <div class="col-md-6 billing-address">
-                            <h4 class="underline"><i class="fa fa-file-text"></i> {% trans %}Billing address{% endtrans %}</h4>
-                            {% for line in contact.default_billing_address or [] %}
-                                <p>{{ line }}</p>
-                            {% else %}
-                                <i class="fa fa-warning text-warning"></i> {% trans %}No billing address defined.{% endtrans %}
-                            {% endfor %}
-                        </div>
-                    </div>
+            {% for contact_section in contact_sections %}
+                {% call content_block(contact_section.name, contact_section.icon) %}
+                    {% include contact_section.template with context %}
                 {% endcall %}
-            {% endif %}
-
-            {% call content_block(_("Orders"), "fa-inbox") %}
-                {% from "shuup/admin/macros/order_view.jinja" import order_view with context %}
-                {{ order_view(orders) }}
-            {% endcall %}
-            {% if contact.members %}
-                {% call content_block(_("Members"), "fa-user") %}
-                    {% if not contact.members.count() %}
-                        {{ _("No members.") }}
-
-                    {% else %}
-                    <table class="table table-condensed table-striped">
-                    <thead>
-                        <tr>
-                            <th>{{ _("Name") }}</th>
-                            <th>{{ _("Email") }}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for member in contact.members.all() %}
-                            <tr>
-                                {% set url = shuup_admin.model_url(member) %}
-                                <td>{% if url %}<a href="{{ url }}">{% endif %}{{ member.name }}{% if url %}</a>{% endif %}</td>
-                                <td>{{ member.email }}</td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                    </table>
-                    {% endif %}
-                {% endcall %}
-            {% endif %}
+            {% endfor %}
         </div>
     {% endcall %}
 {% endblock %}
 
-{%- macro render_objects(objs) -%}
-    {%- for obj in objs -%}
-        {{- render_object(obj) -}}
-        {%- if not loop.last %}, {% endif -%}
-    {%- endfor -%}
-{%- endmacro -%}
-
-{%- macro render_object(obj) -%}
-    {% set url = shuup_admin.model_url(obj) %}
-    {% if url %}<a href="{{ url }}">{% endif %}
-        {{- obj -}}
-    {% if url %}</a>{% endif %}
-{%- endmacro -%}
+{% block extra_js %}
+{% for contact_section in contact_sections %}
+    {% if contact_section.extra_js %}
+        {% include contact_section.extra_js with context %}
+    {% endif %}
+{% endfor %}
+{% endblock %}

--- a/shuup/admin/templates/shuup/admin/macros/general.jinja
+++ b/shuup/admin/templates/shuup/admin/macros/general.jinja
@@ -103,3 +103,17 @@
         </div>
     </div>
 {% endmacro %}
+
+{%- macro render_objects(objs) -%}
+    {%- for obj in objs -%}
+        {{- render_object(obj) -}}
+        {%- if not loop.last %}, {% endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+
+{%- macro render_object(obj) -%}
+    {% set url = shuup_admin.model_url(obj) %}
+    {% if url %}<a href="{{ url }}">{% endif %}
+        {{- obj -}}
+    {% if url %}</a>{% endif %}
+{%- endmacro -%}

--- a/shuup/testing/__init__.py
+++ b/shuup/testing/__init__.py
@@ -25,6 +25,15 @@ class ShuupTestingAppConfig(AppConfig):
             "shuup.testing.simple_checkout_phase.PaymentPhaseProvider",
             "shuup.testing.simple_checkout_phase.ShipmentPhaseProvider",
         ],
+        "admin_contact_toolbar_button": [
+             "shuup.testing.admin_module.toolbar:MockContactToolbarButton",
+        ],
+        "admin_contact_edit_toolbar_button": [
+             "shuup.testing.admin_module.toolbar:MockContactToolbarButton",
+        ],
+        "admin_contact_section": [
+             "shuup.testing.admin_module.sections:MockContactSection",
+        ]
     }
 
 

--- a/shuup/testing/admin_module/sections.py
+++ b/shuup/testing/admin_module/sections.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext as _
+
+from shuup.admin.base import Section
+
+
+class MockContactSection(Section):
+    identifier = "contact_mock_section"
+    name = _("mock section title")
+    icon = "fa-globe"
+    template = "shuup_testing/_contact_mock_section.jinja"
+    order = 9
+
+    @staticmethod
+    def visible_for_object(contact):
+        return True
+
+    @staticmethod
+    def get_context_data(contact):
+        context = {}
+        context['mock_context'] = "mock section context data"
+        return context

--- a/shuup/testing/admin_module/toolbar.py
+++ b/shuup/testing/admin_module/toolbar.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.admin.toolbar import URLActionButton
+
+
+class MockContactToolbarButton(URLActionButton):
+    def __init__(self, contact, **kwargs):
+
+        kwargs["icon"] = "fa fa-user"
+        kwargs["text"] = _("Hello") + contact.full_name
+        kwargs["extra_css_class"] = "btn-info"
+        kwargs["url"] = "/#mocktoolbarbutton"
+
+        self.contact = contact
+
+        super(MockContactToolbarButton, self).__init__(**kwargs)

--- a/shuup/testing/templates/shuup_testing/_contact_mock_section.jinja
+++ b/shuup/testing/templates/shuup_testing/_contact_mock_section.jinja
@@ -1,0 +1,3 @@
+mock section content
+
+{{ contact_mock_section.mock_context}}

--- a/shuup_tests/admin/test_contact_extensibility.py
+++ b/shuup_tests/admin/test_contact_extensibility.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from django.utils.encoding import force_text
+
+from shuup.admin.modules.contacts.views.detail import ContactDetailView
+from shuup.admin.modules.contacts.views.edit import ContactEditView
+from shuup.testing.factories import create_random_person, get_default_shop
+from shuup.testing.utils import apply_request_middleware
+
+
+@pytest.mark.django_db
+def test_contact_edit_has_custom_toolbar_button(rf, admin_user):
+    get_default_shop()
+    contact = create_random_person(locale="en_US", minimum_name_comp_len=5)
+
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
+    view_func = ContactEditView.as_view()
+    response = view_func(request, pk=contact.pk)
+    content = force_text(response.render().content)
+    assert "#mocktoolbarbutton" in content, 'custom toolbar button not found on edit page'
+
+
+@pytest.mark.django_db
+def test_contact_detail_has_custom_toolbar_button(rf, admin_user):
+    get_default_shop()
+    contact = create_random_person(locale="en_US", minimum_name_comp_len=5)
+
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
+    view_func = ContactDetailView.as_view()
+    response = view_func(request, pk=contact.pk)
+    content = force_text(response.render().content)
+    assert "#mocktoolbarbutton" in content, 'custom toolbar button not found on detail page'
+
+
+@pytest.mark.django_db
+def test_contact_detail_has_custom_section(rf, admin_user):
+    get_default_shop()
+    contact = create_random_person(locale="en_US", minimum_name_comp_len=5)
+
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
+    view_func = ContactDetailView.as_view()
+    response = view_func(request, pk=contact.pk)
+    content = force_text(response.render().content)
+
+    assert "mock section title" in content, 'custom section title not found on detail page'
+    assert "mock section content" in content, 'custom section content not found on detail page'
+    assert "mock section context data" in content, 'custom section context data not found on detail page'
+    


### PR DESCRIPTION
Makes contact views extendable similar to Order views

Adds three new extensibility points into the contact views using the provides system.

- `admin_contact_toolbar_button` and `admin_contact_edit_toolbar_button`
provide toolbar extensibility for detail and edit views respectively.
- `admin_contact_section` makes it easy to add additional sections to contacts detail view.

The existing contact detail view was refactored to take advantage of the new sections system.

Refs SHUUP-2892