### PR TITLE
Admin: Add past orders section for product page (SHUUP-3105)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -41,6 +41,7 @@ Localization
 Admin
 ~~~~~
 
+- Add Orders section to product detail page
 - Add `admin_product_section` provide to make product detail extendable
 - Fix bug with empty customer names in order list view
 - Add warning when editing order with no customer contact

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -41,6 +41,7 @@ Localization
 Admin
 ~~~~~
 
+- Add `admin_product_section` provide to make product detail extendable
 - Fix bug with empty customer names in order list view
 - Add warning when editing order with no customer contact
 - Show account manager info on order detail page

--- a/doc/provides.rst
+++ b/doc/provides.rst
@@ -85,6 +85,9 @@ Core
     Additional ``FormPart`` classes for Product editing.
     (This is used by pricing modules, for instance.)
 
+``admin_product_section``
+    Additional ``Section`` subclasses for Product edit sections.
+
 ``admin_shop_form_part``
     Additional ``FormPart`` classes for Shop editing.
 

--- a/shuup/admin/__init__.py
+++ b/shuup/admin/__init__.py
@@ -64,6 +64,9 @@ class ShuupAdminAppConfig(AppConfig):
             "shuup.admin.modules.contacts.sections:AddressesContactSection",
             "shuup.admin.modules.contacts.sections:OrdersContactSection",
             "shuup.admin.modules.contacts.sections:MembersContactSection",
+        ],
+        "admin_product_section": [
+            "shuup.admin.modules.products.sections:ProductOrdersSection"
         ]
     }
 

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-29 01:21+0000\n"
+"POT-Creation-Date: 2016-08-01 06:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -1366,6 +1366,9 @@ msgid "Purchasing"
 msgstr ""
 
 msgid "Shipping & Payment"
+msgstr ""
+
+msgid "No orders found"
 msgstr ""
 
 msgid "This product is currently not orderable."

--- a/shuup/admin/modules/products/sections.py
+++ b/shuup/admin/modules/products/sections.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext as _
+
+from shuup.admin.base import Section
+from shuup.core.models import Order
+
+
+class ProductOrdersSection(Section):
+    identifier = "product_orders"
+    name = _("Orders")
+    icon = "fa-inbox"
+    template = "shuup/admin/products/_product_orders.jinja"
+    order = 1
+
+    @staticmethod
+    def visible_for_object(product):
+        return bool(product.pk)
+
+    @staticmethod
+    def get_context_data(product):
+        # TODO: restrict to first 100 orders - do pagination later
+        return Order.objects.filter(lines__product_id=product.id).distinct()[:100]

--- a/shuup/admin/modules/products/views/edit.py
+++ b/shuup/admin/modules/products/views/edit.py
@@ -22,6 +22,7 @@ from shuup.admin.modules.products.forms import (
     ProductMediaFormSet, ShopProductForm
 )
 from shuup.admin.utils.views import CreateOrUpdateView
+from shuup.apps.provides import get_provide_objects
 from shuup.core.models import (
     Product, ProductType, Shop, ShopProduct, ShopStatus, TaxClass
 )
@@ -190,4 +191,11 @@ class ProductEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView
                 except ObjectDoesNotExist:
                     orderability_errors.extend(["%s: %s" % (shop.name, _("Product is not available."))])
         context["orderability_errors"] = orderability_errors
+        context["product_sections"] = []
+        product_sections_provides = sorted(get_provide_objects("admin_product_section"), key=lambda x: x.order)
+        for admin_product_section in product_sections_provides:
+            if admin_product_section.visible_for_object(self.object):
+                context["product_sections"].append(admin_product_section)
+                context[admin_product_section.identifier] = admin_product_section.get_context_data(self.object)
+
         return context

--- a/shuup/admin/templates/shuup/admin/products/_product_orders.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_product_orders.jinja
@@ -1,0 +1,37 @@
+<div class="table-responsive">
+    <table class="table table-striped table-bordered">
+        <thead>
+            <tr>
+                <th>{% trans %}Order{% endtrans %}</th>
+                <th>{% trans %}Order Date{% endtrans %}</th>
+                <th>{% trans %}Customer{% endtrans %}</th>
+                <th>{% trans %}Status{% endtrans %}</th>
+                <th>{% trans %}Payment Status{% endtrans %}</th>
+                <th>{% trans %}Shipping Status{% endtrans %}</th>
+                <th class="text-right">{% trans %}Total{% endtrans %}</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for order in product_orders %}
+            {% set order_url = shuup_admin.model_url(order, "detail") %}
+            <tr>
+                <td>
+                {% if order_url %}
+                <a href="{{ order_url }}">{{ order.identifier }}</a>
+                {% else %}
+                {{ order.identifier }}
+                {% endif %}
+                </td>
+                <td>{{ order.order_date|datetime }}</td>
+                <td>{{ order.customer }}</td>
+                <td>{{ order.get_status_display() }}</td>
+                <td>{{ order.get_payment_status_display() }}</td>
+                <td>{{ order.get_shipping_status_display() }}</td>
+                <td class="text-right">{{ order.taxful_total_price|money }}</td>
+            </tr>
+        {% else %}
+            <tr><td class="text-center" colspan="7"><em>{% trans %}No orders found{% endtrans %}</em></td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/shuup/admin/templates/shuup/admin/products/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/products/edit.jinja
@@ -1,5 +1,5 @@
 {% extends "shuup/admin/base.jinja" %}
-{% from "shuup/admin/macros/general.jinja" import content_with_sidebar %}
+{% from "shuup/admin/macros/general.jinja" import content_with_sidebar, content_block %}
 
 {% block content %}
     {% if orderability_errors %}
@@ -10,13 +10,20 @@
             </p>
         </div>
     {% endif %}
-    {% call content_with_sidebar(content_id="product_form") %}
-        <form method="post" id="product_form">
-            {% csrf_token %}
-            {% for form_def in form.form_defs.values() %}
-                {% include form_def.template_name with context %}
+    {% call content_with_sidebar(content_id="product_details") %}
+        <div id="product_details">
+            <form method="post" id="product_form">
+                {% csrf_token %}
+                {% for form_def in form.form_defs.values() %}
+                    {% include form_def.template_name with context %}
+                {% endfor %}
+            </form>
+            {% for product_section in product_sections %}
+                {% call content_block(product_section.name, product_section.icon) %}
+                    {% include product_section.template with context %}
+                {% endcall %}
             {% endfor %}
-        </form>
+        </div>
     {% endcall %}
 {% endblock %}
 
@@ -28,4 +35,9 @@
             $("#product_form").attr("action", "{{ url('shuup_admin:product.new') }}").submit();
         }
     </script>
+    {% for product_section in product_sections %}
+        {% if product_section.extra_js %}
+            {% include product_section.extra_js with context %}
+        {% endif %}
+    {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Note - I added a new provides key - `admin_product_section`. Using the pre-existing `form_part` provide seemed wrong since we're dealing with read-only tabular data.

Refs SHUUP-3105