### PR TITLE
Campaign inheritance (SHUUP-3141)

### DIFF
--- a/shuup/campaigns/models/basket_line_effects.py
+++ b/shuup/campaigns/models/basket_line_effects.py
@@ -107,7 +107,9 @@ class DiscountFromProduct(BasketLineEffect):
             if line.product.pk not in product_ids:
                 continue
             amnt = (self.discount_amount * line.quantity) if not self.per_line_discount else self.discount_amount
-            line.discount_amount = order_source.create_price(amnt)
+            discount_price = order_source.create_price(amnt)
+            if not line.discount_amount or line.discount_amount < discount_price:
+                line.discount_amount = discount_price
         return []
 
 
@@ -145,8 +147,12 @@ class DiscountFromCategoryProducts(BasketLineEffect):
 
             if self.discount_amount:
                 amount = self.discount_amount * line.quantity
-                line.discount_amount = order_source.create_price(amount)
+                discount_price = order_source.create_price(amount)
             elif self.discount_percentage:
                 amount = line.taxless_price * self.discount_percentage
-                line.discount_amount = order_source.create_price(amount)
+                discount_price = order_source.create_price(amount)
+
+            if not line.discount_amount or line.discount_amount < discount_price:
+                line.discount_amount = discount_price
+
         return []

--- a/shuup/campaigns/models/catalog_filters.py
+++ b/shuup/campaigns/models/catalog_filters.py
@@ -57,7 +57,7 @@ class ProductFilter(CatalogFilter):
     products = models.ManyToManyField(Product, verbose_name=_("product"))
 
     def matches(self, shop_product):
-        return (shop_product.pk in self.values.values_list("pk", flat=True))
+        return (shop_product.product.pk in self.values.values_list("pk", flat=True))
 
     def filter_queryset(self, queryset):
         return queryset.filter(product_id__in=self.products.values_list("id", flat=True))

--- a/shuup_tests/campaigns/test_filters.py
+++ b/shuup_tests/campaigns/test_filters.py
@@ -5,14 +5,19 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+from decimal import Decimal
 from django.utils.encoding import force_text
 
+from shuup.campaigns.models import CatalogCampaign
 from shuup.campaigns.models.catalog_filters import (
     CatalogFilter, CategoryFilter, ProductFilter, ProductTypeFilter
 )
+from shuup.campaigns.models.product_effects import ProductDiscountPercentage
 from shuup.core.models import Category, ShopProduct
-from shuup.testing.factories import create_product, get_default_category
+from shuup.front.basket import get_basket
+from shuup.testing.factories import create_product, get_default_category, get_default_supplier
 from shuup_tests.campaigns import initialize_test
+from shuup_tests.utils import printable_gibberish
 
 
 @pytest.mark.django_db
@@ -85,3 +90,33 @@ def test_product_type_filter(rf):
     assert product_type_filter.filter_queryset(ShopProduct.objects.all()).exists()  # filter matches
 
     assert product_type_filter.name.lower() in force_text(product_type_filter.description)
+
+
+@pytest.mark.django_db
+def test_productfilter_works(rf):
+    request, shop, group = initialize_test(rf, False)
+    price = shop.create_price
+    product_price = "100"
+    discount_percentage = "0.30"
+
+    supplier = get_default_supplier()
+    product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=product_price)
+    shop_product = product.get_shop_instance(shop)
+
+    # create catalog campaign
+    catalog_filter = ProductFilter.objects.create()
+    catalog_filter.products.add(product)
+
+    assert catalog_filter.matches(shop_product)
+
+    catalog_campaign = CatalogCampaign.objects.create(shop=shop, active=True, name="test")
+    catalog_campaign.filters.add(catalog_filter)
+    cdp = ProductDiscountPercentage.objects.create(campaign=catalog_campaign, discount_percentage=discount_percentage)
+
+    # add product to basket
+    basket = get_basket(request)
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+    basket.save()
+
+    expected_total = price(product_price) - (Decimal(discount_percentage) * price(product_price))
+    assert basket.total_price == expected_total

