### PR TITLE
Fix admin content block styling (SHUUP-2992)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -41,6 +41,7 @@ Localization
 Admin
 ~~~~~
 
+- Fix product "Add new image" link
 - Fix content block styles that are styled by id
 - Add Orders section to product detail page
 - Add `admin_product_section` provide to make product detail extendable

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -41,6 +41,7 @@ Localization
 Admin
 ~~~~~
 
+- Fix content block styles that are styled by id
 - Add Orders section to product detail page
 - Add `admin_product_section` provide to make product detail extendable
 - Fix bug with empty customer names in order list view

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -41,6 +41,7 @@ Localization
 Admin
 ~~~~~
 
+- Fix product variation variable delete for non-english users
 - Fix product "Add new image" link
 - Fix content block styles that are styled by id
 - Add Orders section to product detail page

--- a/shuup/admin/modules/products/static_src/product-variation-variable-editor.js
+++ b/shuup/admin/modules/products/static_src/product-variation-variable-editor.js
@@ -88,7 +88,7 @@ window.VariationVariableEditor = (function(m, _) {
             ).concat([m("td")]))
         );
         bodyRows = bodyRows.concat(
-            _.map(_.reject(variable.values, gettext("DELETE")), _.partial(valueTr, ctrl))
+            _.map(_.reject(variable.values, "DELETE"), _.partial(valueTr, ctrl))
         );
         return m("div.product-variable", {key: variable.pk}, [
             m("div.variable-heading.clearfix", [
@@ -114,7 +114,7 @@ window.VariationVariableEditor = (function(m, _) {
     function view(ctrl) {
         var variablesDiv = m(
             "div.product-variable-wrap",
-            _.map(_.reject(variables, gettext("DELETE")), _.partial(renderVariable, ctrl))
+            _.map(_.reject(variables, "DELETE"), _.partial(renderVariable, ctrl))
         );
         var identifierFieldsCheckbox = m("p", [
             m("label.small", [

--- a/shuup/admin/static_src/product/edit_media.js
+++ b/shuup/admin/static_src/product/edit_media.js
@@ -45,8 +45,9 @@ $(function() {
 
     $(".media-add-new-panel").on("click", function(e) {
         e.preventDefault();
-        const panelCount = $("#" + $(this).data("target-panels") + " .panel").length;
-        const $source = $("#placeholder-panel");
+        const section = $(this).data("target-panels");
+        const panelCount = $("#" + section + " .panel").length;
+        const $source = $("#" + section + "-placeholder-panel");
         const html = $source.html().replace(/__prefix__/g, panelCount - 1).replace(/__prefix_name__/g, panelCount);
 
         $(html).insertBefore($source);

--- a/shuup/admin/templates/shuup/admin/macros/general.jinja
+++ b/shuup/admin/templates/shuup/admin/macros/general.jinja
@@ -20,8 +20,8 @@
     </div>
 {% endmacro %}
 
-{% macro content_block(heading, icon, extra_classes="") %}
-    <div class="content-block">
+{% macro content_block(heading, icon, extra_classes="", id="") %}
+    <div id="{{ id }}" class="content-block">
         <div class="title">
             {% if heading %}
                 <h2 class="block-title">{% if icon %} <i class="fa {{ icon }}"></i> {% endif %}{{ heading }}</h2>

--- a/shuup/admin/templates/shuup/admin/products/_edit_media_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_media_form.jinja
@@ -89,20 +89,20 @@
 
 
 {%- set is_image_form = media_form.prefix == "images" %}
+{%- set id = "product-images-section" if is_image_form else "product-media-section" %}
 {%- set name = _("Product Images") if is_image_form else _("Product Media") %}
 
-{% call content_block(name, "fa-camera") %}
+{% call content_block(name, "fa-camera", id=id) %}
     {{ media_form.management_form }}
     {% for f in media_form %}
         {{ render_media_form(f, media_form, loop.index, is_image_form) }}
     {% endfor %}
-    <div class="hide" id="placeholder-panel">
+    <div class="hide" id="{{ id }}-placeholder-panel">
         {{ render_media_form(media_form.empty_form, media_form, "__prefix_name__", is_image_form) }}
     </div>
     <hr>
-{%- set target_panels = "product-images-section" if is_image_form else "product-media-section" %}
 {%- set target_id = "id_images" if is_image_form else "id_media" %}
-<a class="btn btn-lg btn-text media-add-new-panel" href="#" data-target-id="{{ target_id }}" data-target-panels="{{ target_panels }}">+ {% if is_image_form %}{% trans %}Add new image{% endtrans %}{% else %}{% trans %}Add new media{% endtrans %}{% endif %}</a>
+<a class="btn btn-lg btn-text media-add-new-panel" href="#" data-target-id="{{ target_id }}" data-target-panels="{{ id }}">+ {% if is_image_form %}{% trans %}Add new image{% endtrans %}{% else %}{% trans %}Add new media{% endtrans %}{% endif %}</a>
 
 {% endcall %}
 

--- a/shuup/admin/templates/shuup/admin/products/variation/_simple_variation_children.jinja
+++ b/shuup/admin/templates/shuup/admin/products/variation/_simple_variation_children.jinja
@@ -1,7 +1,7 @@
 {% from "shuup/admin/macros/general.jinja" import content_block %}
 {% set children_formset = form["children"] %}
 
-{% call content_block(_("Simple Variation Children"), "fa-sitemap") %}
+{% call content_block(_("Simple Variation Children"), "fa-sitemap", id="simple-variation-children-section") %}
     {% for mf in children_formset.management_form %}{{ mf|safe }}{% endfor %}
     <table class="table table-striped">
         <thead>

--- a/shuup/admin/templates/shuup/admin/products/variation/_variable_variation_children.jinja
+++ b/shuup/admin/templates/shuup/admin/products/variation/_variable_variation_children.jinja
@@ -1,7 +1,7 @@
 {% from "shuup/admin/macros/general.jinja" import content_block %}
 {% set children_form = form["children"] %}
 
-{% call content_block(_("Variable Children"), "fa-sitemap") %}
+{% call content_block(_("Variable Children"), "fa-sitemap", id="variable-children-section") %}
     <table class="table table-striped">
         <thead>
         <tr>

--- a/shuup/admin/templates/shuup/admin/products/variation/_variation_variables.jinja
+++ b/shuup/admin/templates/shuup/admin/products/variation/_variation_variables.jinja
@@ -1,7 +1,7 @@
 {% from "shuup/admin/macros/general.jinja" import content_block %}
 {% set var_form = form["variables"] %}
 
-{% call content_block(_("Variables"), "fa-clone") %}
+{% call content_block(_("Variables"), "fa-clone", id="variables-section") %}
     <div id="variation-variable-editor"></div>
     {{ var_form["data"]|safe }}
     <script>


### PR DESCRIPTION
Wrap content blocks in untranslated section id so styling and behavior is
consistent across languages. Also fix variation variable delete functionality
across languages.

Refs SHUUP-2992