### PR TITLE
Front registration: Skip message if activation email is not send (SHUUP-3172)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -94,6 +94,7 @@ Addons
 Front
 ~~~~~
 
+- Do not show messages in registration if activation is not required
 - Show public images only on the product detail page
 - Add ability for customers to save their cart
 - Ensure email is not blank prior to sending password recovery email

--- a/shuup/front/apps/registration/views.py
+++ b/shuup/front/apps/registration/views.py
@@ -27,7 +27,9 @@ def activation_complete(request):
 
 
 def registration_complete(request):
-    messages.success(request, _("Registration complete. Please follow the instructions sent to your email address."))
+    if settings.SHUUP_REGISTRATION_REQUIRES_ACTIVATION:
+        messages.success(
+            request, _("Registration complete. Please follow the instructions sent to your email address."))
     return redirect(settings.LOGIN_REDIRECT_URL)
 
 


### PR DESCRIPTION
No need for extra messages in registration if activation is not required.
The customer is logged in so it should be obvious that registration was
successful.