### PR TITLE
Admin: Convert product edit collapsed sections into tabs (SHUUP-3234)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -22,6 +22,7 @@ Localization
 Admin
 ~~~~~
 
+- Product edit: Convert collapsed sections into tabs
 - Increment quantity when quick adding products with existing lines in order creator
 - Add option for automatically adding product lines when creating order
 - Order editing: Tax number is now shown for Company Contacts

--- a/shuup/admin/modules/products/views/edit.py
+++ b/shuup/admin/modules/products/views/edit.py
@@ -49,9 +49,9 @@ class ProductBaseFormPart(FormPart):
         )
 
         yield TemplatedFormDef(
-            "base_collapsed",
+            "base_extra",
             forms.Form,
-            template_name="shuup/admin/products/_edit_collapsed_base_form.jinja",
+            template_name="shuup/admin/products/_edit_extra_base_form.jinja",
             required=False
         )
 
@@ -104,11 +104,11 @@ class ShopProductFormPart(FormPart):
                 kwargs={"instance": shop_product, "initial": self.get_initial()}
             )
 
-            # the collapsed form template uses ShopProductForm
+            # the hidden extra form template that uses ShopProductForm
             yield TemplatedFormDef(
-                "shop%d_collapsed" % shop.pk,
+                "shop%d_extra" % shop.pk,
                 forms.Form,
-                template_name="shuup/admin/products/_edit_collapsed_shop_form.jinja",
+                template_name="shuup/admin/products/_edit_extra_shop_form.jinja",
                 required=False
             )
 

