### PR TITLE
Refund fixes (SHUUP-3031, SHUUP-3032)

### DIFF
--- a/shuup/admin/templates/shuup/admin/orders/create_refund.jinja
+++ b/shuup/admin/templates/shuup/admin/orders/create_refund.jinja
@@ -63,7 +63,7 @@
             $blankForm.find("span.select2.select2-container").remove();
             var $newForm = $blankForm.clone();
             var html = $newForm.get(0).outerHTML.replace(/__prefix__/g, getTotalFormsNumber());
-            $newForm = $(html);
+            $newForm = $(html).removeClass('hidden');
             $newForm.find('.hidden').removeClass('hidden');
             $newForm.insertAfter($lastForm);
         }

--- a/shuup/core/models/_orders.py
+++ b/shuup/core/models/_orders.py
@@ -636,7 +636,7 @@ class Order(MoneyPropped, models.Model):
             raise NoRefundToCreateException
         self.cache_prices()
         line_data = [
-            {"line": line, "quantity": line.quantity, "restock": restock_products}
+            {"line": line, "quantity": line.quantity, "restock_products": restock_products}
             for line in self.lines.all()
             if (line.taxful_price or (line.type == OrderLineType.PRODUCT))
         ]


### PR DESCRIPTION
* Ensure new form is visible when "Add More Refunds" is clicked.
* Ensure products are restocked when full refunds are done with the product
restock checkbox ticked.