### PR TITLE
Package orderability changes (SH-145)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,7 @@ Unreleased
 Core
 ~~~~
 
+- Fix issue with package product validation errors in order creator
 - Fix bug in product and category slug generation
 
 Localization

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -33,6 +33,7 @@ Addons
 Front
 ~~~~~
 
+- Notify customer of unorderable basket lines
 - Load JS catalog for superusers
 
 Xtheme

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -33,6 +33,7 @@ Addons
 Front
 ~~~~~
 
+- Fix handling of package products in basket
 - Notify customer of unorderable basket lines
 - Load JS catalog for superusers
 

--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -216,8 +216,9 @@ class ShopProduct(MoneyPropped, models.Model):
                         customer=customer,
                         ignore_minimum=ignore_minimum
                 ):
+                    message = getattr(error, "message", "")
                     code = getattr(error, "code", None)
-                    yield ValidationError("%s: %s" % (child_product, error), code=code)
+                    yield ValidationError("%s: %s" % (child_product, message), code=code)
 
         if supplier and self.product.stock_behavior == StockBehavior.STOCKED:
             for error in supplier.get_orderability_errors(self, quantity, customer=customer):

--- a/shuup/core/order_creator/_source.py
+++ b/shuup/core/order_creator/_source.py
@@ -488,6 +488,11 @@ class OrderSource(object):
 
             if supplier and line.supplier != supplier:
                 continue
+
+            package_children = line.product.get_package_child_to_quantity_map()
+            for product, quantity in iteritems(package_children):
+                q_counter[product] += quantity
+
             product = line.product
             q_counter[product] += line.quantity
 

--- a/shuup/front/basket/objects.py
+++ b/shuup/front/basket/objects.py
@@ -94,7 +94,9 @@ class BaseBasket(OrderSource):
         self.storage = get_storage()
         self._data = None
         self.dirty = False
-        self._lines_cache = None
+        self._orderable_lines_cache = None
+        self._unorderable_lines_cache = None
+        self._lines_cached = False
         self.customer = getattr(request, "customer", None)
         self.orderer = getattr(request, "person", None)
         self.creator = getattr(request, "user", None)
@@ -222,17 +224,35 @@ class BaseBasket(OrderSource):
         self.dirty = bool(self.dirty or modified)
         return modified
 
+    def _cache_lines(self):
+        lines = [BasketLine.from_dict(self, line) for line in self._data_lines]
+        orderable_lines = []
+        unorderable_lines = []
+        for line in lines:
+            if line.type != OrderLineType.PRODUCT:
+                orderable_lines.append(line)
+            elif line.shop_product.is_orderable(line.supplier, self.request.customer, line.quantity):
+                orderable_lines.append(line)
+            else:
+                unorderable_lines.append(line)
+            assert ((line in orderable_lines) or (line in unorderable_lines))
+        self._orderable_lines_cache = orderable_lines
+        self._unorderable_lines_cache = unorderable_lines
+        self._lines_cached = True
+
+    @property
+    def is_empty(self):
+        return not bool(self.get_lines())
+
+    def get_unorderable_lines(self):
+        if self.dirty or not self._lines_cached:
+            self._cache_lines()
+        return self._unorderable_lines_cache
+
     def get_lines(self):
-        if self.dirty or not self._lines_cache:
-            lines = [BasketLine.from_dict(self, line) for line in self._data_lines]
-            orderable_lines = []
-            for line in lines:
-                if line.type != OrderLineType.PRODUCT:
-                    orderable_lines.append(line)
-                elif line.shop_product.is_orderable(line.supplier, self.request.customer, line.quantity):
-                    orderable_lines.append(line)
-            self._lines_cache = orderable_lines
-        return self._lines_cache
+        if self.dirty or not self._lines_cached:
+            self._cache_lines()
+        return self._orderable_lines_cache
 
     def _initialize_product_line_data(self, product, supplier, shop, quantity=0):
         if product.variation_children.count():

