### PR TITLE
Contact creation refactor (SHUUP-3158)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -23,6 +23,7 @@ Localization
 Admin
 ~~~~~
 
+- Allow billing address to be used as shipping address on contact creation
 - Split person contact and company contact creation into separate actions
 - Rearrange product creation and edit pages so that all pertinent info is
   visible simultaneously

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -23,6 +23,7 @@ Localization
 Admin
 ~~~~~
 
+- Split person contact and company contact creation into separate actions
 - Rearrange product creation and edit pages so that all pertinent info is
   visible simultaneously
 - Allow content blocks to be initialized as collapsed

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -23,6 +23,7 @@ Localization
 Admin
 ~~~~~
 
+- Add contact type filter to contact list view
 - Allow billing address to be used as shipping address on contact creation
 - Split person contact and company contact creation into separate actions
 - Rearrange product creation and edit pages so that all pertinent info is

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-05 18:54+0000\n"
+"POT-Creation-Date: 2016-08-10 17:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
@@ -126,9 +126,6 @@ msgstr ""
 msgid "Visibility"
 msgstr ""
 
-msgid "Parent"
-msgstr ""
-
 msgid "Contact Groups"
 msgstr ""
 
@@ -214,6 +211,9 @@ msgstr ""
 msgid "Activate Contact"
 msgstr ""
 
+msgid "Actions"
+msgstr ""
+
 msgid "Edit..."
 msgstr ""
 
@@ -233,14 +233,14 @@ msgstr ""
 msgid "inactive"
 msgstr ""
 
+#, python-format
+msgid "User %(bind_user)s already has a contact"
+msgstr ""
+
 msgid "Person"
 msgstr ""
 
 msgid "Company"
-msgstr ""
-
-#, python-format
-msgid "User %(bind_user)s already has a contact"
 msgstr ""
 
 msgid "Email"
@@ -309,9 +309,11 @@ msgstr ""
 msgid "Root"
 msgstr ""
 
+#, python-brace-format
 msgid "{num} subfolders moved to {folder}."
 msgstr ""
 
+#, python-brace-format
 msgid "{num} files moved to {folder}."
 msgstr ""
 
@@ -396,18 +398,6 @@ msgstr ""
 msgid "Shipments"
 msgstr ""
 
-msgid "Create Payment"
-msgstr ""
-
-msgid "Create Shipment"
-msgstr ""
-
-msgid "Create Refund"
-msgstr ""
-
-msgid "Actions"
-msgstr ""
-
 msgid "Set Complete"
 msgstr ""
 
@@ -426,9 +416,19 @@ msgstr ""
 msgid "This order cannot modified at this point"
 msgstr ""
 
+msgid "Create Payment"
+msgstr ""
+
+msgid "Create Shipment"
+msgstr ""
+
+msgid "Create Refund"
+msgstr ""
+
 msgid "Unable to set order as completed at this point"
 msgstr ""
 
+#, python-brace-format
 msgid "Order status changed: {old_status} to {new_status}"
 msgstr ""
 
@@ -806,6 +806,7 @@ msgstr ""
 msgid "Edit %(model)s"
 msgstr ""
 
+#, python-brace-format
 msgid "Create {service_name}"
 msgstr ""
 
@@ -965,6 +966,7 @@ msgstr ""
 msgid "This user is not active."
 msgstr ""
 
+#, python-brace-format
 msgid "You're now logged in as {username}"
 msgstr ""
 
@@ -1103,16 +1105,16 @@ msgstr ""
 msgid "Add more"
 msgstr ""
 
-msgid "Shipping address"
-msgstr ""
-
-msgid "No shipping address defined."
-msgstr ""
-
 msgid "Billing address"
 msgstr ""
 
 msgid "No billing address defined."
+msgstr ""
+
+msgid "Shipping address"
+msgstr ""
+
+msgid "No shipping address defined."
 msgstr ""
 
 msgid "Full Name"
@@ -1501,8 +1503,8 @@ msgstr ""
 
 #, python-format
 msgid ""
-"Telemetry data was last submitted at %(submission_datetime)s - (%"
-"(submission_timesince)s) ago"
+"Telemetry data was last submitted at %(submission_datetime)s - "
+"(%(submission_timesince)s) ago"
 msgstr ""
 
 msgid "See the data that was submitted."

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-10 17:43+0000\n"
+"POT-Creation-Date: 2016-08-10 17:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -1136,6 +1136,9 @@ msgid "Merchant Notes"
 msgstr ""
 
 msgid "No members."
