### PR TITLE
Add product quick add (SHUUP-3152)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -22,6 +22,8 @@ Localization
 Admin
 ~~~~~
 
+- Increment quantity when quick adding products with existing lines in order creator
+- Add option for automatically adding product lines when creating order
 - Order editing: Tax number is now shown for Company Contacts
 
 Addons

--- a/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-15 21:35+0000\n"
+"POT-Creation-Date: 2016-08-17 00:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -320,6 +320,9 @@ msgid ""
 "Search product by name, SKU, or barcode and press button to add product line."
 msgstr ""
 
+msgid "Automatically add selected product"
+msgstr ""
+
 msgid "No shipping method"
 msgstr ""
 
@@ -379,9 +382,6 @@ msgid "Add new value"
 msgstr ""
 
 msgid "Variable Name"
-msgstr ""
-
-msgid "DELETE"
 msgstr ""
 
 msgid "Variable"

--- a/shuup/admin/modules/orders/static_src/create/actions/index.js
+++ b/shuup/admin/modules/orders/static_src/create/actions/index.js
@@ -42,6 +42,10 @@ const beginCreatingOrder = createAction("beginCreatingOrder");
 const endCreatingOrder = createAction("endCreatingOrder");
 // Comment action
 export const setComment = createAction("setComment");
