### PR TITLE
Fix bug with empty customer names in order list view (SHUUP-3149)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add `get_customer_name` for `Order`
 - Exclude images from product `get_public_media`
 - Add parameter to `PriceDisplayFilter` to specify tax display mode
 - Add soft deletion of categories

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -41,6 +41,7 @@ Localization
 Admin
 ~~~~~
 
+- Fix bug with empty customer names in order list view
 - Add warning when editing order with no customer contact
 - Show account manager info on order detail page
 - Remove "Purchased" checkbox from product images section

--- a/shuup/admin/modules/orders/views/list.py
+++ b/shuup/admin/modules/orders/views/list.py
@@ -25,7 +25,7 @@ class OrderListView(PicotableListView):
         Column("identifier", _(u"Order"), linked=True, filter_config=TextFilter(operator="startswith")),
         Column("order_date", _(u"Order Date"), display="format_order_date", filter_config=DateRangeFilter()),
         Column(
-            "customer", _(u"Customer"),
+            "customer_name", _(u"Customer"), display="format_customer_name",
             filter_config=MultiFieldTextFilter(filter_fields=("customer__email", "customer__name"))
         ),
         Column("status", _(u"Status"), filter_config=ChoicesFilter(choices=OrderStatus.objects.all())),
@@ -40,6 +40,9 @@ class OrderListView(PicotableListView):
 
     def get_queryset(self):
         return super(OrderListView, self).get_queryset().exclude(deleted=True)
+
+    def format_customer_name(self, instance, *args, **kwargs):
+        return instance.get_customer_name() or ""
 
     def format_order_date(self, instance, *args, **kwargs):
         return get_locally_formatted_datetime(instance.order_date)

--- a/shuup/core/models/_orders.py
+++ b/shuup/core/models/_orders.py
@@ -833,6 +833,12 @@ class Order(MoneyPropped, models.Model):
             self.payment_status == PaymentStatus.NOT_PAID
         )
 
+    def get_customer_name(self):
+        name_attrs = ["customer", "billing_address", "orderer", "shipping_address"]
+        for attr in name_attrs:
+            if getattr(self, "%s_id" % attr):
+                return getattr(self, attr).name
+
 
 OrderLogEntry = define_log_model(Order)
 

--- a/shuup_tests/core/test_order_customer_name.py
+++ b/shuup_tests/core/test_order_customer_name.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from shuup.testing.factories import (
+    create_empty_order, create_random_company, create_random_person
+)
+
+
+@pytest.mark.django_db
+def test_order_customer_name_from_billing_address():
+    person = create_random_person()
+    order = create_empty_order()
+    order.orderer = person
+    order.save()
+    order.refresh_from_db()
+    assert order.customer_id is None
+    assert order.orderer_id is not None
+    assert order.get_customer_name() == order.billing_address.name
+    assert order.shipping_address_id is not None
+
+@pytest.mark.django_db
+def test_order_customer_name_from_shipping_address():
+    order = create_empty_order()
+    assert order.customer_id is None
+    assert order.orderer_id is None
+    order.billing_address = None
+    order.save()
+    order.refresh_from_db()
+    assert order.get_customer_name() == order.shipping_address.name
+
+
+@pytest.mark.django_db
+def test_order_customer_name_from_orderer():
+    person = create_random_person()
+    order = create_empty_order()
+    order.orderer = person
+    order.billing_address = None
+    order.save()
+    order.refresh_from_db()
+
+    assert order.customer_id is None
+    assert order.billing_address_id is None
+    assert order.get_customer_name() == order.orderer.name
+    assert order.shipping_address_id is not None
+
+
+@pytest.mark.django_db
+def test_order_customer_name_from_customer():
+    company = create_random_company()
+    person = create_random_person()
+    order = create_empty_order()
+    order.customer = company
+    order.orderer = person
+    order.save()
+    order.refresh_from_db()
+    assert order.shipping_address_id is not None
+    assert order.billing_address_id is not None
+    assert order.orderer_id is not None
+    assert order.get_customer_name() == order.customer.name


### PR DESCRIPTION
* Core: Add `get_customer_name` for `Order`
* Admin: Fix bug with empty customer names in order list view