### PR TITLE
Require Parler related settings when loading application (#597)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Prevent Shuup from loading if Parler related settings are missing
 - Prevent shipping products with insufficient physical stock
 - Telemetry is now being sent if there is no previous submission
 - ``CompanyContact.full_name`` now returns name and name extension (if available)

--- a/shuup/core/__init__.py
+++ b/shuup/core/__init__.py
@@ -6,6 +6,7 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from shuup.apps import AppConfig
+from shuup.core.excs import MissingSettingException
 
 
 class ShuupCoreAppConfig(AppConfig):
@@ -26,6 +27,13 @@ class ShuupCoreAppConfig(AppConfig):
             "shuup.core.pricing.default_pricing:DefaultPricingModule"
         ],
     }
+
+    def ready(self):
+        from django.conf import settings
+        if not getattr(settings, "PARLER_DEFAULT_LANGUAGE_CODE", None):
+            raise MissingSettingException("PARLER_DEFAULT_LANGUAGE_CODE must be set.")
+        if not getattr(settings, "PARLER_LANGUAGES", None):
+            raise MissingSettingException("PARLER_LANGUAGES must be set.")
 
 
 default_app_config = "shuup.core.ShuupCoreAppConfig"

--- a/shuup/core/excs.py
+++ b/shuup/core/excs.py
@@ -32,6 +32,10 @@ class InvalidRefundAmountException(Exception):
     pass
 
 
+class MissingSettingException(Exception):
+    pass
+
+
 class ProductNotOrderableProblem(Problem):
     pass
 

--- a/shuup_tests/core/test_settings.py
+++ b/shuup_tests/core/test_settings.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from django.apps import apps
+from django.test import override_settings
+
+from shuup.core import MissingSettingException
+
+
+@pytest.mark.parametrize("setting_key, value, should_raise", [
+    ("PARLER_DEFAULT_LANGUAGE_CODE", None, True),
+    ("PARLER_DEFAULT_LANGUAGE_CODE", False, True),
+    ("PARLER_DEFAULT_LANGUAGE_CODE", "", True),
+    ("PARLER_DEFAULT_LANGUAGE_CODE", "en", False),
+    ("PARLER_LANGUAGES", None, True),
+    ("PARLER_LANGUAGES", False, True),
+    ("PARLER_LANGUAGES", "", True),
+    ("PARLER_LANGUAGES", {}, True),
+    ("PARLER_LANGUAGES", {None: [1,2]}, False),
+    ("PARLER_LANGUAGES", {"en": [1,2]}, False),
+])
+@pytest.mark.django_db
+def test_parler_language_code(setting_key, value, should_raise):
+    kwargs = {setting_key: value}
+    with override_settings(**kwargs):
+        if should_raise:
+            with pytest.raises(MissingSettingException):
+                apps.get_app_config('shuup').ready()


### PR DESCRIPTION
Parler settings were actually required by Shuup and running the application without them caused errors.

This issue was comprehensively documented by @akx in issue #597.

Fixes #597 