### PR TITLE
Admin: Add option for automatically adding product lines (SHUUP-3152)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -22,6 +22,8 @@ Localization
 Admin
 ~~~~~
 
+- Increment quantity when quick adding products with existing lines in order creator
+- Add option for automatically adding product lines
 - Add ``admin_product_toolbar_action_item`` provider for product edit toolbar
 - Add deprecation warning for ``admin_contact_toolbar_button`` usages
 - Add ``admin_contact_toolbar_action_item`` provider for contact toolbar

--- a/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-07-29 18:55+0000\n"
+"POT-Creation-Date: 2016-08-11 20:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -317,6 +317,9 @@ msgid ""
 "Search product by name, SKU, or barcode and press button to add product line."
 msgstr ""
 
+msgid "Automatically add selected product"
+msgstr ""
+
 msgid "No shipping method"
 msgstr ""
 
@@ -376,9 +379,6 @@ msgid "Add new value"
 msgstr ""
 
 msgid "Variable Name"
-msgstr ""
-
-msgid "DELETE"
 msgstr ""
 
 msgid "Variable"

--- a/shuup/admin/modules/orders/static_src/create/view/lines.js
+++ b/shuup/admin/modules/orders/static_src/create/view/lines.js
@@ -146,6 +146,11 @@ export function renderOrderLines(store, shop, lines) {
 }
 
 var select2 = {
+    focus: function() {
+        if (select2.element) {
+            select2.element.select2("open");
+        }
+    },
     clear: function() {
         if (select2.element) {
             select2.element.select2("val", null);
@@ -165,7 +170,9 @@ var select2 = {
                     productQuickSelect.currentProduct(null);
                     el.select2()
                         .on("change", function() {
-                            ctrl.onchange($(this).val());
+                            if ($(this).val()){
+                                ctrl.onchange($(this).val());
+                            }
                         });
                 }
             } else {
@@ -175,16 +182,39 @@ var select2 = {
     }
 };
 
+
 var productQuickSelect = {
+    controller: function(store) {
+      this.store = store;
+    },
     clearSelection: function() {
         productQuickSelect.currentProduct(null);
         select2.clear();
     },
+    autoAdd: m.prop(true),
+    quickAddProduct: function (store, productId) {
+        const {lines} = store.getState();
+        var line = _.find(lines, function(o) { return (o.product.id === parseInt(productId));});
+        if (line === undefined) {
+            store.dispatch(addLine());
+            store.dispatch(retrieveProductData({id: productId, forLine: _.last(store.getState().lines).id}));
+        }
+        else {
+            store.dispatch(setLineProperty(line.id, "quantity", parseFloat(line.quantity) + 1));
+        }
+        select2.focus();
+    },
     currentProduct: m.prop(),
     changeProduct: function(id) {
         productQuickSelect.currentProduct(id);
+        if (id && productQuickSelect.autoAdd()){
+            productQuickSelect.quickAddProduct(productQuickSelect.store,id);
+            productQuickSelect.currentProduct(null);
+            select2.clear();
+        }
     },
-    view: function() {
+    view: function(ctrl, args) {
+        productQuickSelect.store = args.store;
         return m.component(select2, {
             onchange: this.changeProduct,
         });
@@ -222,7 +252,7 @@ export function orderLinesView(store, isCreating) {
             m("div.col-sm-6", [
                 m("fieldset", [
                     m("legend", gettext("Quick add product line")),
-                    productQuickSelect,
+                    m.component(productQuickSelect, {store: store}),
                     m("button.btn.text-success" + (isCreating ? ".disabled": ""), {
                         disabled: isCreating,
                         onclick: () => {
@@ -241,6 +271,12 @@ export function orderLinesView(store, isCreating) {
                         onclick: productQuickSelect.clearSelection,
                     }, m("i.fa.fa-trash")),
                     m("span.help-block", gettext("Search product by name, SKU, or barcode and press button to add product line.")),
+                    m("input", {
+                        type: "checkbox",
+                        checked: productQuickSelect.autoAdd,
+                        onchange: function () { productQuickSelect.autoAdd(this.checked); }
+                    }),
+                    m("span.quick-add-check-text", gettext("Automatically add selected product")),
                 ])
             ]),
         ]),


### PR DESCRIPTION
Add an option in order creator automatically add the first matching
product line when using quick add.

This can be enabled by default by configuring the
`SHUUP_ADMIN_ORDER_CREATOR_QUICK_ADD_DEFAULT` setting.

Refs SHUUP-3152