### PR TITLE
Fixes for translation fallbacks and JS catalog loading (SH-17, SH-90)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,8 @@ Unreleased
 Core
 ~~~~
 
+- Fix bug in product and category slug generation
+
 Localization
 ~~~~~~~~~~~~
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -21,6 +21,7 @@ Localization
 Admin
 ~~~~~
 
+- Add lang parameter for JS catalog load
 - Add key prefix to JavaScript catalog cache
 - Allow shop language to be set via admin
 - Allow form group edit views to show errors as messages

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -21,6 +21,7 @@ Localization
 Admin
 ~~~~~
 
+- Add key prefix to JavaScript catalog cache
 - Allow shop language to be set via admin
 - Allow form group edit views to show errors as messages
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -61,6 +61,8 @@ Guide
 General/miscellaneous
 ~~~~~~~~~~~~~~~~~~~~~
 
+- MultiLanguageModelForm: Use Parler default as a default
+
 SHUUP 0.4.4
 -----------
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -61,6 +61,10 @@ Guide
 General/miscellaneous
 ~~~~~~~~~~~~~~~~~~~~~
 
+- MultiLanguageModelForm: Avoid partially/empty translation objects
+   - Delete untranslated objects from database
+   - Only set translation object to database if it is translated
+   - Ensure required fields if language is partially translated
 - MultiLanguageModelForm: Use Parler default as a default
 
 SHUUP 0.4.4

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -32,6 +32,8 @@ Addons
 Front
 ~~~~~
 
+- Load JS catalog for superusers
+
 Xtheme
 ~~~~~~
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -37,6 +37,8 @@ Front
 Xtheme
 ~~~~~~
 
+- Skip adding JS-catalog for editing
+
 Classic Gray Theme
 ~~~~~~~~~~~~~~~~~~
 

--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -54,6 +54,7 @@ class ProductBaseForm(MultiLanguageModelForm):
             "description",
             "keywords",
             "name",
+            "slug",
             "status_text",
             "variation_name",
         )

--- a/shuup/admin/templates/shuup/admin/base.jinja
+++ b/shuup/admin/templates/shuup/admin/base.jinja
@@ -14,7 +14,7 @@
         {% block extra_css %}{% endblock -%}
         {% block extra_head %}{% endblock -%}
         <script>var ShuupAdminConfig = {{ shuup_admin.get_config()|json }};</script>
-        <script type="text/javascript" src="{{ url("shuup_admin:js-catalog") }}"></script>
+        <script type="text/javascript" src="{{ url("shuup_admin:js-catalog") }}?lang={{ LANGUAGE_CODE }}"></script>
     </head>
     <body class="{% block body_class %}{% endblock %} {{ "popup" if request.GET.popup else "" }}">
         {% block top %}

--- a/shuup/admin/templates/shuup/admin/products/_edit_base_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_base_form.jinja
@@ -5,6 +5,7 @@
     <div class="col-md-12">
         {% call(form, language, map) language_dependent_content_tabs(product_form, tab_id_prefix="language") %}
             {{ bs3.field(product_form[map.name]) }}
+            {{ bs3.field(product_form[map.slug]) }}
             {{ bs3.field(product_form[map.description], widget_class="remarkable-field") }}
         {% endcall %}
     </div>

--- a/shuup/core/migrations/0008_blank_slugs_for_product.py
+++ b/shuup/core/migrations/0008_blank_slugs_for_product.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shuup', '0007_shop_languages_config'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='producttranslation',
+            name='slug',
+            field=models.SlugField(null=True, verbose_name='slug', blank=True, max_length=255),
+        ),
+    ]

--- a/shuup/core/models/_categories.py
+++ b/shuup/core/models/_categories.py
@@ -136,10 +136,10 @@ class Category(MPTTModel, TranslatableModel):
         return True
 
     @staticmethod
-    def _get_slug_name(self):
+    def _get_slug_name(self, translation):
         if self.status == CategoryStatus.DELETED:
             return None
-        return self.safe_translation_getter("name")
+        return getattr(translation, "name", self.pk)
 
     def delete(self, using=None):
         raise NotImplementedError("Not implemented: Use `soft_delete()` for categories.")

