### PR TITLE
Admin: Fix breadcrumbs for Picotable settings views (SH-208)

### DIFF
--- a/shuup/admin/modules/contacts/__init__.py
+++ b/shuup/admin/modules/contacts/__init__.py
@@ -54,7 +54,7 @@ class ContactModule(AdminModule):
                 permissions=get_default_model_permissions(Contact),
             ),
             admin_url(
-                "^list-settings/",
+                "^contacts/list-settings/",
                 "shuup.admin.modules.settings.views.ListSettingsView",
                 name="contact.list_settings",
                 permissions=get_default_model_permissions(Contact),

--- a/shuup/admin/modules/orders/__init__.py
+++ b/shuup/admin/modules/orders/__init__.py
@@ -95,7 +95,7 @@ class OrderModule(AdminModule):
 
             ),
             admin_url(
-                "^list-settings/",
+                "^orders/list-settings/",
                 "shuup.admin.modules.settings.views.ListSettingsView",
                 name="order.list_settings",
                 permissions=get_default_model_permissions(Order),

--- a/shuup/admin/modules/users/__init__.py
+++ b/shuup/admin/modules/users/__init__.py
@@ -68,7 +68,7 @@ class UserModule(AdminModule):
                 permissions=permissions
             ),
             admin_url(
-                "^list-settings/",
+                "^contacts/list-settings/",
                 "shuup.admin.modules.settings.views.ListSettingsView",
                 name="user.list_settings",
                 permissions=permissions,

--- a/shuup/admin/utils/urls.py
+++ b/shuup/admin/utils/urls.py
@@ -155,7 +155,7 @@ def get_edit_and_list_urls(url_prefix, view_template, name_template, permissions
             permissions=permissions
         ),
         admin_url(
-            "^list-settings/",
+            "%s/list-settings/" % url_prefix,
             "shuup.admin.modules.settings.views.ListSettingsView",
             name=name_template % "list_settings",
             permissions=permissions,


### PR DESCRIPTION
Fix urls when creating list-settings urls so breadcrumbs can be
correctly inferred.

Note, if the breadcrumb can't be inferred (i.e., in the Campaigns module), then no breadcrumbs are displayed. This should be fine for now, since at least it doesn't show incorrect breadcrumbs.

SH-208