### PR TITLE
Simple CMS: Add error when setting parent to self (SHUUP-3083)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -121,6 +121,7 @@ Discount Pricing
 Simple CMS
 ~~~~~~~~~~
 
+- Show error when attempting to make a page a child of itself
 - Fix plugin links
 
 Default Tax

--- a/shuup/simple_cms/admin_module/views.py
+++ b/shuup/simple_cms/admin_module/views.py
@@ -77,6 +77,13 @@ class PageForm(MultiLanguageModelForm):
 
         return data
 
+    def clean_parent(self):
+        parent = self.cleaned_data["parent"]
+        if self.instance and parent and self.instance.id == parent.id:
+            self.add_error("parent", _("A page may not be made a child of itself."))
+        else:
+            return parent
+
     def is_url_valid(self, language_code, field_name, url):
         """
         Ensure URL given is unique.

--- a/shuup/simple_cms/locale/en/LC_MESSAGES/django.po
+++ b/shuup/simple_cms/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-25 01:12+0000\n"
+"POT-Creation-Date: 2016-07-28 23:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -42,6 +42,9 @@ msgid "%(label)s is required when any %(language)s field is filled."
 msgstr ""
 
 msgid "Please fill at least one language fully."
+msgstr ""
+
+msgid "A page may not be made a child of itself."
 msgstr ""
 
 msgid "Title"

--- a/shuup_tests/simple_cms/test_page_creation.py
+++ b/shuup_tests/simple_cms/test_page_creation.py
@@ -68,6 +68,13 @@ def test_page_form(rf):
     page = form.save()
     assert set(page.get_available_languages()) == {"fi", "en"}  # English GET
 
+    # Try to make page a child of itself
+    data.update({"parent": page.pk})
+    form = form_class(**dict(form_kwargs, data=data, instance=page))
+    form.full_clean()
+    assert form.errors
+    del data["parent"]
+
     # add dummy page with simple url, page is in english
     dummy = create_page(url="test")
 


### PR DESCRIPTION
Add a form error when setting parent page to itself rather than raising
an exception.

Refs SHUUP-3083