--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-16 22:53+0000\n"
+"POT-Creation-Date: 2016-09-01 22:20+0000\n"
 "PO-Revision-Date: 2016-08-04 10:51-0700\n"
 "Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
@@ -74,12 +74,6 @@ msgstr ""
 msgid "My Saved Carts"
 msgstr ""
 
-msgid "Add all products to cart"
-msgstr ""
-
-msgid "Delete cart"
-msgstr ""
-
 msgid "Product"
 msgstr ""
 
@@ -102,6 +96,12 @@ msgid "Details"
 msgstr ""
 
 msgid "You haven't saved any carts yet."
+msgstr ""
+
+msgid "Add all products to cart"
+msgstr ""
+
+msgid "Delete cart"
 msgstr ""
 
 msgid "Please enter a basket title."
@@ -260,19 +260,6 @@ msgstr ""
 msgid "products"
 msgstr ""
 
-msgid "Shop is currently in maintenance mode."
-msgstr ""
-
-msgid ""
-"There were errors on submitted form fields. Please check them and try again."
-msgstr ""
-
-msgid "Product added to cart"
-msgstr ""
-
-msgid "There was an error adding the product to the basket"
-msgstr ""
-
 msgid "Shopping cart"
 msgstr ""
 
@@ -288,109 +275,19 @@ msgstr ""
 msgid "You are unable to proceed to checkout!"
 msgstr ""
 
-msgid "Continue Shopping"
-msgstr ""
-
-msgid "Proceed to checkout"
-msgstr ""
-
-msgid "Save cart"
-msgstr ""
-
-msgid "Cart Title"
-msgstr ""
-
-msgid "Save"
-msgstr ""
-
-msgid "Coupon is not available."
-msgstr ""
-
-msgid "Error when adding coupon."
-msgstr ""
-
-msgid "Cart"
-msgstr ""
-
-msgid "Items"
-msgstr ""
-
-msgid "View cart"
-msgstr ""
-
-msgid "Qty"
-msgstr ""
-
-msgid "Remove product from basket"
-msgstr ""
-
-msgid "Have a coupon code? Enter it here"
-msgstr ""
-
-msgid "Coupon Code"
-msgstr ""
-
-msgid "Submit Code"
-msgstr ""
-
 msgid "Checkout"
 msgstr ""
 
-msgid "Continue"
+msgid "There are errors"
 msgstr ""
 
-msgid "excl. tax"
-msgstr ""
-
-msgid "Billing address"
+msgid "Errors"
 msgstr ""
 
 msgid "Ordering for a company?"
 msgstr ""
 
 msgid "Please fill out these fields if you are ordering for a company."
-msgstr ""
-
-msgid "Shipping address"
-msgstr ""
-
-msgid "Ship to my billing address"
-msgstr ""
-
-msgid "Delivery"
-msgstr ""
-
-msgid "Delivery method"
-msgstr ""
-
-msgid "Billing"
-msgstr ""
-
-msgid "Add comment"
-msgstr ""
-
-msgid "Place Order"
-msgstr ""
-
-msgid "There are errors"
-msgstr ""
-
-msgid "Choose Shipping Method"
-msgstr ""
-
-msgid "Choose Payment Method"
-msgstr ""
-
-msgid "Errors"
-msgstr ""
-
-msgid "Ordering for a company"
-msgstr ""
-
-msgid "Other information"
-msgstr ""
-
-msgid "Place the order"
 msgstr ""
 
 msgid "Bad Request"
@@ -420,51 +317,6 @@ msgstr ""
 msgid ""
 "Unfortunately an internal server error occurred. Try refreshing the page or "
 "try again later."
