### PR TITLE
Admin: Copy category visibility to products (SHUUP-3069)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -32,6 +32,7 @@ Localization
 Admin
 ~~~~~
 
+- Add ability to copy category visibility settings to products
 - Reorganize main menu
 - Show customer comment on order detail page
 - Redirect to order detail page on order submission

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-20 22:19+0000\n"
+"POT-Creation-Date: 2016-07-21 20:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
@@ -46,7 +46,7 @@ msgstr ""
 msgid "Campaigns"
 msgstr ""
 
-msgid "Store front"
+msgid "Storefront"
 msgstr ""
 
 msgid "Addons"
@@ -107,6 +107,13 @@ msgid "Remove Products"
 msgstr ""
 
 msgid "Remove selected products from this category"
+msgstr ""
+
+msgid "Invalid category"
+msgstr ""
+
+#, python-format
+msgid "Visibility settings copied to %d product(s)"
 msgstr ""
 
 msgid "Status"
@@ -298,9 +305,11 @@ msgstr ""
 msgid "Root"
 msgstr ""
 
+#, python-brace-format
 msgid "{num} subfolders moved to {folder}."
 msgstr ""
 
+#, python-brace-format
 msgid "{num} files moved to {folder}."
 msgstr ""
 
@@ -418,6 +427,7 @@ msgstr ""
 msgid "Unable to set order as completed at this point"
 msgstr ""
 
+#, python-brace-format
 msgid "Order status changed: {old_status} to {new_status}"
 msgstr ""
 
@@ -777,6 +787,7 @@ msgstr ""
 msgid "Edit %(model)s"
 msgstr ""
 
+#, python-brace-format
 msgid "Create {service_name}"
 msgstr ""
 
@@ -1039,6 +1050,9 @@ msgid "Log out"
 msgstr ""
 
 msgid "General Information"
+msgstr ""
+
+msgid "Copy visibility settings to products"
 msgstr ""
 
 msgid "Category Image"
@@ -1426,8 +1440,8 @@ msgstr ""
 
 #, python-format
 msgid ""
-"Telemetry data was last submitted at %(submission_datetime)s - (%"
-"(submission_timesince)s) ago"
+"Telemetry data was last submitted at %(submission_datetime)s - "
+"(%(submission_timesince)s) ago"
 msgstr ""
 
 msgid "See the data that was submitted."

--- a/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-20 22:19+0000\n"
+"POT-Creation-Date: 2016-07-21 20:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
@@ -31,18 +31,21 @@ msgstr ""
 msgid "New file name?"
 msgstr ""
 
-#, c-format
+#, javascript-format
 msgid "Are you sure you want to delete the file %s?"
 msgstr ""
 
 msgid "New folder name?"
 msgstr ""
 
-#, c-format
+#, javascript-format
 msgid "Are you sure you want to delete the %s folder?"
 msgstr ""
 
 msgid "New folder"
+msgstr ""
+
+msgid "current"
 msgstr ""
 
 msgid "Oldest first"
@@ -92,7 +95,7 @@ msgstr ""
 msgid "Delete folder"
 msgstr ""
 
-#, c-format
+#, javascript-format
 msgid "Order %s created."
 msgstr ""
 
@@ -277,7 +280,7 @@ msgid ""
 "customer first."
 msgstr ""
 
-#, c-format
+#, javascript-format
 msgid "All prices are in %s currency."
 msgstr ""
 
@@ -332,7 +335,7 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#, c-format
+#, javascript-format
 msgid "Value %s Name"
 msgstr ""
 
@@ -378,20 +381,20 @@ msgstr ""
 msgid "The results could not be loaded"
 msgstr ""
 
-#, c-format
+#, javascript-format
 msgid "Please delete %s character"
 msgid_plural "Please delete %s characters"
 msgstr[0] ""
 msgstr[1] ""
 
-#, c-format
+#, javascript-format
 msgid "Please enter %s or more characters"
 msgstr ""
 
 msgid "Loading more results..."
 msgstr ""
 
-#, c-format
+#, javascript-format
 msgid "You can only select %s item"
 msgid_plural "You can only select %s items"
 msgstr[0] ""
@@ -436,7 +439,7 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#, c-format
+#, javascript-format
 msgid "Filter by %s"
 msgstr ""
 

