### PR TITLE
Tax field changes for US taxes (SH-190)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,7 @@ Unreleased
 Core
 ~~~~
 
+- Update tax name max length to 124 characters
 - Fix issue with package product validation errors in order creator
 - Fix bug in product and category slug generation
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -67,6 +67,8 @@ Simple CMS
 Default Tax
 ~~~~~~~~~~~
 
+- Change postal codes pattern to textfield
+
 Guide
 ~~~~~
 

--- a/shuup/core/migrations/0009_update_tax_name_max_length.py
+++ b/shuup/core/migrations/0009_update_tax_name_max_length.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shuup', '0008_blank_slugs_for_product'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='taxtranslation',
+            name='name',
+            field=models.CharField(verbose_name='name', max_length=124),
+        ),
+    ]

--- a/shuup/core/models/_taxes.py
+++ b/shuup/core/models/_taxes.py
@@ -33,7 +33,7 @@ class Tax(MoneyPropped, ChangeProtected, TranslatableShuupModel):
         unique=True, editable=True, verbose_name=_("code"), help_text="")
 
     translations = TranslatedFields(
-        name=models.CharField(max_length=64, verbose_name=_("name")),
+        name=models.CharField(max_length=124, verbose_name=_("name")),
     )
 
     rate = models.DecimalField(

--- a/shuup/default_tax/migrations/0002_postal_code_pattern_to_text.py
+++ b/shuup/default_tax/migrations/0002_postal_code_pattern_to_text.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_tax', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='taxrule',
+            name='postal_codes_pattern',
+            field=models.TextField(verbose_name='postal codes pattern', blank=True),
+        ),
+    ]

--- a/shuup/default_tax/models.py
+++ b/shuup/default_tax/models.py
@@ -40,9 +40,8 @@ class TaxRule(models.Model):
     region_codes_pattern = models.CharField(
         max_length=500, blank=True,
         verbose_name=_("region codes pattern"))
-    postal_codes_pattern = models.CharField(
-        max_length=500, blank=True,
-        verbose_name=_("postal codes pattern"))
+    postal_codes_pattern = models.TextField(
+        blank=True, verbose_name=_("postal codes pattern"))
 
     _postal_codes_min = models.CharField(max_length=100, blank=True, null=True)
     _postal_codes_max = models.CharField(max_length=100, blank=True, null=True)


### PR DESCRIPTION
* Core: Update tax name max length to 124 characters
* Default tax: Change tax rule postal codes pattern to textfield