-msgstr ""
-
-msgid "Categories"
-msgstr ""
-
-msgid "Edit account details"
-msgstr ""
-
-msgid "Edit company details"
-msgstr ""
-
-msgid "My orders"
-msgstr ""
-
-msgid "My saved carts"
-msgstr ""
-
-msgid "My wishlists"
-msgstr ""
-
-msgid "Admin panel"
-msgstr ""
-
-msgid "Log out"
-msgstr ""
-
-msgid "Log in"
-msgstr ""
-
-msgid "Username or email address"
-msgstr ""
-
-msgid "Password"
-msgstr ""
-
-msgid "Forgot your password?"
-msgstr ""
-
-msgid "New user? Register here!"
-msgstr ""
-
-msgid "Menu"
-msgstr ""
-
-msgid "Products"
 msgstr ""
 
 msgid "Welcome to Shuup!"
@@ -499,22 +351,96 @@ msgstr ""
 msgid "ask an administrator to select a theme."
 msgstr ""
 
-msgid "Preview"
+msgid "Product added to cart"
 msgstr ""
 
-msgid "Files"
+msgid "There was an error adding the product to the basket"
 msgstr ""
 
-msgid "Products ordered"
+msgid "Qty"
 msgstr ""
 
-msgid "Tax breakdown"
+msgid "Remove product from basket"
 msgstr ""
 
-msgid "Payment"
+msgid ""
+"The following items are not currently available (or are not available in the "
+"desired quantity) and cannot be included in your order."
 msgstr ""
 
-msgid "Company"
+msgid "Continue Shopping"
+msgstr ""
+
+msgid "Proceed to checkout"
+msgstr ""
+
+msgid "Have a coupon code? Enter it here"
+msgstr ""
+
+msgid "Coupon Code"
+msgstr ""
+
+msgid "Submit Code"
+msgstr ""
+
+msgid "Save cart"
+msgstr ""
+
+msgid "Cart Title"
+msgstr ""
+
+msgid "Save"
+msgstr ""
+
+msgid "Coupon is not available."
+msgstr ""
+
+msgid "Error when adding coupon."
+msgstr ""
+
+msgid "Categories"
+msgstr ""
+
+msgid "Show Grid/List"
+msgstr ""
+
+msgid "Grid/list view"
+msgstr ""
+
+msgid "Continue"
+msgstr ""
+
+msgid "Billing address"
+msgstr ""
+
+msgid "Shipping address"
+msgstr ""
+
+msgid "Ship to my billing address"
+msgstr ""
+
+msgid "Choose Shipping Method"
+msgstr ""
+
+msgid "Choose Payment Method"
+msgstr ""
+
+msgid "Delivery"
+msgstr ""
+
+msgid "Delivery method"
+msgstr ""
+
+msgid "Billing"
+msgstr ""
+
+msgid "Add comment"
+msgstr ""
+
+msgid "Other information"
+msgstr ""
+
+msgid "Place Order"
 msgstr ""
 
 msgid "Previous"
@@ -523,28 +449,74 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-msgid "Maintenance mode"
-msgstr ""
-
-msgid "Shop is currently down for maintenance."
-msgstr ""
-
-msgid "Thank you for your order!"
+msgid "Shop is currently in maintenance mode."
 msgstr ""
 
 msgid ""
-"Your order has been received. You can see the details of your order below."
+"There were errors on submitted form fields. Please check them and try again."
 msgstr ""
 
-msgid "User account activation"
+msgid "Edit account details"
 msgstr ""
 
-msgid ""
-"If you want to be able to see your order history, please create a password "
-"for your account: "
+msgid "Edit company details"
 msgstr ""
 
-msgid "Send"
+msgid "My orders"
+msgstr ""
+
+msgid "My saved carts"
+msgstr ""
+
+msgid "My wishlists"
+msgstr ""
+
+msgid "Admin panel"
+msgstr ""
+
+msgid "Log out"
+msgstr ""
+
+msgid "Username or email address"
+msgstr ""
+
+msgid "Password"
+msgstr ""
+
+msgid "Log in"
+msgstr ""
+
+msgid "Forgot your password?"
+msgstr ""
+
+msgid "New user? Register here!"
+msgstr ""
+
+msgid "Cart"
+msgstr ""
+
+msgid "Items"
+msgstr ""
+
+msgid "View cart"
+msgstr ""
+
+msgid "Menu"
+msgstr ""
+
+msgid "Products"
+msgstr ""
+
+msgid "Files"
+msgstr ""
+
+msgid "excl. tax"
+msgstr ""
+
+msgid "Products ordered"
+msgstr ""
+
+msgid "Tax breakdown"
 msgstr ""
 
 msgid "Tax"
