### PR TITLE
Front: Check for blank email on password reset

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -87,6 +87,7 @@ Addons
 Front
 ~~~~~
 
+- Ensure email is not blank prior to sending password recovery email
 - Send notify event from company created
 - Send notify event from user registration
 - Fix bug in cart list view with empty taxful total price

--- a/shuup/front/apps/auth/forms.py
+++ b/shuup/front/apps/auth/forms.py
@@ -103,7 +103,9 @@ class RecoverPasswordForm(forms.Form):
             self.process_user(user)
 
     def process_user(self, user_to_recover):
-        if not user_to_recover.has_usable_password() or not hasattr(user_to_recover, 'email'):
+        if (not user_to_recover.has_usable_password() or
+           not hasattr(user_to_recover, 'email') or
+           not user_to_recover.email):
             return False
 
         context = {

--- a/shuup_tests/front/test_registration.py
+++ b/shuup_tests/front/test_registration.py
@@ -141,6 +141,23 @@ def test_password_recovery_user_receives_email_3(client):
 
 
 @pytest.mark.django_db
+def test_password_recovery_user_with_no_email(client):
+    get_default_shop()
+    user = get_user_model().objects.create_user(
+        username="random_person",
+        password="asdfg"
+    )
+    n_outbox_pre = len(mail.outbox)
+    client.post(
+        reverse("shuup:recover_password"),
+        data={
+            "username": user.username
+        }
+    )
+    assert (len(mail.outbox) == n_outbox_pre), "No recovery emails sent"
+
+
+@pytest.mark.django_db
 def test_user_will_be_redirected_to_user_account_page_after_activation(client):
     """
     1. Register user


### PR DESCRIPTION
Ensure the users email is not blank prior to sending the password reset email.

Refs SHUUP-3125