### PR TITLE
Core: Fix negative quantities when refunding shipped items

### DIFF
--- a/shuup/core/models/_orders.py
+++ b/shuup/core/models/_orders.py
@@ -796,12 +796,14 @@ class Order(MoneyPropped, models.Model):
             products[product_id]['unshipped'] -= quantity
 
         refunded_prods = self.lines.refunds().filter(
-            type=OrderLineType.QUANTITY_REFUND).distinct().values_list("parent_line__product_id", flat=True)
+            type=OrderLineType.QUANTITY_REFUND,
+            parent_line__type=OrderLineType.PRODUCT
+        ).distinct().values_list("parent_line__product_id", flat=True)
         for product_id in refunded_prods:
             refunds = self.lines.refunds().filter(parent_line__product_id=product_id)
             refunded_quantity = refunds.aggregate(total=models.Sum("quantity"))["total"] or 0
             products[product_id]["refunded"] = refunded_quantity
-            products[product_id]["unshipped"] -= refunded_quantity
+            products[product_id]["unshipped"] = max(products[product_id]["unshipped"] - refunded_quantity, 0)
 
         return products
 


### PR DESCRIPTION
Fix negative quantities when refunding shipped items.

Also fix related error in `Order.get_product_summary` when querying
refunded product lines.

Refs SHUUP-2917