### PR TITLE
Refund inventory, discount, and tax fixes (SHUUP-3114, SHUUP-3036)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Fix refunds for discount lines
 - Fix restocking issue when refunding unshipped products
 - Make payments for `CustomPaymentProcessor` not paid by default
 - Fix shipping status for orders with refunds

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Fix restocking issue when refunding unshipped products
 - Make payments for `CustomPaymentProcessor` not paid by default
 - Fix shipping status for orders with refunds
 - Fix bug in order total price rounding

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-26 00:11+0000\n"
+"POT-Creation-Date: 2016-07-26 00:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -496,6 +496,9 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
+msgid "Total incl. tax to refund"
+msgstr ""
+
 msgid "Restock products"
 msgstr ""
 
@@ -509,10 +512,13 @@ msgstr ""
 msgid "This order already has existing refunds"
 msgstr ""
 
+msgid "Refund amount cannot be 0"
+msgstr ""
+
 msgid "Refund amount exceeds order amount."
 msgstr ""
 
-msgid "Refund amount cannot be 0"
+msgid "Refund amounts should match sign on parent line."
 msgstr ""
 
 msgid "Refund created."

--- a/shuup/admin/templates/shuup/admin/orders/create_refund.jinja
+++ b/shuup/admin/templates/shuup/admin/orders/create_refund.jinja
@@ -95,6 +95,8 @@
                     $refund.find("input[id$='amount']"), line && line["amount"] != 0);
                 setFormGroupVisibility(
                     $refund.find("input[id$='restock_products']"), line && line["type"] === "product");
+                $refund.find("input[id$='quantity']").val(line.quantity);
+                $refund.find("input[id$='amount']").val(line.amount);
             });
         }
 

--- a/shuup/admin/templates/shuup/admin/orders/create_refund.jinja
+++ b/shuup/admin/templates/shuup/admin/orders/create_refund.jinja
@@ -10,8 +10,8 @@
       {% endfor %}
       </select>
     </div>
-    {{ bs3.field(form.quantity, form_group_class="form-group hidden") }}
-    {{ bs3.field(form.amount, form_group_class="form-group hidden") }}
+    {{ bs3.field(form.quantity, form_group_class="form-group hidden", set_disabled=True) }}
+    {{ bs3.field(form.amount, form_group_class="form-group hidden", set_disabled=True) }}
     {{ bs3.field(form.restock_products, form_group_class="form-group hidden") }}
 {% endmacro %}
 

--- a/shuup/core/excs.py
+++ b/shuup/core/excs.py
@@ -28,6 +28,10 @@ class RefundExceedsAmountException(Exception):
     pass
 
 
+class InvalidRefundAmountException(Exception):
+    pass
+
+
 class ProductNotOrderableProblem(Problem):
     pass
 

--- a/shuup/core/locale/en/LC_MESSAGES/django.po
+++ b/shuup/core/locale/en/LC_MESSAGES/django.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+OME DESCRIPTIVE TITLE.
 # Copyright (C) 2015 THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-09 01:09+0000\n"
+"POT-Creation-Date: 2016-07-26 00:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -393,10 +393,7 @@ msgstr ""
 msgid "discount"
 msgstr ""
 
-msgid "quantity refund"
-msgstr ""
-
-msgid "amount refund"
+msgid "refund"
 msgstr ""
 
 msgid "rounding"
@@ -1264,6 +1261,15 @@ msgid "Default Pricing"
 msgstr ""
 
 msgid "Insufficient stock"
+msgstr ""
+
+msgid "inventory"
+msgstr ""
+
+msgid "restock"
+msgstr ""
+
+msgid "restock logical"
 msgstr ""
 
 msgid "Untaxed"

--- a/shuup/core/migrations/0003_update_orderline_refunds.py
+++ b/shuup/core/migrations/0003_update_orderline_refunds.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models, connection
+
+
+def combine_refund_types(apps, schema_editor):
+    # convert AMOUNT_REFUND (8) to REFUND (6)
+    with connection.cursor() as c:
+        c.execute("UPDATE shuup_orderline SET type = 6 WHERE type = 8")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shuup', '0002_rounding'),
+    ]
+
+    operations = [
+        migrations.RunPython(combine_refund_types),
+    ]