--- a/shuup/admin/modules/categories/__init__.py
+++ b/shuup/admin/modules/categories/__init__.py
@@ -14,7 +14,7 @@ from shuup.admin.base import AdminModule, MenuEntry, SearchResult
 from shuup.admin.menu import PRODUCTS_MENU_CATEGORY
 from shuup.admin.utils.permissions import get_default_model_permissions
 from shuup.admin.utils.urls import (
-    derive_model_url, get_edit_and_list_urls, get_model_url
+    admin_url, derive_model_url, get_edit_and_list_urls, get_model_url
 )
 from shuup.core.models import Category
 
@@ -25,7 +25,14 @@ class CategoryModule(AdminModule):
     breadcrumbs_menu_entry = MenuEntry(text=name, url="shuup_admin:category.list", category=PRODUCTS_MENU_CATEGORY)
 
     def get_urls(self):
-        return get_edit_and_list_urls(
+        return [
+            admin_url(
+                "^categories/(?P<pk>\d+)/copy-visibility/$",
+                "shuup.admin.modules.categories.views.CategoryCopyVisibilityView",
+                name="category.copy_visibility",
+                permissions=get_default_model_permissions(Category)
+            )
+        ] + get_edit_and_list_urls(
             url_prefix="^categories",
             view_template="shuup.admin.modules.categories.views.Category%sView",
             name_template="category.%s",

--- a/shuup/admin/modules/categories/forms.py
+++ b/shuup/admin/modules/categories/forms.py
@@ -78,9 +78,14 @@ class CategoryProductForm(forms.Form):
     @atomic
     def save(self):
         data = self.cleaned_data
+        is_visible = self.category.status == CategoryStatus.VISIBLE
+        visibility_groups = self.category.visibility_groups.all()
         primary_product_ids = [int(product_id) for product_id in data.get("primary_products", [])]
         for shop_product in ShopProduct.objects.filter(shop_id=self.shop.id, product_id__in=primary_product_ids):
             shop_product.primary_category = self.category
+            shop_product.visible = is_visible
+            shop_product.visibility_limit = self.category.visibility.value
+            shop_product.visibility_groups = visibility_groups
             shop_product.save()
             shop_product.categories.add(self.category)
             if data.get("update_product_category", False):

--- a/shuup/admin/modules/categories/views/__init__.py
+++ b/shuup/admin/modules/categories/views/__init__.py
@@ -4,7 +4,8 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+from .copy import CategoryCopyVisibilityView
 from .edit import CategoryEditView
 from .list import CategoryListView
 
-__all__ = ["CategoryEditView", "CategoryListView"]
+__all__ = ["CategoryEditView", "CategoryListView", "CategoryCopyVisibilityView"]

--- a/shuup/admin/templates/shuup/admin/categories/_edit_base_form.jinja
+++ b/shuup/admin/templates/shuup/admin/categories/_edit_base_form.jinja
@@ -18,6 +18,12 @@
     {{ bs3.field(category_form.visibility) }}
     {{ bs3.field(category_form.visibility_groups) }}
     {{ bs3.field(category_form.shops) }}
+    <div class="form-group">
+    <label class="control-label"></label>
+    <button class="btn btn-primary" onclick="copyVisibilityToProducts(event, $(this))">
+        <i class="fa fa-clone"></i> {% trans %}Copy visibility settings to products{% endtrans %}
+    </button>
+    </div>
 {% endcall %}
 
 {% call content_block(_("Category Image"), "fa-camera") %}

--- a/shuup/admin/templates/shuup/admin/categories/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/categories/edit.jinja
@@ -11,7 +11,30 @@
         </form>
     {% endcall %}
 {% endblock %}
-
 {% block extra_js %}
     <script src="{{ static("shuup_admin/js/remarkable.js") }}"></script>
+    <script>
+        function copyVisibilityToProducts(event, $el){
+            event.preventDefault();
+            $el.attr("disabled", true);
+            $.ajax({
+                type: "POST",
+                url: "{{ url('shuup_admin:category.copy_visibility', pk=category.pk) }}",
+                data: {csrfmiddlewaretoken: window.ShuupAdminConfig.csrf},
+                success: function(msg) {
+                    window.Messages.enqueue({tags: "info", text: msg.message});
+                },
+                error: function(response) {
+                    var message = _("An unexpected error has occurred.");
+                    if(response.responseJSON && response.responseJSON.message){
+                        message = response.responseJSON.message;
+                    }
+                    window.Messages.enqueue({tags: "error", text: message});
+                },
+                complete: function(){
+                    $el.attr("disabled", false);
+                }
+            });
+        }
+    </script>
 {% endblock %}


### PR DESCRIPTION
Add the ability to copy category visibility settings to products with the
corresponding main category. Also copy category visibility settings over to
products when using the category product management form.

Refs SHUUP-3069