### PR TITLE
Admin: require shipping address before creating shipment (SHUUP-3257)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,6 +18,8 @@ Localization
 Admin
 ~~~~~
 
+- Prevent shipping orders without a defined shipping address
+
 Addons
 ~~~~~~
 

--- a/shuup/admin/modules/orders/views/shipment.py
+++ b/shuup/admin/modules/orders/views/shipment.py
@@ -20,7 +20,9 @@ from shuup.admin.toolbar import PostActionButton, Toolbar
 from shuup.admin.utils.forms import add_form_errors_as_messages
 from shuup.admin.utils.urls import get_model_url
 from shuup.apps.provides import get_provide_objects
-from shuup.core.excs import NoProductsToShipException
+from shuup.core.excs import (
+    NoProductsToShipException, NoShippingAddressException
+)
 from shuup.core.models import Order, Product, Shipment, Supplier
 from shuup.utils.excs import Problem
 
@@ -192,6 +194,8 @@ class OrderCreateShipmentView(UpdateView):
         except NoProductsToShipException:
             messages.error(self.request, _("No products to ship."))
             return self.form_invalid(form)
+        except NoShippingAddressException:
+            messages.error(self.request, _("Shipping address is not set."))
         else:
             messages.success(self.request, _("Shipment %s created.") % shipment.id)
             return HttpResponseRedirect(get_model_url(order))

--- a/shuup/core/excs.py
+++ b/shuup/core/excs.py
@@ -12,6 +12,10 @@ class ImmutabilityError(ValueError):
     pass
 
 
+class NoShippingAddressException(Exception):
+    pass
+
+
 class NoProductsToShipException(Exception):
     pass
 


### PR DESCRIPTION
The order form already requires shipping information when creating an
order. This commit ensures that a shipping_address is set on the order
at the time of shipment creation, otherwise it raises a
NoShippingAddressException.

Refs SHUUP-3257