### PR TITLE
Admin: Improve category list filtering (SHUUP-2983)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Combine `TreeManager` and `TranslatableManager` querysets for categories
 - Exclude deleted orders from valid queryset
 - Enable soft delete for shipments
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -22,6 +22,7 @@ Localization
 Admin
 ~~~~~
 
+- Add picotable select2 and MPTT filters
 - Hide cancelled orders by default from orders lists
 - Add option to delete shipments
 - Apply picotable text filters on change rather than on enter/on focus out

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -22,6 +22,7 @@ Localization
 Admin
 ~~~~~
 
+- Improve category list view parent/child representation and filtering
 - Add picotable select2 and MPTT filters
 - Hide cancelled orders by default from orders lists
 - Add option to delete shipments

--- a/shuup/admin/static_src/base/less/shuup/picotable.less
+++ b/shuup/admin/static_src/base/less/shuup/picotable.less
@@ -73,6 +73,31 @@
                 }
             }
         }
+
+        .select2 {
+            width: 100% !important;
+            outline: none;
+
+            .select2-selection {
+                border: 0;
+                background-color: #fff;
+                min-height: 32px;
+                padding: 0;
+                outline: none;
+
+                .select2-selection__rendered {
+                    line-height: 32px;
+                }
+
+                .select2-selection__arrow {
+                    height: 32px;
+                }
+            }
+        }
+
+        .select2-dropdown {
+            z-index: 2000 !important;
+        }
     }
 
     tbody {

--- a/shuup/admin/static_src/base/less/shuup/select.less
+++ b/shuup/admin/static_src/base/less/shuup/select.less
@@ -35,6 +35,10 @@ span.select2.select2-container {
     }
 }
 
+span.select2-dropdown {
+    z-index: 2000;
+}
+
 @media (min-width: 768px) and (max-width: 1200px) {
     span.select2.select2-container {
       width: 66.66666667% !important;

--- a/shuup/admin/static_src/picotable/picotable.js
+++ b/shuup/admin/static_src/picotable/picotable.js
@@ -225,14 +225,22 @@ const Picotable = (function(m, storage) {
             var valueJS = JSON.parse(this.value);
             ctrl.setFilterValue(col.id, valueJS);
         };
+        var select2Config = function() {
+            return function(el, isInit) {
+                if(!isInit) {
+                    $(el).select2();
+                }
+            };
+        };
+
         var select = m("select.form-control", {
+            config: col.filter.select2? select2Config(): null,
             value: JSON.stringify(value),
             onchange: setFilterValueFromSelect
         }, Util.map(col.filter.choices, function(choice) {
             return m("option", {value: JSON.stringify(choice[0]), key: choice[0]}, choice[1]);
         }));
         return m("div.choice-filter", select);
-
     }
 
     function getDefaultValues(ctrl) {

--- a/shuup/admin/utils/picotable.py
+++ b/shuup/admin/utils/picotable.py
@@ -76,7 +76,7 @@ class ChoicesFilter(Filter):
         choices = maybe_call(self.choices, context=context)
         if isinstance(choices, QuerySet):
             choices = [(c.pk, c) for c in choices]
-        return [("_all", "")] + [
+        return [("_all", "---------")] + [
             (force_text(value, strings_only=True), force_text(display))
             for (value, display)
             in choices
@@ -92,6 +92,23 @@ class ChoicesFilter(Filter):
         if value == "_all":
             return queryset
         return queryset.filter(**{(self.filter_field or column.id): value})
+
+
+class Select2Filter(ChoicesFilter):
+    type = "select2"
+
+    def to_json(self, context):
+        json_dict = super(Select2Filter, self).to_json(context)
+        json_dict["select2"] = True
+        return json_dict
+
+
+class MPTTFilter(Select2Filter):
+    type = "mptt"
+
+    def filter_queryset(self, queryset, column, value):
+        qs = super(MPTTFilter, self).filter_queryset(queryset, column, value)
+        return qs.get_descendants(include_self=True)
 
 
 class RangeFilter(Filter):

--- a/shuup/core/models/_categories.py
+++ b/shuup/core/models/_categories.py
@@ -16,6 +16,8 @@ from enumfields import Enum, EnumIntegerField
 from filer.fields.image import FilerImageField
 from mptt.managers import TreeManager
 from mptt.models import MPTTModel, TreeForeignKey
+from mptt.querysets import TreeQuerySet
+from parler.managers import TranslatableQuerySet
 from parler.models import (
     TranslatableManager, TranslatableModel, TranslatedFields
 )
@@ -48,7 +50,16 @@ class CategoryVisibility(Enum):
         VISIBLE_TO_GROUPS = _('visible to certain customer groups')
 
 
-class CategoryManager(TranslatableManager, TreeManager):
+class CategoryQuerySet(TranslatableQuerySet, TreeQuerySet):
+    pass
+
+
+class CategoryManager(TreeManager, TranslatableManager):
+    queryset_class = CategoryQuerySet
+
+    def get_queryset(self):
+        return self.queryset_class(self.model, using=self._db).order_by(self.tree_id_attr, self.left_attr)
+
     def all_visible(self, customer, shop=None, language=None):
         root = (self.language(language) if language else self).all()
 


### PR DESCRIPTION
Improve the usability of the admin category list view
    * Remove the parent column and instead indent the name column to represent
      parent/child relationships
    * Add a picotable select2 filter
    * Add an MPTT filter which allows filtering by parent and all descendants
    * Combine both `TranslatableManager` and `TreeManager` `get_queryset` calls

Refs SHUUP-2983