### PR TITLE
Fix product visibility (SH-79)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -28,6 +28,7 @@ Addons
 Front
 ~~~~~
 
+- Fix product search to only show searchable products
 - Rename `get_visible_products` to `get_listed_products`
 - Define simple search result list column width in less instead of template
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,8 @@ Unreleased
 Core
 ~~~~
 
+- Add visibility field to ShopProduct
+
 Localization
 ~~~~~~~~~~~~
 
@@ -26,6 +28,7 @@ Addons
 Front
 ~~~~~
 
+- Rename `get_visible_products` to `get_listed_products`
 - Define simple search result list column width in less instead of template
 
 Xtheme

--- a/shuup/admin/modules/categories/forms.py
+++ b/shuup/admin/modules/categories/forms.py
@@ -12,7 +12,9 @@ from django.utils.translation import ugettext_lazy as _
 from shuup.admin.forms.fields import Select2MultipleField
 from shuup.admin.forms.widgets import MediaChoiceWidget
 from shuup.admin.utils.forms import filter_form_field_choices
-from shuup.core.models import Category, CategoryStatus, Product, ShopProduct
+from shuup.core.models import (
+    Category, CategoryStatus, Product, ShopProduct, ShopProductVisibility
+)
 from shuup.utils.multilanguage_model_form import MultiLanguageModelForm
 
 
@@ -83,7 +85,9 @@ class CategoryProductForm(forms.Form):
         primary_product_ids = [int(product_id) for product_id in data.get("primary_products", [])]
         for shop_product in ShopProduct.objects.filter(shop_id=self.shop.id, product_id__in=primary_product_ids):
             shop_product.primary_category = self.category
-            shop_product.visible = is_visible
+            shop_product.visibility = (
+                ShopProductVisibility.ALWAYS_VISIBLE if is_visible else ShopProductVisibility.NOT_VISIBLE
+            )
             shop_product.visibility_limit = self.category.visibility.value
             shop_product.visibility_groups = visibility_groups
             shop_product.save()

--- a/shuup/admin/modules/categories/views/copy.py
+++ b/shuup/admin/modules/categories/views/copy.py
@@ -10,7 +10,9 @@ from django.http.response import JsonResponse
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import View
 
-from shuup.core.models import Category, CategoryStatus, ShopProduct
+from shuup.core.models import (
+    Category, CategoryStatus, ShopProduct, ShopProductVisibility
+)
 
 
 class CategoryCopyVisibilityView(View):
@@ -29,7 +31,9 @@ class CategoryCopyVisibilityView(View):
         category_shops = category.shops.all()
         category_visibility_groups = category.visibility_groups.all()
         for product in ShopProduct.objects.filter(shop__in=category_shops, primary_category__pk=category.pk):
-            product.visible = is_visible
+            product.visibility = (
+                ShopProductVisibility.ALWAYS_VISIBLE if is_visible else ShopProductVisibility.NOT_VISIBLE
+            )
             product.visibility_limit = category.visibility.value
             product.visibility_groups = category_visibility_groups
             product.save()

--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -74,10 +74,8 @@ class ShopProductForm(forms.ModelForm):
             "default_price_value",
             "minimum_price_value",
             "suppliers",
-            "visible",
-            "listed",
+            "visibility",
             "purchasable",
-            "searchable",
             "visibility_limit",
             "visibility_groups",
             "purchase_multiple",
@@ -97,8 +95,6 @@ class ShopProductForm(forms.ModelForm):
         }
 
     def __init__(self, **kwargs):
-        if not kwargs["instance"].pk:
-            kwargs["instance"].visible = False
         super(ShopProductForm, self).__init__(**kwargs)
         category_qs = Category.objects.all_except_deleted()
         self.fields["default_price_value"].required = True

--- a/shuup/admin/modules/products/views/edit.py
+++ b/shuup/admin/modules/products/views/edit.py
@@ -133,7 +133,6 @@ class ShopProductFormPart(FormPart):
     def get_initial(self):
         if not self.object.pk:
             return {
-                "visible": True,
                 "suppliers": [Supplier.objects.first()]
             }
 

