### PR TITLE
Registration: Fix bug in importing macro

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -71,6 +71,7 @@ Guide
 General/miscellaneous
 ~~~~~~~~~~~~~~~~~~~~~
 
+* Fix bug in importing macro in registration app
 * Fix bug in pdf utils while fetching static resources
 
 SHUUP 0.4.3

--- a/shuup/front/apps/registration/templates/shuup/registration/register.jinja
+++ b/shuup/front/apps/registration/templates/shuup/registration/register.jinja
@@ -1,5 +1,5 @@
 {% extends "shuup/front/base.jinja" %}
-{% from "shuup/front/macros.jinja" import render_field %}
+{% from "shuup/front/macros/general.jinja" import render_field %}
 
 {% block title %}{% trans %}Register{% endtrans %}{% endblock %}
 


### PR DESCRIPTION
Import `render_field` from `shuup/front/macros/general.jinja`
instead of `shuup/front/macros.jinja` that does not exist.