--- a/shuup_tests/campaigns/test_multiple_campaigns.py
+++ b/shuup_tests/campaigns/test_multiple_campaigns.py
@@ -1,0 +1,97 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from decimal import Decimal
+
+import pytest
+from shuup.campaigns.models import (
+    BasketCampaign, BasketLineEffect, CatalogCampaign
+)
+from shuup.campaigns.models.basket_conditions import (
+    CategoryProductsBasketCondition, ComparisonOperator
+)
+from shuup.campaigns.models.basket_line_effects import (
+    DiscountFromCategoryProducts, DiscountFromProduct
+)
+from shuup.campaigns.models.catalog_filters import ProductFilter
+from shuup.campaigns.models.product_effects import ProductDiscountPercentage
+from shuup.front.basket import get_basket
+from shuup.testing.factories import (
+    create_product, get_default_category, get_default_supplier
+)
+from shuup_tests.campaigns import initialize_test
+from shuup_tests.utils import printable_gibberish
+
+
+@pytest.mark.django_db
+def test_multiple_campaigns_cheapest_price(rf):
+    request, shop, group = initialize_test(rf, False)
+    price = shop.create_price
+    product_price = "100"
+    discount_percentage = "0.30"
+    discount_amount_value = "10"
+    total_discount_amount = "50"
+
+    expected_total = price(product_price) - (Decimal(discount_percentage) * price(product_price))
+    matching_expected_total = price(product_price) - price(total_discount_amount)
+
+    category = get_default_category()
+    supplier = get_default_supplier()
+    product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=product_price, category=category)
+    shop_product = product.get_shop_instance(shop)
+    shop_product.categories.add(category)
+
+    # create catalog campaign
+    catalog_filter = ProductFilter.objects.create()
+    catalog_filter.products.add(product)
+    catalog_campaign = CatalogCampaign.objects.create(shop=shop, active=True, name="test")
+    catalog_campaign.filters.add(catalog_filter)
+
+    cdp = ProductDiscountPercentage.objects.create(campaign=catalog_campaign, discount_percentage=discount_percentage)
+
+    # create basket campaign
+    condition = CategoryProductsBasketCondition.objects.create(category=category, operator=ComparisonOperator.EQUALS, quantity=1)
+    basket_campaign = BasketCampaign.objects.create(shop=shop, public_name="test", name="test", active=True)
+    basket_campaign.conditions.add(condition)
+
+    effect = DiscountFromProduct.objects.create(campaign=basket_campaign, discount_amount=discount_amount_value)
+    effect.products.add(product)
+
+    # add product to basket
+    basket = get_basket(request)
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+
+    final_lines = basket.get_final_lines()
+    assert len(final_lines) == 1
+    assert basket.total_price == expected_total
+
+    effect.discount_amount = total_discount_amount
+    effect.save()
+    basket.uncache()
+    catalog_campaign.save()  # save to bump caches
+    basket_campaign.save()  # save to bump caches
+
+    assert basket.total_price == matching_expected_total  # discount is now bigger than the original
+
+    effect.delete()  # remove effect
+    basket.uncache()
+    catalog_campaign.save()  # save to bump caches
+    basket_campaign.save()  # save to bump caches
+
+    assert BasketLineEffect.objects.count() == 0
+
+    assert basket.total_price == expected_total
+    # add new effect
+    effect = DiscountFromCategoryProducts.objects.create(category=category, campaign=basket_campaign, discount_amount=discount_amount_value)
+    assert basket.total_price == expected_total
+
+    effect.discount_amount = total_discount_amount
+    effect.save()
+    basket.uncache()
+    catalog_campaign.save()  # save to bump caches
+    basket_campaign.save()  # save to bump caches
+    assert basket.total_price == matching_expected_total  # discount is now bigger than the original


### PR DESCRIPTION
First batch of fixes for campaigns. Campaigns should be worked even more to give more control to merchant to decide when campaigns are actually matched.

Fix a bug with `ProductFilter` where the `shop_product.pk` was compared to `product.pk`.
Fix an issue with basket line effects not honoring the previously given discounts

Refs SHUUP-3141