### PR TITLE
Add orderable minimum (SHUUP-3049, SHUUP-3052)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add support to sell products after stock is zero
 - Fix refunds for discount lines
 - Fix restocking issue when refunding unshipped products
 - Make payments for `CustomPaymentProcessor` not paid by default

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-26 00:56+0000\n"
+"POT-Creation-Date: 2016-07-26 01:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
@@ -114,6 +114,9 @@ msgstr ""
 
 #, python-format
 msgid "Visibility settings copied to %d product(s)"
+
+#, python-format
+msgid "%s has been deleted."
 msgstr ""
 
 msgid "Status"
@@ -305,9 +308,11 @@ msgstr ""
 msgid "Root"
 msgstr ""
 
+#, python-brace-format
 msgid "{num} subfolders moved to {folder}."
 msgstr ""
 
+#, python-brace-format
 msgid "{num} files moved to {folder}."
 msgstr ""
 
@@ -428,6 +433,7 @@ msgstr ""
 msgid "Unable to set order as completed at this point"
 msgstr ""
 
+#, python-brace-format
 msgid "Order status changed: {old_status} to {new_status}"
 msgstr ""
 
@@ -579,7 +585,15 @@ msgstr ""
 msgid "Create Product with SKU \"%s\""
 msgstr ""
 
+msgid ""
+"Number of units that can be purchased after the product is out of stock. Set "
+"to blank for product to be purchasable without limits"
+msgstr ""
+
 msgid "Minimum Purchase Quantity must be greater than 0."
+msgstr ""
+
+msgid "Backorder maximum must be greater than or equal to 0."
 msgstr ""
 
 #, python-format
@@ -793,6 +807,7 @@ msgstr ""
 msgid "Edit %(model)s"
 msgstr ""
 
+#, python-brace-format
 msgid "Create {service_name}"
 msgstr ""
 
@@ -1462,8 +1477,8 @@ msgstr ""
 
 #, python-format
 msgid ""
-"Telemetry data was last submitted at %(submission_datetime)s - (%"
-"(submission_timesince)s) ago"
+"Telemetry data was last submitted at %(submission_datetime)s - "
+"(%(submission_timesince)s) ago"
 msgstr ""
 
 msgid "See the data that was submitted."

--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -81,6 +81,7 @@ class ShopProductForm(forms.ModelForm):
             "visibility_groups",
             "purchase_multiple",
             "minimum_purchase_quantity",
+            "backorder_maximum",
             "limit_shipping_methods",
             "limit_payment_methods",
             "shipping_methods",
@@ -89,6 +90,10 @@ class ShopProductForm(forms.ModelForm):
             "categories",
             # TODO: "shop_primary_image",
         )
+        help_texts = {
+            "backorder_maximum": _("Number of units that can be purchased after the product is out of stock. "
+                                   "Set to blank for product to be purchasable without limits")
+        }
 
     def __init__(self, **kwargs):
         if not kwargs["instance"].pk:
@@ -101,6 +106,12 @@ class ShopProductForm(forms.ModelForm):
         if minimum_purchase_quantity <= 0:
             raise ValidationError(_("Minimum Purchase Quantity must be greater than 0."))
         return minimum_purchase_quantity
+
+    def clean_backorder_maximum(self):
+        backorder_maximum = self.cleaned_data.get("backorder_maximum")
+        if backorder_maximum is not None and backorder_maximum < 0:
+            raise ValidationError(_("Backorder maximum must be greater than or equal to 0."))
+        return backorder_maximum
 
 
 class ProductAttributesForm(forms.Form):

--- a/shuup/admin/templates/shuup/admin/products/_edit_shop_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_shop_form.jinja
@@ -19,6 +19,7 @@
     {{ bs3.field(shop_product_form.suppliers) }}
     {{ bs3.field(shop_product_form.purchase_multiple) }}
     {{ bs3.field(shop_product_form.minimum_purchase_quantity) }}