--- a/shuup/admin/templates/shuup/admin/products/_edit_shop_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_shop_form.jinja
@@ -7,9 +7,7 @@
 </div>
 <div class="row content">
     <div class="col-md-6">
-        {{ bs3.field(shop_product_form.visible) }}
-        {{ bs3.field(shop_product_form.listed) }}
-        {{ bs3.field(shop_product_form.searchable) }}
+        {{ bs3.field(shop_product_form.visibility) }}
         {{ bs3.field(shop_product_form.visibility_limit) }}
         {{ bs3.field(shop_product_form.visibility_groups) }}
         {{ bs3.field(shop_product_form.primary_category) }}

--- a/shuup/core/api/products.py
+++ b/shuup/core/api/products.py
@@ -41,7 +41,7 @@ class ProductViewSet(ModelViewSet):
     def get_queryset(self):
         if getattr(self.request.user, 'is_superuser', False):
             return Product.objects.all_except_deleted()
-        return Product.objects.list_visible(
+        return Product.objects.listed(
             customer=self.request.customer,
             shop=self.request.shop
         )
@@ -55,7 +55,7 @@ class ShopProductViewSet(ModelViewSet):
         if getattr(self.request.user, 'is_superuser', False):
             products = Product.objects.all_except_deleted()
         else:
-            products = Product.objects.list_visible(
+            products = Product.objects.listed(
                 customer=self.request.customer,
                 shop=self.request.shop
             )

--- a/shuup/core/locale/en/LC_MESSAGES/django.po
+++ b/shuup/core/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-18 18:55+0000\n"
+"POT-Creation-Date: 2016-08-23 21:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -688,10 +688,16 @@ msgstr ""
 msgid "child product"
 msgstr ""
 
-msgid "suppliers"
+msgid "not visible"
 msgstr ""
 
 msgid "listed"
+msgstr ""
+
+msgid "always visible"
+msgstr ""
+
+msgid "suppliers"
 msgstr ""
 
 msgid "purchasable"

--- a/shuup/core/migrations/0005_shopproduct_visibilty.py
+++ b/shuup/core/migrations/0005_shopproduct_visibilty.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from shuup.core.models._product_shops import ShopProductVisibility
+import enumfields.fields
+
+
+def shop_product_visibility(apps, schema_editor):
+    ShopProduct = apps.get_model("shuup", "ShopProduct")
+    for shop_product in ShopProduct.objects.all():
+        listed = shop_product.listed
+        searchable = shop_product.searchable
+        if not (listed or searchable):
+            visibility = ShopProductVisibility.NOT_VISIBLE
+        elif listed and not searchable:
+            visibility = ShopProductVisibility.LISTED
+        elif searchable and not listed:
+            visibility = ShopProductVisibility.SEARCHABLE
+        else:
+            visibility = ShopProductVisibility.ALWAYS_VISIBLE
+
+        shop_product.visibility = visibility
+        shop_product.save()
+
+def reverse_shop_product_visibility(apps, schema_editor):
+    ShopProduct = apps.get_model("shuup", "ShopProduct")
+    for shop_product in ShopProduct.objects.all():
+        visibility = shop_product.visibility
+        if visibility == ShopProductVisibility.NOT_VISIBLE:
+            visible = False
+            listed = False
+            searchable = False
+        elif visibility == ShopProductVisibility.LISTED:
+            visible = True
+            listed = True
+            searchable = False
+        elif visibility == ShopProductVisibility.SEARCHABLE:
+            visible = True
+            listed = False
+            searchable = True
+        else:
+            visible = True
+            listed = True
+            searchable = True
+        shop_product.visible = visible
+        shop_product.listed = listed
+        shop_product.searchable = searchable
+        shop_product.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shuup', '0004_update_orderline_refunds'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='shopproduct',
+            name='visibility',
+            field=enumfields.fields.EnumIntegerField(enum=ShopProductVisibility, db_index=True, verbose_name='visibility', default=0),
+        ),
+        migrations.RunPython(shop_product_visibility, reverse_code=reverse_shop_product_visibility),
+        migrations.RemoveField(
+            model_name='shopproduct',
+            name='visible',
+        ),
+        migrations.RemoveField(
+            model_name='shopproduct',
+            name='listed',
+        ),
+        migrations.RemoveField(
+            model_name='shopproduct',
+            name='searchable',
+        ),
+
+    ]