+msgstr ""
+
+msgid "Use billing address as shipping address"
 msgstr ""
 
 msgid "Billing Address"

--- a/shuup/admin/modules/contacts/form_parts.py
+++ b/shuup/admin/modules/contacts/form_parts.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django import forms
+from django.contrib.auth import get_user_model
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.admin.form_part import FormPart, TemplatedFormDef
+from shuup.admin.modules.contacts.forms import (
+    AddressForm, CompanyContactBaseForm, PersonContactBaseForm
+)
+from shuup.core.models import ImmutableAddress, PersonContact
+from shuup.utils.excs import Problem
+from shuup.utils.form_group import FormDef
+
+
+class CompanyContactBaseFormPart(FormPart):
+    priority = -1000
+
+    def get_form_defs(self):
+        yield TemplatedFormDef(
+            "base",
+            CompanyContactBaseForm,
+            template_name="shuup/admin/contacts/_edit_base_form.jinja",
+            required=True,
+            kwargs={"instance": self.object if self.object.pk else None}
+        )
+
+    def form_valid(self, form):
+        self.object = form["base"].save()
+        return self.object  # Identity may have changed (not the original object we put in)
+
+
+class PersonContactBaseFormPart(FormPart):
+    priority = -1000
+
+    def get_user(self):
+        bind_user_id = self.request.REQUEST.get("user_id")
+        if bind_user_id:
+            bind_user = get_user_model().objects.get(pk=bind_user_id)
+            if PersonContact.objects.filter(user=bind_user).exists():
+                raise Problem(_("User %(bind_user)s already has a contact", bind_user=bind_user))
+        else:
+            bind_user = None
+        return bind_user
+
+    def get_form_defs(self):
+        yield TemplatedFormDef(
+            "base",
+            PersonContactBaseForm,
+            template_name="shuup/admin/contacts/_edit_base_form.jinja",
+            required=True,
+            kwargs={"instance": self.object if self.object.pk else None, "user": self.get_user()}
+        )
+
+    def form_valid(self, form):
+        self.object = form["base"].save()
+        return self.object  # Identity may have changed (not the original object we put in)
+
+
+class ContactAddressesFormPart(FormPart):
+    priority = -900
+
+    def get_form_defs(self):
+        initial = {}  # TODO: should we do this? model_to_dict(self.object, AddressForm._meta.fields)
+        yield FormDef(
+            name="shipping_address", form_class=AddressForm,
+            required=False, kwargs={"instance": self.object.default_shipping_address, "initial": initial}
+        )
+        yield FormDef(
+            name="billing_address", form_class=AddressForm,
+            required=False, kwargs={"instance": self.object.default_billing_address, "initial": initial}
+        )
+        # Using a pseudo formdef to group the two actual formdefs...
+        yield TemplatedFormDef(
+            name="addresses", form_class=forms.Form,
+            required=False, template_name="shuup/admin/contacts/_edit_addresses_form.jinja"
+        )
+
+    def form_valid(self, form):
+        for obj_key, form_name in [
+            ("default_shipping_address", "shipping_address"),
+            ("default_billing_address", "billing_address"),
+        ]:
+            addr_form = form[form_name]
+            if addr_form.changed_data:
+                if addr_form.instance.pk and isinstance(addr_form.instance, ImmutableAddress):
+                    addr_form.instance.pk = None  # Force resave
+                addr = addr_form.save()
+                setattr(self.object, obj_key, addr)
+                self.object.save()

