### PR TITLE
Admin: Fix missing shipping_address on order views (SH-120)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -126,6 +126,7 @@ Core
 Admin
 ~~~~~
 
+- Fix missing shipping_address on orders views
 - Add contact type filter to contact list view
 - Allow billing address to be used as shipping address on contact creation
 - Split person contact and company contact creation into separate actions

--- a/shuup/admin/templates/shuup/admin/orders/detail.jinja
+++ b/shuup/admin/templates/shuup/admin/orders/detail.jinja
@@ -49,7 +49,7 @@
                     <div class="row contact-addresses">
                         <div class="col-md-6 billing-address">
                             <h4 class="underline"><i class="fa fa-file-text"></i> {% trans %}Billing address{% endtrans %}</h4>
-                            {% for line in order.billing_address %}
+                            {% for line in order.billing_address or [] %}
                                 <p>{{ line }}</p>
                             {% else %}
                                 <p><i class="fa fa-warning text-warning"></i> {% trans %}No billing address defined.{% endtrans %}</p>
@@ -57,7 +57,7 @@
                         </div>
                         <div class="col-md-6 shipping-address">
                             <h4 class="underline"><i class="fa fa-truck"></i> {% trans %}Shipping address{% endtrans %}</h4>
-                            {% for line in order.shipping_address %}
+                            {% for line in order.shipping_address or [] %}
                                 <p>{{ line }}</p>
                             {% else %}
                                 <p><i class="fa fa-warning text-warning"></i> {% trans %}No shipping address defined.{% endtrans %}</p>


### PR DESCRIPTION
Simply hides the shipping address in Order detail if it's missing,
though the order form should prevent this from happening in the first
place.

Refs SH-120