--- a/shuup/core/suppliers/enums.py
+++ b/shuup/core/suppliers/enums.py
@@ -12,7 +12,9 @@ from enumfields import Enum
 class StockAdjustmentType(Enum):
     INVENTORY = 1
     RESTOCK = 2
+    RESTOCK_LOGICAL = 3
 
     class Labels:
         INVENTORY = _("inventory")
         RESTOCK = _("restock")
+        RESTOCK_LOGICAL = _("restock logical")

--- a/shuup/simple_supplier/module.py
+++ b/shuup/simple_supplier/module.py
@@ -56,8 +56,10 @@ class SimpleSupplierModule(BaseSupplierModule):
         sv, _ = StockCount.objects.get_or_create(supplier_id=supplier_id, product_id=product_id)
         sv.logical_count = values["logical_count"]
         sv.physical_count = values["physical_count"]
-        latest_event = StockAdjustment.objects.filter(
-            supplier=supplier_id, product=product_id).order_by("-created_on").first()
+        latest_event = (
+            StockAdjustment.objects
+            .filter(supplier=supplier_id, product=product_id, type=StockAdjustmentType.INVENTORY)
+            .last())
         if latest_event:
             sv.stock_value_value = latest_event.purchase_price_value * sv.logical_count
         sv.save(update_fields=("logical_count", "physical_count", "stock_value_value"))

--- a/shuup/simple_supplier/utils.py
+++ b/shuup/simple_supplier/utils.py
@@ -44,8 +44,7 @@ def get_current_stock_value(supplier_id, product_id):
         .filter(supplier_id=supplier_id, product_id=product_id)
         .exclude(
             Q(order__status__role=OrderStatusRole.CANCELED) |
-            Q(type=OrderLineType.AMOUNT_REFUND) |
-            Q(type=OrderLineType.QUANTITY_REFUND))
+            Q(type=OrderLineType.REFUND))
         .aggregate(total=Sum("quantity"))["total"] or 0)
     orders_refunded_before_shipment = (
         StockAdjustment.objects

--- a/shuup/simple_supplier/utils.py
+++ b/shuup/simple_supplier/utils.py
@@ -39,25 +39,25 @@ def get_current_stock_value(supplier_id, product_id):
         .filter(supplier_id=supplier_id, product_id=product_id)
         .exclude(type=StockAdjustmentType.RESTOCK_LOGICAL)
         .aggregate(total=Sum("delta"))["total"] or 0)
