### PR TITLE
Admin: Create a 'Save as a copy' button on product toolbar

### DIFF
--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -124,6 +124,9 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+msgid "Save as a copy"
+msgstr ""
+
 #, python-format
 msgid "%(count)s member added"
 msgid_plural "%(count)s members added"

--- a/shuup/admin/modules/products/views/toolbars.py
+++ b/shuup/admin/modules/products/views/toolbars.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext as _
 
 from shuup.admin.toolbar import (
     DropdownActionButton, DropdownDivider, DropdownHeader, DropdownItem,
-    get_default_edit_toolbar, Toolbar
+    get_default_edit_toolbar, JavaScriptActionButton, Toolbar
 )
 from shuup.admin.utils.urls import get_model_url
 
@@ -33,6 +33,13 @@ class EditProductToolbar(Toolbar):
     def _build_existing_product(self):
         product = self.product
         # :type product: shuup.core.models.Product
+
+        save_as_copy_button = JavaScriptActionButton(
+            onclick="saveAsACopy()",
+            text=_("Save as a copy"),
+            icon="fa fa-clone",
+        )
+        self.append(save_as_copy_button)
 
         cross_sell_button = DropdownItem(
             text=_("Manage Cross-Selling"),

--- a/shuup/admin/templates/shuup/admin/products/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/products/edit.jinja
@@ -23,4 +23,9 @@
 {% block extra_js %}
     <script src="{{ static("shuup_admin/js/product.js") }}"></script>
     <script src="{{ static("shuup_admin/js/remarkable.js") }}"></script>
+    <script>
+        function saveAsACopy(){
+            $("#product_form").attr("action", "{{ url('shuup_admin:product.new') }}").submit();
+        }
+    </script>
 {% endblock %}


### PR DESCRIPTION
Create a 'Save as a copy' button on product admin toolbar to make it easier to duplicate products.