### PR TITLE
Fix using "force_text()" on coupons

### DIFF
--- a/shuup/campaigns/models/campaigns.py
+++ b/shuup/campaigns/models/campaigns.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
-from django.utils.encoding import force_text
+from django.utils.encoding import force_text, python_2_unicode_compatible
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 from enumfields import Enum
@@ -296,6 +296,7 @@ class CouponUsage(models.Model):
         return cls.objects.create(order=order, coupon=coupon)
 
 
+@python_2_unicode_compatible
 class Coupon(models.Model):
     admin_url_suffix = "coupons"
 

--- a/shuup_tests/campaigns/test_coupons.py
+++ b/shuup_tests/campaigns/test_coupons.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from django.utils.encoding import force_text
+
+from shuup.campaigns.models.campaigns import Coupon
+
+@pytest.mark.django_db
+def test_utf8_coupon_force_text(rf):
+    code = u"HEINÄ"
+    coupon = Coupon(code=code)
+    try:
+        text = force_text(coupon)
+    except UnicodeDecodeError:
+        text = ""
+    assert text == code


### PR DESCRIPTION
Coupons with unicode in their code would result in an UnicodeDecodeError when passed
to the "force_text()" function. Fix this issue.