### PR TITLE
Simple supplier: Make admin stock management columns static (SH-205)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -108,6 +108,8 @@ Classic Gray Theme
 Simple Supplier
 ~~~~~~~~~~~~~~~
 
+- Make stock management columns static
+
 Order Printouts
 ~~~~~~~~~~~~~~~
 

--- a/shuup/simple_supplier/admin_module/views.py
+++ b/shuup/simple_supplier/admin_module/views.py
@@ -48,6 +48,10 @@ class StocksListView(PicotableListView):
         )
     ]
 
+    def __init__(self):
+        super(StocksListView, self).__init__()
+        self.columns = self.default_columns
+
     def get_object_abstract(self, instance, item):
         item.update({"_linked_in_mobile": False, "_url": self.get_object_url(instance.product)})
         return [


### PR DESCRIPTION
Since the stock management list view is linked to Product model
and the stock management does not have model of it's own the
dynamic column configurations can't be used for stock management
with current implementation.