### PR TITLE
Admin: Fix bug in sort and add new fields to customer name filter (SHUUP-3149 / SHUUP-3176)

### DIFF
--- a/shuup/admin/modules/orders/views/list.py
+++ b/shuup/admin/modules/orders/views/list.py
@@ -25,8 +25,13 @@ class OrderListView(PicotableListView):
         Column("identifier", _(u"Order"), linked=True, filter_config=TextFilter(operator="startswith")),
         Column("order_date", _(u"Order Date"), display="format_order_date", filter_config=DateRangeFilter()),
         Column(
-            "customer_name", _(u"Customer"), display="format_customer_name",
-            filter_config=MultiFieldTextFilter(filter_fields=("customer__email", "customer__name"))
+            "customer", _(u"Customer"), display="format_customer_name",
+            filter_config=MultiFieldTextFilter(
+                filter_fields=(
+                    "customer__email", "customer__name", "billing_address__name",
+                    "shipping_address__name", "orderer__name"
+                )
+            )
         ),
         Column("status", _(u"Status"), filter_config=ChoicesFilter(choices=OrderStatus.objects.all())),
         Column("payment_status", _(u"Payment Status"), filter_config=ChoicesFilter(choices=PaymentStatus.choices)),


### PR DESCRIPTION
* Fix problem with sorting with customer_name
* Add billing address, shipping address and orderer names to
customer name filters. Since the customer name is shown based
on these fields then the filter should work with those.

Refs SHUUP-3149 / SHUUP-3176