### PR TITLE
Utils: Fix issue with pdf stylesheets (SHUUP-2933)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -59,6 +59,7 @@ Guide
 General/miscellaneous
 ~~~~~~~~~~~~~~~~~~~~~
 
+* Fix bug in pdf utils while fetching static resources
 
 SHUUP 0.4.3
 -----------

--- a/shuup/utils/pdf.py
+++ b/shuup/utils/pdf.py
@@ -23,7 +23,7 @@ except ImportError:
 
 def _fetch_static_resource_str(resource_file):
     resource_path = os.path.realpath(os.path.join(settings.STATIC_ROOT, resource_file))
-    if not resource_path.startswith(settings.STATIC_ROOT):
+    if not resource_path.startswith(os.path.realpath(settings.STATIC_ROOT)):
         raise ValueError(
             "Possible file system traversal shenanigan detected with %(path)s" % {"path": resource_file})
 


### PR DESCRIPTION
Check whether the resource path startswith realpath from
`settings.STATIC_ROOT`.

In case settings STATIC_ROOT is behind symlink the resource path
will not anymore start with STATIC_ROOT since symlink is resolved.