### PR TITLE
Re-style contactgroup pricing form (SHUUP-3011)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -79,6 +79,8 @@ Campaigns
 Customer Group Pricing
 ~~~~~~~~~~~~~~~~~~~~~~
 
+- Re-style contactgroup pricing admin form
+
 Discount Pricing
 ~~~~~~~~~~~~~~~~
 

--- a/shuup/customer_group_pricing/templates/shuup/admin/customer_group_pricing/form_part.jinja
+++ b/shuup/customer_group_pricing/templates/shuup/admin/customer_group_pricing/form_part.jinja
@@ -1,24 +1,23 @@
 {% from "shuup/admin/macros/general.jinja" import content_block with context %}
 {% set sp_form = form["customer_group_pricing"] %}
 {% call content_block(_("Customer Group Pricing"), "fa-money") %}
-    <div class="table-responsive">
-        <table class="table table-bordered table-condensed table-striped">
-            <tbody>
-            <tr>
-                <th></th>
-                {% for group in sp_form.groups %}
-                    <th scope="col">{% if group %}{{ group }}{% else %}<i>{% trans %}Default price{% endtrans %}</i>{% endif %}</th>
-                {% endfor %}
-            </tr>
-            {% for shop in sp_form.shops %}
-                <tr>
-                    <th scope="row">{% if shop %}{{ shop }}{% else %}<i>{% trans %}Other shops{% endtrans %}</i>{% endif %}</th>
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h2 class="panel-title">
+                {% for shop in sp_form.shops %}
+                    {% if shop %}{{ shop }}{% else %}{% trans %}Other shops{% endtrans %}{% endif %}
+            </h2>
+        </div>
+        <div class="panel-body">
+            <div class="content">
+                <div class="form-group">
                     {% for group in sp_form.groups %}
-                        <td>{{ bs3.field(sp_form.get_shop_group_field(shop, group), set_placeholder=False, render_label=False) }}</td>
+                        <label>{{ group }}</label>
+                        {{ bs3.field(sp_form.get_shop_group_field(shop, group), set_placeholder=False, render_label=False) }}
                     {% endfor %}
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
     </div>
 {% endcall %}


### PR DESCRIPTION
Make more than 2-3 contactgroups usable at the same time by re-organising the layout.
Make it responsive.

Refs SHUUP-3011