### PR TITLE
Product creation/edit redesign (SHUUP-3168)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -23,6 +23,8 @@ Localization
 Admin
 ~~~~~
 
+- Rearrange product creation and edit pages so that all pertinent info is
+  visible simultaneously
 - Allow content blocks to be initialized as collapsed
 - Add ``admin_product_toolbar_action_item`` provider for product edit toolbar
 - Add deprecation warning for ``admin_contact_toolbar_button`` usages

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -23,6 +23,7 @@ Localization
 Admin
 ~~~~~
 
+- Allow content blocks to be initialized as collapsed
 - Add ``admin_product_toolbar_action_item`` provider for product edit toolbar
 - Add deprecation warning for ``admin_contact_toolbar_button`` usages
 - Add ``admin_contact_toolbar_action_item`` provider for contact toolbar

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Fix `FormattedDecimalField` default value for form fields
 - Combine `TreeManager` and `TranslatableManager` querysets for categories
 - Exclude deleted orders from valid queryset
 - Enable soft delete for shipments

--- a/shuup/admin/static_src/base/js/content-blocks.js
+++ b/shuup/admin/static_src/base/js/content-blocks.js
@@ -7,6 +7,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 $(function() {
+    let $contentBlocks = $(".content-block");
+    let $contentWraps = $contentBlocks.find(".content-wrap");
+
     $(".toggle-contents").click(function(event) {
         const $collapseElement = $(this).closest(".content-block").find(".content-wrap");
         event.preventDefault();
@@ -17,7 +20,7 @@ $(function() {
             $(this).closest(".title").toggleClass("open");
         }
     });
-    $(".content-block").each(function() {
+    $contentBlocks.each(function() {
         if ($(this).find(".has-error").length) {
             $(this).find(".block-title").addClass("mobile-error-indicator");
         }
@@ -25,4 +28,10 @@ $(function() {
 
     // Activate first sidebar-list-item with errors
     $("a.sidebar-list-item.errors").first().trigger("click");
+
+    // clear inline height: 0 on resize since we want blocks to be expanded on medium screens
+    // this circumvents the need for !important in our css
+    $(window).resize(_.debounce(function(){
+        $contentWraps.css("height", "");
+    }, 100));
 });

--- a/shuup/admin/static_src/base/less/shuup/content-blocks.less
+++ b/shuup/admin/static_src/base/less/shuup/content-blocks.less
@@ -8,10 +8,6 @@
     border: solid #ededed;
     border-width: 3px 1px;
 
-    @media (max-width: @screen-sm-max) {
-        display: block !important;
-    }
-
     @media (min-width: @screen-md-min) {
         padding: 30px;
         margin-bottom: 30px;
@@ -74,7 +70,6 @@
         @media (min-width: @screen-md-min) {
             display: block;
             visibility: visible;
-            height: auto !important;
         }
 
         .content {
@@ -124,6 +119,33 @@
         @media (min-width: @screen-sm-min) {
             dd { margin-left: 220px; }
             dt { width: 200px; }
+        }
+    }
+
+    &.collapsed {
+        .title {
+            &.open {
+                .block-title {
+                    border-color: @brand-primary;
+                    padding-bottom: 15px;
+                }
+            }
+
+            .block-title {
+                border-color: #fff;
+                padding-bottom: 0;
+            }
+        }
+
+        .toggle-contents {
+            display: block;
+        }
+        .collapse {
+            display: none;
+        }
+
+        .collapse.in {
+            display: block;
         }
     }
 }

--- a/shuup/admin/templates/shuup/admin/macros/general.jinja
+++ b/shuup/admin/templates/shuup/admin/macros/general.jinja
@@ -20,8 +20,8 @@
     </div>
 {% endmacro %}
 
-{% macro content_block(heading, icon, extra_classes="", id="") %}
-    <div id="{{ id }}" class="content-block">
+{% macro content_block(heading, icon, extra_classes="", id="", collapsed=False) %}
+    <div id="{{ id }}" class="content-block {% if collapsed %}collapsed{% endif %}">
         <div class="title">
             {% if heading %}
                 <h2 class="block-title">{% if icon %} <i class="fa {{ icon }}"></i> {% endif %}{{ heading }}</h2>

--- a/shuup/admin/templates/shuup/admin/products/_edit_attribute_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_attribute_form.jinja
@@ -3,7 +3,7 @@
 
 {% set attr_form = form[form_def.name] %}
 
-{% call content_block(_("Attributes"), "fa-tags") %}
+{% call content_block(_("Attributes"), "fa-tags", collapsed=True) %}
     {{ language_dependent_content_tabs(attr_form, tab_id_prefix="attributes") }}
     <div class="form-divider"></div>
     {{ render_monolingual_fields(attr_form) }}

--- a/shuup/admin/templates/shuup/admin/products/_edit_base_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_base_form.jinja
@@ -3,34 +3,16 @@
 {% set product_form = form["base"] %}
 
 {% call content_block(_("General Information"), "fa-info-circle") %}
-    {{ bs3.field(product_form.type) }}
-    {{ bs3.field(product_form.sku) }}
     {% call(form, language, map) language_dependent_content_tabs(product_form, tab_id_prefix="language") %}
         {{ bs3.field(product_form[map.name]) }}
         {{ bs3.field(product_form[map.description], widget_class="remarkable-field") }}
     {% endcall %}
-{% endcall %}
-
-{% call content_block(_("Additional Details"), "fa-file-text") %}
-    {{ bs3.field(product_form.barcode) }}
-    {{ bs3.field(product_form.gtin) }}
-    {{ bs3.field(product_form.category) }}
+    {{ bs3.field(product_form.type) }}
+    {{ bs3.field(product_form.sku) }}
     {{ bs3.field(product_form.stock_behavior) }}
     {{ bs3.field(product_form.shipping_mode) }}
-    {% call(form, language, map) language_dependent_content_tabs(product_form, tab_id_prefix="additional-language") %}
-        {{ bs3.field(product_form[map.variation_name]) }}
-        {{ bs3.field(product_form[map.status_text]) }}
-        {{ bs3.field(product_form[map.keywords]) }}
-    {% endcall %}
-{% endcall %}
-
-{% call content_block(_("Accounting"), "fa-book") %}
-    {{ bs3.field(product_form.accounting_identifier) }}
-    {{ bs3.field(product_form.profit_center) }}
-    {{ bs3.field(product_form.cost_center) }}
     {{ bs3.field(product_form.tax_class) }}
 {% endcall %}
-
 {% call content_block(_("Physical Properties"), "fa-cog") %}
     {{ bs3.field(product_form.width) }}
     {{ bs3.field(product_form.height) }}
@@ -38,8 +20,4 @@
     {{ bs3.field(product_form.sales_unit) }}
     {{ bs3.field(product_form.net_weight) }}
     {{ bs3.field(product_form.gross_weight) }}
-{% endcall %}
-
-{% call content_block(_("Manufacturer"), "fa-building") %}
-    {{ bs3.field(product_form.manufacturer) }}
 {% endcall %}

--- a/shuup/admin/templates/shuup/admin/products/_edit_collapsed_base_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_collapsed_base_form.jinja
@@ -1,0 +1,24 @@
+{% from "shuup/admin/macros/general.jinja" import content_block %}
+{% from "shuup/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
+{% set product_form = form["base"] %}
+
+{% call content_block(_("Additional Details"), "fa-file-text", collapsed=True) %}
+    {{ bs3.field(product_form.barcode) }}
+    {{ bs3.field(product_form.gtin) }}
+    {{ bs3.field(product_form.category) }}
+    {% call(form, language, map) language_dependent_content_tabs(product_form, tab_id_prefix="additional-language") %}
+        {{ bs3.field(product_form[map.variation_name]) }}
+        {{ bs3.field(product_form[map.status_text]) }}
+        {{ bs3.field(product_form[map.keywords]) }}
+    {% endcall %}
+{% endcall %}
+
+{% call content_block(_("Accounting"), "fa-book", collapsed=True) %}
+    {{ bs3.field(product_form.accounting_identifier) }}
+    {{ bs3.field(product_form.profit_center) }}
+    {{ bs3.field(product_form.cost_center) }}
+{% endcall %}
+
+{% call content_block(_("Manufacturer"), "fa-building", collapsed=True) %}
+    {{ bs3.field(product_form.manufacturer) }}
+{% endcall %}

--- a/shuup/admin/templates/shuup/admin/products/_edit_collapsed_shop_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_collapsed_shop_form.jinja
@@ -1,0 +1,13 @@
+{% from "shuup/admin/macros/general.jinja" import content_block %}
+{# use the base form #}
+{% set base_form_name = form_def.name.split('_')[0] %}
+{% set shop_product_form = form[base_form_name] %}
+{% set shop_name = shop_product_form.instance.shop.name %}
+{% set shop_name_prefix = shop_product_form.instance.shop.name ~ " - " %}
+
+{% call content_block(shop_name_prefix ~ _("Shipping & Payment"), "fa-truck", collapsed=True) %}
+    {{ bs3.field(shop_product_form.limit_payment_methods) }}
+    {{ bs3.field(shop_product_form.limit_shipping_methods) }}
+    {{ bs3.field(shop_product_form.payment_methods) }}
+    {{ bs3.field(shop_product_form.shipping_methods) }}
+{% endcall %}

--- a/shuup/admin/templates/shuup/admin/products/_edit_media_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_media_form.jinja
@@ -87,12 +87,10 @@
     </div>
 {% endmacro %}
 
-
 {%- set is_image_form = media_form.prefix == "images" %}
 {%- set id = "product-images-section" if is_image_form else "product-media-section" %}
 {%- set name = _("Product Images") if is_image_form else _("Product Media") %}
-
-{% call content_block(name, "fa-camera", id=id) %}
+{% call content_block(name, "fa-camera", id=id, collapsed=True) %}
     {{ media_form.management_form }}
     {% for f in media_form %}
         {{ render_media_form(f, media_form, loop.index, is_image_form) }}
@@ -103,6 +101,4 @@
     <hr>
 {%- set target_id = "id_images" if is_image_form else "id_media" %}
 <a class="btn btn-lg btn-text media-add-new-panel" href="#" data-target-id="{{ target_id }}" data-target-panels="{{ id }}">+ {% if is_image_form %}{% trans %}Add new image{% endtrans %}{% else %}{% trans %}Add new media{% endtrans %}{% endif %}</a>
-
 {% endcall %}
-

--- a/shuup/admin/templates/shuup/admin/products/_edit_shop_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_shop_form.jinja
@@ -21,10 +21,3 @@
     {{ bs3.field(shop_product_form.minimum_purchase_quantity) }}
     {{ bs3.field(shop_product_form.backorder_maximum) }}
 {% endcall %}
-
-{% call content_block(shop_name_prefix ~ _("Shipping & Payment"), "fa-truck") %}
-    {{ bs3.field(shop_product_form.limit_payment_methods) }}
-    {{ bs3.field(shop_product_form.limit_shipping_methods) }}
-    {{ bs3.field(shop_product_form.payment_methods) }}
-    {{ bs3.field(shop_product_form.shipping_methods) }}
-{% endcall %}

--- a/shuup/admin/templates/shuup/admin/products/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/products/edit.jinja
@@ -10,21 +10,24 @@
             </p>
         </div>
     {% endif %}
-    {% call content_with_sidebar(content_id="product_details") %}
-        <div id="product_details">
-            <form method="post" id="product_form">
-                {% csrf_token %}
-                {% for form_def in form.form_defs.values() %}
+    <form method="post" id="product_form">
+        {% csrf_token %}
+        {% for form_def in form.form_defs.values() %}
+            {% if form_def.required %}
+                {% include form_def.template_name with context %}
+            {% endif %}
+        {% endfor %}
+        {% for form_def in form.form_defs.values() %}
+            {% if not form_def.required %}
                     {% include form_def.template_name with context %}
-                {% endfor %}
-            </form>
-            {% for product_section in product_sections %}
-                {% call content_block(product_section.name, product_section.icon) %}
-                    {% include product_section.template with context %}
-                {% endcall %}
-            {% endfor %}
-        </div>
-    {% endcall %}
+            {% endif %}
+        {% endfor %}
+    </form>
+    {% for product_section in product_sections %}
+        {% call content_block(product_section.name, product_section.icon, collapsed=True) %}
+            {% include product_section.template with context %}
+        {% endcall %}
+    {% endfor %}
 {% endblock %}
 
 {% block extra_js %}

--- a/shuup/core/fields/__init__.py
+++ b/shuup/core/fields/__init__.py
@@ -8,6 +8,7 @@
 from __future__ import unicode_literals
 
 import decimal
+import numbers
 
 import babel
 from django import forms
@@ -86,8 +87,8 @@ class FormattedDecimalField(models.DecimalField):
     """
     def value_from_object(self, obj):
         value = super(FormattedDecimalField, self).value_from_object(obj)
-        if isinstance(value, decimal.Decimal):
-            return self.format_decimal(value)
+        if isinstance(value, numbers.Number):
+            return self.format_decimal(decimal.Decimal(str(value)))
 
     def format_decimal(self, value, max_digits=100, exponent_limit=100):
         assert isinstance(value, decimal.Decimal)

--- a/shuup/customer_group_pricing/templates/shuup/admin/customer_group_pricing/form_part.jinja
+++ b/shuup/customer_group_pricing/templates/shuup/admin/customer_group_pricing/form_part.jinja
@@ -1,6 +1,6 @@
 {% from "shuup/admin/macros/general.jinja" import content_block with context %}
 {% set sp_form = form["customer_group_pricing"] %}
-{% call content_block(_("Customer Group Pricing"), "fa-money") %}
+{% call content_block(_("Customer Group Pricing"), "fa-money", collapsed=True) %}
     <div class="panel panel-default">
         <div class="panel-heading">
             <h2 class="panel-title">

--- a/shuup/simple_supplier/templates/shuup/simple_supplier/admin/product_form_part.jinja
+++ b/shuup/simple_supplier/templates/shuup/simple_supplier/admin/product_form_part.jinja
@@ -30,34 +30,40 @@
     {% for product in form.products %}
         {% set product_url = shuup_admin.model_url(product) %}
         <div class="row">
-        {% if product.is_stocked() %}
-            {{ render_product(form.get_suppliers(product), product, product_url, product_qty) }}
-        {% else %}
-            <p>
-                {% trans product_name=product.name, product_url=product_url -%}
-                    Product <a href="{{ product_url }}" target="_blank">{{ product_name }}</a> is not stocked.
-                {%- endtrans %}
-                {% trans -%}
-                    Please set product stock behavior at Additional Details section.
-                {%- endtrans %}
-            </p>
-        {% endif %}
+            <div class="col-sm-12">
+                {% if product.is_stocked() %}
+                    {{ render_product(form.get_suppliers(product), product, product_url, product_qty) }}
+                {% else %}
+                    <p>
+                        {% trans product_name=product.name, product_url=product_url -%}
+                            Product <a href="{{ product_url }}" target="_blank">{{ product_name }}</a> is not stocked.
+                        {%- endtrans %}
+                        {% trans -%}
+                            Please set product stock behavior at Additional Details section.
+                        {%- endtrans %}
+                    </p>
+                {% endif %}
+            </div>
         </div>
     {% endfor %}
 {% endmacro %}
 
-{% call content_block(_("Stock management"), "fa-cubes") %}
+{% call content_block(_("Stock management"), "fa-cubes", collapsed=True) %}
     {% if ss_form.can_manage_stock() %}
         {{ render_products(ss_form) }}
     {% else %}
-        <p>
-            {% trans module_name=ss_form.module_name -%}
-                No suppliers with {{ module_name }} available.
-            {%- endtrans %}
-            {% trans module_name=ss_form.module_name, supplier_url=shuup_admin.model_url(ss_form.supplier_model, kind="list", default="#") -%}
-                Please set {{ module_name }} module for at least one of the <a href="{{ supplier_url }}" target="_blank">Suppliers</a>.
-            {%- endtrans %}
-        </p>
+        <div class="row">
+            <div class="col-sm-12">
+                <p>
+                    {% trans module_name=ss_form.module_name -%}
+                        No suppliers with {{ module_name }} available.
+                    {%- endtrans %}
+                    {% trans module_name=ss_form.module_name, supplier_url=shuup_admin.model_url(ss_form.supplier_model, kind="list", default="#") -%}
+                        Please set {{ module_name }} module for at least one of the <a href="{{ supplier_url }}" target="_blank">Suppliers</a>.
+                    {%- endtrans %}
+                </p>
+            </div>
+        </div>
     {% endif %}
 {% endcall %}
 

--- a/shuup_tests/browser/admin/test_product_detail.py
+++ b/shuup_tests/browser/admin/test_product_detail.py
@@ -31,6 +31,7 @@ def test_product_detail(browser, admin_user, live_server):
     # Test product save
     new_sku = "some-new-sku"
     browser.find_by_id("id_base-sku").fill(new_sku)
+    browser.execute_script("window.scrollTo(0,0)")
     browser.find_by_xpath('//button[@form="product_form"]').first.click()
 
     product.refresh_from_db()

--- a/shuup_tests/core/test_fields.py
+++ b/shuup_tests/core/test_fields.py
@@ -81,3 +81,14 @@ def test_formatted_decimal_field_overridden_step():
     rendered_field = force_text(TestForm()['f'])
     rendered_step = re.search('step="(.*?)"', rendered_field).group(1)
     assert rendered_step == '0.1'
+
+
+def test_formatted_decimal_field_default():
+    class TestModelForm(ModelForm):
+        class Meta:
+            model = Product
+            fields = ["width"]
+
+    rendered_form = force_text(TestModelForm(instance=Product()))
+    rendered_value = re.search('value="(.*)"', rendered_form).group(1)
+    assert rendered_value == "0"


### PR DESCRIPTION
Products can now be created by simply adding a product name and pressing save. Note the product is not orderable since supplier is not defaulted.

* Fix `FormattedDecimalField` default value
* Allow content blocks to be collapsed on initialization
* Rearrange product creation and edit pages