### PR TITLE
Allow superadmins to login as customers (SHUUP-2968)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -36,6 +36,7 @@ Localization
 Admin
 ~~~~~
 
+- Allow superadmins to login as customer
 - Show orderability errors in package product management
 - Show stocks in package product management
 - Add link to order line product detail page in order editor

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -77,6 +77,7 @@ Addons
 Front
 ~~~~~
 
+- Fix single page checkout for customers not associated with a company
 - Use contact default addresses for company creation
 - Use home country by default in customer information addresses
 

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -932,12 +932,31 @@ msgstr ""
 msgid "Deactivate User"
 msgstr ""
 
+msgid "Login as User"
+msgstr ""
+
 #, python-format
 msgid "User bound to contact %(contact)s."
 msgstr ""
 
 #, python-format
 msgid "%(user)s is now %(state)s."
+msgstr ""
+
+msgid "No shop configured."
+msgstr ""
+
+msgid "User is not bound to a person contact."
+msgstr ""
+
+msgid "You are already logged in."
+msgstr ""
+
+msgid "This user is not active."
+msgstr ""
+
+#, python-brace-format
+msgid "You're now logged in as {username}"
 msgstr ""
 
 msgid "Username"

--- a/shuup/admin/modules/users/__init__.py
+++ b/shuup/admin/modules/users/__init__.py
@@ -61,6 +61,12 @@ class UserModule(AdminModule):
                 name="user.list",
                 permissions=permissions
             ),
+            admin_url(
+                "^users/(?P<pk>\d+)/login/$",
+                "shuup.admin.modules.users.views.LoginAsUserView",
+                name="user.login-as",
+                permissions=permissions
+            )
         ]
 
     def get_menu_entries(self, request):

--- a/shuup/admin/modules/users/views/__init__.py
+++ b/shuup/admin/modules/users/views/__init__.py
@@ -4,7 +4,7 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from .detail import UserDetailView
+from .detail import LoginAsUserView, UserDetailView
 from .list import UserListView
 from .password import UserChangePasswordView, UserResetPasswordView
 from .permissions import UserChangePermissionsView
@@ -15,4 +15,5 @@ __all__ = [
     "UserChangePasswordView",
     "UserResetPasswordView",
     "UserChangePermissionsView",
+    "LoginAsUserView"
 ]

--- a/shuup/admin/modules/users/views/detail.py
+++ b/shuup/admin/modules/users/views/detail.py
@@ -252,6 +252,7 @@ class LoginAsUserView(DetailView):
         front_url = get_front_url()
         user = self.get_object()
         username_field = self.model.USERNAME_FIELD
+        impersonator_user_id = request.user.pk
 
         if not front_url:
             raise Problem(_("No shop configured."))
@@ -271,7 +272,7 @@ class LoginAsUserView(DetailView):
                     break
 
         login(request, user)
-
+        request.session["impersonator_user_id"] = impersonator_user_id
         message = _("You're now logged in as {username}").format(username=user.__dict__[username_field])
         messages.success(request, message)
         return HttpResponseRedirect(front_url)

--- a/shuup/admin/modules/users/views/detail.py
+++ b/shuup/admin/modules/users/views/detail.py
@@ -10,14 +10,17 @@ from __future__ import unicode_literals
 import random
 
 from django import forms
+from django.conf import settings as django_settings
 from django.contrib import messages
-from django.contrib.auth import get_user_model
-from django.core.urlresolvers import reverse
+from django.contrib.auth import get_user_model, load_backend, login
+from django.core.exceptions import PermissionDenied
+from django.core.urlresolvers import NoReverseMatch, reverse
 from django.db.transaction import atomic
 from django.forms.models import modelform_factory
 from django.http.response import HttpResponseRedirect
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
+from django.views.generic.detail import DetailView
 
 from shuup.admin.toolbar import (
     DropdownActionButton, DropdownDivider, DropdownItem,
@@ -28,6 +31,15 @@ from shuup.admin.utils.views import CreateOrUpdateView
 from shuup.core.models import Contact, PersonContact
 from shuup.utils.excs import Problem
 from shuup.utils.text import flatten
+
+
+def get_front_url():
+    front_url = None
+    try:
+        front_url = reverse("shuup:index")
+    except NoReverseMatch:
+        front_url = None
+    return front_url
 
 
 class BaseUserForm(forms.ModelForm):
@@ -147,6 +159,14 @@ class UserDetailToolbar(Toolbar):
                 text=_(u"Deactivate User"),
                 extra_css_class="btn-gray",
             ))