--- a/shuup/admin/modules/contacts/forms.py
+++ b/shuup/admin/modules/contacts/forms.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django import forms
+from django.utils.encoding import force_text
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.admin.forms.fields import Select2MultipleField
+from shuup.admin.forms.widgets import PersonContactChoiceWidget
+from shuup.core.models import (
+    CompanyContact, ContactGroup, MutableAddress, PersonContact
+)
+
+FIELDS_BY_MODEL_NAME = {
+    "Contact": (
+        "is_active", "language", "marketing_permission", "phone", "www",
+        "timezone", "prefix", "suffix", "name_ext", "email", "tax_group",
+        "merchant_notes", "account_manager"
+    ),
+    "PersonContact": (
+        "first_name", "last_name", "gender", "birth_date"
+    ),
+    "CompanyContact": (
+        "name", "tax_number", "members"
+    )
+}
+
+
+class ContactBaseFormMixin(object):
+    def __init__(self, *args, **kwargs):
+        super(ContactBaseFormMixin, self).__init__(*args, **kwargs)
+        self.init_fields()
+
+    def init_fields(self):
+        self.fields["groups"] = forms.ModelMultipleChoiceField(
+            queryset=ContactGroup.objects.all_except_defaults(),
+            initial=(self.instance.groups.all_except_defaults() if self.instance.pk else ()),
+            required=False,
+            widget=forms.SelectMultiple(),
+            label=_("Contact Groups")
+        )
+        if "account_manager" in self.fields:
+            self.fields["account_manager"].widget = PersonContactChoiceWidget(clearable=True)
+
+    def save(self, commit=True):
+        if not self.instance.pk:
+            self.instance.is_active = True
+        obj = super(ContactBaseFormMixin, self).save(commit)
+        obj.groups = [obj.get_default_group()] + list(self.cleaned_data["groups"])
+        return obj
+
+
+class PersonContactBaseForm(ContactBaseFormMixin, forms.ModelForm):
+    class Meta:
+        model = PersonContact
+        fields = list(FIELDS_BY_MODEL_NAME["PersonContact"]) + list(FIELDS_BY_MODEL_NAME["Contact"])
+
+    def __init__(self, user=None, *args, **kwargs):
+        self.user = user
+        super(PersonContactBaseForm, self).__init__(*args, **kwargs)
+
+    def init_fields(self):
+        super(PersonContactBaseForm, self).init_fields()
+        for field_name in ("first_name", "last_name"):
+            self.fields[field_name].required = True
+
+    def save(self, commit=True):
+        self.instance.name = self.cleaned_data["first_name"] + " " + self.cleaned_data["last_name"]
+        obj = super(PersonContactBaseForm, self).save(commit)
+        if self.user and not getattr(obj, "user", None):  # Allow binding only once
+            obj.user = self.user
+            obj.save()
+        return obj
+
+
+class CompanyContactBaseForm(ContactBaseFormMixin, forms.ModelForm):
+    class Meta:
+        model = CompanyContact
+        fields = list(FIELDS_BY_MODEL_NAME["CompanyContact"]) + list(FIELDS_BY_MODEL_NAME["Contact"])
+
+    def init_fields(self):
+        super(CompanyContactBaseForm, self).init_fields()
+        members_field = Select2MultipleField(model=PersonContact, required=False)
+        if self.instance.pk and hasattr(self.instance, "members"):
+            members_field.widget.choices = [
+                (object.pk, force_text(object)) for object in self.instance.members.all()
+            ]
+        self.fields["members"] = members_field
+
+
+class AddressForm(forms.ModelForm):
+    class Meta:
+        model = MutableAddress
+        fields = (
+            "prefix", "name", "suffix", "name_ext",
+            "phone", "email",
+            "street", "street2", "street3",
+            "postal_code", "city",
+            "region_code", "region",
+            "country"
+        )

--- a/shuup/admin/modules/contacts/views/edit.py
+++ b/shuup/admin/modules/contacts/views/edit.py
@@ -5,230 +5,45 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-
 from __future__ import unicode_literals
 
-from django import forms
-from django.contrib.auth import get_user_model
-from django.db.models.loading import get_model
 from django.db.transaction import atomic
-from django.forms import BaseModelForm
-from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
 
