### PR TITLE
Fix: removed unnecessary str() call for python2 compatible class

### DIFF
--- a/shuup/core/models/_units.py
+++ b/shuup/core/models/_units.py
@@ -36,7 +36,7 @@ class SalesUnit(TranslatableModel):
         verbose_name_plural = _('sales units')
 
     def __str__(self):
-        return str(self.safe_translation_getter("name", default=None))
+        return self.safe_translation_getter("name", default=None)
 
     @property
     def allow_fractions(self):


### PR DESCRIPTION
When the unit name contains unicode chars an exception is raised on python 2.7