### PR TITLE
Fix an issue where None comparison to int is failing

### DIFF
--- a/shuup/admin/modules/orders/views/shipment.py
+++ b/shuup/admin/modules/orders/views/shipment.py
@@ -156,7 +156,7 @@ class OrderCreateShipmentView(UpdateView):
             (int(key.replace("q_", "")), value)
             for (key, value)
             in six.iteritems(form.cleaned_data)
-            if key.startswith("q_") and value > 0
+            if key.startswith("q_") and (value > 0 if value else False)
         )
         order = self.object
         product_map = Product.objects.in_bulk(set(product_ids_to_quantities.keys()))


### PR DESCRIPTION
This comparision would raise an "unorderable types: NoneType()> int()" exception. Fix this by checking
for a value before comparing.

Traceback of said error:
![image](https://cloud.githubusercontent.com/assets/6592571/17698118/e282ea5c-63c1-11e6-8508-7c8ed0598923.png)