-from shuup.admin.form_part import (
-    FormPart, FormPartsViewMixin, SaveFormPartsMixin, TemplatedFormDef
+from shuup.admin.form_part import FormPartsViewMixin, SaveFormPartsMixin
+from shuup.admin.modules.contacts.form_parts import (
+    CompanyContactBaseFormPart, PersonContactBaseFormPart
 )
-from shuup.admin.forms.fields import Select2MultipleField
-from shuup.admin.forms.widgets import PersonContactChoiceWidget
 from shuup.admin.toolbar import get_default_edit_toolbar
 from shuup.admin.utils.urls import get_model_url
 from shuup.admin.utils.views import CreateOrUpdateView
 from shuup.apps.provides import get_provide_objects
-from shuup.core.models import (
-    CompanyContact, Contact, ContactGroup, ImmutableAddress, MutableAddress,
-    PersonContact
-)
-from shuup.utils.excs import Problem
-from shuup.utils.form_group import FormDef
-
-
-class ContactBaseForm(BaseModelForm):
-    """
-    This form is notoriously confusing in that it works in several different modes
-    depending on what the instance being passed in is.
-
-    If the instance is an unsaved object, the form will show fields for the common
-    superclass Contact as well as a type selection field.
-    When saving the object, a _new_ instance is created, as its class will have been
-    specialized into the actual concrete polymorphic type. (I said this is confusing.)
-
-    If the instance is a saved object, its type is checked and only the related
-    fields are shown and none of that specialization stuff occurs.
-
-    """
-
-    FIELDS_BY_MODEL_NAME = {
-        "Contact": (
-            "is_active", "language", "marketing_permission", "phone", "www",
-            "timezone", "prefix", "suffix", "name_ext", "email", "tax_group",
-            "merchant_notes", "account_manager"
-        ),
-        "PersonContact": (
-            "gender", "birth_date", "first_name", "last_name"
-        ),
-        "CompanyContact": (
-            "name", "tax_number", "members"
-        )
-    }
-
-    def __init__(self, bind_user=None, *args, **kwargs):
-        class Meta:  # faux ModelForm Meta
-            model = Contact
-            fields = ()
-            exclude = ()
-
-        self.base_fields = {}
-        self._meta = Meta
-        super(ContactBaseForm, self).__init__(*args, **kwargs)
-        self.contact_class = None
-        self.bind_user = bind_user
-
-        if self.bind_user:
-            self.contact_class = PersonContact
-            self.initial.setdefault("name", self.bind_user.get_full_name())
-        if self.instance.pk:
-            self.contact_class = self.instance.__class__
-
-        self.generate_fields()
-
-    def formfield_callback(self, f, **kwargs):
-        if str(f) == "shuup.CompanyContact.members":
-            formfield = Select2MultipleField(
-                model=PersonContact, required=False, help_text=f.help_text)
-            if hasattr(self.instance, "members"):
-                formfield.widget.choices = [
-                    (object.pk, force_text(object)) for object in self.instance.members.all()
-                ]
-            return formfield
-        return f.formfield(**kwargs)
-
-    def generate_fields(self):
-        self.fields["type"] = forms.ChoiceField(choices=[
-            ("PersonContact", _("Person")),
-            ("CompanyContact", _("Company"))
-        ], label=_("Type"))
-        self.fields["groups"] = forms.ModelMultipleChoiceField(
-            queryset=ContactGroup.objects.all(),
-            initial=(self.instance.groups.all() if self.instance.pk else ()),
-            required=False,
-            widget=forms.CheckboxSelectMultiple(),
-            label=_("Contact Groups")
-        )
-        self.fields_by_model = {}
-
-        classes = (Contact, PersonContact, CompanyContact)
-        if self.contact_class:
-            classes = (self.contact_class, Contact,)
-            self._meta.model = classes[0]
-
-        for model_cls in classes:
-            model_name = str(model_cls.__name__)
-            model_fields = forms.fields_for_model(
-                model_cls, fields=self.FIELDS_BY_MODEL_NAME[model_name], formfield_callback=self.formfield_callback)
-            self.fields_by_model[model_name] = model_fields
-            self.fields.update(model_fields.items())
-
-        if self.contact_class:
-            self.fields.pop("type")  # Can't change that.
-
-        if not self.instance.pk:
-            self.fields.pop("is_active")
-
-        self.fields["account_manager"].widget = PersonContactChoiceWidget(clearable=True)
-
-    def set_model_from_cleaned_data(self):
-        if "type" in self.fields:
-            contact_type = self.cleaned_data["type"]
-        else:
-            contact_type = str(self._meta.model.__name__)
-
-        self._meta.fields = set(self.fields_by_model["Contact"]) | set(self.fields_by_model[contact_type])
-        self._meta.model = get_model("shuup", contact_type)
-        if not self.instance.pk:  # For new objects, "materialize" the abstract superclass.
-            self.instance = self._meta.model()
-        assert issubclass(self._meta.model, Contact)
-
-    def _clean_fields(self):
-        super(ContactBaseForm, self)._clean_fields()
-        self.set_model_from_cleaned_data()
-
-    def save(self, commit=True):
-        obj = super(ContactBaseForm, self).save(commit)
-        if self.bind_user and not getattr(obj, "user", None):  # Allow binding only once
-            obj.user = self.bind_user
-            obj.save()
-
-        obj.groups = self.cleaned_data["groups"]
-        return obj
-
-
-class ContactBaseFormPart(FormPart):
-    priority = -1000  # Show this first, no matter what
-
-    def get_form_defs(self):
-        bind_user_id = self.request.REQUEST.get("user_id")
-        if bind_user_id:
-            bind_user = get_user_model().objects.get(pk=bind_user_id)
-            if PersonContact.objects.filter(user=bind_user).exists():
-                raise Problem(_("User %(bind_user)s already has a contact", bind_user=bind_user))
-        else:
-            bind_user = None
-        yield TemplatedFormDef(
-            "base",
-            ContactBaseForm,
-            template_name="shuup/admin/contacts/_edit_base_form.jinja",
-            required=True,
-            kwargs={"instance": self.object, "bind_user": bind_user}
-        )
-
-    def form_valid(self, form):
-        self.object = form["base"].save()
-        return self.object  # Identity may have changed (not the original object we put in)
-
-
-class AddressForm(forms.ModelForm):
-    class Meta:
-        model = MutableAddress
-        fields = (
-            "prefix", "name", "suffix", "name_ext",
-            "phone", "email",
-            "street", "street2", "street3",
-            "postal_code", "city",
-            "region_code", "region",
-            "country"
-        )
-
-
-class ContactAddressesFormPart(FormPart):
-    priority = -900
-
-    def get_form_defs(self):
-        initial = {}  # TODO: should we do this? model_to_dict(self.object, AddressForm._meta.fields)
-        yield FormDef(
-            name="shipping_address", form_class=AddressForm,
-            required=False, kwargs={"instance": self.object.default_shipping_address, "initial": initial}
-        )
-        yield FormDef(
-            name="billing_address", form_class=AddressForm,
-            required=False, kwargs={"instance": self.object.default_billing_address, "initial": initial}
-        )
-        # Using a pseudo formdef to group the two actual formdefs...
-        yield TemplatedFormDef(
-            name="addresses", form_class=forms.Form,
-            required=False, template_name="shuup/admin/contacts/_edit_addresses_form.jinja"
-        )
-
-    def form_valid(self, form):
-        for obj_key, form_name in [
-            ("default_shipping_address", "shipping_address"),
-            ("default_billing_address", "billing_address"),
-        ]:
-            addr_form = form[form_name]
-            if addr_form.changed_data:
-                if addr_form.instance.pk and isinstance(addr_form.instance, ImmutableAddress):
-                    addr_form.instance.pk = None  # Force resave
-                addr = addr_form.save()
-                setattr(self.object, obj_key, addr)
-                self.object.save()
+from shuup.core.models import Contact, PersonContact
 
 
 class ContactEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView):
     model = Contact
     template_name = "shuup/admin/contacts/edit.jinja"
     context_object_name = "contact"