--- a/shuup/core/models/_products.py
+++ b/shuup/core/models/_products.py
@@ -237,7 +237,7 @@ class Product(TaxableItem, AttributableMixin, TranslatableModel):
     translations = TranslatedFields(
         name=models.CharField(max_length=256, verbose_name=_('name')),
         description=models.TextField(blank=True, verbose_name=_('description')),
-        slug=models.SlugField(verbose_name=_('slug'), max_length=255, null=True),
+        slug=models.SlugField(verbose_name=_('slug'), max_length=255, blank=True, null=True),
         keywords=models.TextField(blank=True, verbose_name=_('keywords')),
         status_text=models.CharField(
             max_length=128, blank=True,
@@ -439,10 +439,10 @@ class Product(TaxableItem, AttributableMixin, TranslatableModel):
         self.save()
 
     @staticmethod
-    def _get_slug_name(self):
+    def _get_slug_name(self, translation=None):
         if self.deleted:
             return None
-        return (self.safe_translation_getter("name") or self.sku)
+        return getattr(translation, "name", self.sku)
 
     def save(self, *args, **kwargs):
         if self.net_weight and self.net_weight > 0:

--- a/shuup/core/utils/slugs.py
+++ b/shuup/core/utils/slugs.py
@@ -6,20 +6,28 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils.text import force_text, slugify
 
 
 def generate_multilanguage_slugs(object, name_getter, slug_length=128):
-    original_language = object.get_current_language()
-    try:
-        for language_code, language_name in settings.LANGUAGES:
-            object.set_current_language(language_code)
-            name = force_text(name_getter(object))
-            if name:
-                slug = slugify(name)
-            else:
-                slug = None
-            object.slug = (slug[:slug_length] if slug else None)
-        object.save_translations()
-    finally:
-        object.set_current_language(original_language)
+    translations_model = object._parler_meta.root_model
+    for language_code, language_name in settings.LANGUAGES:
+        try:
+            translation = object.get_translation(language_code=language_code)
+            translation.refresh_from_db()
+        except ObjectDoesNotExist:
+            # For some reason the `get_translation` raises if the object is created recently
+            translation = translations_model.objects.filter(master_id=object.id, language_code=language_code).first()
+            if not translation:
+                # Guessing the translation is deleted recently so let's just skip this language
+                continue
+
+        # Since slugs can be set by the merchant let's not override if already set
+        if not translation or translation.slug:
+            continue
+
+        name = force_text(name_getter(object, translation))
+        slug = slugify(name)
+        translation.slug = (slug[:slug_length] if slug else None)
+        translation.save()

--- a/shuup/front/templates/shuup/front/base.jinja
+++ b/shuup/front/templates/shuup/front/base.jinja
@@ -27,6 +27,9 @@
     {% else %}
         <link rel="stylesheet" href="{{ static("shuup/front/css/style.css") }}">
     {% endif %}
+    {% if user.is_superuser %}
+        <script type="text/javascript" src="{{ url("shuup_admin:js-catalog") }}?lang={{ LANGUAGE_CODE }}"></script>
+    {% endif %}
 </head>
 <body>
     {{ macros.render_maintenance_mode_notification() }}

--- a/shuup/utils/i18n.py
+++ b/shuup/utils/i18n.py
@@ -14,6 +14,7 @@ from django.apps import apps
 from django.utils import translation
 from django.utils.lru_cache import lru_cache
 from django.utils.timezone import localtime
+from django.utils.translation import get_language
 from django.views.decorators.cache import cache_page
 from django.views.i18n import javascript_catalog
 
@@ -131,7 +132,7 @@ def get_language_name(language_code):
     return language_code
 
 
-@cache_page(3600)
+@cache_page(3600, key_prefix="js18n-%s" % get_language())
 def javascript_catalog_all(request, domain='djangojs'):
     """
     Get JavaScript message catalog for all apps in INSTALLED_APPS.

--- a/shuup/utils/multilanguage_model_form.py
+++ b/shuup/utils/multilanguage_model_form.py
@@ -11,6 +11,7 @@ import copy
 from collections import defaultdict
 
 import six
+from django.conf import settings
 from django.forms.models import model_to_dict, ModelForm
 from django.utils.translation import get_language
 from parler.forms import TranslatableModelForm
@@ -33,7 +34,8 @@ class MultiLanguageModelForm(TranslatableModelForm):
     def __init__(self, **kwargs):
         self.languages = to_language_codes(kwargs.pop("languages", ()))
 
-        self.default_language = kwargs.pop("default_language", getattr(self, 'language', get_language()))
+        self.default_language = kwargs.pop(
+            "default_language", getattr(self, 'language', getattr(settings, "PARLER_DEFAULT_LANGUAGE_CODE")))
         if self.default_language not in self.languages:
             raise ValueError("Language %r not in %r" % (self.default_language, self.languages))
 

--- a/shuup/utils/multilanguage_model_form.py
+++ b/shuup/utils/multilanguage_model_form.py
@@ -13,8 +13,10 @@ from collections import defaultdict
 import six
 from django.conf import settings
 from django.forms.models import model_to_dict, ModelForm
+from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import get_language
 from parler.forms import TranslatableModelForm
+from parler.utils.context import switch_language
 
 from shuup.utils.i18n import get_language_name
 
@@ -54,6 +56,7 @@ class MultiLanguageModelForm(TranslatableModelForm):
         self.trans_field_map = defaultdict(dict)
         self.trans_name_map = defaultdict(dict)
         self.translated_field_names = []
+        self.required_translated_field_names = []
         self.non_default_languages = sorted(set(self.languages) - set([self.default_language]))
         self.language_names = dict((lang, get_language_name(lang)) for lang in self.languages)
 
@@ -64,6 +67,8 @@ class MultiLanguageModelForm(TranslatableModelForm):
             for lang in self.languages:
                 language_field = copy.deepcopy(base)
                 language_field_name = "%s__%s" % (f.name, lang)
+                if language_field.required:
+                    self.required_translated_field_names.append(language_field_name)
                 language_field.required = language_field.required and (lang in self.required_languages)
                 language_field.label = "%s [%s]" % (language_field.label, self.language_names.get(lang))
                 self.base_fields[language_field_name] = language_field
@@ -95,18 +100,38 @@ class MultiLanguageModelForm(TranslatableModelForm):
         except KeyError:
             return super(MultiLanguageModelForm, self).__getitem__(key + "__" + self.default_language)
 
+    def clean(self):
+        """
+        Avoid partially translated languages where the translated fields that
+        is required is not set.
+        """
+        data = self.cleaned_data
+        for language, field_names in self.trans_name_map.items():
+            if not any(data.get(field_name) for field_name in field_names.values()):
+                continue  # No need to check this language further
+            for field_name in field_names.values():
+                if field_name in self.required_translated_field_names and not data.get(field_name):
+                    self.add_error(field_name, _("This field is required."))
+        return data
+
     def _save_translations(self, instance, data):
         translations_model = self._get_translation_model()
         current_translations = dict(
             (trans.language_code, trans)
             for trans
-            in translations_model.objects.filter(master=instance, language_code__in=self.languages)
+            in translations_model.objects.filter(master_id=instance.id, language_code__in=self.languages)
         )
         for lang, field_map in six.iteritems(self.trans_field_map):
-            current_translations[lang] = translation = (
-                current_translations.get(lang) or translations_model(master=instance, language_code=lang)
-            )
             translation_fields = dict((src_name, data.get(src_name)) for src_name in field_map)
+            translation = current_translations.get(lang)
+            # Add translation only if at least one translated field is given
+            if not any(translation_fields.values()):
+                if translation:
+                    translation.delete()  # No translations set so delete the object also.
+                continue
+            current_translations[lang] = translation = (
+                translation or translations_model(master=instance, language_code=lang)
+            )
             for src_name, field in six.iteritems(field_map):
                 field.save_form_data(translation, translation_fields[src_name])
             self._save_translation(instance, translation)
@@ -127,15 +152,24 @@ class MultiLanguageModelForm(TranslatableModelForm):
     def save(self, commit=True):
         self._set_fields_for_language(self.default_language)
         self.pre_master_save(self.instance)
+
+        # Save is necessary here since translations can not be
+        # attached to non saved object
         self.instance = self._save_master(commit)
         self._save_translations(self.instance, self.cleaned_data)
+
+        # Save the master once again since the save might involve
+        # some procedures that requires translations like generating
+        # slug from translated name.
+        self._save_master(commit)
         return self.instance
 
     def _set_fields_for_language(self, language):
-        self.instance.set_current_language(language)
-        for field in self.translation_fields:
-            value = self.cleaned_data["%s__%s" % (field.name, language)]
-            field.save_form_data(self.instance, value)
+        with switch_language(self.instance, language):
+            self.instance.set_current_language(language)
+            for field in self.translation_fields:
+                value = self.cleaned_data["%s__%s" % (field.name, language)]
+                field.save_form_data(self.instance, value)
 
     def _save_master(self, commit=True):
         # We skip TranslatableModelForm on purpose!

--- a/shuup/xtheme/editing.py
+++ b/shuup/xtheme/editing.py
@@ -7,7 +7,6 @@
 # LICENSE file in the root directory of this source tree.
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.staticfiles.storage import staticfiles_storage
-from django.core.urlresolvers import reverse
 from django.middleware.csrf import get_token
 
 from shuup.xtheme.resources import add_resource, InlineScriptResource
@@ -98,5 +97,4 @@ def add_edit_resources(context):
         "edit": is_edit_mode(request),
         "csrfToken": get_token(request),
     }))
-    add_resource(context, "head_end", reverse("shuup_admin:js-catalog"))
     add_resource(context, "body_end", staticfiles_storage.url("xtheme/editor-injection.js"))

--- a/shuup_tests/browser/admin/test_order_creator.py
+++ b/shuup_tests/browser/admin/test_order_creator.py
@@ -41,6 +41,7 @@ def test_order_creator_view(browser, admin_user, live_server):
 
     initialize_admin_browser_test(browser, live_server)
     _visit_order_creator_view(browser, live_server)
+    _test_language_change(browser)
     _test_customer_data(browser, person)
     _test_add_lines(browser)
     _test_quick_add_lines(browser)
@@ -53,6 +54,32 @@ def _visit_order_creator_view(browser, live_server):
     url = reverse("shuup_admin:order.new")
     browser.visit("%s%s" % (live_server, url))
     assert browser.is_element_present_by_css("h1.main-header")
+
+def _test_language_change(browser):
+    assert browser.is_element_present_by_css("h2[class='block-title']")
+    # By default the initialization the admin should be in English
+    found_customer_details_en = False
+    for block_title in browser.find_by_css("h2[class='block-title']"):
+        if "Customer Details" in block_title.text:
+            found_customer_details_en = True
+    assert found_customer_details_en
+
+    # Make sure that the translations is handled correctly and change to Finnish
+    browser.find_by_id("dropdownMenu").click()
+    browser.find_by_xpath('//a[@data-value="fi"]').first.click()
+
+    wait_until_appeared(browser, "h2[class='block-title']")
+    found_customer_details_fi = False
+    for block_title in browser.find_by_css("h2[class='block-title']"):
+        if "Asiakkaan tiedot" in block_title.text:
+            found_customer_details_fi = True
+
+    assert found_customer_details_fi
+
+    # And back in English
+    browser.find_by_id("dropdownMenu").click()
+    browser.find_by_xpath('//a[@data-value="en"]').first.click()
+    wait_until_appeared(browser, "h2[class='block-title']")
 
 
 def _test_customer_data(browser, person):

--- a/shuup_tests/core/test_generating_slugs.py
+++ b/shuup_tests/core/test_generating_slugs.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.test import override_settings
+from django.utils.text import slugify
+from django.utils.translation import activate
+
+from shuup.testing.factories import create_product, get_default_category
+
+
+@pytest.mark.django_db
+@override_settings(**{"LANGUAGES": (("en", "en"), ("fi", "fi")), "PARLER_DEFAULT_LANGUAGE_CODE": "fi"})
+def test_generate_slugs_for_product():
+    activate("en")
+    product_name = "Some name"
+    product = create_product(sku="1", **{"name": "Some name"})
+    assert product.slug == slugify(product_name)
+
+    # Test that slug is only generated when it's empty on save
+    new_name = "Some new name"
+    product.name = new_name
+    product.save()
+    assert product.slug == slugify(product_name), "Old slug"
+    product.slug = ""
+    product.save()
+    assert product.slug == slugify(new_name), "New slug generated"
+
+    # Check that slug is not generated to other languages
+    with pytest.raises(ObjectDoesNotExist):
+        translation = product.get_translation("fi")
+        translation.refresh_from_db()  # If the translation object was returned from cache
+
+
+@pytest.mark.django_db
+@override_settings(**{"LANGUAGES": (("en", "en"), ("fi", "fi")), "PARLER_DEFAULT_LANGUAGE_CODE": "fi"})
+def test_generate_slugs_for_category():
+    activate("en")
+    category = get_default_category()
+    assert category.slug == slugify(category.name)
+    default_slug = category.slug
+
+    # Test that slug is only generated when it's empty on save
+    new_name = "Some new cat name"
+    category.name = new_name
+    category.save()
+    assert category.slug == default_slug, "Old slug"
+    category.slug = ""
+    category.save()
+    assert category.slug == slugify(new_name), "New slug generated"
+
+    # Check that slug is not generated to other languages
+    with pytest.raises(ObjectDoesNotExist):
+        translation = category.get_translation("fi")
+        translation.refresh_from_db()  # If the translation object was returned from cache
+
+
+@pytest.mark.django_db
+@override_settings(**{"LANGUAGES": (("en", "en"), ("fi", "fi"), ("ja", "ja")), "PARLER_DEFAULT_LANGUAGE_CODE": "fi"})
+def test_slug_is_generate_from_translation():
+    activate("en")
+    category = get_default_category()
+    assert category.slug == slugify(category.name)
+    default_slug = category.slug
+    activate("fi")
+    category.set_current_language("fi")
+    name_fi = "Joku nimi"
+    category.name = name_fi
+    category.save()
+    assert category.slug == slugify(name_fi)
+
+    # Make sure english still have default slug
+    activate("en")
+    category.set_current_language("en")
+    assert category.slug == default_slug
+
+    # Make sure Japanese does not have translations generated
+    # Check that slug is not generated to other languages
+    with pytest.raises(ObjectDoesNotExist):
+        translation = category.get_translation("ja")
+        translation.refresh_from_db()  # If the translation object was returned from cache

--- a/shuup_tests/utils/test_multilanguage_model_form.py
+++ b/shuup_tests/utils/test_multilanguage_model_form.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from django.conf import settings
+from django.test import override_settings
+from django.utils.translation import activate
+
+from shuup.testing.factories import get_default_shop
+from shuup.admin.modules.shops.views.edit import ShopBaseForm
+from shuup_tests.utils.forms import get_form_data
+
+
+@pytest.mark.django_db
+@override_settings(**{"LANGUAGES": (("en", "en"), ("fi", "fi")), "PARLER_DEFAULT_LANGUAGE_CODE": "fi"})
+def test_default_language_finnish():
+    activate("en")
+    test_name_en = "Test shop"
+    test_name_fi = "Testi kauppa"
+    shop = get_default_shop()
+    shop.name = test_name_en
+    shop.public_name = test_name_en
+    shop.save()
+
+    shop_form = ShopBaseForm(instance=shop, languages=settings.LANGUAGES)
+    data = get_form_data(shop_form, prepared=True)
+    assert data.get("name__en") == test_name_en
+    assert not data.get("name__fi")
+    shop_form = ShopBaseForm(data=data, instance=shop, languages=settings.LANGUAGES)
+    shop_form.full_clean()
+    assert not shop_form.is_valid() and shop_form.errors
+
+    data["name__fi"] = test_name_fi
+    data["public_name__fi"] = test_name_fi
+    shop_form = ShopBaseForm(data=data, instance=shop, languages=settings.LANGUAGES)
+    shop_form.full_clean()
+    assert shop_form.is_valid() and not shop_form.errors
+    shop_form.save()
+
+    shop.set_current_language("en")
+    assert shop.name == test_name_en, "English activated"
+    shop.set_current_language("fi")
+    assert shop.name == test_name_fi, "Finnish activated"
+
+
+@pytest.mark.django_db
+@override_settings(**{"LANGUAGES": (("en", "en"), ("fi", "fi")), "PARLER_DEFAULT_LANGUAGE_CODE": "en"})
+def test_default_language_english():
+    activate("en")
+    test_name_en = "Test shop"
+    shop = get_default_shop()
+    shop.name = test_name_en
+    shop.public_name = test_name_en
+    shop.save()
+
+    shop_form = ShopBaseForm(instance=shop, languages=settings.LANGUAGES)
+    data = get_form_data(shop_form, prepared=True)
+    assert data.get("name__en") == test_name_en
+    assert not data.get("name__fi")
+    shop_form = ShopBaseForm(data=data, instance=shop, languages=settings.LANGUAGES)
+    shop_form.full_clean()
+    assert shop_form.is_valid() and not shop_form.errors

--- a/shuup_tests/utils/test_multilanguage_model_form.py
+++ b/shuup_tests/utils/test_multilanguage_model_form.py
@@ -8,11 +8,14 @@
 import pytest
 
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 from django.test import override_settings
+from django.test.client import RequestFactory
 from django.utils.translation import activate
 
-from shuup.testing.factories import get_default_shop
+from shuup.admin.modules.services.forms import PaymentMethodForm
 from shuup.admin.modules.shops.views.edit import ShopBaseForm
+from shuup.testing.factories import get_default_shop, get_default_payment_method
 from shuup_tests.utils.forms import get_form_data
 
 
@@ -65,3 +68,63 @@ def test_default_language_english():
     shop_form = ShopBaseForm(data=data, instance=shop, languages=settings.LANGUAGES)
     shop_form.full_clean()
     assert shop_form.is_valid() and not shop_form.errors
+
+
+@pytest.mark.django_db
+@override_settings(**{"LANGUAGES": (("en", "en"), ("fi", "fi"), ("ja", "ja")), "PARLER_DEFAULT_LANGUAGE_CODE": "en"})
+def test_model_form_partially_translated():
+    activate("en")
+    request = RequestFactory().get("/")
+    test_name_en = "Test shop"
+    payment_method = get_default_payment_method()
+    payment_method.name = test_name_en
+    payment_method.save()
+
+    form = PaymentMethodForm(instance=payment_method, request=request, languages=settings.LANGUAGES)
+    data = get_form_data(form, prepared=True)
+    assert data.get("name__en") == test_name_en
+    assert not data.get("name__fi")
+    form = PaymentMethodForm(data=data, instance=payment_method, request=request, languages=settings.LANGUAGES)
+    form.full_clean()
+    assert form.is_valid() and not form.errors
+    payment_method = form.save()
+
+    # Add description for Finnish and and name in Finnish should be required
+    data["description__fi"] = "Some description"
+    form = PaymentMethodForm(data=data, instance=payment_method, request=request, languages=settings.LANGUAGES)
+    form.full_clean()
+    assert not form.is_valid() and form.errors
+
+    test_name_fi = "Some method name in finnish"
+    data["name__fi"] = test_name_fi
+    form = PaymentMethodForm(data=data, instance=payment_method, request=request, languages=settings.LANGUAGES)
+    form.full_clean()
+    assert form.is_valid() and not form.errors
+    payment_method = form.save()
+
+    assert payment_method.name == test_name_en, "Object in English"
+
+    activate("fi")
+    payment_method.set_current_language("fi")
+    assert payment_method.name == test_name_fi, "Object in Finnish"
+
+    activate("ja")
+    payment_method.set_current_language("ja")
+    assert payment_method.name == test_name_en, "Should fallback to English"
+
+    # Check that no sneaky translations is not created for Japan
+    with pytest.raises(ObjectDoesNotExist):
+        translation = payment_method.get_translation("ja")
+        translation.refresh_from_db()  # Just in case if the translation object comes from cache or something
+
+    # Empty finnish translations and see if Finnish starts fallbacks too
+    data["name__fi"] = data["description__fi"] = ""
+    form = PaymentMethodForm(data=data, instance=payment_method, request=request, languages=settings.LANGUAGES)
+    form.full_clean()
+    assert form.is_valid() and not form.errors
+    form.save()
+
+    # Check that no sneaky translations is not created for Finnish
+    with pytest.raises(ObjectDoesNotExist):
+        translation = payment_method.get_translation("fi")
+        translation.refresh_from_db()  # Just in case if the translation object comes from cache or something


### PR DESCRIPTION
* MultiLanguageModelForm: Use Parler default as a default
* MultiLanguageModelForm: Avoid partially/empty translation objects
* Core: Fix bug in product and category slugs generation
* Admin: Add key prefix to JavaScript catalog page cache
* Admin: Add lang parameter for JS catalog load
* Xtheme: Skip adding JS-catalog for editing
* Tests: Add test for loading JS catalog