--- a/shuup/core/models/__init__.py
+++ b/shuup/core/models/__init__.py
@@ -32,7 +32,9 @@ from ._payments import Payment
 from ._persistent_cache import PersistentCacheEntry
 from ._product_media import ProductMedia, ProductMediaKind
 from ._product_packages import ProductPackageLink
-from ._product_shops import ProductVisibility, ShopProduct
+from ._product_shops import (
+    ProductVisibility, ShopProduct, ShopProductVisibility
+)
 from ._product_variation import (
     ProductVariationLinkStatus, ProductVariationResult,
     ProductVariationVariable, ProductVariationVariableValue
@@ -138,6 +140,7 @@ __all__ = [
     "ShuupModel",
     "Shop",
     "ShopProduct",
+    "ShopProductVisibility",
     "ShopStatus",
     "StaffOnlyBehaviorComponent",
     "StockBehavior",

--- a/shuup/front/apps/simple_search/views.py
+++ b/shuup/front/apps/simple_search/views.py
@@ -105,7 +105,7 @@ class SearchView(ListView):
         query = self.form.cleaned_data["q"]
         if not query:  # pragma: no cover
             return Product.objects.none()
-        return Product.objects.list_visible(self.request.shop, self.request.customer).filter(
+        return Product.objects.visible(self.request.shop, self.request.customer).filter(
             pk__in=get_search_product_ids(self.request, query))
 
     def get_context_data(self, **kwargs):

--- a/shuup/front/apps/simple_search/views.py
+++ b/shuup/front/apps/simple_search/views.py
@@ -67,7 +67,9 @@ def get_search_product_ids(request, query, limit=150):
     if product_ids is None:
         entry_query = get_compiled_query(
             query, ['sku', 'translations__name', 'translations__description', 'translations__keywords'])
-        product_ids = list(Product.objects.filter(entry_query).distinct().values_list("pk", flat=True))[:limit]
+        product_ids = list(
+            Product.objects.searchable(shop=request.shop).filter(entry_query).distinct().values_list("pk", flat=True)
+        )[:limit]
         cache.set(cache_key, product_ids, 60 * 5)
     return product_ids
 
@@ -105,7 +107,7 @@ class SearchView(ListView):
         query = self.form.cleaned_data["q"]
         if not query:  # pragma: no cover
             return Product.objects.none()
-        return Product.objects.visible(self.request.shop, self.request.customer).filter(
+        return Product.objects.searchable(self.request.shop, self.request.customer).filter(
             pk__in=get_search_product_ids(self.request, query))
 
     def get_context_data(self, **kwargs):

--- a/shuup/front/template_helpers/general.py
+++ b/shuup/front/template_helpers/general.py
@@ -17,8 +17,11 @@ from shuup.utils.translation import cache_translations_for_tree
 
 
 @contextfunction
-def get_visible_products(context, n_products, ordering=None, filter_dict=None, orderable_only=True):
+def get_listed_products(context, n_products, ordering=None, filter_dict=None, orderable_only=True):
     """
+    Returns all products marked as listed that are determined to be
+    visible based on the current context.
+
     :param context: Rendering context
     :type context: jinja2.runtime.Context
     :param n_products: Number of products to return
@@ -36,7 +39,7 @@ def get_visible_products(context, n_products, ordering=None, filter_dict=None, o
     shop = request.shop
     if not filter_dict:
         filter_dict = {}
-    products_qs = Product.objects.list_visible(
+    products_qs = Product.objects.listed(
         shop=shop,
         customer=customer,
         language=get_language(),
@@ -89,7 +92,7 @@ def get_best_selling_products(context, n_products=12, cutoff_days=30, orderable_
 @contextfunction
 def get_newest_products(context, n_products=6, orderable_only=True):
     request = context["request"]
-    products = get_visible_products(
+    products = get_listed_products(
         context,
         n_products,
         ordering="-pk",
@@ -102,7 +105,7 @@ def get_newest_products(context, n_products=6, orderable_only=True):
 @contextfunction
 def get_random_products(context, n_products=6, orderable_only=True):
     request = context["request"]
-    products = get_visible_products(
+    products = get_listed_products(
         context,
         n_products,
         ordering="?",
@@ -115,7 +118,7 @@ def get_random_products(context, n_products=6, orderable_only=True):
 @contextfunction
 def get_all_manufacturers(context):
     request = context["request"]
-    products = Product.objects.list_visible(shop=request.shop, customer=request.customer)
+    products = Product.objects.listed(shop=request.shop, customer=request.customer)
     manufacturers_ids = products.values_list("manufacturer__id").distinct()
     manufacturers = Manufacturer.objects.filter(pk__in=manufacturers_ids)
     return manufacturers

--- a/shuup/front/views/category.py
+++ b/shuup/front/views/category.py
@@ -55,7 +55,7 @@ class CategoryView(DetailView):
         if manufacturers:
             filters["manufacturer__in"] = manufacturers
 
-        products = Product.objects.list_visible(
+        products = Product.objects.listed(
             customer=self.request.customer,
             shop=self.request.shop
         ).filter(**filters).distinct()

--- a/shuup_tests/admin/test_category_module.py
+++ b/shuup_tests/admin/test_category_module.py
@@ -16,7 +16,10 @@ from shuup.admin.modules.categories.forms import (
 from shuup.admin.modules.categories.views import (
     CategoryCopyVisibilityView, CategoryEditView
 )
-from shuup.core.models import Category, CategoryStatus, CategoryVisibility
+from shuup.core.models import (
+    Category, CategoryStatus, CategoryVisibility,
+    ShopProductVisibility
+)
 from shuup.testing.factories import (
     CategoryFactory, create_product, get_default_category,
     get_default_customer_group, get_default_shop
@@ -79,7 +82,7 @@ def test_products_form_add():
     assert (shop_product.primary_category == category)
     assert (category in shop_product.categories.all())
     assert (shop_product.visibility_limit.value == category.visibility.value)
-    assert (shop_product.visible == False)
+    assert (shop_product.visibility == ShopProductVisibility.NOT_VISIBLE)
     assert (product.category is None)
 
 
@@ -206,7 +209,7 @@ def test_category_copy_visibility(rf, admin_user):
     response = view(request, pk=category.pk)
     shop_product.refresh_from_db()
     assert response.status_code == 200
-    assert shop_product.visible == False
+    assert shop_product.visibility == ShopProductVisibility.NOT_VISIBLE
     assert shop_product.visibility_limit.value == category.visibility.value
     assert shop_product.visibility_groups.count() == category.visibility_groups.count()
     assert set(shop_product.visibility_groups.all()) == set(category.visibility_groups.all())

--- a/shuup_tests/admin/test_order_creator.py
+++ b/shuup_tests/admin/test_order_creator.py
@@ -19,7 +19,9 @@ from django.utils.encoding import force_text
 from shuup.admin.modules.orders.views.edit import (
     encode_address, encode_method, OrderEditView
 )
-from shuup.core.models import Order, OrderLineType, Tax, TaxClass
+from shuup.core.models import (
+    Order, OrderLineType, ShopProductVisibility, Tax, TaxClass
+)
 from shuup.default_tax.models import TaxRule
 from shuup.testing.factories import (
     create_empty_order, create_order_with_product, create_product,
@@ -68,7 +70,7 @@ def get_frontend_order_state(contact, valid_lines=True):
             shop=shop
         )
         not_visible_shop_product = not_visible_product.get_shop_instance(shop)
-        not_visible_shop_product.visible = False
+        not_visible_shop_product.visibility = ShopProductVisibility.NOT_VISIBLE
         not_visible_shop_product.save()
         lines = [
             {"id": "x", "type": "product"},  # no product?

--- a/shuup_tests/core/test_product_variations.py
+++ b/shuup_tests/core/test_product_variations.py
@@ -10,7 +10,7 @@ import pytest
 
 from shuup.core.models import (
     ProductMode, ProductVariationResult, ProductVariationVariable,
-    ProductVariationVariableValue, ShopProduct
+    ProductVariationVariableValue, ShopProduct, ShopProductVisibility
 )
 from shuup.testing.factories import create_product, get_default_shop
 
@@ -22,7 +22,9 @@ def test_simple_variation():
     children = [create_product("SimpleVarChild-%d" % x) for x in range(10)]
     for child in children:
         child.link_to_parent(parent)
-        sp = ShopProduct.objects.create(shop=shop, product=child, listed=True)
+        sp = ShopProduct.objects.create(
+            shop=shop, product=child, visibility=ShopProductVisibility.ALWAYS_VISIBLE
+        )
         assert child.is_variation_child()
         assert not sp.is_list_visible()  # Variation children are not list visible
 

--- a/shuup_tests/core/test_products.py
+++ b/shuup_tests/core/test_products.py
@@ -9,52 +9,63 @@
 import pytest
 
 from shuup.core.models import (
-    AnonymousContact, get_person_contact, Product, ProductVisibility
+    AnonymousContact, get_person_contact, Product, ProductVisibility,
+    ShopProductVisibility
 )
 from shuup.testing.factories import (
-    get_default_shop_product, get_default_customer_group
+    create_product, get_default_customer_group, get_default_shop,
+    get_default_shop_product
 )
 from shuup_tests.core.utils import modify
 from shuup_tests.utils.fixtures import regular_user
 
 
+@pytest.mark.parametrize("visibility,show_in_list,show_in_search", [
+    (ShopProductVisibility.NOT_VISIBLE, False, False),
+    (ShopProductVisibility.SEARCHABLE, False, True),
+    (ShopProductVisibility.LISTED, True, False),
+    (ShopProductVisibility.ALWAYS_VISIBLE, True, True),
+])
 @pytest.mark.django_db
-@pytest.mark.usefixtures("regular_user")
-def test_product_query(admin_user, regular_user):
+def test_product_query(visibility, show_in_list, show_in_search, admin_user, regular_user):
+    shop = get_default_shop()
+    product = create_product("test-sku", shop=shop)
+    shop_product = product.get_shop_instance(shop)
     anon_contact = AnonymousContact()
-    shop_product = get_default_shop_product()
-    shop = shop_product.shop
-    product = shop_product.product
     regular_contact = get_person_contact(regular_user)
     admin_contact = get_person_contact(admin_user)
 
+    shop_product.visibility = visibility
+    shop_product.save()
 
-    with modify(shop_product, save=True,
-                listed=True,
-                visible=True,
-                visibility_limit=ProductVisibility.VISIBLE_TO_ALL
-                ):
-        assert Product.objects.list_visible(shop=shop, customer=anon_contact).filter(pk=product.pk).exists()
+    assert shop_product.visibility_limit == ProductVisibility.VISIBLE_TO_ALL
 
-    with modify(shop_product, save=True,
-                listed=False,
-                visible=True,
-                visibility_limit=ProductVisibility.VISIBLE_TO_ALL
-                ):
-        assert not Product.objects.list_visible(shop=shop, customer=anon_contact).filter(pk=product.pk).exists()
-        assert not Product.objects.list_visible(shop=shop, customer=regular_contact).filter(pk=product.pk).exists()
-        assert Product.objects.list_visible(shop=shop, customer=admin_contact).filter(pk=product.pk).exists()
+    # Anonymous contact should be the same as no contact
+    assert (product in Product.objects.listed(shop=shop)) == show_in_list
+    assert (product in Product.objects.searchable(shop=shop)) == show_in_search
+    assert (product in Product.objects.listed(shop=shop, customer=anon_contact)) == show_in_list
+    assert (product in Product.objects.searchable(shop=shop, customer=anon_contact)) == show_in_search
 
-    with modify(shop_product, save=True,
-                listed=True,
-                visible=True,
-                visibility_limit=ProductVisibility.VISIBLE_TO_LOGGED_IN
-                ):
-        assert not Product.objects.list_visible(shop=shop, customer=anon_contact).filter(pk=product.pk).exists()
-        assert Product.objects.list_visible(shop=shop, customer=regular_contact).filter(pk=product.pk).exists()
+    # Admin should see all non-deleted results
+    assert product in Product.objects.listed(shop=shop, customer=admin_contact)
+    assert product in Product.objects.searchable(shop=shop, customer=admin_contact)
 
+    # Anonymous contact shouldn't see products with logged in visibility limit
+    shop_product.visibility_limit = ProductVisibility.VISIBLE_TO_LOGGED_IN
+    shop_product.save()
+    assert product not in Product.objects.listed(shop=shop, customer=anon_contact)
+    assert product not in Product.objects.searchable(shop=shop, customer=anon_contact)
+
+    # Reset visibility limit
+    shop_product.visibility_limit = ProductVisibility.VISIBLE_TO_ALL
+    shop_product.save()
+
+    # No one should see deleted products
     product.soft_delete()
-    assert not Product.objects.all_except_deleted().filter(pk=product.pk).exists()
+    assert product not in Product.objects.listed(shop=shop)
+    assert product not in Product.objects.searchable(shop=shop)
+    assert product not in Product.objects.listed(shop=shop, customer=admin_contact)
+    assert product not in Product.objects.searchable(shop=shop, customer=admin_contact)
 
 
 @pytest.mark.django_db
@@ -69,10 +80,10 @@ def test_product_query_with_group_visibility(regular_user):
     shop_product.visibility_groups.add(default_group)
     regular_contact = get_person_contact(regular_user)
 
-    assert not Product.objects.list_visible(shop=shop, customer=regular_contact).filter(pk=product.pk).exists()
+    assert not Product.objects.listed(shop=shop, customer=regular_contact).filter(pk=product.pk).exists()
     regular_contact.groups.add(default_group)
-    assert Product.objects.list_visible(shop=shop, customer=regular_contact).filter(pk=product.pk).count() == 1
+    assert Product.objects.listed(shop=shop, customer=regular_contact).filter(pk=product.pk).count() == 1
 
     shop_product.visibility_groups.add(regular_contact.get_default_group())
     # Multiple visibility groups for shop product shouldn't cause duplicate matches
-    assert Product.objects.list_visible(shop=shop, customer=regular_contact).filter(pk=product.pk).count() == 1
+    assert Product.objects.listed(shop=shop, customer=regular_contact).filter(pk=product.pk).count() == 1

--- a/shuup_tests/front/test_basket_commands.py
+++ b/shuup_tests/front/test_basket_commands.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ValidationError
 from django.http.response import HttpResponseRedirect, JsonResponse
 
 from shuup.core.models import (
-    ProductVariationVariable, ProductVariationVariableValue
+    ProductVariationVariable, ProductVariationVariableValue, ShopProductVisibility
 )
 from shuup.front.basket import commands as basket_commands
 from shuup.front.basket import get_basket_command_dispatcher
@@ -173,7 +173,7 @@ def test_basket_update_errors():
     assert len(error_messages) == 1
     assert any("not supplied" in msg.message for msg in error_messages)
 
-    shop_product.visible = False
+    shop_product.visibility = ShopProductVisibility.NOT_VISIBLE
     shop_product.save()
 
     basket_commands.handle_update(request, basket, **{"q_%s" % line_id: "2"})

--- a/shuup_tests/front/test_general_template_helpers.py
+++ b/shuup_tests/front/test_general_template_helpers.py
@@ -28,7 +28,7 @@ def test_get_root_categories():
 
 
 @pytest.mark.django_db
-def test_get_visible_products_orderable_only():
+def test_get_listed_products_orderable_only():
     context = get_jinja_context()
     shop = get_default_shop()
     simple_supplier = get_simple_supplier()
@@ -41,23 +41,23 @@ def test_get_visible_products_orderable_only():
         shop=shop,
         stock_behavior=StockBehavior.STOCKED
     )
-    assert len(general.get_visible_products(context, n_products, orderable_only=True)) == 0
-    assert len(general.get_visible_products(context, n_products, orderable_only=False)) == 1
+    assert len(general.get_listed_products(context, n_products, orderable_only=True)) == 0
+    assert len(general.get_listed_products(context, n_products, orderable_only=False)) == 1
 
     # Increase stock on product
     quantity = product.get_shop_instance(shop).minimum_purchase_quantity
     simple_supplier.adjust_stock(product.id, quantity)
-    assert len(general.get_visible_products(context, n_products, orderable_only=True)) == 1
-    assert len(general.get_visible_products(context, n_products, orderable_only=False)) == 1
+    assert len(general.get_listed_products(context, n_products, orderable_only=True)) == 1
+    assert len(general.get_listed_products(context, n_products, orderable_only=False)) == 1
 
     # Decrease stock on product
     simple_supplier.adjust_stock(product.id, -quantity)
-    assert len(general.get_visible_products(context, n_products, orderable_only=True)) == 0
-    assert len(general.get_visible_products(context, n_products, orderable_only=False)) == 1
+    assert len(general.get_listed_products(context, n_products, orderable_only=True)) == 0
+    assert len(general.get_listed_products(context, n_products, orderable_only=False)) == 1
 
 
 @pytest.mark.django_db
-def test_get_visible_products_filter():
+def test_get_listed_products_filter():
     context = get_jinja_context()
     shop = get_default_shop()
     supplier = get_default_supplier()
@@ -73,12 +73,12 @@ def test_get_visible_products_filter():
         shop=shop,
     )
     filter_dict = {"id": product_1.id}
-    product_list = general.get_visible_products(context, n_products=2, filter_dict=filter_dict)
+    product_list = general.get_listed_products(context, n_products=2, filter_dict=filter_dict)
     assert product_1 in product_list
     assert product_2 not in product_list
 
     # Test also with orderable_only False
-    product_list = general.get_visible_products(context, n_products=2, filter_dict=filter_dict, orderable_only=False)
+    product_list = general.get_listed_products(context, n_products=2, filter_dict=filter_dict, orderable_only=False)
     assert product_1 in product_list
     assert product_2 not in product_list
 

--- a/shuup_tests/functional/test_admin_orders.py
+++ b/shuup_tests/functional/test_admin_orders.py
@@ -16,7 +16,8 @@ from django.utils import translation
 from django.utils.translation import activate
 
 from shuup.core.models import (
-    CustomPaymentProcessor, PaymentMethod, RoundingMode, Tax, TaxClass
+    CustomPaymentProcessor, PaymentMethod, RoundingMode, ShopProductVisibility,
+    Tax, TaxClass
 )
 from shuup.default_tax.models import TaxRule
 from shuup.testing.factories import (
@@ -64,7 +65,7 @@ def get_frontend_order_state(contact, payment_method, product_price, valid_lines
             shop=shop
         )
         not_visible_shop_product = not_visible_product.get_shop_instance(shop)
-        not_visible_shop_product.visible = False
+        not_visible_shop_product.visibility = ShopProductVisibility.NOT_VISIBLE
         not_visible_shop_product.save()
         lines = [
             {"id": "x", "type": "product"},  # no product?


### PR DESCRIPTION
Replace visibility-related fields (visible, listed, searchable) for shop products with an enum indicating visibility mode.

Also, replace `list_visible` manager with a `visible` manager, and add additional `listed` and `searchable` managers for getting listed or searchable products.

Refs SH-79