### PR TITLE
Fetch user IP using django ipware

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ REQUIRES = [
     'pytz>=2015.4',
     'requests>=2.7,<3',
     'six>=1.9,<2',
+    'django-ipware>=1.1.5,<2'
 ]
 
 REQUIRES_FOR_PYTHON2_ONLY = [

--- a/shuup/addons/admin_module/views/list.py
+++ b/shuup/addons/admin_module/views/list.py
@@ -22,6 +22,7 @@ from shuup.addons.manager import (
 from shuup.admin.toolbar import (
     NewActionButton, PostActionButton, Toolbar, URLActionButton
 )
+from shuup.utils.http import get_request_ip
 
 
 class AddonEnableDisableForm(forms.Form):
@@ -68,7 +69,7 @@ class AddonListView(FormView):
                 new_enabled_addons,
                 comment="Written via Shuup admin (user %s; IP %s; time %s)" % (
                     self.request.user.pk,
-                    self.request.META.get("REMOTE_ADDR"),
+                    get_request_ip(self.request),
                     now().isoformat()
                 )
             )

--- a/shuup/admin/modules/demo/__init__.py
+++ b/shuup/admin/modules/demo/__init__.py
@@ -22,6 +22,7 @@ from shuup.admin.dashboard import (
     DashboardMoneyBlock, DashboardNumberBlock, DashboardValueBlock
 )
 from shuup.testing.text_data import random_title
+from shuup.utils.http import get_request_ip
 from shuup.utils.i18n import get_current_babel_locale
 
 
@@ -73,7 +74,7 @@ class DemoModule(AdminModule):
     def get_notifications(self, request):
         if not self.check_demo_optin(request):
             return
-        yield Notification(text="Your IP is %s" % request.META.get("REMOTE_ADDR"))
+        yield Notification(text="Your IP is %s" % get_request_ip(request))
         yield Notification(title="Dice", text="Your lucky number is %d" % random.randint(1, 43), kind="success")
         yield Notification(title="Stock Alert", text="Items X, Y, Z are running low", kind="warning")
         yield Notification(title="Outstanding Orders", text="10 orders have not been touched in 7 days", kind="danger")

--- a/shuup/admin/modules/orders/views/edit.py
+++ b/shuup/admin/modules/orders/views/edit.py
@@ -32,6 +32,7 @@ from shuup.core.models import (
     PaymentMethod, PersonContact, Product, ShippingMethod, Shop, ShopStatus
 )
 from shuup.core.pricing import get_pricing_module
+from shuup.utils.http import get_request_ip
 from shuup.utils.i18n import (
     format_money, format_percent, get_current_babel_locale,
     get_locally_formatted_datetime
@@ -363,7 +364,7 @@ class OrderEditView(CreateOrUpdateView):
         source = create_source_from_state(
             state,
             creator=request.user,
-            ip_address=request.META.get("REMOTE_ADDR"),
+            ip_address=get_request_ip(request),
             order_to_update=self.object if self.object.pk else None
         )
         # Calculate final lines for confirmation
@@ -393,7 +394,7 @@ class OrderEditView(CreateOrUpdateView):
             order = create_order_from_state(
                 state,
                 creator=request.user,
-                ip_address=request.META.get("REMOTE_ADDR"),
+                ip_address=get_request_ip(request),
             )
             messages.success(request, _("Order %(identifier)s created.") % vars(order))
         return JsonResponse({

--- a/shuup/front/basket/objects.py
+++ b/shuup/front/basket/objects.py
@@ -20,6 +20,7 @@ from shuup.core.models import OrderLineType, PaymentMethod, ShippingMethod
 from shuup.core.order_creator import OrderSource, SourceLine
 from shuup.core.order_creator._source import LineSource
 from shuup.front.basket.storage import BasketCompatibilityError, get_storage
+from shuup.utils.http import get_request_ip
 from shuup.utils.numbers import parse_decimal_string
 from shuup.utils.objects import compare_partial_dicts
 
@@ -90,7 +91,7 @@ class BaseBasket(OrderSource):
         self.basket_name = basket_name
         self.request = request
         if request:
-            self.ip_address = request.META.get("REMOTE_ADDR")
+            self.ip_address = get_request_ip(request)
         self.storage = get_storage()
         self._data = None
         self.dirty = False

--- a/shuup/utils/http.py
+++ b/shuup/utils/http.py
@@ -8,6 +8,8 @@
 import time
 
 import requests
+from django.conf import settings
+from ipware.ip import get_ip, get_real_ip
 
 
 def retry_request(n_retries=5, **kwargs):
@@ -39,3 +41,11 @@ def retry_request(n_retries=5, **kwargs):
         resp.raise_for_status()
 
     raise Exception("An unknown problem occurred with a request.")
+
+
+def get_request_ip(request):
+
+    if settings.DEBUG:
+        return get_ip(request)
+    else:
+        return get_real_ip(request)


### PR DESCRIPTION
When in production environment, it is strict necessary to fetch real user IP through other existing META keywords, set by some proxies.