### PR TITLE
Simple CMS: Fix plugin links

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -93,6 +93,8 @@ Discount Pricing
 Simple CMS
 ~~~~~~~~~~
 
+- Fix plugin links
+
 Default Tax
 ~~~~~~~~~~~
 

--- a/shuup/simple_cms/templates/shuup/simple_cms/plugins/page_links.jinja
+++ b/shuup/simple_cms/templates/shuup/simple_cms/plugins/page_links.jinja
@@ -4,7 +4,7 @@
         <ul>
         {% for page in pages %}
             <li>
-                <a href="{{ page.url }}">{{ page }}</a>
+                <a href="/{{ page.url }}">{{ page }}</a>
             </li>
         {% endfor %}
         </ul>

--- a/shuup_tests/simple_cms/test_plugins.py
+++ b/shuup_tests/simple_cms/test_plugins.py
@@ -48,3 +48,15 @@ def test_page_links_plugin_show_all():
 
     plugin = PageLinksPlugin({"show_all_pages": True})
     assert page in plugin.get_context_data(context)["pages"]
+
+
+@pytest.mark.django_db
+def test_plugin_renders_absolute_links():
+    """
+    Test that the plugin renders only absolute links.
+    """
+    context = get_jinja_context()
+    page = create_page(eternal=True, visible_in_menu=True)
+    absolute_link = "/%s" % page.url
+    plugin = PageLinksPlugin({"show_all_pages": True})
+    assert absolute_link in plugin.render(context)


### PR DESCRIPTION
Make sure plugin only renders absolute links.

Refs SHUUP-3119