### PR TITLE
Core: Make payments for `CustomPaymentProcessor` not paid

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Make payments for `CustomPaymentProcessor` not paid by default
 - Fix shipping status for orders with refunds
 - Fix bug in order total price rounding
 - Fix bug with duplicates in `Product.objects.list_visible()`

--- a/shuup/core/models/_service_payment.py
+++ b/shuup/core/models/_service_payment.py
@@ -176,4 +176,3 @@ class CustomPaymentProcessor(PaymentProcessor):
                     payment_identifier="Cash-%s" % now().isoformat(),
                     description="Cash Payment"
                 )
-        super(CustomPaymentProcessor, self).process_payment_return_request(service, order, request)

--- a/shuup/testing/factories.py
+++ b/shuup/testing/factories.py
@@ -46,6 +46,7 @@ from shuup.utils.filer import filer_image_from_data
 from shuup.utils.money import Money
 
 from .image_generator import generate_image
+from .models import PaymentWithCheckoutPhase
 
 DEFAULT_IDENTIFIER = "default"
 DEFAULT_NAME = "Default"
@@ -297,6 +298,10 @@ def get_default_tax_class():
 
 def get_custom_payment_processor():
     return _get_service_provider(CustomPaymentProcessor)
+
+
+def get_payment_processor_with_checkout_phase():
+    return _get_service_provider(PaymentWithCheckoutPhase)
 
 
 def get_custom_carrier():

--- a/shuup_tests/core/test_custom_payment_processor.py
+++ b/shuup_tests/core/test_custom_payment_processor.py
@@ -25,7 +25,7 @@ from shuup.testing.factories import (
 @pytest.mark.django_db
 @pytest.mark.parametrize('choice_identifier, expected_payment_status', [
     ('cash', PaymentStatus.FULLY_PAID),
-    ('manual', PaymentStatus.DEFERRED)
+    ('manual', PaymentStatus.NOT_PAID)
 ])
 def test_custom_payment_processor_cash_service(choice_identifier, expected_payment_status):
     shop = get_default_shop()


### PR DESCRIPTION
Make payments for `CustomPaymentProcessor` not paid instead of deferred
by default to allow orders with manual service methods to be edited in
admin.

Refs SHUUP-3118