### PR TITLE
Fix an issue where None comparison to int is failing

### DIFF
--- a/shuup/admin/modules/orders/views/shipment.py
+++ b/shuup/admin/modules/orders/views/shipment.py
@@ -156,7 +156,7 @@ class OrderCreateShipmentView(UpdateView):
             (int(key.replace("q_", "")), value)
             for (key, value)
             in six.iteritems(form.cleaned_data)
-            if key.startswith("q_") and value > 0
+            if key.startswith("q_") and (value > 0 if value else False)
         )
         order = self.object
         product_map = Product.objects.in_bulk(set(product_ids_to_quantities.keys()))


### PR DESCRIPTION
This comparision would raise an "unorderable types: NoneType()> int()" exception. Fix this by checking
for a value before comparing.

There were issues with Travis https://github.com/shuup/shuup/pull/724 so ths will replace that PR.