+// Quick add actions
+export const setAutoAdd = createAction("setAutoAdd");
+export const clearQuickAddProduct = createAction("clearQuickAddProduct");
+export const setQuickAddProduct = createAction("setQuickAddProduct");
 
 export const retrieveProductData = function ({id, forLine, quantity}) {
     return (dispatch, getState) => {
@@ -167,12 +171,27 @@ function handleFinalizeResponse(dispatch, data) {
 export const beginFinalizingOrder = function () {
     return (dispatch, getState) => {
         dispatch(beginCreatingOrder());
-        const state = _.assign({}, getState(), {productData: null, order: null}); // We don't care about that substate
+        const state = _.assign({}, getState(), {productData: null, order: null, quickAdd: null}); // We don't care about that substate
         post("finalize", {state}).then((data) => {
             handleFinalizeResponse(dispatch, data);
         }, (data) => {  // error handler
             handleFinalizeResponse(dispatch, data);
         });
         dispatch(createAction("beginFinalizingOrder")());
+    };
+};
+
+
+export const addProduct = function(product) {
+    return (dispatch, getState) => {
+        const {lines, quickAdd} = getState();
+        var line = _.find(lines, function(o) { return (o.product && o.product.id === parseInt(product.id));});
+        if (line === undefined) {
+            dispatch(addLine());
+            dispatch(retrieveProductData({id: product.id, forLine: _.last(getState().lines).id}));
+        }
+        else {
+            dispatch(setLineProperty(line.id, "quantity", parseFloat(line.quantity) + 1));
+        }
     };
 };

--- a/shuup/admin/modules/orders/static_src/create/index.js
+++ b/shuup/admin/modules/orders/static_src/create/index.js
@@ -49,7 +49,7 @@ export function init(config = {}) {
     const customerData = config.customerData;
 
     const persistor = persistStore(store);
-    persistor.purge(["customerDetails"]);
+    persistor.purge(["customerDetails", "quickAdd"]);
     const resetOrder = window.localStorage.getItem("resetSavedOrder") || "false";
     var savedOrder = {id: null};
     if (resetOrder === "true") {

--- a/shuup/admin/modules/orders/static_src/create/reducers/index.js
+++ b/shuup/admin/modules/orders/static_src/create/reducers/index.js
@@ -16,6 +16,7 @@ import customerDetails from "./customerDetails";
 import methods from "./methods";
 import order from "./order";
 import comment from "./comment";
+import quickAdd from "./quickAdd";
 
 const childReducer = combineReducers({
     lines,
@@ -26,7 +27,8 @@ const childReducer = combineReducers({
     customerDetails,
     methods,
     order,
-    comment
+    comment,
+    quickAdd
 });
 
 export default function(state, action) {

--- a/shuup/admin/modules/orders/static_src/create/reducers/quickAdd.js
+++ b/shuup/admin/modules/orders/static_src/create/reducers/quickAdd.js
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Shuup.
+ *
+ * Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {handleActions} from "redux-actions";
+import _ from "lodash";
+
+export default handleActions({
+    setAutoAdd: ((state, {payload}) => _.assign(state, {autoAdd: payload})),
+    setQuickAddProduct: ((state, {payload}) => _.assign(state, {product: payload})),
+    clearQuickAddProduct: ((state, {payload}) => _.assign(state, {product: {id: "", text: ""}})),
+    setFocusOnQuickAdd: ((state, {payload}) => _.assign(state, {focus: payload}))
+}, {
+    autoAdd: true,
+    focus: false,
+    product: {
+        id: "",
+        text: ""
+    }
+});

--- a/shuup/admin/modules/orders/static_src/create/view/customers.js
+++ b/shuup/admin/modules/orders/static_src/create/view/customers.js
@@ -48,7 +48,7 @@ function renderAddress(store, shop, customer, address, addressType) {
                 m("label.control-label", field.label),
                 selectBox(_.get(address, field.key, ""), function () {
                     store.dispatch(setAddressProperty(addressType, field.key, this.value));
-                }, shop.countries)
+                }, shop.countries, "id", "name", addressType + "-" + field.key)
             ]);
         }
         var onchange = function () {
@@ -71,6 +71,7 @@ function renderAddress(store, shop, customer, address, addressType) {
             m("label.control-label", field.label),
             m("input.form-control", {
                 type: "text",
+                name: addressType + "-" + field.key,
                 placeholder: field.label,
                 required: isRequired,
                 value: _.get(address, field.key, ""),
@@ -207,6 +208,7 @@ export function customerSelectView(store) {
         m("hr"),
         m("label", [
             m("input", {
+                name: "save-address",
                 type: "checkbox",
                 checked: customer.saveAddress,
                 onchange: function() {
@@ -217,6 +219,7 @@ export function customerSelectView(store) {
         ]),
         m("label", [
             m("input", {
+                name: "ship-to-billing-address",
                 type: "checkbox",
                 checked: customer.shipToBillingAddress,
                 onchange: function() {
@@ -227,6 +230,7 @@ export function customerSelectView(store) {
         ]),
         m("label", [
             m("input", {
+                name: "order-for-company",
                 type: "checkbox",
                 checked: customer.isCompany,
                 onchange: function() {

--- a/shuup/admin/modules/orders/static_src/create/view/lines.js
+++ b/shuup/admin/modules/orders/static_src/create/view/lines.js
@@ -12,6 +12,7 @@ import BrowseAPI from "BrowseAPI";
 
 function renderNumberCell(store, line, value, fieldId, canEditPrice, min=null) {
     return m("input.form-control", {
+            name: fieldId,
             type: "number",
             step: line.step,
             min: min != null ? min : "",
@@ -30,7 +31,7 @@ function renderNumberCell(store, line, value, fieldId, canEditPrice, min=null) {
 }
 
 export function renderOrderLines(store, shop, lines) {
-    return _(lines).map((line) => {
+    return _(lines).map((line, idx) => {
         var text = line.text, canEditPrice = true;
         var editCell = null;
         const showPrice = (line.type !== "text");
@@ -149,6 +150,7 @@ export function renderOrderLines(store, shop, lines) {
 var Select2 = {
     view: function(ctrl, attrs) {
         return m("select", {
+            name: attrs.name,
             config: Select2.config(attrs)
         });
     },
@@ -187,6 +189,7 @@ var ProductQuickSelect = {
         const {store} = attrs;
 
         return m.component(Select2, {
+            name: "product-quick-select",
             model: "shuup.product",
             attrs: {
                 ajax: {
@@ -234,7 +237,7 @@ export function orderLinesView(store, isCreating) {
             "p",
             shop.selected.pricesIncludeTaxes ? gettext("All prices include taxes.") : gettext("Taxes not included.")
         ),
-        m("div.list-group", renderOrderLines(store, shop.selected, lines)),
+        m("div.list-group", {id: "lines"}, renderOrderLines(store, shop.selected, lines)),
         m("hr"),
         m("div.row", [
             m("div.col-sm-6",
@@ -250,11 +253,12 @@ export function orderLinesView(store, isCreating) {
                     }
                 }, m("i.fa.fa-plus"), " " + gettext("Add new line"))
             ),
-            m("div.col-sm-6", [
+            m("div.col-sm-6", {id: "quick-add"}, [
                 m("fieldset", [
                     m("legend", gettext("Quick add product line")),
                     m.component(ProductQuickSelect, {store: store}),
                     m("button.btn.text-success" + (isCreating ? ".disabled": ""), {
+                        id: "add-product",
                         disabled: isCreating,
                         onclick: () => {
                             if (quickAdd.product.id){
@@ -264,6 +268,7 @@ export function orderLinesView(store, isCreating) {
                         }
                     }, m("i.fa.fa-plus")),
                     m("button.btn.text-success" + (isCreating ? ".disabled": ""), {
+                        id: "clear-quick-add",
                         disabled: isCreating,
                         onclick: () => {
                             store.dispatch(clearQuickAddProduct());
@@ -271,6 +276,7 @@ export function orderLinesView(store, isCreating) {
                     }, m("i.fa.fa-trash")),
                     m("span.help-block", gettext("Search product by name, SKU, or barcode and press button to add product line.")),
                     m("input", {
+                        name: "auto-add",
                         type: "checkbox",
                         checked: quickAdd.autoAdd,
                         onchange: function() {

--- a/shuup/admin/modules/orders/static_src/create/view/lines.js
+++ b/shuup/admin/modules/orders/static_src/create/view/lines.js
@@ -6,7 +6,7 @@
  * This source code is licensed under the AGPLv3 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import {addLine, deleteLine, retrieveProductData, setLineProperty, updateTotals} from "../actions";
+import {addLine, deleteLine, retrieveProductData, setLineProperty, updateTotals, setQuickAddProduct, clearQuickAddProduct, setAutoAdd, addProduct} from "../actions";
 import {LINE_TYPES, selectBox} from "./utils";
 import BrowseAPI from "BrowseAPI";
 
@@ -145,29 +145,35 @@ export function renderOrderLines(store, shop, lines) {
     }).compact().value();
 }
 
-var select2 = {
-    clear: function() {
-        if (select2.element) {
-            select2.element.select2("val", null);
-        }
-    },
+
+var Select2 = {
     view: function(ctrl, attrs) {
         return m("select", {
-            config: select2.config(attrs), "data-model": "shuup.product"});
+            config: Select2.config(attrs)
+        });
     },
     config: function(ctrl) {
         return function(element, isInitialized) {
             if(typeof jQuery !== "undefined" && typeof jQuery.fn.select2 !== "undefined") {
-                var el = $(element);
-                select2.element = el;
+                let $el = $(element);
                 if (!isInitialized) {
-                    // This is needed to reset prop when going back from confirmation view
-                    productQuickSelect.currentProduct(null);
-                    el.select2()
-                        .on("change", function() {
-                            ctrl.onchange($(this).val());
-                        });
+                    activateSelect($el, ctrl.model, ctrl.attrs).on("change", () => {
+                        // note: data is only populated when an element is actually clicked or enter is pressed
+                        const data = $el.select2("data");
+                        ctrl.onchange(data);
+                        if(ctrl.focus()){
+                            // close it first to clear the search box...
+                            $el.select2("close");
+                            $el.select2("open");
+                        }
+                    });
+                } else {
+                    // this doesn't actually set the value for ajax autoadd
+                    $el.val(ctrl.value().id).trigger("change");
+                    // trigger select2 dropdown repositioning
+                    $(window).scroll();
                 }
+
             } else {
                 alert(gettext("Missing JavaScript dependencies detected"));
             }
@@ -175,24 +181,50 @@ var select2 = {
     }
 };
 
-var productQuickSelect = {
-    clearSelection: function() {
-        productQuickSelect.currentProduct(null);
-        select2.clear();
-    },
-    currentProduct: m.prop(),
-    changeProduct: function(id) {
-        productQuickSelect.currentProduct(id);
-    },
-    view: function() {
-        return m.component(select2, {
-            onchange: this.changeProduct,
+
+var ProductQuickSelect = {
+    view: function(ctrl, attrs) {
+        const {store} = attrs;
+
+        return m.component(Select2, {
+            model: "shuup.product",
+            attrs: {
+                ajax: {
+                    processResults: function (data) {
+                        const {quickAdd} = store.getState();
+                        const results = {
+                            results: $.map(data.results, function (item) {
+                                return {text: item.name, id: item.id};
+                            })
+                        };
+                        if(quickAdd.autoAdd && results.results.length === 1) {
+                            store.dispatch(setQuickAddProduct(results.results[0]));
+                            store.dispatch(addProduct(results.results[0]));
+                            store.dispatch(clearQuickAddProduct());
+                            return {results: []};
+                        }
+                        return results;
+                    }
+                }
+            },
+            value: () => store.getState().quickAdd.product,
+            focus: () => store.getState().quickAdd.autoAdd && store.getState().quickAdd.product.id,
+            onchange: (product) => {
+                const {quickAdd} = store.getState();
+                if(product && product.length) {
+                    if(quickAdd.autoAdd) {
+                        store.dispatch(addProduct(product[0]));
+                    } else {
+                        store.dispatch(setQuickAddProduct(product[0]));
+                    }
+                }
+            }
         });
     }
 };
 
 export function orderLinesView(store, isCreating) {
-    const {lines, shop} = store.getState();
+    const {lines, shop, quickAdd} = store.getState();
     // This is needed to make select work when going back from confirmation view
     store.dispatch(updateTotals(store.getState));
     return m("div", [
@@ -210,10 +242,9 @@ export function orderLinesView(store, isCreating) {
                     disabled: isCreating,
                     onclick: () => {
                         store.dispatch(addLine());
-                        var productId = productQuickSelect.currentProduct();
-                        if (productId){
+                        if (quickAdd.product.id){
                             store.dispatch(retrieveProductData(
-                                {id: productId, forLine: _.last(store.getState().lines).id}
+                                {id: quickAdd.product.id, forLine: _.last(store.getState().lines).id}
                             ));
                         }
                     }
@@ -222,25 +253,32 @@ export function orderLinesView(store, isCreating) {
             m("div.col-sm-6", [
                 m("fieldset", [
                     m("legend", gettext("Quick add product line")),
-                    productQuickSelect,
+                    m.component(ProductQuickSelect, {store: store}),
                     m("button.btn.text-success" + (isCreating ? ".disabled": ""), {
                         disabled: isCreating,
                         onclick: () => {
-                            store.dispatch(addLine());
-                            var productId = productQuickSelect.currentProduct();
-                            if (productId){
-                                store.dispatch(retrieveProductData(
-                                    {id: productId, forLine: _.last(store.getState().lines).id}
-                                ));
+                            if (quickAdd.product.id){
+                                store.dispatch(addProduct(quickAdd.product));
+                                store.dispatch(clearQuickAddProduct());
                             }
-                            productQuickSelect.clearSelection();
                         }
                     }, m("i.fa.fa-plus")),
                     m("button.btn.text-success" + (isCreating ? ".disabled": ""), {
                         disabled: isCreating,
-                        onclick: productQuickSelect.clearSelection,
+                        onclick: () => {
+                            store.dispatch(clearQuickAddProduct());
+                        }
                     }, m("i.fa.fa-trash")),
                     m("span.help-block", gettext("Search product by name, SKU, or barcode and press button to add product line.")),
+                    m("input", {
+                        type: "checkbox",
+                        checked: quickAdd.autoAdd,
+                        onchange: function() {
+                            store.dispatch(clearQuickAddProduct());
+                            store.dispatch(setAutoAdd(this.checked));
+                        }
+                    }),
+                    m("span.quick-add-check-text", " " + gettext("Automatically add selected product")),
                 ])
             ]),
         ]),

--- a/shuup/admin/modules/orders/static_src/create/view/methods.js
+++ b/shuup/admin/modules/orders/static_src/create/view/methods.js
@@ -18,7 +18,7 @@ function renderMethod(store, mode, title, selectedMethod, choices, emptyChoice) 
                     (mode === "shipping" ?
                         store.dispatch(setShippingMethod(newMethod)) : store.dispatch(setPaymentMethod(newMethod)));
                     store.dispatch(updateTotals(store.getState));
-                }, [].concat({id: 0, name: emptyChoice}, choices || []))
+                }, [].concat({id: 0, name: emptyChoice}, choices || []), "id", "name", mode)
             ]
         )
     ];

--- a/shuup/admin/modules/orders/static_src/create/view/utils.js
+++ b/shuup/admin/modules/orders/static_src/create/view/utils.js
@@ -28,14 +28,14 @@ export const ADDRESS_FIELDS = [
     {key: "country", label: gettext("Country"), "required": true}
 ];
 
-export function selectBox(value, onchange, choices, valueGetter = "id", nameGetter = "name") {
+export function selectBox(value, onchange, choices, valueGetter = "id", nameGetter = "name", name = "") {
     if (_.isString(valueGetter)) {
         valueGetter = _.partialRight(_.get, valueGetter);
     }
     if (_.isString(nameGetter)) {
         nameGetter = _.partialRight(_.get, nameGetter);
     }
-    return m("select.form-control", {value, onchange}, choices.map(
+    return m("select.form-control", {value, onchange, name}, choices.map(
         (obj) => m("option", {value: valueGetter(obj)}, nameGetter(obj))
     ));
 }

--- a/shuup/admin/static_src/base/js/select.js
+++ b/shuup/admin/static_src/base/js/select.js
@@ -7,42 +7,48 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+function activateSelect($select, model, attrs={}) {
+    if(model === undefined) {
+        return $select.select2($.extend(true, {
+            language: "xx",
+            matcher: function(search, data) {
+                const needle = $.trim(search.term || "").toUpperCase();
+                const haystack = data.text.toUpperCase();
+                if(haystack.indexOf(needle) == 0) {
+                    return data;
+                }
+                return false;
+            }
+        }, attrs));
+    }
+    return $select.select2($.extend(true, {
+        language: "xx",
+        minimumInputLength: 3,
+        ajax: {
+            url: "/sa/select",
+            dataType: "json",
+            data: function(params) {
+                return {model: model, search: params.term};
+            },
+            processResults: function (data) {
+                return {
+                    results: $.map(data.results, function (item) {
+                        return {text: item.name, id: item.id};
+                    })
+                };
+            }
+        }
+    }, attrs));
+}
+
 function activateSelects() {
     $("select").each(function(idx, object) {
         const select = $(object);
-        const model = select.data("model");
-        if(model === undefined) {
-            select.select2({
-                language: "xx",
-                matcher: function(search, data) {
-                    const needle = $.trim(search.term || "").toUpperCase();
-                    const haystack = data.text.toUpperCase();
-                    if(haystack.indexOf(needle) == 0) {
-                        return data;
-                    }
-                    return false;
-                }
-            });
-            return true;
+        // only activate selects that aren't already select2 inputs
+        if(!select.hasClass("select2-hidden-accessible")){
+            const model = select.data("model");
+            activateSelect(select, model);
         }
-        select.select2({
-            language: "xx",
-            minimumInputLength: 3,
-            ajax: {
-                url: "/sa/select",
-                dataType: "json",
-                data: function(params) {
-                    return {model: model, search: params.term};
-                },
-                processResults: function (data) {
-                    return {
-                        results: $.map(data.results, function (item) {
-                            return {text: item.name, id: item.id};
-                        })
-                    };
-                }
-            }
-        });
     });
 }
 
@@ -83,5 +89,6 @@ $(function(){
             }
         };
     });
+
     activateSelects();
 });

--- a/shuup/admin/templates/shuup/admin/services/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/services/edit.jinja
@@ -52,6 +52,7 @@
 
             // Remove activated select2 spans from placeholder
             $source.find("span.select2.select2-container").remove();
+            $source.find("select.select2-hidden-accessible").removeClass("select2-hidden-accessible");
             var targetID = $selection.data("target-id");
             var $totalFormsField = $("#" + targetID + "-TOTAL_FORMS");
             var componentCount = parseInt($totalFormsField.val());

--- a/shuup/campaigns/templates/shuup/campaigns/admin/edit_campaigns.jinja
+++ b/shuup/campaigns/templates/shuup/campaigns/admin/edit_campaigns.jinja
@@ -79,6 +79,7 @@
 
             // Remove activated select2 spans from placeholder
             $source.find("span.select2.select2-container").remove();
+            $source.find("select.select2-hidden-accessible").removeClass("select2-hidden-accessible");
             var targetID = $selection.data("target-id");
             var $totalFormsField = $("#" + targetID + "-TOTAL_FORMS");
             var componentCount = parseInt($totalFormsField.val());

--- a/shuup_tests/browser/admin/test_order_creator.py
+++ b/shuup_tests/browser/admin/test_order_creator.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+import pytest
+import time
+
+from django.core.urlresolvers import reverse
+
+from shuup.core.models import Order, OrderStatus
+from shuup.testing.factories import create_empty_order, get_default_shop, create_product
+from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import wait_until_disappeared
+
+
+pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
+
+
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_order_creator_view(browser, admin_user, live_server):
+    shop = get_default_shop()
+    product0 = create_product("test-sku0", shop=shop)
+    product1 = create_product("test-sku1", shop=shop)
+
+    initialize_admin_browser_test(browser, live_server)
+    _visit_order_creator_view(browser, live_server)
+    _test_quick_add_lines(browser)
+
+
+def _visit_order_creator_view(browser, live_server):
+    browser.execute_script("window.localStorage.setItem('resetSavedOrder', 'true')")
+    url = reverse("shuup_admin:order.new")
+    browser.visit("%s%s" % (live_server, url))
+    assert browser.is_element_present_by_css("h1.main-header")
+
+
+def _test_quick_add_lines(browser):
+    assert browser.find_by_css("input[name='auto-add']").first.checked == True
+    # add line automatically just by searching and finding direct match
+    browser.execute_script("window.scrollTo(0, document.getElementById('quick-add').getBoundingClientRect().top - 200)")
+    browser.find_by_id("quick-add").find_by_css('.select2').click()
+
+    assert len(browser.find_by_id("quick-add").find_by_css('.select2-container--open')) == 1, "select is open"
+    browser.find_by_css("input.select2-search__field").first.value = "test-sku1"
+    wait_until_disappeared(browser, "select2-results__message")
+    line_items = browser.find_by_id("lines").find_by_css('.list-group-item')
+    assert len(line_items) == 1, "one line item added"
+    assert len(browser.find_by_id("quick-add").find_by_css('.select2-container--open')) == 1, "select is open after add"
+    assert line_items.first.find_by_css('input[name="quantity"]').first.value == '1', "one piece added"
+
+    browser.find_by_css("input.select2-search__field").first.value = "test-sku1"
+    wait_until_disappeared(browser, "select2-results__message")
+    line_items = browser.find_by_id("lines").find_by_css('.list-group-item')
+    assert len(line_items) == 1, "only one line item exists"
+    assert line_items.first.find_by_css('input[name="quantity"]').first.value == '2', "two pieces added"
+
+    # add line automatically by searching and clicking on match
+    browser.find_by_css("input.select2-search__field").first.value = "test-sku"
+    wait_until_disappeared(browser, "select2-results__message")
+    browser.execute_script('$($(".select2-results__option")[0]).trigger({type: "mouseup"})')
+    assert line_items.first.find_by_css('input[name="quantity"]').first.value == '3', "three pieces added"
+
+    # add line manually
+    browser.uncheck("auto-add")
+    browser.find_by_id("quick-add").find_by_css('.select2').click()
+    browser.find_by_css("input.select2-search__field").first.value = "test-sku0"
+    wait_until_disappeared(browser, "select2-results__message")
+    browser.execute_script('$($(".select2-results__option")[0]).trigger({type: "mouseup"})')
+    browser.find_by_id("add-product").first.click()
+    line_items = browser.find_by_id("lines").find_by_css('.list-group-item')
+    assert len(line_items) == 2, "two line items exist"


### PR DESCRIPTION
Refactor `activateSelects`
Add the ability for products to be added to the order without any keyboard/mouse interaction.
Add browser tests for order line entry

Refs SHUUP-3152