-    base_form_part_classes = [ContactBaseFormPart, ContactAddressesFormPart]
     form_part_class_provide_key = "admin_contact_form_part"
+
+    def get_contact_type(self):
+        contact_type = self.request.REQUEST.get("type", "")
+        if self.object.pk:
+            if type(self.object) is PersonContact:
+                contact_type = "person"
+            else:
+                contact_type = "company"
+        return contact_type
+
+    def get_form_part_classes(self):
+        form_part_classes = []
+        contact_type = self.get_contact_type()
+        if contact_type == "person":
+            form_part_classes.append(PersonContactBaseFormPart)
+        else:
+            form_part_classes.append(CompanyContactBaseFormPart)
+        form_part_classes += list(get_provide_objects(self.form_part_class_provide_key))
+        return form_part_classes
 
     @atomic
     def form_valid(self, form):
@@ -245,3 +60,8 @@ class ContactEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView
             toolbar.append(button(self.object))
 
         return toolbar
+
+    def get_context_data(self, **kwargs):
+        context = super(ContactEditView, self).get_context_data(**kwargs)
+        context["contact_type"] = self.get_contact_type()
+        return context

--- a/shuup/admin/modules/contacts/views/list.py
+++ b/shuup/admin/modules/contacts/views/list.py
@@ -7,10 +7,12 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 
+from django.core.urlresolvers import reverse
 from django.db.models import Count, Q
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from shuup.admin.toolbar import NewActionButton, Toolbar
 from shuup.admin.utils.picotable import (
     ChoicesFilter, Column, RangeFilter, TextFilter
 )
