### PR TITLE
CORE Overwrite empty language fields with default value (SH-90)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -128,6 +128,8 @@ Released on 2016-08-12 03:00pm -0800.
 Core
 ~~~~
 
+- Fix `MultiLanguageModelForm` to overwrite empty language fields with default value
+- Add datamigration to add missing translations from default values 
 - Fix `FormattedDecimalField` default value for form fields
 - Combine `TreeManager` and `TranslatableManager` querysets for categories
 - Exclude deleted orders from valid queryset

--- a/shuup/core/migrations/0006_data_migrate_language_fallback.py
+++ b/shuup/core/migrations/0006_data_migrate_language_fallback.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.apps import apps as django_apps
+from django.conf import settings
+from django.db import migrations
+from django.utils import translation
+from parler.models import TranslatableModel, TranslationDoesNotExist
+from django.db.utils import OperationalError
+
+
+def to_language_codes(languages):
+    languages = languages or (translation.get_language(),)
+    if languages and isinstance(languages[0], (list, tuple)):
+        # `languages` looks like a `settings.LANGUAGES`, so fix it
+        languages = [code for (code, name) in languages]
+    return languages
+
+
+def save_values_from_default_to_lang(default_translation, translation_object, fields):
+
+    for field in fields:
+        default_value = getattr(default_translation, field.name, '')
+        orig_value = getattr(translation_object, field.name)
+
+        if not orig_value and default_value != orig_value:
+            setattr(translation_object, field.name, default_value)
+
+        translation_object.save()
+
+
+def add_missing_values(model, default_lang, languages):
+
+    objects = model.objects.all()
+
+    _translations = getattr(model, 'translations', getattr(model, 'base_translations', None))
+
+    translation_model = _translations.related.related_model
+
+    base_fields = translation_model.get_translated_fields()
+
+    translation_model_fields = [
+        f for f in translation_model._meta.fields
+        if f.name in base_fields and not f.unique
+    ]
+
+    try:
+        for obj in objects:
+            # model being translatable does not guarantee translations exist
+            if _translations.count():
+                default_translation = obj.get_translation(default_lang)
+
+                for lang in languages:
+                    if lang == default_lang:
+                        continue
+                    try:
+                        save_values_from_default_to_lang(
+                            default_translation, obj.get_translation(lang), translation_model_fields)
+                    except TranslationDoesNotExist:
+                        # translation for lang does not exist so skip it.
+                        pass
+    except OperationalError:
+        # Ignores cases where model's' table doesn't exist yet. This may happen if
+        # migration runs on empty DB and not all models tables have been created yet.
+        pass
+
+
+def fallback_language_migration(apps, schema_editor):
+
+    translatable_models = [model for model in django_apps.get_models()
+                           if issubclass(model, TranslatableModel)]
+
+    default_lang = settings.PARLER_DEFAULT_LANGUAGE_CODE
+    languages = to_language_codes(settings.LANGUAGES)
+
+    for model in translatable_models:
+        add_missing_values(model, default_lang, languages)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+         migrations.RunPython(fallback_language_migration, reverse_code=migrations.RunPython.noop),
+    ]

--- a/shuup/utils/multilanguage_model_form.py
+++ b/shuup/utils/multilanguage_model_form.py
@@ -106,7 +106,12 @@ class MultiLanguageModelForm(TranslatableModelForm):
             )
             translation_fields = dict((src_name, data.get(src_name)) for src_name in field_map)
             for src_name, field in six.iteritems(field_map):
-                field.save_form_data(translation, translation_fields[src_name])
+                if translation_fields[src_name] or field.unique:
+                    field.save_form_data(translation, translation_fields[src_name])
+                else:
+                    default_value = data.get(src_name.replace(lang, self.default_language))
+                    field.save_form_data(translation, default_value)
+
             self._save_translation(instance, translation)
 
     def _save_translation(self, instance, translation):


### PR DESCRIPTION
When a user completes a form that includes translatable fields (e.g.
Product) and only fill out the default language portion (e.g. English)
the form will fill out the other language fields with that of the
english. This fix is meant to address limitations in django-parlers own
fallback mechanism.

This commit also includes a new management command
`shuup_fallback_language` that will perform the same functionality on
existing models. It's meant to be ran only once as a migration step.