### PR TITLE
Simple Search: Set column width in less (SHUUP-3201)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -24,6 +24,8 @@ Addons
 Front
 ~~~~~
 
+- Define simple search result list column width in less instead of template
+
 Xtheme
 ~~~~~~
 

--- a/shuup/front/apps/simple_search/templates/shuup/simple_search/search.jinja
+++ b/shuup/front/apps/simple_search/templates/shuup/simple_search/search.jinja
@@ -39,9 +39,7 @@
         <p class="lead">{% trans query=form.cleaned_data.q, n=products|count %}{{ n }} results found for "<strong>{{ query }}</strong>".{% endtrans %}</p>
         <div class="row">
         {% for product in products %}
-            <div class="col-sm-4 col-md-3">
-                {{ product_macros.product_box(product, show_description=True, class="product-card box") }}
-            </div>
+            {{ product_macros.product_box(product, show_description=True, class="product-card box search-view") }}
         {% endfor %}
         </div>
     {% endif %}

--- a/shuup/front/static_src/less/front/product-card.less
+++ b/shuup/front/static_src/less/front/product-card.less
@@ -33,6 +33,11 @@
         }
     }
 
+    &.search-view {
+        .make-sm-column(4);
+        .make-md-column(3);
+    }
+
     .labels {
         position: absolute;
         left: 5px;


### PR DESCRIPTION
Add extra class `search-view` for product-box and set
column width in less to enable more customizable search
list.