@@ -35,6 +37,14 @@ class ContactListView(PicotableListView):
         Column("n_orders", _(u"# Orders"), class_name="text-right", filter_config=RangeFilter(step=1)),
         Column("groups", _("Groups"), filter_config=ChoicesFilter(ContactGroup.objects.all(), "groups"))
     ]
+
+    def get_toolbar(self):
+        return Toolbar([
+            NewActionButton.for_model(
+                PersonContact, url=reverse("shuup_admin:contact.new") + "?type=person"),
+            NewActionButton.for_model(
+                CompanyContact, extra_css_class="btn-info", url=reverse("shuup_admin:contact.new") + "?type=company")
+        ])
 
     def get_queryset(self):
         groups = self.get_filter().get("groups")

--- a/shuup/admin/modules/contacts/views/list.py
+++ b/shuup/admin/modules/contacts/views/list.py
@@ -22,11 +22,24 @@ from shuup.core.models import (
 )
 
 
+class ContactTypeFilter(ChoicesFilter):
+    def __init__(self):
+        super(ContactTypeFilter, self).__init__(choices=[("person", _("Person")), ("company", _("Company"))])
+
+    def filter_queryset(self, queryset, column, value):
+        if value == "_all":
+            return queryset
+        model_class = PersonContact
+        if value == "company":
+            model_class = CompanyContact
+        return queryset.instance_of(model_class)
+
+
 class ContactListView(PicotableListView):
     model = Contact
     columns = [
         Column("name", _(u"Name"), linked=True, filter_config=TextFilter()),
-        Column("type", _(u"Type"), display="get_type_display", sortable=False),  # TODO: Add a filter
+        Column("type", _(u"Type"), display="get_type_display", sortable=False, filter_config=ContactTypeFilter()),
         Column("email", _(u"Email"), filter_config=TextFilter()),
         Column("phone", _(u"Phone"), filter_config=TextFilter()),
         Column(

--- a/shuup/admin/modules/users/views/detail.py
+++ b/shuup/admin/modules/users/views/detail.py
@@ -128,7 +128,7 @@ class UserDetailToolbar(Toolbar):
                 text=_(u"Contact Details"),
             ))
         else:
-            contact_url = reverse("shuup_admin:contact.new") + "?user_id=%s" % user.pk
+            contact_url = reverse("shuup_admin:contact.new") + "?type=person&user_id=%s" % user.pk
             menu_items.append(DropdownItem(
                 url=contact_url,
                 icon="fa fa-plus",

--- a/shuup/admin/static_src/base/less/shuup/select.less
+++ b/shuup/admin/static_src/base/less/shuup/select.less
@@ -18,12 +18,19 @@ span.select2.select2-container {
     }
 
     span.selection span.select2-selection {
-        min-height: 38px;
-        padding: 5px 0 5px 0;
         border-width: 2px;
         background: #F3F3F3;
         font-weight: normal;
         font-size: 1.3rem;
+        min-height: 38px;
+
+        &.select2-selection--single {
+            padding: 5px 0 5px 0;
+        }
+
+        &.select2-selection--multiple {
+            padding: 2px 0 2px 0;
+        }
 
         span.select2-selection__rendered {
             color: #555555;

--- a/shuup/admin/templates/shuup/admin/contacts/_contact_addresses.jinja
+++ b/shuup/admin/templates/shuup/admin/contacts/_contact_addresses.jinja
@@ -1,18 +1,18 @@
 <div class="row contact-addresses">
-    <div class="col-md-6 shipping-address">
-        <h4 class="underline"><i class="fa fa-truck"></i> {% trans %}Shipping address{% endtrans %}</h4>
-        {% for line in contact.default_shipping_address or [] %}
-            <p>{{ line }}</p>
-        {% else %}
-            <i class="fa fa-warning text-warning"></i> {% trans %}No shipping address defined.{% endtrans %}
-        {% endfor %}
-    </div>
     <div class="col-md-6 billing-address">
         <h4 class="underline"><i class="fa fa-file-text"></i> {% trans %}Billing address{% endtrans %}</h4>
         {% for line in contact.default_billing_address or [] %}
             <p>{{ line }}</p>
         {% else %}
             <i class="fa fa-warning text-warning"></i> {% trans %}No billing address defined.{% endtrans %}
+        {% endfor %}
+    </div>
+    <div class="col-md-6 shipping-address">
+        <h4 class="underline"><i class="fa fa-truck"></i> {% trans %}Shipping address{% endtrans %}</h4>
+        {% for line in contact.default_shipping_address or [] %}
+            <p>{{ line }}</p>
+        {% else %}
+            <i class="fa fa-warning text-warning"></i> {% trans %}No shipping address defined.{% endtrans %}
         {% endfor %}
     </div>
 </div>

--- a/shuup/admin/templates/shuup/admin/contacts/_edit_addresses_form.jinja
+++ b/shuup/admin/templates/shuup/admin/contacts/_edit_addresses_form.jinja
@@ -17,6 +17,15 @@
 {% endmacro %}
 
 {% call content_block(_("Addresses"), "fa-map-marker") %}
+    <div class="row">
+        <div class="col-lg-12">
+            <label>
+                <input id="billing-to-shipping" type="checkbox">
+                {% trans %}Use billing address as shipping address{% endtrans %}
+            </label>
+        </div>
+    </div>
+    <br />
     <div class="row contact-addresses">
         <div class="col-lg-6 billing-address">
             <h4 class="underline"><i class="fa fa-file-text"></i> {% trans %}Billing Address{% endtrans %}</h4>

--- a/shuup/admin/templates/shuup/admin/contacts/_edit_base_form.jinja
+++ b/shuup/admin/templates/shuup/admin/contacts/_edit_base_form.jinja
@@ -1,27 +1,46 @@
 {% from "shuup/admin/macros/general.jinja" import content_block %}
 {% set contact_form = form["base"] %}
 
-{% call content_block(_("Basic details"), "fa-info-circle") %}
-    {{ bs3.field(contact_form.type) }}
+{% macro render_contact_fields() %}
     {{ bs3.field(contact_form.is_active) }}
-    {{ bs3.field(contact_form.groups) }}
-    {{ bs3.field(contact_form.name) }}
-    {{ bs3.field(contact_form.first_name) }}
-    {{ bs3.field(contact_form.last_name) }}
     {{ bs3.field(contact_form.name_ext) }}
-    {{ bs3.field(contact_form.email) }}
+    {{ bs3.field(contact_form["prefix"]) }}
+    {{ bs3.field(contact_form.suffix) }}
     {{ bs3.field(contact_form.phone) }}
+    {{ bs3.field(contact_form.email) }}
+    {{ bs3.field(contact_form.marketing_permission) }}
     {{ bs3.field(contact_form.language) }}
     {{ bs3.field(contact_form.timezone) }}
     {{ bs3.field(contact_form.www) }}
-    {{ bs3.field(contact_form.marketing_permission) }}
-    {{ bs3.field(contact_form.gender) }}
-    {{ bs3.field(contact_form.birth_date) }}
-    {{ bs3.field(contact_form["prefix"]) }}
-    {{ bs3.field(contact_form.suffix) }}
-    {{ bs3.field(contact_form.tax_number) }}
     {{ bs3.field(contact_form.tax_group) }}
     {{ bs3.field(contact_form.merchant_notes) }}
-    {{ bs3.field(contact_form.members) }}
     {{ bs3.field(contact_form.account_manager) }}
+{% endmacro %}
+
+{% macro render_person_contact_fields(is_new) %}
+    {{ bs3.field(contact_form.first_name) }}
+    {{ bs3.field(contact_form.last_name) }}
+    {{ bs3.field(contact_form.gender) }}
+    {% if not is_new %}
+        {{ bs3.field(contact_form.birth_date) }}
+        {{ render_contact_fields() }}
+    {% endif %}
+{% endmacro %}
+
+{% macro render_company_contact_fields(is_new) %}
+    {{ bs3.field(contact_form.name) }}
+    {{ bs3.field(contact_form.tax_number) }}
+    {{ bs3.field(contact_form.members) }}
+    {% if not is_new %}
+        {{ render_contact_fields() }}
+    {% endif %}
+{% endmacro %}
+
+{% call content_block(_("Basic details"), "fa-info-circle") %}
+    {{ bs3.field(contact_form.groups) }}
+    {% if contact_type == "person" %}
+        {{ render_person_contact_fields(is_new) }}
+    {% else %}
+        {{ render_company_contact_fields(is_new) }}
+    {% endif %}
 {% endcall %}

--- a/shuup/admin/templates/shuup/admin/contacts/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/contacts/edit.jinja
@@ -13,3 +13,36 @@
         </form>
     {% endcall %}
 {% endblock %}
+
+{% block extra_js %}
+<script>
+(function(){
+    var shouldCopyFields = false;
+
+    function copyFieldValue() {
+        if(!shouldCopyFields) {
+            return;
+        }
+        var targetName = $(this).attr("id").split("-")[1];
+        var $target = $("#id_shipping_address-"+targetName);
+        $target.val($(this).val());
+        if($target.is('select')) {
+            $target.select2().val($(this).select2().val())
+        }
+    }
+
+    $('#billing-to-shipping').click(function(){
+        if($(this).is(':checked')){
+            shouldCopyFields = true;
+            $('.shipping-address :input').attr('readonly', true);
+            $('.billing-address :input').change();
+        } else {
+            shouldCopyFields = false;
+            $('.shipping-address :input').attr('readonly', false);
+        }
+    });
+
+    $('.billing-address :input').on("input change", copyFieldValue);
+}());
+</script>
+{% endblock %}

--- a/shuup/admin/templates/shuup/admin/orders/detail.jinja
+++ b/shuup/admin/templates/shuup/admin/orders/detail.jinja
@@ -47,20 +47,20 @@
             {% if order.shipping_address_id or order.billing_address_id %}
                 {% call content_block(_("Addresses"), "fa-map-marker") %}
                     <div class="row contact-addresses">
-                        <div class="col-md-6 shipping-address">
-                            <h4 class="underline"><i class="fa fa-truck"></i> {% trans %}Shipping address{% endtrans %}</h4>
-                            {% for line in order.shipping_address %}
-                                <p>{{ line }}</p>
-                            {% else %}
-                                <p><i class="fa fa-warning text-warning"></i> {% trans %}No shipping address defined.{% endtrans %}</p>
-                            {% endfor %}
-                        </div>
                         <div class="col-md-6 billing-address">
                             <h4 class="underline"><i class="fa fa-file-text"></i> {% trans %}Billing address{% endtrans %}</h4>
                             {% for line in order.billing_address %}
                                 <p>{{ line }}</p>
                             {% else %}
                                 <p><i class="fa fa-warning text-warning"></i> {% trans %}No billing address defined.{% endtrans %}</p>
+                            {% endfor %}
+                        </div>
+                        <div class="col-md-6 shipping-address">
+                            <h4 class="underline"><i class="fa fa-truck"></i> {% trans %}Shipping address{% endtrans %}</h4>
+                            {% for line in order.shipping_address %}
+                                <p>{{ line }}</p>
+                            {% else %}
+                                <p><i class="fa fa-warning text-warning"></i> {% trans %}No shipping address defined.{% endtrans %}</p>
                             {% endfor %}
                         </div>
                     </div>

--- a/shuup/core/models/_contacts.py
+++ b/shuup/core/models/_contacts.py
@@ -39,6 +39,9 @@ class ContactGroupQuerySet(TranslatableQuerySet):
             models.Q(show_prices_including_taxes__isnull=False) |
             models.Q(hide_prices__isnull=False))
 
+    def all_except_defaults(self):
+        return self.exclude(identifier__in=PROTECTED_CONTACT_GROUP_IDENTIFIERS)
+
 
 class ContactGroup(TranslatableShuupModel):
     identifier = InternalIdentifierField(unique=True)


### PR DESCRIPTION
* Add "New person" and "New company" toolbar buttons to list view
* Split out company contact and person contact edit into two separate forms
* Use select2multiple for contact group input
* Mark first name and last name as required for person contacts
* Show only required and related fields on contact creation
* Show all fields on contact edit
* Allow billing address to be used as shipping address when creating a contact. Also, put billing address before contact address for order and contact detail address sections.
* Add type filter to contact list view
* Make select2 multiple default height more in line with other form inputs. (note: it still isn't exact due to browser sub-pixel rendering but its better than before - before it was ~4 pixels taller, now it is <1px different).