@@ -562,13 +534,32 @@ msgstr ""
 msgid "Total including tax"
 msgstr ""
 
-msgid "Payment canceled"
+msgid "Company"
 msgstr ""
 
-msgid "You have canceled payment"
+msgid "Preview"
 msgstr ""
 
-msgid "Retry payment"
+msgid "Also available in"
+msgstr ""
+
+#, python-format
+msgid "Save %(discount_percent)s"
+msgstr ""
+
+msgid "Product Information"
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
+msgid "Attributes"
+msgstr ""
+
+msgid "Includes these products"
+msgstr ""
+
+msgid "No product description available"
 msgstr ""
 
 msgid "SKU"
@@ -601,47 +592,55 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-msgid "Add to cart"
-msgstr ""
-
-msgid "Product is not orderable."
-msgstr ""
-
 msgid "Select"
 msgstr ""
 
 msgid "Select product"
 msgstr ""
 
+msgid "Add to cart"
+msgstr ""
+
+msgid "Product is not orderable."
+msgstr ""
+
+msgid "Maintenance mode"
+msgstr ""
+
+msgid "Shop is currently down for maintenance."
+msgstr ""
+
+msgid "Thank you for your order!"
+msgstr ""
+
+msgid ""
+"Your order has been received. You can see the details of your order below."
+msgstr ""
+
+msgid "User account activation"
+msgstr ""
+
+msgid ""
+"If you want to be able to see your order history, please create a password "
+"for your account: "
+msgstr ""
+
+msgid "Send"
+msgstr ""
+
+msgid "Payment canceled"
+msgstr ""
+
+msgid "You have canceled payment"
+msgstr ""
+
+msgid "Retry payment"
+msgstr ""
+
+msgid "Error"
+msgstr ""
+
 msgid "Combination not available"
-msgstr ""
-
-msgid "Show Grid/List"
-msgstr ""
-
-msgid "Grid/list view"
-msgstr ""
-
-#, python-format
-msgid "Save %(discount_percent)s"
-msgstr ""
-
-msgid "Product Information"
-msgstr ""
-
-msgid "Description"
-msgstr ""
-
-msgid "Attributes"
-msgstr ""
-
-msgid "Includes these products"
-msgstr ""
-
-msgid "No product description available"
-msgstr ""
-
-msgid "Also available in"
 msgstr ""
 
 msgid "Open product page"

--- a/shuup/front/static_src/less/front/basket.less
+++ b/shuup/front/static_src/less/front/basket.less
@@ -100,6 +100,15 @@
         }
     }
 