--- a/shuup/admin/static_src/base/less/shuup/content-blocks.less
+++ b/shuup/admin/static_src/base/less/shuup/content-blocks.less
@@ -21,7 +21,7 @@
         position: relative;
 
         &.open {
-            .block-title {
+            .block-title, .block-subtitle {
                 @media (max-width: @screen-sm-max) {
                     border-color: @brand-primary;
                     padding-bottom: 15px;
@@ -30,7 +30,7 @@
             .toggle-contents i { transform: rotate(90deg); }
         }
 
-        .block-title {
+        .block-title, .block-subtitle {
             border-bottom: 3px solid @brand-primary;
             padding-bottom: 15px;
             margin-bottom: 0px;
@@ -129,13 +129,13 @@
     &.collapsed {
         .title {
             &.open {
-                .block-title {
+                .block-title, .block-subtitle {
                     border-color: @brand-primary;
                     padding-bottom: 15px;
                 }
             }
 
-            .block-title {
+            .block-title, .block-subtitle {
                 border-color: #fff;
                 padding-bottom: 0;
             }

--- a/shuup/admin/static_src/base/less/shuup/content-blocks.less
+++ b/shuup/admin/static_src/base/less/shuup/content-blocks.less
@@ -8,6 +8,10 @@
     border: solid #ededed;
     border-width: 3px 1px;
 
+    @media (max-width: @screen-sm-max) {
+        display: block !important;
+    }
+
     @media (min-width: @screen-md-min) {
         padding: 30px;
         margin-bottom: 30px;

--- a/shuup/admin/templates/shuup/admin/products/_edit_base_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_base_form.jinja
@@ -1,23 +1,29 @@
-{% from "shuup/admin/macros/general.jinja" import content_block %}
 {% from "shuup/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
 {% set product_form = form["base"] %}
 
-{% call content_block(_("General Information"), "fa-info-circle") %}
-    {% call(form, language, map) language_dependent_content_tabs(product_form, tab_id_prefix="language") %}
-        {{ bs3.field(product_form[map.name]) }}
-        {{ bs3.field(product_form[map.description], widget_class="remarkable-field") }}
-    {% endcall %}
-    {{ bs3.field(product_form.type) }}
-    {{ bs3.field(product_form.sku) }}
-    {{ bs3.field(product_form.stock_behavior) }}
-    {{ bs3.field(product_form.shipping_mode) }}
-    {{ bs3.field(product_form.tax_class) }}
-{% endcall %}
-{% call content_block(_("Physical Properties"), "fa-cog") %}
-    {{ bs3.field(product_form.width) }}
-    {{ bs3.field(product_form.height) }}
-    {{ bs3.field(product_form.depth) }}
-    {{ bs3.field(product_form.sales_unit) }}
-    {{ bs3.field(product_form.net_weight) }}
-    {{ bs3.field(product_form.gross_weight) }}
-{% endcall %}
+<div class="row">
+    <div class="col-md-12">
+        {% call(form, language, map) language_dependent_content_tabs(product_form, tab_id_prefix="language") %}
+            {{ bs3.field(product_form[map.name]) }}
+            {{ bs3.field(product_form[map.description], widget_class="remarkable-field") }}
+        {% endcall %}
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-6">
+        {{ bs3.field(product_form.type) }}
+        {{ bs3.field(product_form.sku) }}
+        {{ bs3.field(product_form.stock_behavior) }}
+        {{ bs3.field(product_form.shipping_mode) }}
+        {{ bs3.field(product_form.tax_class) }}
+    </div>
+    <div class="col-md-6">
+        {{ bs3.field(product_form.width) }}
+        {{ bs3.field(product_form.height) }}
+        {{ bs3.field(product_form.depth) }}
+        {{ bs3.field(product_form.sales_unit) }}
+        {{ bs3.field(product_form.net_weight) }}
+        {{ bs3.field(product_form.gross_weight) }}
+    </div>
+</div>

--- a/shuup/admin/templates/shuup/admin/products/_edit_extra_base_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_extra_base_form.jinja
@@ -2,7 +2,7 @@
 {% from "shuup/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
 {% set product_form = form["base"] %}
 
-{% call content_block(_("Additional Details"), "fa-file-text", collapsed=True) %}
+{% call content_block(_("Additional Details"), "fa-file-text") %}
     {{ bs3.field(product_form.barcode) }}
     {{ bs3.field(product_form.gtin) }}
     {{ bs3.field(product_form.category) }}
@@ -13,12 +13,6 @@
     {% endcall %}
 {% endcall %}
 
-{% call content_block(_("Accounting"), "fa-book", collapsed=True) %}
-    {{ bs3.field(product_form.accounting_identifier) }}
-    {{ bs3.field(product_form.profit_center) }}
-    {{ bs3.field(product_form.cost_center) }}
-{% endcall %}
-
-{% call content_block(_("Manufacturer"), "fa-building", collapsed=True) %}
+{% call content_block(_("Manufacturer"), "fa-building") %}
     {{ bs3.field(product_form.manufacturer) }}
 {% endcall %}

--- a/shuup/admin/templates/shuup/admin/products/_edit_extra_shop_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_extra_shop_form.jinja
@@ -3,9 +3,9 @@
 {% set base_form_name = form_def.name.split('_')[0] %}
 {% set shop_product_form = form[base_form_name] %}
 {% set shop_name = shop_product_form.instance.shop.name %}
-{% set shop_name_prefix = shop_product_form.instance.shop.name ~ " - " %}
+{% set shop_name_prefix = shop_name ~ " - " %}
 
-{% call content_block(shop_name_prefix ~ _("Shipping & Payment"), "fa-truck", collapsed=True) %}
+{% call content_block(shop_name_prefix ~ _("Shipping & Payment"), "fa-truck") %}
     {{ bs3.field(shop_product_form.limit_payment_methods) }}
     {{ bs3.field(shop_product_form.limit_shipping_methods) }}
     {{ bs3.field(shop_product_form.payment_methods) }}

--- a/shuup/admin/templates/shuup/admin/products/_edit_media_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_media_form.jinja
@@ -90,7 +90,7 @@
 {%- set is_image_form = media_form.prefix == "images" %}
 {%- set id = "product-images-section" if is_image_form else "product-media-section" %}
 {%- set name = _("Product Images") if is_image_form else _("Product Media") %}
-{% call content_block(name, "fa-camera", id=id, collapsed=True) %}
+{% call content_block(name, "fa-camera", id=id) %}
     {{ media_form.management_form }}
     {% for f in media_form %}
         {{ render_media_form(f, media_form, loop.index, is_image_form) }}

--- a/shuup/admin/templates/shuup/admin/products/_edit_shop_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_shop_form.jinja
@@ -1,23 +1,26 @@
 {% from "shuup/admin/macros/general.jinja" import content_block %}
 {% set shop_product_form = form[form_def.name] %}
 {% set shop_name = shop_product_form.instance.shop.name %}
-{% set shop_name_prefix = shop_product_form.instance.shop.name ~ " - " %}
 
-{% call content_block(shop_name_prefix ~ _("Visibility"), "fa-eye") %}
-    {{ bs3.field(shop_product_form.visible) }}
-    {{ bs3.field(shop_product_form.listed) }}
-    {{ bs3.field(shop_product_form.searchable) }}
-    {{ bs3.field(shop_product_form.visibility_limit) }}
-    {{ bs3.field(shop_product_form.visibility_groups) }}
-    {{ bs3.field(shop_product_form.primary_category) }}
-    {{ bs3.field(shop_product_form.categories) }}
-{% endcall %}
-
-{% call content_block(shop_name_prefix ~ _("Purchasing"), "fa-shopping-cart") %}
-    {{ bs3.field(shop_product_form.default_price_value) }}
-    {{ bs3.field(shop_product_form.minimum_price_value) }}
-    {{ bs3.field(shop_product_form.suppliers) }}
-    {{ bs3.field(shop_product_form.purchase_multiple) }}
-    {{ bs3.field(shop_product_form.minimum_purchase_quantity) }}
-    {{ bs3.field(shop_product_form.backorder_maximum) }}
-{% endcall %}
+<div class="title">
+    <h2 class="block-subtitle"><i class="fa fa-home"></i>{{ shop_name }}</h2>
+</div>
+<div class="row content">
+    <div class="col-md-6">
+        {{ bs3.field(shop_product_form.visible) }}
+        {{ bs3.field(shop_product_form.listed) }}
+        {{ bs3.field(shop_product_form.searchable) }}
+        {{ bs3.field(shop_product_form.visibility_limit) }}
+        {{ bs3.field(shop_product_form.visibility_groups) }}
+        {{ bs3.field(shop_product_form.primary_category) }}
+        {{ bs3.field(shop_product_form.categories) }}
+    </div>
+    <div class="col-md-6">
+        {{ bs3.field(shop_product_form.default_price_value) }}
+        {{ bs3.field(shop_product_form.minimum_price_value) }}
+        {{ bs3.field(shop_product_form.suppliers) }}
+        {{ bs3.field(shop_product_form.purchase_multiple) }}
+        {{ bs3.field(shop_product_form.minimum_purchase_quantity) }}
+        {{ bs3.field(shop_product_form.backorder_maximum) }}
+    </div>
+</div>

--- a/shuup/admin/templates/shuup/admin/products/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/products/edit.jinja
@@ -5,29 +5,36 @@
     {% if orderability_errors %}
         <div class="container-fluid">
             {# TODO: FIX THIS FOR MOBILE SCREEN SIZES #}
-            <p class="pull-right" data-toggle="tooltip" data-title="{% for error in orderability_errors %}{{ error }} {% endfor %}" data-placement="bottom">
+            <p class="pull-right"
+               data-toggle="tooltip"
+               data-title="{% for error in orderability_errors %}{{ error }} {% endfor %}"
+               data-placement="bottom">
                 <i class="fa fa-info-circle text-info"></i> {% trans %}This product is currently not orderable.{% endtrans %}
             </p>
         </div>
     {% endif %}
-    <form method="post" id="product_form">
-        {% csrf_token %}
-        {% for form_def in form.form_defs.values() %}
-            {% if form_def.required %}
-                {% include form_def.template_name with context %}
-            {% endif %}
-        {% endfor %}
-        {% for form_def in form.form_defs.values() %}
-            {% if not form_def.required %}
+    {% call content_with_sidebar(content_id="product_form") %}
+        <form method="post" id="product_form">
+            {% csrf_token %}
+            {% call content_block(_("General Information"), "fa-info-circle") %}
+                {% for form_def in form.form_defs.values() %}
+                    {% if form_def.required %}
+                        {% include form_def.template_name with context %}
+                    {% endif %}
+                {% endfor %}
+            {% endcall %}
+            {% for form_def in form.form_defs.values() %}
+                {% if not form_def.required %}
                     {% include form_def.template_name with context %}
-            {% endif %}
-        {% endfor %}
-    </form>
-    {% for product_section in product_sections %}
-        {% call content_block(product_section.name, product_section.icon, collapsed=True) %}
-            {% include product_section.template with context %}
-        {% endcall %}
-    {% endfor %}
+                {% endif %}
+            {% endfor %}
+            {% for product_section in product_sections %}
+                {% call content_block(product_section.name, product_section.icon) %}
+                    {% include product_section.template with context %}
+                {% endcall %}
+            {% endfor %}
+        </form>
+    {% endcall %}
 {% endblock %}
 
 {% block extra_js %}

--- a/shuup/customer_group_pricing/templates/shuup/admin/customer_group_pricing/form_part.jinja
+++ b/shuup/customer_group_pricing/templates/shuup/admin/customer_group_pricing/form_part.jinja
@@ -1,6 +1,6 @@
 {% from "shuup/admin/macros/general.jinja" import content_block with context %}
 {% set sp_form = form["customer_group_pricing"] %}
-{% call content_block(_("Customer Group Pricing"), "fa-money", collapsed=True) %}
+{% call content_block(_("Customer Group Pricing"), "fa-money") %}
     <div class="panel panel-default">
         <div class="panel-heading">
             <h2 class="panel-title">

--- a/shuup/simple_supplier/templates/shuup/simple_supplier/admin/product_form_part.jinja
+++ b/shuup/simple_supplier/templates/shuup/simple_supplier/admin/product_form_part.jinja
@@ -48,7 +48,7 @@
     {% endfor %}
 {% endmacro %}
 
-{% call content_block(_("Stock management"), "fa-cubes", collapsed=True) %}
+{% call content_block(_("Stock management"), "fa-cubes") %}
     {% if ss_form.can_manage_stock() %}
         {{ render_products(ss_form) }}
     {% else %}

--- a/shuup_tests/browser/admin/test_product_detail.py
+++ b/shuup_tests/browser/admin/test_product_detail.py
@@ -43,3 +43,8 @@ def test_product_detail(browser, admin_user, live_server):
         if "Actions" in dropdown.text:
             dropdown.click()
     browser.find_by_xpath('//a[@href="#%s"]' % product.sku).first.click()
+
+    # Make sure that the tabs is clickable in small devices
+    browser.driver.set_window_size(480, 960)
+    browser.find_by_id("product-images-section").first.click()
+    browser.find_by_id("additional-details-section").first.click()


### PR DESCRIPTION
* At product edit convert collapsed sections into tabs
* At product edit divide required/general information to
two columns to avoid scrolling
* Hide accounting tab at admin product edit as unused information
* Do not collapse admin module product section at customer group
pricing and simple supplier apps