+
+        if (self.request.user.is_superuser and get_front_url() and
+                user.is_active and not user.is_superuser and not user.is_staff):
+            self.append(PostActionButton(
+                post_url=reverse("shuup_admin:user.login-as", kwargs={"pk": user.pk}),
+                text=_(u"Login as User"),
+                extra_css_class="btn-gray"
+            ))
         # TODO: Add extensibility
 
 
@@ -223,3 +243,35 @@ class UserDetailView(CreateOrUpdateView):
     def dispatch(self, request, *args, **kwargs):
         self.model = get_user_model()
         return super(UserDetailView, self).dispatch(request, *args, **kwargs)
+
+
+class LoginAsUserView(DetailView):
+    model = get_user_model()
+
+    def post(self, request, *args, **kwargs):
+        front_url = get_front_url()
+        user = self.get_object()
+        username_field = self.model.USERNAME_FIELD
+
+        if not front_url:
+            raise Problem(_("No shop configured."))
+        if user == request.user:
+            raise Problem(_("You are already logged in."))
+        if not getattr(request.user, "is_superuser", False):
+            raise PermissionDenied
+        if getattr(user, "is_superuser", False) or getattr(user, "is_staff", False):
+            raise PermissionDenied
+        if not getattr(user, "is_active", False):
+            raise Problem(_("This user is not active."))
+
+        if not hasattr(user, 'backend'):
+            for backend in django_settings.AUTHENTICATION_BACKENDS:
+                if user == load_backend(backend).get_user(user.pk):
+                    user.backend = backend
+                    break
+
+        login(request, user)
+
+        message = _("You're now logged in as {username}").format(username=user.__dict__[username_field])
+        messages.success(request, message)
+        return HttpResponseRedirect(front_url)

--- a/shuup/front/checkout/_mixins.py
+++ b/shuup/front/checkout/_mixins.py
@@ -26,7 +26,7 @@ class TaxNumberCleanMixin(object):
         tax_number = self.cleaned_data.get("tax_number")
 
         if (not company_name) and (not tax_number):
-            return {}
+            return self.cleaned_data
         elif company_name and not tax_number:
             raise ValidationError(_("Tax number required for companies"))
         elif tax_number and not company_name:

--- a/shuup/front/checkout/confirm.py
+++ b/shuup/front/checkout/confirm.py
@@ -6,6 +6,7 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from django import forms
+from django.contrib.auth import get_user_model
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import FormView
@@ -66,6 +67,8 @@ class ConfirmPhase(CheckoutPhaseViewMixin, FormView):
         basket.orderer = self.request.person
         basket.customer = self.request.customer
         basket.creator = self.request.user
+        if "impersonator_user_id" in self.request.session:
+            basket.creator = get_user_model().objects.get(pk=self.request.session["impersonator_user_id"])
         basket.status = OrderStatus.objects.get_default_initial()
         order_creator = get_basket_order_creator()
         order = order_creator.create_order(basket)

--- a/shuup/front/checkout/single_page.py
+++ b/shuup/front/checkout/single_page.py
@@ -8,6 +8,7 @@
 from __future__ import unicode_literals
 
 from django import forms
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
@@ -92,6 +93,9 @@ class SingleCheckoutPhase(CheckoutPhaseViewMixin, FormView):
         basket.shop = self.request.shop
         basket.orderer = self.request.person
         basket.customer = self.request.customer
+        basket.creator = self.request.user
+        if "impersonator_user_id" in self.request.session:
+            basket.creator = get_user_model().objects.get(pk=self.request.session["impersonator_user_id"])
         basket.shipping_address = form["shipping"].save(commit=False)
         basket.billing_address = form["billing"].save(commit=False)
         basket.shipping_method = order_data.pop("shipping_method")


### PR DESCRIPTION
* Add "Login as User" button to user detail screen which allows superadmins
to login as customers.
* Set `order.creator` to impersonator
* Misc: Fix single page checkout view for customers not associated with a company
Refs SHUUP-2968