### PR TITLE
Product media fixes (SHUUP-2993)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -90,6 +90,7 @@ Addons
 Front
 ~~~~~
 
+- Show public images only on the product detail page
 - Add ability for customers to save their cart
 - Ensure email is not blank prior to sending password recovery email
 - Send notify event from company created

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Exclude images from product `get_public_media`
 - Add parameter to `PriceDisplayFilter` to specify tax display mode
 - Add soft deletion of categories
 - Add support to sell products after stock is zero

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -40,6 +40,7 @@ Localization
 Admin
 ~~~~~
 
+- Remove "Purchased" checkbox from product images section
 - Trim search criteria when using select2 inputs
 - Fix bug in permission change form error message
 - Limit change permissions only for superusers

--- a/shuup/admin/templates/shuup/admin/products/_edit_media_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_media_form.jinja
@@ -65,7 +65,9 @@
                 <div id="collapse-{{ id }}" class="advanced-container collapse" role="tabpanel" aria-labelledby="media-{{ id }}">
                     <div class="advanced-body">
                         {{ bs3.field(f.public) }}
-                        {{ bs3.field(f.purchased) }}
+                        {% if not is_image_form %}
+                            {{ bs3.field(f.purchased) }}
+                        {% endif %}
                         {{ bs3.field(f.shops) }}
                         {{ bs3.field(f.kind) }}
                         {% set tab_id = id + "-additional-language" %}

--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -104,6 +104,11 @@ class ShopProduct(MoneyPropped, models.Model):
         else:
             return self.product.primary_image
 
+    @property
+    def public_primary_image(self):
+        primary_image = self.primary_image
+        return primary_image if primary_image and primary_image.public else None
+
     def get_visibility_errors(self, customer):
         if self.product.deleted:
             yield ValidationError(_('This product has been deleted.'), code="product_deleted")
@@ -275,3 +280,7 @@ class ShopProduct(MoneyPropped, models.Model):
     @property
     def images(self):
         return self.product.media.filter(shops=self.shop, kind=ProductMediaKind.IMAGE).order_by("ordering")
+
+    @property
+    def public_images(self):
+        return self.images.filter(public=True)

--- a/shuup/core/models/_products.py
+++ b/shuup/core/models/_products.py
@@ -24,6 +24,7 @@ from shuup.core.utils.slugs import generate_multilanguage_slugs
 from shuup.utils.analog import define_log_model, LogEntryKind
 
 from ._attributes import AppliedAttribute, AttributableMixin, Attribute
+from ._product_media import ProductMediaKind
 from ._product_packages import ProductPackageLink
 from ._product_variation import (
     get_all_available_combinations, get_combination_hash_from_variable_mapping,
@@ -604,7 +605,7 @@ class Product(TaxableItem, AttributableMixin, TranslatableModel):
         ))
 
     def get_public_media(self):
-        return self.media.filter(enabled=True, public=True)
+        return self.media.filter(enabled=True, public=True).exclude(kind=ProductMediaKind.IMAGE)
 
     def is_stocked(self):
         return (self.stock_behavior == StockBehavior.STOCKED)

--- a/shuup/front/views/product.py
+++ b/shuup/front/views/product.py
@@ -64,14 +64,8 @@ class ProductDetailView(DetailView):
 
         context["shop_product"] = self.shop_product
 
-        primary_image = None
-        if self.shop_product.shop_primary_image_id:
-            primary_image = self.shop_product.shop_primary_image
-        elif product.primary_image_id:
-            primary_image = self.shop_product.primary_image
-
-        context["primary_image"] = primary_image
-        context["images"] = self.shop_product.images.all()
+        context["primary_image"] = self.shop_product.public_primary_image
+        context["images"] = self.shop_product.public_images
 
         # TODO: Maybe add hook for ProductDetailView get_context_data?
         # dispatch_hook("get_context_data", view=self, context=context)


### PR DESCRIPTION
* Exclude images from `get_product_media` to coincide with admin
product media/images representation. Also add properties
to shop product to get public images.

* Hide the "Purchased" checkbox since it is applicable only for product media. Note: I left the description field since lightbox uses it.

* Only show public images on product detail page