### PR TITLE
Admin: Add duplicate contact warning to order creator (SHUUP-3110)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -38,6 +38,7 @@ Localization
 Admin
 ~~~~~
 
+- Add warning to order creator when creating duplicate contacts
 - Show discounted unit price on order confirmation page
 - Add order address validation to admin order creator
 - Fix bug when editing anonymous orders

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-28 19:11+0000\n"
+"POT-Creation-Date: 2016-07-29 01:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -114,6 +114,10 @@ msgstr ""
 
 #, python-format
 msgid "Visibility settings copied to %d product(s)"
+msgstr ""
+
+#, python-format
+msgid "%s has been deleted."
 msgstr ""
 
 msgid "Status"

--- a/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-28 22:37+0000\n"
+"POT-Creation-Date: 2016-07-29 01:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -136,6 +136,14 @@ msgid "Billing address"
 msgstr ""
 
 msgid "Shipping address"
+msgstr ""
+
+#, javascript-format
+msgid "Customer with same %s already exists."
+msgstr ""
+
+#, javascript-format
+msgid "Click to select user %s."
 msgstr ""
 
 msgid "Full Name"

--- a/shuup/admin/modules/orders/static_src/create/view/customers.js
+++ b/shuup/admin/modules/orders/static_src/create/view/customers.js
@@ -6,10 +6,39 @@
  * This source code is licensed under the AGPLv3 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import {get} from "../api";
 import {clearExistingCustomer, retrieveCustomerData, setAddressProperty,
     setAddressSavingOption, setShipToBillingAddress, setIsCompany, showCustomerModal, retrieveCustomerDetails} from "../actions";
 import {ADDRESS_FIELDS, selectBox, contentBlock, infoRow, table, modal} from "./utils";
 import BrowseAPI from "BrowseAPI";
+
+function removeWarningBlocks(parentElement){
+    var previousWarnings = parentElement.getElementsByClassName("duplicate-warning");
+
+    while(previousWarnings[0]){
+        previousWarnings[0].parentNode.removeChild(previousWarnings[0]);
+    }
+}
+
+function buildWarningBlock(store, parentElement, fieldName, customerName, customerId) {
+    var warningBlock = document.createElement("div");
+    warningBlock.className = "duplicate-warning help-block";
+
+    var warning = document.createElement("div");
+    warning.innerHTML = interpolate(gettext("Customer with same %s already exists."), [fieldName]);
+    warningBlock.appendChild(warning);
+
+    var link = document.createElement("a");
+    link.href = "#";
+    link.onclick = function() {
+        store.dispatch(retrieveCustomerData({id: customerId}));
+        removeWarningBlocks(document);
+    };
+    link.innerHTML = interpolate(gettext("Click to select user %s."), [customerName]);
+    warningBlock.appendChild(link);
+
+    parentElement.appendChild(warningBlock);
+}
 
 function renderAddress(store, shop, customer, address, addressType) {
     return _(ADDRESS_FIELDS).map((field) => {
@@ -22,6 +51,22 @@ function renderAddress(store, shop, customer, address, addressType) {
                 }, shop.countries)
             ]);
         }
+        var onchange = function () {
+            store.dispatch(setAddressProperty(addressType, field.key, this.value));
+        };
+        if (field.key === "tax_number" || field.key === "email"){
+            onchange = function() {
+                store.dispatch(setAddressProperty(addressType, field.key, this.value));
+                get("customer_exists", {
+                    "field": field.key, "value": this.value
+                }).then((data) => {
+                    removeWarningBlocks(this.parentElement);
+                    if (data.id && data.id !== customer.id) {
+                        buildWarningBlock(store, this.parentElement, field.label.toLowerCase(), data.name, data.id);
+                    }
+                });
+            };
+        }
         return m("div.form-group" + (isRequired ? " required-field" : ""), [
             m("label.control-label", field.label),
             m("input.form-control", {
@@ -29,9 +74,7 @@ function renderAddress(store, shop, customer, address, addressType) {
                 placeholder: field.label,
                 required: isRequired,
                 value: _.get(address, field.key, ""),
-                onchange: function () {
-                    store.dispatch(setAddressProperty(addressType, field.key, this.value));
-                }
+                onchange: onchange
             })
         ]);
     }).value();
@@ -120,7 +163,7 @@ export function renderCustomerDetailModal(store) {
 }
 
 export function customerSelectView(store) {
-    const {customer, customerDetails, shop} = store.getState();
+    const {customer, shop} = store.getState();
     return m("div.form-group", [
         (!customer.id ? m("p", gettext("A new customer will be created based on billing address.")) : null),
         m("br"),


### PR DESCRIPTION
Add duplicate contact warning to order creator.

Also, fix bug when populating company contact tax numbers in order
creator.

Refs SHUUP-3110