+    .basket-unorderable-lines {
+        margin-top: 50px;
+
+        .single-item {
+            background: inherit;
+            border: 1px solid #dfe2e4;
+        }
+    }
+
     .basket-summary {
         .total-price {
             h2 { margin: 0; }

--- a/shuup/front/templates/shuup/front/basket/default_basket.jinja
+++ b/shuup/front/templates/shuup/front/basket/default_basket.jinja
@@ -5,7 +5,7 @@
 {% block content_title %}{% trans %}Shopping cart{% endtrans %}{% endblock %}
 
 {% block content %}
-    {% if basket.is_empty %}
+    {% if basket.is_empty and not basket.get_unorderable_lines() %}
         <p class="lead">
             <i class="fa fa-exclamation-circle text-danger"></i>
             {% trans %}Your shopping cart is empty.{% endtrans %}

--- a/shuup/front/templates/shuup/front/macros/basket.jinja
+++ b/shuup/front/templates/shuup/front/macros/basket.jinja
@@ -7,92 +7,114 @@
             <input name="command" type="hidden" value="update">
             {% csrf_token %}
             {{ render_basket_lines() }}
+            {{ render_unorderable_basket_lines() }}
             {{ render_coupon_div() }}
             {{ render_basket_summary(basket) }}
         </form>
     </div>
 {% endmacro %}
 
-{% macro render_basket_lines() %}
-    {% for line in basket.get_final_lines() %}
-        {% set product = line.product %}
-        {% set shop_product = line.shop_product %}
-        <div class="single-item">
-            {% if product %}
-            <div class="product-image">
-                {% set image = product.primary_image %}
-                {% if image %}
-                    <a class="product-name"
-                       href="{{ shuup.urls.model_url(product) }}">
-                        <img class="img-responsive"
-                             src="{{ image|thumbnail(size=(200, 200)) }}"
-                             alt="{{ line.text }}">
-                    </a>
+{% macro _render_basket_line(line) %}
+    {% set product = line.product %}
+    {% set shop_product = line.shop_product %}
+    <div class="single-item">
+        {% if product %}
+        <div class="product-image">
+            {% set image = product.primary_image %}
+            {% if image %}
+                <a class="product-name"
+                   href="{{ shuup.urls.model_url(product) }}">
+                    <img class="img-responsive"
+                         src="{{ image|thumbnail(size=(200, 200)) }}"
+                         alt="{{ line.text }}">
+                </a>
+            {% else %}
+                <a class="product-name"
+                   href="{{ shuup.urls.model_url(product) }}">
+                    <img class="img-responsive"
+                         src="{{ STATIC_URL }}shuup/front/img/no_image_thumbnail.png">
+                </a>
+            {% endif %}
+        </div>
+        {% endif %}
+        <div class="product-details">
+            <h4 class="name">
+                {% if product %}
+                    <a class="product-name" href="{{ shuup.urls.model_url(product) }}">{{ line.text }}</a>
                 {% else %}
-                    <a class="product-name"
-                       href="{{ shuup.urls.model_url(product) }}">
-                        <img class="img-responsive"
-                             src="{{ STATIC_URL }}shuup/front/img/no_image_thumbnail.png">
-                    </a>
+                    {{ line.text }}
                 {% endif %}
-            </div>
+            </h4>
+            {% if product and product.is_package_parent() %}
+                {{ order_macros.render_package_children(product) }}
             {% endif %}
-            <div class="product-details">
-                <h4 class="name">
-                    {% if product %}
-                        <a class="product-name" href="{{ shuup.urls.model_url(product) }}">{{ line.text }}</a>
-                    {% else %}
-                        {{ line.text }}
-                    {% endif %}
-                </h4>
-                {% if product and product.is_package_parent() %}
-                    {{ order_macros.render_package_children(product) }}
-                {% endif %}
-                <div class="quantity">
-                    {% if product %}
-                        {% if line.can_change_quantity %}
-                        <div class="input-group">
-                            <div class="input-group-addon">
-                                {% trans %}Qty{% endtrans %}
-                            </div>
-                            <input
-                                id="qty_{{ line.line_id }}"
-                                type="number"
-                                name="q_{{ line.line_id }}"
-                                size="2"
-                                class="line_quantity form-control"
-                                step="{{ shop_product.quantity_step }}"
-                                value="{{ line.quantity }}"
-                                min="{{ shop_product.rounded_minimum_purchase_quantity }}">
+            <div class="quantity">
+                {% if product %}
+                    {% if line.can_change_quantity %}
+                    <div class="input-group">
+                        <div class="input-group-addon">
+                            {% trans %}Qty{% endtrans %}
                         </div>
-                        {% else %}
-                            <div class="">{{ _("Quantity") }}: {{ line.quantity }}</div>
-                        {% endif %}
+                        <input
+                            id="qty_{{ line.line_id }}"
+                            type="number"
+                            name="q_{{ line.line_id }}"
+                            size="2"
+                            class="line_quantity form-control"
+                            step="{{ shop_product.quantity_step }}"
+                            value="{{ line.quantity }}"
+                            min="{{ shop_product.rounded_minimum_purchase_quantity }}">
+                    </div>
+                    {% else %}
+                        <div class="">{{ _("Quantity") }}: {{ line.quantity }}</div>
                     {% endif %}
-                </div>
-            </div>
-            {% if show_prices() %}
-                <div class="product-sum">
-                    <h4 class="price text-right">
-                        <small>{% trans %}Total{% endtrans %}: </small>{{ line|price }}
-                        {% if line.is_discounted and line.base_price.value > 0 %}
-                            <br><small><s class="text-muted">{{ line|base_price }}</s></small>
-                        {% endif %}
-                    </h4>
-                </div>
-            {% endif %}
-            <div class="delete">
-                {% if line.can_delete %}
-                    <button type="submit"
-                            class="btn btn-sm"
-                            name="delete_{{ line.line_id }}"
-                            title="{% trans %}Remove product from basket{% endtrans %}">
-                        <i class="fa fa-times"></i>
-                    </button>
                 {% endif %}
             </div>
         </div>
-    {% endfor %}
+        {% if show_prices() %}
+            <div class="product-sum">
+                <h4 class="price text-right">
+                    <small>{% trans %}Total{% endtrans %}: </small>{{ line|price }}
+                    {% if line.is_discounted and line.base_price.value > 0 %}
+                        <br><small><s class="text-muted">{{ line|base_price }}</s></small>
+                    {% endif %}
+                </h4>
+            </div>
+        {% endif %}
+        <div class="delete">
+            {% if line.can_delete %}
+                <button type="submit"
+                        class="btn btn-sm"
+                        name="delete_{{ line.line_id }}"
+                        title="{% trans %}Remove product from basket{% endtrans %}">
+                    <i class="fa fa-times"></i>
+                </button>
+            {% endif %}
+        </div>
+    </div>
+{% endmacro %}
+
+{% macro render_basket_lines() %}
+    {% set lines = basket.get_final_lines() %}
+    {% if lines %}
+        <div class="basket-lines">
+            {% for line in lines %}
+                {{ _render_basket_line(line) }}
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endmacro %}
+
+{% macro render_unorderable_basket_lines() %}
+    {% set unorderable_lines = basket.get_unorderable_lines() %}
+    {% if unorderable_lines %}
+        <div class="basket-unorderable-lines">
+            <p class="text-danger">{% trans %}The following items are not currently available (or are not available in the desired quantity) and cannot be included in your order.{% endtrans %}</p>
+            {% for line in unorderable_lines %}
+                {{ _render_basket_line(line) }}
+            {% endfor %}
+        </div>
+    {% endif %}
 {% endmacro %}
 
 {%  macro render_basket_summary(basket) %}

--- a/shuup_tests/front/utils.py
+++ b/shuup_tests/front/utils.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from shuup.core.models import StockBehavior
+from shuup.testing.factories import create_package_product
+
+
+def get_unstocked_package_product_and_stocked_child(shop, supplier, child_logical_quantity=1):
+    package_product = create_package_product("Package-Product-Test", shop=shop, supplier=supplier, children=1)
+    assert package_product.stock_behavior == StockBehavior.UNSTOCKED
+
+    quantity_map = package_product.get_package_child_to_quantity_map()
+    assert len(quantity_map.keys()) == 1
+
+    child_product = list(quantity_map.keys())[0]
+    child_product.stock_behavior = StockBehavior.STOCKED
+    child_product.save()
+
+    assert quantity_map[child_product] == 1
+
+    supplier.adjust_stock(child_product.id, child_logical_quantity)
+
+    stock_status = supplier.get_stock_status(child_product.id)
+    assert stock_status.logical_count == child_logical_quantity
+
+    return package_product, child_product


### PR DESCRIPTION
Fix handling of package orderability in Front and Core.

Also, display package orderability problems to customer in basket view to allow them to make changes (for example, if the stock changes after the product is placed into basket).

One test (test_basket_update_errors) has been removed since implementation has changed a bit regarding when orderability errors are shown.