### PR TITLE
Admin: Allow form group edit views to show errors as messages

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -19,6 +19,8 @@ Localization
 Admin
 ~~~~~
 
+- Allow form group edit views to show errors as messages
+
 Addons
 ~~~~~~
 

--- a/shuup/admin/modules/products/views/edit.py
+++ b/shuup/admin/modules/products/views/edit.py
@@ -196,6 +196,7 @@ class ProductEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView
         ProductMediaFormPart
     ]
     form_part_class_provide_key = "admin_product_form_part"
+    add_form_errors_as_messages = True
 
     @atomic
     def form_valid(self, form):


### PR DESCRIPTION
Allow create-or-update views using form parts to show form errors as
messages.

Refs SH-24