+    {{ bs3.field(shop_product_form.backorder_maximum) }}
 {% endcall %}
 
 {% call content_block(shop_name_prefix ~ _("Shipping & Payment"), "fa-truck") %}

--- a/shuup/core/locale/en/LC_MESSAGES/django.po
+++ b/shuup/core/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-26 00:56+0000\n"
+"POT-Creation-Date: 2016-07-26 01:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -686,6 +686,9 @@ msgid "listed"
 msgstr ""
 
 msgid "purchasable"
+msgstr ""
+
+msgid "backorder maximum"
 msgstr ""
 
 msgid "purchase multiple"

--- a/shuup/core/migrations/0003_shopproduct_backorder_maximum.py
+++ b/shuup/core/migrations/0003_shopproduct_backorder_maximum.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import shuup.core.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shuup', '0002_rounding'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='shopproduct',
+            name='backorder_maximum',
+            field=shuup.core.fields.QuantityField(verbose_name='backorder maximum', null=True, default=0, max_digits=36, blank=True, decimal_places=9),
+        ),
+    ]

--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -42,6 +42,7 @@ class ShopProduct(MoneyPropped, models.Model):
     visibility_groups = models.ManyToManyField(
         "ContactGroup", related_name='visible_products', verbose_name=_('visible for groups'), blank=True
     )
+    backorder_maximum = QuantityField(default=0, blank=True, null=True, verbose_name=_('backorder maximum'))
     purchase_multiple = QuantityField(default=0, verbose_name=_('purchase multiple'))
     minimum_purchase_quantity = QuantityField(default=1, verbose_name=_('minimum purchase'))
     limit_shipping_methods = models.BooleanField(default=False, verbose_name=_("limited for shipping methods"))

--- a/shuup/core/suppliers/base.py
+++ b/shuup/core/suppliers/base.py
@@ -60,10 +60,11 @@ class BaseSupplierModule(object):
         :rtype: iterable[ValidationError]
         """
         stock_status = self.get_stock_status(shop_product.product_id)
+        backorder_maximum = shop_product.backorder_maximum
         if stock_status.error:
             yield ValidationError(stock_status.error, code="stock_error")
         if shop_product.product.stock_behavior == StockBehavior.STOCKED:
-            if quantity > stock_status.logical_count:
+            if backorder_maximum is not None and quantity > stock_status.logical_count + backorder_maximum:
                 yield ValidationError(stock_status.message or _(u"Insufficient stock"), code="stock_insufficient")
 
     def adjust_stock(self, product_id, delta, created_by=None, type=StockAdjustmentType.INVENTORY):

--- a/shuup_tests/core/test_suppliers.py
+++ b/shuup_tests/core/test_suppliers.py
@@ -9,7 +9,8 @@ import pytest
 
 from shuup.core.models import StockBehavior
 from shuup.testing.factories import (
-    create_random_person, get_default_shop, get_default_shop_product, get_default_supplier
+    create_random_person, get_default_shop, get_default_shop_product,
+    get_default_supplier
 )
 
 
@@ -36,3 +37,17 @@ def test_get_suppliable_products():
     product.save()
     # Make sure supplier now omits unorderable product
     assert not list(supplier.get_suppliable_products(shop, customer=customer))
+    assert len(list(supplier.get_orderability_errors(shop_product, quantity=1, customer=customer))) == 1
+
+    shop_product.backorder_maximum = 10
+    shop_product.save()
+
+    assert len(list(supplier.get_suppliable_products(shop, customer=customer))) == 1
+    assert len(list(supplier.get_orderability_errors(shop_product, quantity=10, customer=customer))) == 0
+    assert len(list(supplier.get_orderability_errors(shop_product, quantity=11, customer=customer))) == 1
+
+    shop_product.backorder_maximum = None
+    shop_product.save()
+
+    assert len(list(supplier.get_suppliable_products(shop, customer=customer))) == 1
+    assert len(list(supplier.get_orderability_errors(shop_product, quantity=1000, customer=customer))) == 0


### PR DESCRIPTION
Allow products to be sold after stock logical count is less than or equal to zero.