-    orders_bought = (
+    products_bought = (
         OrderLine.objects
         .filter(supplier_id=supplier_id, product_id=product_id)
         .exclude(
             Q(order__status__role=OrderStatusRole.CANCELED) |
             Q(type=OrderLineType.REFUND))
         .aggregate(total=Sum("quantity"))["total"] or 0)
-    orders_refunded_before_shipment = (
+    products_refunded_before_shipment = (
         StockAdjustment.objects
         .filter(supplier_id=supplier_id, product_id=product_id, type=StockAdjustmentType.RESTOCK_LOGICAL)
         .aggregate(total=Sum("delta"))["total"] or 0)
-    orders_sent = (
+    products_sent = (
         ShipmentProduct.objects
         .filter(shipment__supplier=supplier_id, product_id=product_id)
         .aggregate(total=Sum("quantity"))["total"] or 0)
 
     return {
-        "logical_count": events - orders_bought + orders_refunded_before_shipment,
-        "physical_count": events - orders_sent
+        "logical_count": events - products_bought + products_refunded_before_shipment,
+        "physical_count": events - products_sent
     }
 
 
@@ -102,7 +102,7 @@ def get_stock_adjustment_div(request, supplier, product):
     :rtype: str
     """
     latest_adjustment = StockAdjustment.objects.filter(
-        product=product, supplier=supplier).order_by("-created_on").first()
+        product=product, supplier=supplier, type=StockAdjustmentType.INVENTORY).last()
     purchase_price = (latest_adjustment.purchase_price_value if latest_adjustment else Decimal("0.00"))
     context = {
         "product": product,

--- a/shuup/testing/factories.py
+++ b/shuup/testing/factories.py
@@ -531,11 +531,14 @@ def add_product_to_order(order, supplier, product, quantity, taxless_base_unit_p
                                    order_line=product_order_line,
                                    product=product, quantity=quantity,
                                    supplier=supplier)
-    product_order_line.base_unit_price = order.shop.create_price(taxless_base_unit_price)
+    base_unit_price = order.shop.create_price(taxless_base_unit_price)
+    if order.prices_include_tax:
+        base_unit_price *= (1 + tax_rate)
+    product_order_line.base_unit_price = order.shop.create_price(base_unit_price)
     product_order_line.save()
     product_order_line.taxes.add(OrderLineTax.from_tax(
         get_test_tax(tax_rate),
-        product_order_line.taxless_price.amount,
+        Money(quantity * taxless_base_unit_price, order.currency),
         order_line=product_order_line,
     ))
 

--- a/shuup_tests/admin/test_refund_creator.py
+++ b/shuup_tests/admin/test_refund_creator.py
@@ -11,7 +11,7 @@ import pytest
 from shuup.admin.modules.orders.views.refund import (
     OrderCreateFullRefundView, OrderCreateRefundView
 )
-from shuup.core.models import Order, OrderLineType
+from shuup.core.models import OrderLineType
 from shuup.testing.factories import (
     create_order_with_product, create_product, get_default_shop,
     get_default_supplier
@@ -35,7 +35,7 @@ def test_create_refund_view(rf, admin_user):
     data = {
         "form-0-line_number": 0,
         "form-0-quantity": 1,
-        "form-0-amount": 0,
+        "form-0-amount": 1,
         "form-0-restock_products": False,
         "form-INITIAL_FORMS": 0,
         "form-MAX_NUM_FORMS": 1000,
@@ -50,9 +50,10 @@ def test_create_refund_view(rf, admin_user):
     assert order.has_refunds()
 
     assert len(order.lines.all()) == 2
-    refund_line = order.lines.filter(type=OrderLineType.QUANTITY_REFUND).last()
+    refund_line = order.lines.filter(type=OrderLineType.REFUND).last()
     assert refund_line
     assert refund_line.taxful_price == -product_line.taxful_price
+
 
 @pytest.mark.django_db
 def test_create_full_refund_view(rf, admin_user):
@@ -68,8 +69,6 @@ def test_create_full_refund_view(rf, admin_user):
     assert len(order.lines.all()) == 1
     assert order.taxful_total_price.amount.value != 0
 
-    product_line = order.lines.first()
-
     data = {
         "restock_products": "on",
     }
@@ -82,7 +81,6 @@ def test_create_full_refund_view(rf, admin_user):
     order.cache_prices()
 
     assert order.taxful_total_price.amount.value == 0
-    refund_line = order.lines.filter(type=OrderLineType.QUANTITY_REFUND).last()
+    refund_line = order.lines.filter(type=OrderLineType.REFUND).last()
     assert refund_line
     assert refund_line.taxful_price == -original_total_price
-

--- a/shuup_tests/admin/test_refund_creator.py
+++ b/shuup_tests/admin/test_refund_creator.py
@@ -26,6 +26,7 @@ def test_create_refund_view(rf, admin_user):
     product = create_product(sku="test-sku", shop=shop, supplier=supplier, default_price=3.33)
     order = create_order_with_product(product, supplier, quantity=1, taxless_base_unit_price=1, shop=shop)
     order.cache_prices()
+    order.save()
 
     assert not order.has_refunds()
     assert len(order.lines.all()) == 1

--- a/shuup_tests/core/test_orders.py
+++ b/shuup_tests/core/test_orders.py
@@ -14,8 +14,8 @@ from django.test import override_settings
 from django.utils.timezone import now
 
 from shuup.core.excs import (
-    NoPaymentToCreateException, NoProductsToShipException,
-    RefundExceedsAmountException
+    InvalidRefundAmountException, NoPaymentToCreateException,
+    NoProductsToShipException, RefundExceedsAmountException
 )
 from shuup.core.models import (
     Order, OrderLine, OrderLineTax, OrderLineType, OrderStatus, PaymentStatus,
@@ -25,7 +25,7 @@ from shuup.core.pricing import TaxfulPrice, TaxlessPrice
 from shuup.testing.factories import (
     create_empty_order, create_order_with_product, create_product, get_address,
     get_default_product, get_default_shop, get_default_supplier,
-    get_default_tax, get_initial_order_status, get_shipping_method
+    get_default_tax, get_initial_order_status
 )
 from shuup.utils.money import Money
 from shuup_tests.simple_supplier.utils import get_simple_supplier
@@ -253,6 +253,7 @@ def test_payments():
     assert order.payment_status == PaymentStatus.FULLY_PAID
     assert not order.can_edit()
 
+
 @pytest.mark.django_db
 def test_refunds():
     shop = get_default_shop()
@@ -263,7 +264,8 @@ def test_refunds():
         default_price=10,
     )
     tax_rate = Decimal("0.1")
-    order = create_order_with_product(product, supplier, 3, 200, tax_rate, shop=shop)
+    taxless_base_unit_price = shop.create_price(200)
+    order = create_order_with_product(product, supplier, 3, taxless_base_unit_price, tax_rate, shop=shop)
     order.payment_status = PaymentStatus.DEFERRED
     order.cache_prices()
     order.save()
@@ -286,38 +288,35 @@ def test_refunds():
 
     # Confirm the value of the refund
     assert order.lines.last().taxful_price == -product_line.base_unit_price
-    assert order.lines.last().tax_amount == -(product_line.base_unit_price * tax_rate).amount
-
-    partial_refund_amount = order.taxful_total_price.amount / 2
-    remaining_amount = order.taxful_total_price.amount - partial_refund_amount
+    assert order.lines.last().tax_amount == -(product_line.taxless_base_unit_price * tax_rate).amount
 
     # Create a refund with a parent line and amount
-    order.create_refund([{"line": product_line, "quantity": 1, "amount": partial_refund_amount}])
+    order.create_refund([{"line": product_line, "quantity": 1, "amount": product_line.taxful_price.amount / 3}])
     assert len(order.lines.all()) == 3
     assert order.lines.last().ordering == 2
 
-    assert order.lines.last().taxful_price.amount == -partial_refund_amount
-    assert order.lines.last().tax_amount == -partial_refund_amount * tax_rate
+    assert order.lines.last().taxful_price.amount == -taxless_base_unit_price.amount * (1 + tax_rate)
+    assert order.lines.last().tax_amount == -taxless_base_unit_price.amount * tax_rate
 
-    assert order.taxless_total_price.amount == remaining_amount * (1 - tax_rate)
-    assert order.taxful_total_price.amount == remaining_amount
+    assert order.taxless_total_price.amount == taxless_base_unit_price.amount
+    assert order.taxful_total_price.amount == taxless_base_unit_price.amount * (1 + tax_rate)
     assert order.can_create_refund()
 
     # Try to refunding remaining amount without a parent line
     with pytest.raises(AssertionError):
-        order.create_refund([{"amount": remaining_amount}])
+        order.create_refund([{"amount": taxless_base_unit_price}])
 
     # refund remaining amount
-    order.create_refund([{"line": product_line, "quantity": 1, "amount": remaining_amount}])
+    order.create_refund([{"line": product_line, "quantity": 1, "amount": product_line.taxful_price.amount / 3}])
     assert len(order.lines.all()) == 4
     assert order.lines.last().ordering == 3
-    assert order.lines.last().taxful_price.amount == -remaining_amount
+    assert order.lines.last().taxful_price.amount == -taxless_base_unit_price.amount * (1 + tax_rate)
 
     assert not order.taxful_total_price.amount
     assert not order.can_create_refund()
 
     with pytest.raises(RefundExceedsAmountException):
-        order.create_refund([{"line": product_line, "quantity": 1, "amount": remaining_amount}])
+        order.create_refund([{"line": product_line, "quantity": 1, "amount": taxless_base_unit_price.amount}])
 
 
 @pytest.mark.django_db
@@ -333,8 +332,9 @@ def test_refund_entire_order():
     supplier.adjust_stock(product.id, 5)
     check_stock_counts(supplier, product, 5, 5)
 
-    order = create_order_with_product(product, supplier, 2, 200, Decimal("0.1"), shop=shop)
+    order = create_order_with_product(product, supplier, 2, 200, Decimal("0.24"), shop=shop)
     order.cache_prices()
+
     original_total_price = order.taxful_total_price
     check_stock_counts(supplier, product, 5, 3)
 
@@ -367,7 +367,6 @@ def test_refund_entire_order_with_product_restock():
 
     order = create_order_with_product(product, supplier, 2, 200, shop=shop)
     order.cache_prices()
-    original_total_price = order.taxful_total_price
 
     check_stock_counts(supplier, product, 5, 3)
 
@@ -376,7 +375,6 @@ def test_refund_entire_order_with_product_restock():
 
     # restock logical count
     check_stock_counts(supplier, product, 5, 5)
-
 
 
 @pytest.mark.django_db
@@ -403,14 +401,15 @@ def test_refund_with_shipment(restock):
     # Shipment should decrease physical count by 2, logical by none
     order.create_shipment({product_line.product: 2}, supplier=supplier)
     check_stock_counts(supplier, product, physical=8, logical=6)
-    assert order.shipping_status ==  ShippingStatus.PARTIALLY_SHIPPED
+    assert order.shipping_status == ShippingStatus.PARTIALLY_SHIPPED
 
     # Check correct refunded quantities
     assert not product_line.refunded_quantity
 
     # Create a refund that refunds from unshipped quantity first, then shipped quantity, check stocks
     check_stock_counts(supplier, product, physical=8, logical=6)
-    order.create_refund([{"line": product_line, "quantity": 3, "amount": Money(600, order.currency), "restock_products": restock}])
+    order.create_refund([
+        {"line": product_line, "quantity": 3, "amount": Money(600, order.currency), "restock_products": restock}])
     assert product_line.refunded_quantity == 3
     assert order.shipping_status == ShippingStatus.FULLY_SHIPPED
     if restock:
@@ -419,7 +418,8 @@ def test_refund_with_shipment(restock):
         check_stock_counts(supplier, product, physical=8, logical=6)
 
     # Create a second refund that refunds the last shipped quantity, check stocks
-    order.create_refund([{"line": product_line, "quantity": 1, "amount": Money(200, order.currency), "restock_products": restock}])
+    order.create_refund([
+        {"line": product_line, "quantity": 1, "amount": Money(200, order.currency), "restock_products": restock}])
     assert product_line.refunded_quantity == 4
     if restock:
         # Make sure we're not restocking more than maximum restockable quantity
@@ -450,7 +450,8 @@ def test_refund_without_shipment(restock):
 
     # Restock value shouldn't matter if we don't have any shipments
     product_line = order.lines.first()
-    order.create_refund([{"line": product_line, "quantity": 2, "amount": Money(400, order.currency), "restock_products": restock}])
+    order.create_refund([
+        {"line": product_line, "quantity": 2, "amount": Money(400, order.currency), "restock_products": restock}])
 
     if restock:
         check_stock_counts(supplier, product, physical=10, logical=10)
@@ -469,7 +470,7 @@ def test_max_refundable_amount():
         default_price=10,
     )
     order = create_order_with_product(product, supplier, 2, 200, shop=shop)
-
+    order.cache_prices()
     assert len(order.lines.all()) == 1
 
     line = order.lines.first()
@@ -494,16 +495,49 @@ def test_refunds_for_discounted_order_lines():
     )
 
     order = create_order_with_product(product, supplier, 2, 200, shop=shop)
-    order.cache_prices()
+    discount_line = OrderLine(type=OrderLineType.DISCOUNT, quantity=1, discount_amount_value=Decimal("0.54321"))
+    order.lines.add(discount_line)
 
-    product_line = order.lines.first()
+    product_line = order.lines.filter(type=OrderLineType.PRODUCT).first()
     product_line.discount_amount = TaxfulPrice(100, order.currency)
+    product_line.save()
     taxful_price_with_discount = product_line.taxful_price
+    order.cache_prices()
+    order.save()
+
     assert product_line.base_price == TaxfulPrice(400, order.currency)
     assert taxful_price_with_discount == TaxfulPrice(300, order.currency)
 
-    order.create_refund([{"line": product_line, "quantity": 1, "amount": (taxful_price_with_discount / 2).amount}])
-    assert order.lines.refunds().first().taxful_price == (-taxful_price_with_discount / 2)
+    # try to refund only the product line - should fail since this would result in a negative total
+    with pytest.raises(RefundExceedsAmountException):
+        order.create_refund([{"line": product_line, "quantity": 2, "amount": taxful_price_with_discount.amount}])
+
+    # try to refund the product line with a negative amount
+    with pytest.raises(InvalidRefundAmountException):
+        order.create_refund([{"line": product_line, "quantity": 1, "amount": -taxful_price_with_discount.amount}])
+    # try to refund the discount line with a positive amount
+    with pytest.raises(InvalidRefundAmountException):
+        order.create_refund([{"line": discount_line, "quantity": 1, "amount": -discount_line.taxful_price.amount}])
+
+    order.create_refund([
+        {"line": discount_line, "quantity": 1, "amount": discount_line.taxful_price.amount},
+        {"line": product_line, "quantity": 2, "amount": taxful_price_with_discount.amount}
+    ])
+    assert product_line.max_refundable_amount.value == 0
+    assert discount_line.max_refundable_amount.value == 0
+    assert order.taxful_total_price.value == 0
+
+    order = create_order_with_product(product, supplier, 2, 200, shop=shop)
+    discount_line = OrderLine(type=OrderLineType.DISCOUNT, quantity=1, discount_amount_value=Decimal("0.54321"))
+    order.lines.add(discount_line)
+    product_line = order.lines.filter(type=OrderLineType.PRODUCT).first()
+    product_line.discount_amount = TaxfulPrice(100, order.currency)
+    product_line.save()
+    order.cache_prices()
+    order.save()
+
+    order.create_full_refund(restock_products=False)
+    assert order.taxful_total_price.value == 0
 
 
 @pytest.mark.django_db
@@ -558,6 +592,7 @@ def test_can_create_payment():
     assert not order.can_create_payment()
 
     order = create_order_with_product(product, supplier, 1, 200, shop=shop)
+    order.cache_prices()
     assert order.can_create_payment()
 
     # Canceled orders can't create payments
@@ -565,14 +600,17 @@ def test_can_create_payment():
     assert not order.can_create_payment()
 
     order = create_order_with_product(product, supplier, 2, 200, shop=shop)
+    order.cache_prices()
     assert order.can_create_payment()
 
     # Partially refunded orders can create payments
-    order.create_refund([{"line": order.lines.first(), "quantity": 1, "amount": Money(200, order.currency), "restock": False}])
+    order.create_refund([
+        {"line": order.lines.first(), "quantity": 1, "amount": Money(200, order.currency), "restock": False}])
     assert order.can_create_payment()
 
     # But fully refunded orders can't
-    order.create_refund([{"line": order.lines.first(), "quantity": 1, "amount": Money(200, order.currency), "restock": False}])
+    order.create_refund([
+        {"line": order.lines.first(), "quantity": 1, "amount": Money(200, order.currency), "restock": False}])
     assert not order.can_create_payment()
 
 
@@ -588,14 +626,17 @@ def test_can_create_refund():
     )
 
     order = create_order_with_product(product, supplier, 2, 200, shop=shop)
+    order.cache_prices()
     assert order.can_create_payment()
 
     # Partially refunded orders can create refunds
-    order.create_refund([{"line": order.lines.first(), "quantity": 1, "amount": Money(200, order.currency), "restock": False}])
+    order.create_refund([
+        {"line": order.lines.first(), "quantity": 1, "amount": Money(200, order.currency), "restock": False}])
     assert order.can_create_refund()
 
     # But fully refunded orders can't
-    order.create_refund([{"line": order.lines.first(), "quantity": 1, "amount": Money(200, order.currency), "restock": False}])
+    order.create_refund([
+        {"line": order.lines.first(), "quantity": 1, "amount": Money(200, order.currency), "restock": False}])
     assert not order.can_create_refund()
 
 
@@ -617,9 +658,9 @@ def test_product_summary():
 
     # Order with 2 unshipped, non-refunded items and a shipping cost
     order = create_order_with_product(product, supplier, 2, 200, shop=shop)
+    order.cache_prices()
     product_line = order.lines.first()
-    sm = get_shipping_method(name="test", price=10)
-    shipping_line  = order.lines.create(type=OrderLineType.SHIPPING, base_unit_price_value=5, quantity=1)
+    shipping_line = order.lines.create(type=OrderLineType.SHIPPING, base_unit_price_value=5, quantity=1)
 
     # Make sure no invalid entries and check product quantities
     product_summary = order.get_product_summary()

--- a/shuup_tests/functional/test_refunds.py
+++ b/shuup_tests/functional/test_refunds.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import decimal
+
+import pytest
+
+from shuup.campaigns.models.basket_conditions import \
+    BasketTotalProductAmountCondition
+from shuup.campaigns.models.basket_effects import BasketDiscountAmount
+from shuup.campaigns.models.campaigns import BasketCampaign, CatalogCampaign
+from shuup.campaigns.models.catalog_filters import CategoryFilter
+from shuup.campaigns.models.product_effects import ProductDiscountAmount
+from shuup.core.models import (
+    AnonymousContact, OrderLineType, ShippingStatus, StockBehavior
+)
+from shuup.core.order_creator import OrderCreator
+from shuup.core.pricing import get_pricing_module
+from shuup.testing.factories import (
+    create_default_tax_rule, create_product, get_default_category,
+    get_default_tax_class, get_initial_order_status, get_shop, get_tax
+)
+from shuup_tests.simple_supplier.utils import get_simple_supplier
+from shuup_tests.utils.basketish_order_source import BasketishOrderSource
+
+INITIAL_PRODUCT_QUANTITY = 10
+
+
+def check_stock_counts(supplier, product, physical, logical):
+    physical_count = supplier.get_stock_statuses([product.id])[product.id].physical_count
+    logical_count = supplier.get_stock_statuses([product.id])[product.id].logical_count
+    assert physical_count == physical
+    assert logical_count == logical
+
+
+def _get_product_data():
+    return [
+        {
+            "sku": "sku1234",
+            "default_price": decimal.Decimal("14.756"),
+            "quantity": decimal.Decimal("1")
+        },
+        {
+            "sku": "sku12345",
+            "default_price": decimal.Decimal("10"),
+            "quantity": decimal.Decimal("2")
+        },
+        {
+            "sku": "sku123456",
+            "default_price": decimal.Decimal("14.756"),
+            "quantity": decimal.Decimal("2")
+        }
+    ]
+
+
+def _get_other_line_data():
+    return [
+        {
+            "type": OrderLineType.SHIPPING,
+            "quantity": 1,
+            "text": "shipping",
+            "base_unit_price_value": decimal.Decimal("10")
+        },
+        {
+            "type": OrderLineType.PAYMENT,
+            "quantity": 1,
+            "text": "payment",
+            "base_unit_price_value": decimal.Decimal("10")
+        }
+    ]
+
+
+def _add_basket_campaign(shop):
+    campaign = BasketCampaign.objects.create(shop=shop, name="test", public_name="test", active=True)
+    BasketDiscountAmount.objects.create(discount_amount=shop.create_price("10"), campaign=campaign)
+    rule = BasketTotalProductAmountCondition.objects.create(value=1)
+    campaign.conditions.add(rule)
+    campaign.save()
+
+
+def _add_catalog_campaign(shop):
+    campaign = CatalogCampaign.objects.create(shop=shop, name="test", public_name="test", active=True)
+    category_filter = CategoryFilter.objects.create()
+    category_filter.categories.add(get_default_category())
+    category_filter.save()
+    ProductDiscountAmount.objects.create(campaign=campaign, discount_amount=5)
+
+
+def _add_taxes():
+    tax = get_tax(code=u'test_code', name=u'default', rate=0.24)
+    create_default_tax_rule(tax)
+
+
+def _get_order(prices_include_tax=False, include_basket_campaign=False, include_catalog_campaign=False):
+    shop = get_shop(prices_include_tax=prices_include_tax)
+    supplier = get_simple_supplier()
+
+    if include_basket_campaign:
+        _add_basket_campaign(shop)
+
+    if include_catalog_campaign:
+        _add_catalog_campaign(shop)
+    _add_taxes()
+
+    source = BasketishOrderSource(shop)
+    source.status = get_initial_order_status()
+    ctx = get_pricing_module().get_context_from_data(shop, AnonymousContact())
+    for product_data in _get_product_data():
+        quantity = product_data.pop("quantity")
+        product = create_product(
+            sku=product_data.pop("sku"),
+            shop=shop,
+            supplier=supplier,
+            stock_behavior=StockBehavior.STOCKED,
+            tax_class=get_default_tax_class(),
+            **product_data)
+        shop_product = product.get_shop_instance(shop)
+        shop_product.categories.add(get_default_category())
+        shop_product.save()
+        supplier.adjust_stock(product.id, INITIAL_PRODUCT_QUANTITY)
+        pi = product.get_price_info(ctx)
+        source.add_line(
+            type=OrderLineType.PRODUCT,
+            product=product,
+            supplier=supplier,
+            quantity=quantity,
+            base_unit_price=pi.base_unit_price,
+            discount_amount=pi.discount_amount
+        )
+    oc = OrderCreator()
+    order = oc.create_order(source)
+    return order
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("prices_include_tax", (True, False))
+def test_create_full_refund(prices_include_tax):
+    supplier = get_simple_supplier()
+    order = _get_order(prices_include_tax, True, True)
+    original_order_total = order.taxful_total_price
+    num_order_lines = order.lines.count()
+
+    order.create_full_refund(restock_products=True)
+
+    for line in order.lines.products():
+        check_stock_counts(supplier, line.product, INITIAL_PRODUCT_QUANTITY, INITIAL_PRODUCT_QUANTITY)
+
+    assert order.has_refunds()
+    assert not order.can_create_refund()
+    assert not order.taxful_total_price_value
+    assert not order.taxless_total_price_value
+    assert order.lines.refunds().count() == num_order_lines
+    assert order.shipping_status == ShippingStatus.FULLY_SHIPPED
+    assert order.get_total_refunded_amount() == original_order_total.amount
+    assert not order.get_total_unrefunded_amount().value
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("prices_include_tax", (True, False))
+def test_create_refund_line_by_line(prices_include_tax):
+    supplier = get_simple_supplier()
+    order = _get_order(prices_include_tax, True, True)
+
+    for line in order.lines.products():
+        check_stock_counts(supplier, line.product, INITIAL_PRODUCT_QUANTITY, INITIAL_PRODUCT_QUANTITY - line.quantity)
+
+    original_order_total = order.taxful_total_price
+    num_order_lines = order.lines.count()
+
+    # refund the discount lines first
+    for line in order.lines.discounts():
+        order.create_refund([
+            {"line": line, "quantity": line.quantity, "amount": line.taxful_price.amount}])
+
+    # refund each line 1 by 1
+    for line in order.lines.products():
+        order.create_refund([
+            {"line": line, "quantity": line.quantity, "amount": line.taxful_price.amount, "restock_products": True}])
+
+    for line in order.lines.products():
+        check_stock_counts(supplier, line.product, INITIAL_PRODUCT_QUANTITY, INITIAL_PRODUCT_QUANTITY)
+
+    assert order.has_refunds()
+    assert not order.can_create_refund()
+    assert not order.taxful_total_price_value
+    assert not order.taxless_total_price_value
+    assert order.lines.refunds().count() == num_order_lines
+    assert order.shipping_status == ShippingStatus.FULLY_SHIPPED
+    assert order.get_total_refunded_amount() == original_order_total.amount
+    assert not order.get_total_unrefunded_amount().value


### PR DESCRIPTION
* Add `StockAdjustmentType` `RESTOCK_LOGICAL` which allows restocking
unshipped products. If an order is partially shipped, restock from the
unshipped inventory first.

* Merge `OrderLineType.QUANTITY_REFUND` and `OrderLineType.AMOUNT_REFUND`
into `OrderLineType.REFUND`. Set refundable quantity and amount as default.

* Create refund order line with equal magnitude and opposite sign
when creating a full refund.

* Create tax lines with `tax_rate` instead of proportionally.

Refs SHUUP-3114, SHUUP-3036