### PR TITLE
Campaigns: Fix bug in DiscountFromCategoryProductsForm (SHUUP-3043)

### DIFF
--- a/shuup/campaigns/admin_module/forms/_basket_effects.py
+++ b/shuup/campaigns/admin_module/forms/_basket_effects.py
@@ -45,7 +45,7 @@ class DiscountFromProductForm(BaseEffectModelForm):
 class DiscountFromCategoryProductsForm(BaseEffectModelForm):
     discount_percentage = PercentageField(
         max_digits=6, decimal_places=5,
-        label=_("discount percentage"),
+        label=_("discount percentage"), required=False,
         help_text=_("The discount percentage for this campaign."))
 
     class Meta(BaseEffectModelForm.Meta):


### PR DESCRIPTION
Make percentage field not required for DiscountFromCategoryProductsForm.
The form field shouldn't be required based on model field.