### PR TITLE
Core: Add method for modifying display options (SHUUP-2974)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add `PriceDisplayOptions.set_option` method for modifying display options
 - Make payments for `CustomPaymentProcessor` not paid by default
 - Fix shipping status for orders with refunds
 - Fix bug in order total price rounding

--- a/shuup/core/pricing/_price_display_options.py
+++ b/shuup/core/pricing/_price_display_options.py
@@ -27,6 +27,15 @@ class PriceDisplayOptions(object):
         self.include_taxes = include_taxes
         self.show_prices = show_prices
 
+    def set_option(self, option, value, caller=None):
+        if option == "include_taxes":
+            self.include_taxes = value
+        elif option == "show_prices":
+            self.show_prices = value
+        else:
+            raise ValueError("Invalid display option")
+        return ""
+
     @property
     def hide_prices(self):
         return not self.show_prices

--- a/shuup_tests/core/test_price_display_options.py
+++ b/shuup_tests/core/test_price_display_options.py
@@ -1,3 +1,5 @@
+import pytest
+
 from shuup.core.pricing import PriceDisplayOptions
 
 
@@ -21,3 +23,15 @@ def test_price_display_options_more():
     options = PriceDisplayOptions(include_taxes=False)
     assert options.show_prices is True
     assert options.include_taxes is False
+
+def test_price_display_set_option():
+    options = PriceDisplayOptions(show_prices=False)
+    assert options.show_prices is False
+    assert options.include_taxes is None
+    options.set_option("show_prices", True)
+    assert options.show_prices is True
+    options.set_option("include_taxes", True)
+    assert options.include_taxes is True
+
+    with pytest.raises(ValueError):
+        options.set_option("not_an_option", True)


### PR DESCRIPTION
Add `PriceDisplayOptions.set_option for modifying display options.

Refs SHUUP-2974