### PR TITLE
Admin: Ensure there is columns in Picotable by default (SH-204)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -78,6 +78,7 @@ Localization
 Admin
 ~~~~~
 
+- Change Picotable columns default behavior
 - Match everywhere in Select2 when no model set
 - Make currency field a dropdown in Shops admin
 - Add possibility to select visible fields in most list views

--- a/shuup/admin/utils/views.py
+++ b/shuup/admin/utils/views.py
@@ -163,7 +163,7 @@ class PicotableListView(PicotableViewMixin, ListView):
     def __init__(self):
         super(PicotableListView, self).__init__()
         self.settings = ViewSettings(self.model, self.default_columns)
-        self.columns = self.settings.columns
+        self.columns = (self.settings.columns or self.default_columns)
 
     def get_toolbar(self):
         buttons = []


### PR DESCRIPTION
In case there is no configurations saved for Picotable list view
columns the columns list is initialized to empty. Avoid this
for empty columns list fallback to default columns.
