### PR TITLE
Fix contact group availability behavior component

### DIFF
--- a/shuup/core/models/_service_behavior.py
+++ b/shuup/core/models/_service_behavior.py
@@ -163,7 +163,7 @@ class GroupAvailabilityBehaviorComponent(ServiceBehaviorComponent):
     groups = models.ManyToManyField("ContactGroup", verbose_name=_("groups"))
 
     def get_unavailability_reasons(self, service, source):
-        if not source.customer.pk:
+        if source.customer and not source.customer.pk:
             yield ValidationError(_("Customer does not belong to any group."))
             return
 


### PR DESCRIPTION
All customers belong to the "Anonymous" group by default (AKA. not signed in users),
thus it's pointless to check for the existance of the user in the database. This
also causes limiting to `not logged in users only` to be impossible.

Fix the issue explained above by removing a check for customer's existance in the database.