### PR TITLE
Front checkout: show company form validation errors for fields (SHUUP-3132)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -94,6 +94,7 @@ Addons
 Front
 ~~~~~
 
+- Checkout show company form validation errors for fields
 - Do not show messages in registration if activation is not required
 - Show public images only on the product detail page
 - Add ability for customers to save their cart

--- a/shuup/front/checkout/_mixins.py
+++ b/shuup/front/checkout/_mixins.py
@@ -6,7 +6,6 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 
-from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 
 from shuup.core.utils import tax_numbers
@@ -28,8 +27,8 @@ class TaxNumberCleanMixin(object):
         if (not company_name) and (not tax_number):
             return self.cleaned_data
         elif company_name and not tax_number:
-            raise ValidationError(_("Tax number required for companies"))
+            self.add_error("tax_number", _("Tax number required for companies"))
         elif tax_number and not company_name:
-            raise ValidationError(_("Cannot use tax number without company name"))
+            self.add_error("company_name", _("Cannot use tax number without company name"))
 
         return self.cleaned_data


### PR DESCRIPTION
At checkout addresses company form. Add tax number and company_name
validation errors for fields instead of just raising validation error.