### PR TITLE
Admin: Use last product id + 1 as a default SKU

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -22,6 +22,7 @@ Localization
 Admin
 ~~~~~
 
+- Use last product id + 1 as default SKU when creating new products
 - Add deprecation warning for ``admin_order_toolbar_button`` usages
 - Add ``admin_order_toolbar_action_item`` provider for order toolbar
 - Improve category list view parent/child representation and filtering

--- a/shuup/admin/modules/products/views/edit.py
+++ b/shuup/admin/modules/products/views/edit.py
@@ -50,13 +50,20 @@ class ProductBaseFormPart(FormPart):
         self.object = form["base"].save()
         return self.object
 
+    def get_sku(self):
+        sku = self.request.GET.get("sku", "")
+        if not sku:
+            last_id = Product.objects.values_list('id', flat=True).first()
+            sku = last_id + 1 if last_id else 1
+        return sku
+
     def get_initial(self):
         if not self.object.pk:
             # Sane defaults...
             name_field = "name__%s" % get_language()
             return {
                 name_field: self.request.GET.get("name", ""),
-                "sku": self.request.GET.get("sku", ""),
+                "sku": self.get_sku(),
                 "type": ProductType.objects.first(),
                 "tax_class": TaxClass.objects.first()
             }


### PR DESCRIPTION
Set default SKU to product id + 1. Note this can result in a duplicate SKU error if the user has multiple "create product" tabs open or if multiple users are creating products simultaneously. Users are, however, provided proper errors in the event of a dup.

Refs SHUUP-2964