### PR TITLE
Fix order edit for orders with child lines (SHUUP-3061)

### DIFF
--- a/shuup/core/order_creator/_modifier.py
+++ b/shuup/core/order_creator/_modifier.py
@@ -44,6 +44,7 @@ class OrderModifier(OrderProcessor):
 
         for line in order.lines.all():
             line.taxes.all().delete()  # Delete all tax lines before OrderLine's
+            line.child_lines.all().delete()  # Ditto for child lines
             line.delete()
 
         return self.finalize_creation(order, order_source)

--- a/shuup/testing/factories.py
+++ b/shuup/testing/factories.py
@@ -494,6 +494,17 @@ def create_product(sku, shop=None, supplier=None, default_price=None, **attrs):
     return product
 
 
+def create_package_product(sku, shop=None, supplier=None, default_price=None, children=4, **attrs):
+    package_product = create_product(sku, shop, supplier, default_price, **attrs)
+    assert not package_product.get_package_child_to_quantity_map()
+    children = [create_product("PackageChild-%d" % x, shop=shop, supplier=supplier) for x in range(children)]
+    package_def = {child: 1 + i for (i, child) in enumerate(children)}
+    package_product.make_package(package_def)
+    assert package_product.is_package_parent()
+    package_product.save()
+    return package_product
+
+
 def create_empty_order(prices_include_tax=False, shop=None):
     order = Order(
         shop=(shop or get_shop(prices_include_tax=prices_include_tax)),

--- a/shuup_tests/core/test_product_packages.py
+++ b/shuup_tests/core/test_product_packages.py
@@ -14,8 +14,8 @@ from shuup.core.models import AnonymousContact, OrderLineType, Tax
 from shuup.core.order_creator import OrderCreator
 from shuup.default_tax.models import TaxRule
 from shuup.testing.factories import (
-    create_product, get_default_shop, get_default_supplier,
-    get_default_tax_class, get_initial_order_status
+    create_package_product, create_product, get_default_shop,
+    get_default_supplier, get_default_tax_class, get_initial_order_status
 )
 from shuup_tests.utils.basketish_order_source import BasketishOrderSource
 
@@ -34,14 +34,7 @@ def get_package_product():
     """
     shop = get_default_shop()
     supplier = get_default_supplier()
-    package_product = create_product("PackageParent", shop=shop, supplier=supplier)
-    assert not package_product.get_package_child_to_quantity_map()
-    children = [create_product("PackageChild-%d" % x, shop=shop, supplier=supplier) for x in range(4)]
-    package_def = {child: 1 + i for (i, child) in enumerate(children)}
-    package_product.make_package(package_def)
-    assert package_product.is_package_parent()
-    package_product.save()
-    return package_product
+    return create_package_product("PackageParent", shop=shop, supplier=supplier)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Ensure child order lines are deleted before parent lines when editing
an order through admin order creator.

Refs SHUUP-3061