### PR TITLE
Fix bugs in default reports (SHUUP-2085 / SHUUP-3219 / SHUUP-3220 / SHUUP-3221)

### DIFF
--- a/shuup/default_reports/reports/sales_per_hour.py
+++ b/shuup/default_reports/reports/sales_per_hour.py
@@ -36,14 +36,14 @@ class SalesPerHour(OrderReportMixin, ShuupReportBase):
         groups = itertools.groupby(orders, lambda x: self.date_hour(x.order_date))
         data = []
         hour_data = {}
-        for base_hour in range(0, 23):
-            hour_data[base_hour] = {"hour": base_hour, "amount": 0, "total_sales": 0}
+        for base_hour in range(0, 24):
+            hour_data[base_hour] = {"hour": base_hour, "order_amount": 0, "total_sales": 0}
         for hour, matches in groups:
             total = 0
             amount = 0
             for match in matches:
                 amount += 1
-                total = total + match.taxful_total_price_value
+                total += match.taxful_total_price_value
 
             hour = int(hour)
             hour_data[hour]["order_amount"] = amount

--- a/shuup/default_reports/reports/total_sales.py
+++ b/shuup/default_reports/reports/total_sales.py
@@ -28,10 +28,11 @@ class TotalSales(OrderReportMixin, ShuupReportBase):
 
     def get_data(self):
         orders = self.get_objects()
+        total_sales_value = orders.aggregate(total=Sum("taxful_total_price_value"))["total"] or 0
         data = [{
             "name": self.shop.name,
             "order_amount": orders.count(),
-            "total_sales": self.shop.create_price(orders.aggregate(total=Sum("taxful_total_price_value"))["total"]),
+            "total_sales": self.shop.create_price(total_sales_value),
             "currency": self.shop.currency
         }]
         return self.get_return_data(data)

--- a/shuup/reports/templates/shuup/reports/report.jinja
+++ b/shuup/reports/templates/shuup/reports/report.jinja
@@ -1,16 +1,16 @@
 {% extends "shuup/admin/base.jinja" %}
-
 {% from "shuup/admin/macros/general.jinja" import content_with_sidebar, content_block %}
-{% from "shuup/admin/macros/multilanguage.jinja" import language_dependent_content_tabs, render_monolingual_fields %}
+{% from "shuup/admin/macros/multilanguage.jinja" import render_monolingual_fields %}
 
 {% block title %}{% trans %}Reports{% endtrans %}{% endblock %}
+
 {% block content %}
     {% call content_block(_("Reports"), "fa-info-circle") %}
         <form method="post" id="service_provider_form">
             {% csrf_token %}
-            {{ bs3.field(form["report"]) }}
+            {{ render_monolingual_fields(form, field_names="report") }}
             <div{% if result %} class="collapse"{% endif %} id="collapse">
-                {{ bs3.form(form, exclude="report") }}
+                {{ render_monolingual_fields(form, exclude="report") }}
             </div>
             {% if result %}
             <div class="row">

--- a/shuup_tests/default_reports/test_default_reports.py
+++ b/shuup_tests/default_reports/test_default_reports.py
@@ -109,7 +109,9 @@ def test_total_sales_per_hour_report(rf):
     return_data = test_info.json_data.get("tables")[0].get("data")
     order_hour = test_info.order.order_date.strftime("%H")
 
-    assert len(return_data) == 23 # all hours present
+    assert len(return_data) == 24 # all hours present
+    assert min([int(data_item.get("hour")) for data_item in return_data]) == 0
+    assert max([int(data_item.get("hour")) for data_item in return_data]) == 23
     for hour_data in return_data:
         if int(hour_data.get("hour")) == int(order_hour):
             assert str(test_info.expected_taxful_total) in hour_data.get("total_sales")


### PR DESCRIPTION
* Use Shuup admin form tools to enable datepickers
* Fix issue with zero total sales
* Fix hours in sales per hour report