### PR TITLE
Admin: Prevent picotable from reloading after every change (SHUUP-3063)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -33,6 +33,7 @@ Localization
 Admin
 ~~~~~
 
+- Prevent picotable from reloading after every change
 - Add ability to copy category visibility settings to products
 - Reorganize main menu
 - Show customer comment on order detail page

--- a/shuup/admin/static_src/picotable/picotable.js
+++ b/shuup/admin/static_src/picotable/picotable.js
@@ -217,6 +217,7 @@ const Picotable = (function(m, storage) {
         var setFilterValueFromSelect = function() {
             var valueJS = JSON.parse(this.value);
             ctrl.setFilterValue(col.id, valueJS);
+            ctrl.refreshSoon();
         };
         var select = m("select.form-control", {
             value: JSON.stringify(value),
@@ -252,6 +253,7 @@ const Picotable = (function(m, storage) {
             }
             filterObj[which] = newValue;
             ctrl.setFilterValue(col.id, filterObj);
+            ctrl.refreshSoon();
         };
         var attrs = {"type": col.filter.range.type || "text"};
         Util.map(["min", "max", "step"], function(key) {
@@ -285,14 +287,22 @@ const Picotable = (function(m, storage) {
     }
 
     function buildColumnTextFilter(ctrl, col, value) {
-        var setFilterValueFromInput = function() {
+        var setFilterValueFromInput = function(event) {
             ctrl.setFilterValue(col.id, this.value);
+            if(event.keyCode === 13 || !this.value) {
+                ctrl.refreshSoon();
+            }
         };
+        var refreshAfterFocusOut = function() {
+            ctrl.refreshSoon();
+        };
+
         var input = m("input.form-control", {
             type: col.filter.text.type || "text",
             value: Util.stringValue(value),
             placeholder: col.filter.placeholder || interpolate(gettext("Filter by %s"), [col.title]),
-            onchange: setFilterValueFromInput,
+            onkeyup: setFilterValueFromInput,
+            onfocusout: refreshAfterFocusOut,
             config: debounceChangeConfig(500)
         });
         return m("div.text-filter", input);
@@ -633,7 +643,6 @@ const Picotable = (function(m, storage) {
             filters[colId] = value;
             filters = Util.omitNulls(filters);
             ctrl.vm.filterValues(filters);
-            ctrl.refreshSoon();
         };
         ctrl.resetFilters = function() {
             ctrl.vm.filterValues({});


### PR DESCRIPTION
Refresh the table when enter is pressed, input value is empty or on outside focus.

Reloading picotable on every filter change causes unwanted bouncing with letters
since the whole page is reloaded isntead of just updating the rows.