### PR TITLE
Front: Add carousel app (SH-11)

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -47,6 +47,11 @@ file_filter = shuup/front/apps/auth/locale/<lang>/LC_MESSAGES/django.po
 source_lang = en
 type = PO
 
+[shuup.front-apps.carousel]
+file_filter = shuup/front/apps/carousel/locale/<lang>/LC_MESSAGES/django.po
+source_lang = en
+type = PO
+
 [shuup.front-apps-customer-information]
 file_filter = shuup/front/apps/customer_information/locale/<lang>/LC_MESSAGES/django.po
 source_lang = en

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -27,6 +27,11 @@ Addons
 Front
 ~~~~~
 
+- Add carousel app
+   - Note! Instances using shuup-carousel addon should be updated to use
+     this new app. There is no migration tools for old carousel and the old
+     carousels and slides needs to be copied manually to new app before
+     removing shuup-carousel addon from installed apps.
 - Enable region codes for checkout addresses
 
 Xtheme

--- a/shuup/front/apps/carousel/__init__.py
+++ b/shuup/front/apps/carousel/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+default_app_config = __name__ + ".apps.AppConfig"

--- a/shuup/front/apps/carousel/admin_module/__init__.py
+++ b/shuup/front/apps/carousel/admin_module/__init__.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext_lazy as _
+from filer.models import File
+
+from shuup.admin.base import AdminModule, MenuEntry
+from shuup.admin.menu import STOREFRONT_MENU_CATEGORY
+from shuup.admin.utils.permissions import get_default_model_permissions
+from shuup.admin.utils.urls import (
+    admin_url, derive_model_url, get_edit_and_list_urls
+)
+from shuup.core.models import Product
+from shuup.front.apps.carousel.models import Carousel
+
+
+class CarouselModule(AdminModule):
+    name = _("Carousels")
+    breadcrumbs_menu_entry = MenuEntry(text=name, url="shuup_admin:carousel.list", category=STOREFRONT_MENU_CATEGORY)
+
+    def get_urls(self):
+        return get_edit_and_list_urls(
+            url_prefix="^carousels",
+            view_template="shuup.front.apps.carousel.admin_module.views.Carousel%sView",
+            name_template="carousel.%s",
+            permissions=get_default_model_permissions(Carousel)
+        ) + [
+            admin_url(
+                "^carousel/(?P<pk>\d+)/delete/$",
+                "shuup.front.apps.carousel.admin_module.views.CarouselDeleteView",
+                name="carousel.delete",
+                permissions=get_default_model_permissions(Carousel)
+            ),
+        ]
+
+    def get_menu_entries(self, request):
+        return [
+            MenuEntry(
+                text=self.name,
+                icon="fa fa-image",
+                url="shuup_admin:carousel.list",
+                category=STOREFRONT_MENU_CATEGORY
+            )
+        ]
+
+    def get_required_permissions(self):
+        return (
+            get_default_model_permissions(Carousel) |
+            get_default_model_permissions(File) |
+            get_default_model_permissions(Product)
+        )
+
+    def get_model_url(self, object, kind):
+        return derive_model_url(Carousel, "shuup_admin:carousel", object, kind)

--- a/shuup/front/apps/carousel/admin_module/forms.py
+++ b/shuup/front/apps/carousel/admin_module/forms.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.forms import BaseModelFormSet, ModelForm
+
+from shuup.admin.forms.widgets import ImageChoiceWidget, ProductChoiceWidget
+from shuup.front.apps.carousel.models import Carousel, Slide
+from shuup.utils.multilanguage_model_form import (
+    MultiLanguageModelForm, to_language_codes
+)
+
+
+class CarouselForm(ModelForm):
+    class Meta:
+        model = Carousel
+        exclude = ()
+
+
+class SlideForm(MultiLanguageModelForm):
+    class Meta:
+        model = Slide
+        exclude = ("carousel",)
+
+    def __init__(self, **kwargs):
+        self.carousel = kwargs.pop("carousel")
+        super(SlideForm, self).__init__(**kwargs)
+
+        self.empty_permitted = False
+        self.fields["product_link"].widget = ProductChoiceWidget(clearable=True)
+        for lang in self.languages:
+            image_field = "image__%s" % lang
+            self.fields[image_field].widget = ImageChoiceWidget(clearable=True)
+            if lang == self.default_language:
+                self.fields[image_field].widget = ImageChoiceWidget(clearable=False)
+                self.fields[image_field].required = True
+                self.fields[image_field].widget.is_required = True
+
+    def pre_master_save(self, instance):
+        instance.carousel = self.carousel
+
+
+class SlideFormSet(BaseModelFormSet):
+    form_class = SlideForm
+    model = Slide
+
+    validate_min = False
+    min_num = 0
+    validate_max = False
+    max_num = 20
+    absolute_max = 20
+    can_delete = True
+    can_order = False
+    extra = 0
+
+    def __init__(self, *args, **kwargs):
+        self.carousel = kwargs.pop("carousel")
+        self.languages = to_language_codes(kwargs.pop("languages", ()))
+        kwargs.pop("empty_permitted")
+        super(SlideFormSet, self).__init__(*args, **kwargs)
+
+    def get_queryset(self):
+        return Slide.objects.filter(carousel=self.carousel)
+
+    def form(self, **kwargs):
+        kwargs.setdefault("carousel", self.carousel)
+        kwargs.setdefault("languages", self.languages)
+        kwargs.setdefault("default_language", settings.PARLER_DEFAULT_LANGUAGE_CODE)
+        return self.form_class(**kwargs)

--- a/shuup/front/apps/carousel/admin_module/views/__init__.py
+++ b/shuup/front/apps/carousel/admin_module/views/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+from ._delete import CarouselDeleteView
+from ._edit import CarouselEditView
+from ._list import CarouselListView
+
+__all__ = [
+    "CarouselDeleteView",
+    "CarouselEditView",
+    "CarouselListView"
+]

--- a/shuup/front/apps/carousel/admin_module/views/_delete.py
+++ b/shuup/front/apps/carousel/admin_module/views/_delete.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django.contrib import messages
+from django.core.urlresolvers import reverse
+from django.http.response import HttpResponseRedirect
+from django.utils.translation import ugettext as _
+from django.views.generic import DetailView
+
+from shuup.admin.utils.urls import get_model_url
+from shuup.front.apps.carousel.models import Carousel
+
+
+class CarouselDeleteView(DetailView):
+    model = Carousel
+    context_object_name = "carousel"
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponseRedirect(get_model_url(self.get_object()))
+
+    def post(self, request, *args, **kwargs):
+        carousel = self.get_object()
+        name = carousel.name
+        carousel.delete()
+        messages.success(request, _(u"%s has been deleted.") % name)
+        return HttpResponseRedirect(reverse("shuup_admin:carousel.list"))

--- a/shuup/front/apps/carousel/admin_module/views/_edit.py
+++ b/shuup/front/apps/carousel/admin_module/views/_edit.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db.transaction import atomic
+
+from shuup.admin.form_part import (
+    FormPart, FormPartsViewMixin, SaveFormPartsMixin, TemplatedFormDef
+)
+from shuup.admin.toolbar import get_default_edit_toolbar
+from shuup.admin.utils.views import CreateOrUpdateView
+from shuup.front.apps.carousel.admin_module.forms import (
+    CarouselForm, SlideFormSet
+)
+from shuup.front.apps.carousel.models import Carousel
+
+
+class CarouselFormPart(FormPart):
+    priority = 1
+    name = "base"
+    form = CarouselForm
+
+    def get_form_defs(self):
+        yield TemplatedFormDef(
+            self.name,
+            self.form,
+            template_name="shuup/carousel/admin/_edit_base_form.jinja",
+            required=True,
+            kwargs={
+                "instance": self.object,
+            }
+        )
+
+    def form_valid(self, form):
+        self.object = form[self.name].save()
+        return self.object
+
+
+class SlideFormPart(FormPart):
+    priority = 2
+    name = "slides"
+    formset = SlideFormSet
+
+    def get_form_defs(self):
+        yield TemplatedFormDef(
+            self.name,
+            self.formset,
+            template_name="shuup/carousel/admin/_edit_slide_form.jinja",
+            required=False,
+            kwargs={"carousel": self.object, "languages": settings.LANGUAGES}
+        )
+
+    def form_valid(self, form):
+        if self.name in form.forms:
+            form.forms[self.name].save()
+
+
+class CarouselEditView(FormPartsViewMixin, SaveFormPartsMixin, CreateOrUpdateView):
+    model = Carousel
+    template_name = "shuup/carousel/admin/edit.jinja"
+    base_form_part_classes = [
+        CarouselFormPart,
+        SlideFormPart,
+    ]
+    context_object_name = "carousel"
+    form_part_class_provide_key = "admin_carousel_form_part"
+
+    def get_toolbar(self):
+        save_form_id = self.get_save_form_id()
+        if save_form_id:
+            return get_default_edit_toolbar(self, save_form_id, delete_url="shuup_admin:carousel.delete")
+
+    @atomic
+    def form_valid(self, form):
+        return self.save_form_parts(form)

--- a/shuup/front/apps/carousel/admin_module/views/_list.py
+++ b/shuup/front/apps/carousel/admin_module/views/_list.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.admin.utils.picotable import Column, TextFilter
+from shuup.admin.utils.views import PicotableListView
+from shuup.front.apps.carousel.models import Carousel
+
+
+class CarouselListView(PicotableListView):
+    model = Carousel
+    columns = [
+        Column(
+            "name",
+            _("Name"),
+            sort_field="name",
+            display="name",
+            filter_config=TextFilter(filter_field="name", placeholder=_("Filter by name..."))
+        ),
+    ]

--- a/shuup/front/apps/carousel/apps.py
+++ b/shuup/front/apps/carousel/apps.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import shuup.apps
+
+
+class AppConfig(shuup.apps.AppConfig):
+    name = "shuup.front.apps.carousel"
+    label = "carousel"
+    provides = {
+        "admin_module": [
+            "shuup.front.apps.carousel.admin_module:CarouselModule"
+        ],
+        "xtheme_plugin": [
+            "shuup.front.apps.carousel.plugins:CarouselPlugin",
+            "shuup.front.apps.carousel.plugins:BannerBoxPlugin"
+        ],
+    }

--- a/shuup/front/apps/carousel/forms.py
+++ b/shuup/front/apps/carousel/forms.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.front.apps.carousel.models import Carousel
+from shuup.xtheme.plugins.forms import GenericPluginForm
+from shuup.xtheme.plugins.widgets import XThemeModelChoiceField
+
+
+class CarouselConfigForm(GenericPluginForm):
+    def populate(self):
+        super(CarouselConfigForm, self).populate()
+        self.fields["carousel"] = XThemeModelChoiceField(
+            label=_("Carousel"),
+            queryset=Carousel.objects.all(),
+            required=False,
+            initial=self.plugin.config.get("carousel") if self.plugin else None
+        )
+
+    def clean(self):
+        cleaned_data = super(CarouselConfigForm, self).clean()
+        carousel = cleaned_data.get("carousel")
+        cleaned_data["carousel"] = carousel.pk if hasattr(carousel, "pk") else None
+        return cleaned_data

--- a/shuup/front/apps/carousel/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/apps/carousel/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,167 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-07 18:58+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Carousels"
+msgstr ""
+
+#, python-format
+msgid "%s has been deleted."
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Filter by name..."
+msgstr ""
+
+msgid "Carousel"
+msgstr ""
+
+msgid "Slide"
+msgstr ""
+
+msgid "Fade"
+msgstr ""
+
+msgid "Current"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "name"
+msgstr ""
+
+msgid "Name is only used to configure carousels."
+msgstr ""
+
+msgid "animation"
+msgstr ""
+
+msgid "Animation type for cycling slides."
+msgstr ""
+
+msgid "interval"
+msgstr ""
+
+msgid "Slide interval in seconds."
+msgstr ""
+
+msgid "pause on hover"
+msgstr ""
+
+msgid "Pauses the cycling of the carousel on mouse over."
+msgstr ""
+
+msgid "show navigation arrows"
+msgstr ""
+
+msgid "show navigation dots"
+msgstr ""
+
+msgid "image width"
+msgstr ""
+
+msgid "Slide images will be cropped to this width."
+msgstr ""
+
+msgid "image height"
+msgstr ""
+
+msgid "Slide images will be cropped to this height."
+msgstr ""
+
+msgid "Name is only used to configure slides."
+msgstr ""
+
+msgid "product link"
+msgstr ""
+
+msgid "category link"
+msgstr ""
+
+msgid "cms page link"
+msgstr ""
+
+msgid "ordering"
+msgstr ""
+
+msgid "link target"
+msgstr ""
+
+msgid "available from"
+msgstr ""
+
+msgid "available to"
+msgstr ""
+
+msgid "caption"
+msgstr ""
+
+msgid "caption text"
+msgstr ""
+
+msgid "When displayed in banner box mode, caption text is shown as a tooltip"
+msgstr ""
+
+msgid "external link"
+msgstr ""
+
+msgid "image"
+msgstr ""
+
+msgid "Slides"
+msgstr ""
+
+msgid "Carousel Plugin"
+msgstr ""
+
+msgid "Banner Box"
+msgstr ""
+
+msgid "Title"
+msgstr ""
+
+msgid "Slides can be added after saving the Carousel."
+msgstr ""
+
+msgid ""
+"This form is also used to define banner boxes. Marked fields only apply to "
+"banner boxes."
+msgstr ""
+
+msgid "Basic details"
+msgstr ""
+
+msgid "Advanced options"
+msgstr ""
+
+msgid "Only image for default language is required."
+msgstr ""
+
+msgid ""
+"If external link is not set link will fallback to product link, category "
+"link or cms page link in this order."
+msgstr ""
+
+msgid "Add new slide"
+msgstr ""
+
+msgid "New Carousel"
+msgstr ""

--- a/shuup/front/apps/carousel/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/front/apps/carousel/locale/fi_FI/LC_MESSAGES/django.po
@@ -1,0 +1,173 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-07 18:59+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Carousels"
+msgstr "Karusellit"
+
+#, python-format
+msgid "%s has been deleted."
+msgstr "%s on poistettu."
+
+msgid "Name"
+msgstr "Nimi"
+
+msgid "Filter by name..."
+msgstr "Rajaa nimellä..."
+
+msgid "Carousel"
+msgstr "Karuselli"
+
+msgid "Slide"
+msgstr "Kuva"
+
+msgid "Fade"
+msgstr "Häivytys"
+
+msgid "Current"
+msgstr "Nykyinen"
+
+msgid "New"
+msgstr "Uusi"
+
+msgid "name"
+msgstr "nimi"
+
+msgid "Name is only used to configure carousels."
+msgstr "Nimeä käytetään vain karusellien konfiguroinnissa."
+
+msgid "animation"
+msgstr "animaatio"
+
+msgid "Animation type for cycling slides."
+msgstr "Animaation tyyppi vaihtuviin kuviin."
+
+msgid "interval"
+msgstr "aikaväli"
+
+msgid "Slide interval in seconds."
+msgstr "Kuvien aikaväli sekunneissa."
+
+msgid "pause on hover"
+msgstr "pysäytä hiiren alle"
+
+msgid "Pauses the cycling of the carousel on mouse over."
+msgstr "Pysäyttää kuvien vaihtumisen kun hiiri viedään kuvan päälle."
+
+msgid "show navigation arrows"
+msgstr "näytä siirtymisnuolet"
+
+msgid "show navigation dots"
+msgstr "näytä siirtymispisteet"
+
+msgid "image width"
+msgstr "kuvan leveys"
+
+msgid "Slide images will be cropped to this width."
+msgstr "Kuvat rajataan tähän leveyteen."
+
+msgid "image height"
+msgstr "kuvan korkeus"
+
+msgid "Slide images will be cropped to this height."
+msgstr "Kuvat rajataan tähän korkeuteen."
+
+msgid "Name is only used to configure slides."
+msgstr "Nimeä käytetään vain kuvien konfigurointiin."
+
+msgid "product link"
+msgstr "tuotelinkki"
+
+msgid "category link"
+msgstr "kategorialinkki"
+
+msgid "cms page link"
+msgstr "sisältösivulinkki"
+
+msgid "ordering"
+msgstr "järjestys"
+
+msgid "link target"
+msgstr "linkin kohde"
+
+msgid "available from"
+msgstr "saatavilla alkaen"
+
+msgid "available to"
+msgstr "saatavilla asti"
+
+msgid "caption"
+msgstr "kuvateksti"
+
+msgid "caption text"
+msgstr "kuvateksti"
+
+msgid "When displayed in banner box mode, caption text is shown as a tooltip"
+msgstr ""
+"Kun tämä näytetään bannerilaatikko-tilassa, kuvateksti näytetään "
+"vinkkitekstinä"
+
+msgid "external link"
+msgstr "ulkoinen linkki"
+
+msgid "image"
+msgstr "kuva"
+
+msgid "Slides"
+msgstr "Kuvat"
+
+msgid "Carousel Plugin"
+msgstr "Karusellilaajennus"
+
+msgid "Banner Box"
+msgstr "Bannerilaatikko"
+
+msgid "Title"
+msgstr "Otsikko"
+
+msgid "Slides can be added after saving the Carousel."
+msgstr "Kuvia voi lisätä karusellin tallentamisen jälkeen."
+
+msgid ""
+"This form is also used to define banner boxes. Marked fields only apply to "
+"banner boxes."
+msgstr ""
+"Tätä lomaketta käytetään myös bannerilaatikoiden määrittelyyn. Merkatut "
+"kentät vaikuttavat vain bannerilaatikoihin."
+
+msgid "Basic details"
+msgstr "Perustiedot"
+
+msgid "Advanced options"
+msgstr "Edistyneet asetukset"
+
+msgid "Only image for default language is required."
+msgstr "Ainoastaan peruskielen kuva vaaditaan."
+
+msgid ""
+"If external link is not set link will fallback to product link, category "
+"link or cms page link in this order."
+msgstr ""
+"Mikäli ulkoista linkkiä ei ole määritelty, käytetään tuote-, kategoria- tai "
+"sisältösivulinkkiä tässä järjestyksessä."
+
+msgid "Add new slide"
+msgstr "Lisää uusi kuva"
+
+msgid "New Carousel"
+msgstr "Uusi karuselli"

--- a/shuup/front/apps/carousel/migrations/0001_initial.py
+++ b/shuup/front/apps/carousel/migrations/0001_initial.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+import filer.fields.image
+import enumfields.fields
+import shuup.front.apps.carousel.models
+import parler.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shuup', '0009_update_tax_name_max_length'),
+        ('shuup_simple_cms', '0001_initial'),
+        ('filer', '0006_auto_20160623_1627'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Carousel',
+            fields=[
+                ('id', models.AutoField(primary_key=True, serialize=False, auto_created=True, verbose_name='ID')),
+                ('name', models.CharField(help_text='Name is only used to configure carousels.', max_length=50, verbose_name='name')),
+                ('animation', enumfields.fields.EnumIntegerField(help_text='Animation type for cycling slides.', enum=shuup.front.apps.carousel.models.CarouselMode, verbose_name='animation', default=0)),
+                ('interval', models.IntegerField(help_text='Slide interval in seconds.', verbose_name='interval', default=5)),
+                ('pause_on_hover', models.BooleanField(help_text='Pauses the cycling of the carousel on mouse over.', verbose_name='pause on hover', default=True)),
+                ('is_arrows_visible', models.BooleanField(verbose_name='show navigation arrows', default=True)),
+                ('use_dot_navigation', models.BooleanField(verbose_name='show navigation dots', default=True)),
+                ('image_width', models.IntegerField(help_text='Slide images will be cropped to this width.', verbose_name='image width', default=1200)),
+                ('image_height', models.IntegerField(help_text='Slide images will be cropped to this height.', verbose_name='image height', default=600)),
+            ],
+            options={
+                'verbose_name': 'Carousel',
+                'verbose_name_plural': 'Carousels',
+            },
+        ),
+        migrations.CreateModel(
+            name='Slide',
+            fields=[
+                ('id', models.AutoField(primary_key=True, serialize=False, auto_created=True, verbose_name='ID')),
+                ('name', models.CharField(help_text='Name is only used to configure slides.', blank=True, max_length=50, verbose_name='name', null=True)),
+                ('ordering', models.IntegerField(verbose_name='ordering', blank=True, default=0, null=True)),
+                ('target', enumfields.fields.EnumIntegerField(verbose_name='link target', enum=shuup.front.apps.carousel.models.LinkTargetType, default=0)),
+                ('available_from', models.DateTimeField(verbose_name='available from', blank=True, null=True)),
+                ('available_to', models.DateTimeField(verbose_name='available to', blank=True, null=True)),
+                ('carousel', models.ForeignKey(related_name='slides', to='carousel.Carousel')),
+                ('category_link', models.ForeignKey(to='shuup.Category', related_name='+', null=True, verbose_name='category link', blank=True)),
+                ('cms_page_link', models.ForeignKey(to='shuup_simple_cms.Page', related_name='+', null=True, verbose_name='cms page link', blank=True)),
+                ('product_link', models.ForeignKey(to='shuup.Product', related_name='+', null=True, verbose_name='product link', blank=True)),
+            ],
+            options={
+                'ordering': ('ordering', 'id'),
+                'verbose_name': 'Slide',
+                'verbose_name_plural': 'Slides',
+            },
+            bases=(parler.models.TranslatableModelMixin, models.Model),
+        ),
+        migrations.CreateModel(
+            name='SlideTranslation',
+            fields=[
+                ('id', models.AutoField(primary_key=True, serialize=False, auto_created=True, verbose_name='ID')),
+                ('language_code', models.CharField(verbose_name='Language', max_length=15, db_index=True)),
+                ('caption', models.CharField(verbose_name='caption', blank=True, max_length=80, null=True)),
+                ('caption_text', models.TextField(help_text='When displayed in banner box mode, caption text is shown as a tooltip', blank=True, verbose_name='caption text', null=True)),
+                ('external_link', models.CharField(verbose_name='external link', blank=True, max_length=160, null=True)),
+                ('image', filer.fields.image.FilerImageField(on_delete=django.db.models.deletion.PROTECT, to='filer.Image', related_name='+', null=True, verbose_name='image', blank=True)),
+                ('master', models.ForeignKey(editable=False, related_name='translations', null=True, to='carousel.Slide')),
+            ],
+            options={
+                'managed': True,
+                'db_tablespace': '',
+                'db_table': 'carousel_slide_translation',
+                'default_permissions': (),
+                'verbose_name': 'Slide Translation',
+            },
+        ),
+        migrations.AlterUniqueTogether(
+            name='slidetranslation',
+            unique_together=set([('language_code', 'master')]),
+        ),
+    ]

--- a/shuup/front/apps/carousel/models.py
+++ b/shuup/front/apps/carousel/models.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.db import models
+from django.db.models import Q
+from django.utils.encoding import python_2_unicode_compatible
+from django.utils.timezone import now
+from django.utils.translation import ugettext as _
+from enumfields import Enum, EnumIntegerField
+from filer.fields.image import FilerImageField
+from parler.managers import TranslatableQuerySet
+from parler.models import TranslatedFields
+
+from shuup.core.models import Category, Product
+from shuup.core.models._base import ShuupModel, TranslatableShuupModel
+from shuup.simple_cms.models import Page
+
+
+class CarouselMode(Enum):
+    SLIDE = 0
+    FADE = 1
+
+    class Labels:
+        SLIDE = _("Slide")
+        FADE = _("Fade")
+
+
+class LinkTargetType(Enum):
+    CURRENT = 0
+    NEW = 1
+
+    class Labels:
+        CURRENT = _("Current")
+        FADE = _("New")
+
+
+class SlideQuerySet(TranslatableQuerySet):
+    def visible(self, dt=None):
+        """
+        Get slides that should be publicly visible.
+
+        This does not do permission checking.
+
+        :param dt: Datetime for visibility check
+        :type dt: datetime.datetime
+        :return: QuerySet of slides.
+        :rtype: QuerySet[Slide]
+        """
+        if not dt:
+            dt = now()
+        q = Q(available_from__lte=dt) & (Q(available_to__gte=dt) | Q(available_to__isnull=True))
+        qs = self.filter(q)
+        return qs
+
+
+@python_2_unicode_compatible
+class Carousel(ShuupModel):
+    name = models.CharField(
+        max_length=50, verbose_name=_("name"), help_text=_("Name is only used to configure carousels.")
+    )
+    animation = EnumIntegerField(
+        CarouselMode, default=CarouselMode.SLIDE, verbose_name=_("animation"),
+        help_text=_("Animation type for cycling slides.")
+    )
+    interval = models.IntegerField(
+        default=5, verbose_name=_("interval"), help_text=_("Slide interval in seconds.")
+    )
+    pause_on_hover = models.BooleanField(
+        default=True, verbose_name=_("pause on hover"),
+        help_text=_("Pauses the cycling of the carousel on mouse over.")
+    )
+    is_arrows_visible = models.BooleanField(default=True, verbose_name=_("show navigation arrows"))
+    use_dot_navigation = models.BooleanField(default=True, verbose_name=_("show navigation dots"))
+    image_width = models.IntegerField(
+        default=1200, verbose_name=_("image width"),
+        help_text=_("Slide images will be cropped to this width.")
+    )
+    image_height = models.IntegerField(
+        default=600, verbose_name=_("image height"),
+        help_text=_("Slide images will be cropped to this height.")
+    )
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        verbose_name = _("Carousel")
+        verbose_name_plural = _("Carousels")
+
+    @property
+    def animation_class_name(self):
+        return "fade" if self.animation == CarouselMode.FADE else "slide"
+
+
+@python_2_unicode_compatible
+class Slide(TranslatableShuupModel):
+    carousel = models.ForeignKey(Carousel, related_name="slides", on_delete=models.CASCADE)
+    name = models.CharField(
+        max_length=50, blank=True, null=True, verbose_name=_("name"),
+        help_text=_("Name is only used to configure slides.")
+    )
+    product_link = models.ForeignKey(
+        Product, related_name="+", blank=True, null=True, verbose_name=_("product link"))
+    category_link = models.ForeignKey(
+        Category, related_name="+", blank=True, null=True, verbose_name=_("category link"))
+    cms_page_link = models.ForeignKey(
+        Page, related_name="+", verbose_name=_("cms page link"), blank=True, null=True)
+    ordering = models.IntegerField(default=0, blank=True, null=True, verbose_name=_("ordering"))
+    target = EnumIntegerField(
+        LinkTargetType, default=LinkTargetType.CURRENT, verbose_name=_("link target")
+    )
+    available_from = models.DateTimeField(null=True, blank=True, verbose_name=_('available from'))
+    available_to = models.DateTimeField(null=True, blank=True, verbose_name=_('available to'))
+
+    translations = TranslatedFields(
+        caption=models.CharField(max_length=80, blank=True, null=True, verbose_name=_("caption")),
+        caption_text=models.TextField(
+            blank=True, null=True, verbose_name=_("caption text"),
+            help_text=_("When displayed in banner box mode, caption text is shown as a tooltip"),
+        ),
+        external_link=models.CharField(max_length=160, blank=True, null=True, verbose_name=_("external link")),
+        image=FilerImageField(
+            blank=True, null=True, related_name="+", verbose_name=_("image"), on_delete=models.PROTECT)
+    )
+
+    def __str__(self):
+        return "%s %s" % (_("Slide"), self.pk)
+
+    class Meta:
+        verbose_name = _("Slide")
+        verbose_name_plural = _("Slides")
+        ordering = ("ordering", "id")
+
+    def get_translated_field(self, attr):
+        if not self.safe_translation_getter(attr):
+            return self.safe_translation_getter(attr, language_code=settings.PARLER_DEFAULT_LANGUAGE_CODE)
+        return getattr(self, attr)
+
+    def get_link_url(self):
+        """
+        Get right link url for this slide.
+
+        Initially external link is used. If not set link will fallback to
+        product_link, external_link or cms_page_link in this order.
+
+        :return: return correct link url for slide if set
+        :rtype: str|None
+        """
+        external_link = self.get_translated_field("external_link")
+        if external_link:
+            return external_link
+        elif self.product_link:
+            return reverse("shuup:product", kwargs=dict(pk=self.product_link.pk, slug=self.product_link.slug))
+        elif self.category_link:
+            return reverse("shuup:category", kwargs=dict(pk=self.category_link.pk, slug=self.category_link.slug))
+        elif self.cms_page_link:
+            return reverse("shuup:cms_page", kwargs=dict(url=self.cms_page_link.url))
+
+    def is_visible(self, dt=None):
+        """
+        Get slides that should be publicly visible.
+
+        This does not do permission checking.
+
+        :param dt: Datetime for visibility check
+        :type dt: datetime.datetime
+        :return: Public visibility status
+        :rtype: bool
+        """
+        if not dt:
+            dt = now()
+
+        return (
+            (self.available_from and self.available_from <= dt) and
+            (self.available_to is None or self.available_to >= dt)
+        )
+
+    def get_link_target(self):
+        """
+        Return link target type string based on selection
+
+        :return: Target type string
+        :rtype: str
+        """
+        if self.target == LinkTargetType.NEW:
+            return "_blank"
+        else:
+            return "_self"
+
+    objects = SlideQuerySet.as_manager()

--- a/shuup/front/apps/carousel/plugins.py
+++ b/shuup/front/apps/carousel/plugins.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.front.apps.carousel.models import Carousel
+from shuup.xtheme import TemplatedPlugin
+from shuup.xtheme.plugins.forms import TranslatableField
+
+from .forms import CarouselConfigForm
+
+
+class CarouselPlugin(TemplatedPlugin):
+    identifier = "shuup.front.apps.carousel.carousel"
+    name = _("Carousel Plugin")
+    template_name = "shuup/carousel/carousel.jinja"
+    fields = [("carousel", None)]
+    editor_form_class = CarouselConfigForm
+
+    def get_context_data(self, context):
+        """
+        Use only slides that has translated image in current language
+
+        :param context: current context
+        :return: updated plugin context
+        :rtype: dict
+        """
+        carousel_id = self.config.get("carousel")
+        return {
+            "request": context["request"],
+            "carousel": Carousel.objects.filter(id=carousel_id).first() if carousel_id else None,
+            "type": "carousel"
+        }
+
+
+class BannerBoxPlugin(CarouselPlugin):
+    identifier = "shuup.front.apps.carousel.banner_box"
+    name = _("Banner Box")
+    editor_form_class = CarouselConfigForm
+    fields = [
+        ("title", TranslatableField(label=_("Title"), required=False, initial="")),
+    ]
+
+    def get_context_data(self, context):
+        """
+        Add title from config to context data
+
+        :param context: Current context
+        :return: updated Plugin context
+        :rtype: dict
+        """
+        data = super(BannerBoxPlugin, self).get_context_data(context)
+        data["title"] = self.get_translated_value("title")
+        data["type"] = "banner_box"
+        return data

--- a/shuup/front/apps/carousel/templates/shuup/carousel/admin/_edit_base_form.jinja
+++ b/shuup/front/apps/carousel/templates/shuup/carousel/admin/_edit_base_form.jinja
@@ -1,0 +1,29 @@
+{% from "shuup/admin/macros/general.jinja" import content_block %}
+{% from "shuup/admin/macros/multilanguage.jinja" import render_monolingual_fields %}
+
+{% macro save_warning(carousel) %}
+    {% if not carousel.pk %}
+        <div class="container-fluid">
+            <i class="fa fa-info-circle text-info"></i>
+            {% trans %}Slides can be added after saving the Carousel.{% endtrans %}
+        </div>
+        <div class="container-fluid">
+            <i class="fa fa-info-circle text-info"></i>
+            {% trans %}This form is also used to define banner boxes. Marked fields only apply to banner boxes.{% endtrans %}
+        </div>
+    {% endif %}
+{% endmacro %}
+
+{% set basic_fields = ["name", "interval"]%}
+{% set base_form = form["base"] %}
+{% set carousel = base_form.instance %}
+
+{% call content_block(_("Basic details"), "fa-info-circle") %}
+    {{ save_warning(carousel) }}
+    {{ render_monolingual_fields(base_form, field_names=basic_fields) }}
+{% endcall %}
+
+{% call content_block(_("Advanced options"), "fa-cog") %}
+    {{ save_warning(carousel) }}
+    {{ render_monolingual_fields(base_form, exclude=basic_fields) }}
+{% endcall %}

--- a/shuup/front/apps/carousel/templates/shuup/carousel/admin/_edit_slide_form.jinja
+++ b/shuup/front/apps/carousel/templates/shuup/carousel/admin/_edit_slide_form.jinja
@@ -1,0 +1,47 @@
+{% from "shuup/admin/macros/general.jinja" import content_block %}
+
+{% from "shuup/admin/macros/multilanguage.jinja" import language_dependent_content_tabs, render_monolingual_fields %}
+
+{% macro render_slide_form(f, form, idx) %}
+    <div class="panel panel-default panel-slide">
+        <div class="panel-heading" role="tab" id="heading{{ idx }}">
+            <a class="panel-title" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapse{{ idx }}" aria-expanded="true" aria-controls="collapse{{ idx }}">
+                <span class="title">
+                {% trans %}Slide{% endtrans %} {%  if f.instance.name %}{{ idx }} {{ f.instance.name }}{% else %}{{ idx }}{% endif %}
+                </span>
+                <i class="fa fa-angle-down pull-right"></i>
+            </a>
+        </div>
+        <div id="collapse{{ idx }}" class="panel-collapse collapse{% if  idx == "__prefix__" or f.errors %} in{% endif %}" role="tabpanel" aria-labelledby="heading{{ idx }}">
+            {{ language_dependent_content_tabs(f, tab_id_prefix=idx) }}
+            <div class="form-divider"></div>
+            {{ render_monolingual_fields(f) }}
+        </div>
+    </div>
+{% endmacro %}
+
+{% set slides_form = form["slides"] %}
+{{ slides_form.management_form }}
+{% if slides_form.carousel.pk %}
+    {% call content_block(_("Slides"), "fa-image") %}
+        <div id="slides-section-wrapper-div">
+            <p class="text-muted small">
+                {% trans -%}
+                    Only image for default language is required.
+                {%- endtrans %}
+                {% trans -%}
+                    If external link is not set link will fallback to product link, category link or cms page link in this order.
+                {%- endtrans %}
+            </p>
+            <a class="btn btn-lg btn-text slide-add-new-panel" href="#" data-target-id="id_slides" data-target-panels="slides-section-wrapper-div">+ {% trans %}Add new slide{% endtrans %}</a>
+            <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+                <div class="hide" id="placeholder-panel">
+                    {{ render_slide_form(slides_form.empty_form, slides_form, "__prefix__") }}
+                </div>
+                {% for f in slides_form %}
+                    {{ render_slide_form(f, slides_form, loop.index) }}
+                {% endfor %}
+            </div>
+        </div>
+    {% endcall %}
+{% endif %}

--- a/shuup/front/apps/carousel/templates/shuup/carousel/admin/edit.jinja
+++ b/shuup/front/apps/carousel/templates/shuup/carousel/admin/edit.jinja
@@ -1,0 +1,39 @@
+{% extends "shuup/admin/base.jinja" %}
+{% from "shuup/admin/macros/general.jinja" import content_with_sidebar %}
+
+{% block title %}{{ carousel.name or _("New Carousel") }}{% endblock %}
+{% block content %}
+    {% call content_with_sidebar(content_id="carousel_form") %}
+        <form method="post" id="carousel_form">
+            {% csrf_token %}
+            {% for form_def in form.form_defs.values() %}
+                {% include form_def.template_name with context %}
+            {% endfor %}
+        </form>
+    {% endcall %}
+{% endblock %}
+
+{% block extra_js %}
+    <script>
+        $(function () {
+            $(".slide-add-new-panel").on("click", function (e) {
+                e.preventDefault();
+                var panelCount = $("#" + $(this).data("target-panels") + " .panel").length;
+                var $source = $("#placeholder-panel");
+                var $html = $($source.html().replace(/__prefix__/g, panelCount - 1));
+                $html.find('.panel-title .title').text('{{ _('Slide') }}' + ' ' + panelCount);
+                $html.insertAfter($source);
+                var targetId = $(this).data("target-id");
+                var $totalFormsField = $("#" + targetId + "-TOTAL_FORMS");
+                $totalFormsField.val(parseInt($totalFormsField.val()) + 1);
+                $(".form-control.datetime").datetimepicker({
+                    format: "yyyy-mm-dd hh:ii",
+                    autoclose: true,
+                    todayBtn: true,
+                    todayHighlight: true,
+                    fontAwesome: true
+                });
+            });
+        });
+    </script>
+{% endblock %}

--- a/shuup/front/apps/carousel/templates/shuup/carousel/carousel.jinja
+++ b/shuup/front/apps/carousel/templates/shuup/carousel/carousel.jinja
@@ -1,0 +1,36 @@
+{% if carousel %}
+    {% set slides = carousel.slides.visible() %}
+{% else %}
+    {% set slides = [] %}
+{% endif %}
+
+{% if slides|length %}
+<section{% if type == "banner_box" %} class="carousel-banner-section"{% endif %}>
+    {% if type == "carousel" %}
+    <div
+        class="owl-carousel carousel-plugin one"
+        data-autoplay="{% if carousel.interval > 0 %}true{% else %}false{% endif %}"
+        data-interval="{{ carousel.interval * 1000 }}"
+        data-arrows-visible="{{ carousel.is_arrows_visible }}"
+        data-pause-on-hover="{{ carousel.pause_on_hover }}"
+        data-use-dot-navigation="{{ carousel.use_dot_navigation }}">
+    {% elif type == "banner_box" %}
+    {% if title %}
+    <div class="title-bar light">
+        <h2>{{ title }}</h2>
+    </div>
+    {% endif %}
+    <div class="owl-carousel carousel-plugin four" data-arrows-visible="{{ carousel.is_arrows_visible }}">
+    {% endif %}
+        {% for slide in slides %}
+            {% set link = slide.get_link_url() %}
+            {% set translated_image = slide.get_translated_field("image") %}
+            {% set cropped_slide = translated_image|thumbnail(size=(carousel.image_width, carousel.image_height), crop="smart", upscale=True) %}
+            {% set caption_text = slide.get_translated_field("caption_text") or "" %}
+            {% if link %}<a href="{{ link }}" target="{{ slide.get_link_target() }}" class="col-inner" data-toggle="tooltip" title="{{ caption_text }}">{% endif %}
+                <img src="{{ cropped_slide }}" alt="{{ caption_text }}">
+            {% if link %}</a>{% endif %}
+        {% endfor %}
+    </div>
+</section>
+{% endif %}

--- a/shuup/front/gulpfile.js
+++ b/shuup/front/gulpfile.js
@@ -45,6 +45,7 @@ gulp.task("js", function() {
         "static_src/js/language_changer.js",
         "static_src/js/navigation.js",
         "static_src/js/pagination.js",
+        "static_src/js/carousel.js",
         "static_src/js/product_preview.js",
         "static_src/js/update_price.js",
         "static_src/js/custom.js"

--- a/shuup/front/static_src/js/carousel.js
+++ b/shuup/front/static_src/js/carousel.js
@@ -1,0 +1,54 @@
+/**
+ * This file is part of Shuup.
+ *
+ * Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+$(function() {
+    $(".carousel-plugin.one").each(function () {
+        var autoplay = JSON.parse($(this).data("autoplay"));
+        var interval = JSON.parse($(this).data("interval"));
+        var arrowsVisible = JSON.parse($(this).data("arrows-visible").toLowerCase());
+        var pauseOnHover = JSON.parse($(this).data("pause-on-hover").toLowerCase());
+        var useDotNavigation = JSON.parse($(this).data("use-dot-navigation").toLowerCase());
+        $(this).owlCarousel({
+            loop: true,
+            autoplay: autoplay,
+            autoplayTimeout: interval,
+            autoplayHoverPause: pauseOnHover,
+            nav: arrowsVisible,
+            navText: [
+                '<i class="fa fa-angle-left .carousel-control .icon-prev"></i>',
+                '<i class="fa fa-angle-right .carousel-control .icon-prev"></i>'
+            ],
+            dots: useDotNavigation,
+            items: 1
+        });
+    });
+
+    $(".carousel-plugin.four").each(function () {
+        var arrowsVisible = JSON.parse($(this).data("arrows-visible").toLowerCase());
+        $(this).owlCarousel({
+            margin: 30,
+            nav: arrowsVisible,
+            navText: [
+                '<i class="fa fa-angle-left .carousel-control .icon-prev"></i>',
+                '<i class="fa fa-angle-right .carousel-control .icon-prev"></i>'
+            ],
+            responsiveClass: true,
+            responsive: {
+                0: { // breakpoint from 0 up
+                    items: 2
+                },
+                640: { // breakpoint from 640 up
+                    items: 2
+                },
+                992: { // breakpoint from 992 up
+                    items: 4
+                }
+            }
+        });
+    });
+});

--- a/shuup/front/static_src/less/front/carousel.less
+++ b/shuup/front/static_src/less/front/carousel.less
@@ -125,3 +125,60 @@
         }
     }
 }
+
+.carousel-plugin {
+    .fa {
+        font-size: 30px;
+        z-index: 10;
+        position: absolute;
+        top: 50%;
+        margin-top: -15px;
+    }
+    .fa-angle-left {
+        left: -25px;
+        z-index: 1000;
+    }
+    .fa-angle-right {
+        right: -25px;
+    }
+
+    &.one {
+        .fa-angle-left {
+            left: 40px;
+        }
+        .fa-angle-right {
+            right: 40px;
+        }
+        .owl-dots {
+            position: absolute;
+            bottom: 0 !important;
+            left: 50%;
+            z-index: 15;
+            width: 60%;
+            margin-left: -30%;
+            padding-left: 0;
+            list-style: none;
+            text-align: center;
+        }
+        .owl-dot {
+            background: transparent;
+            border-radius: 10px;
+            border: 1px solid #6f6f6f;
+            display: inline-block;
+            height: 10px;
+            margin: 1px;
+            width: 10px;
+            &.active {
+                margin: 0;
+                width:  12px;
+                height: 12px;
+                background-color: #6f6f6f;
+            }
+        }
+    }
+}
+.carousel-banner-section {
+    margin-top: 30px;
+    margin-bottom: 15px;
+    padding: 0 30px;
+}

--- a/shuup_tests/front/test_carousel.py
+++ b/shuup_tests/front/test_carousel.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shuup Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from datetime import datetime, timedelta
+
+import pytest
+from django.utils import translation
+from filer.models import Image
+
+from shuup.front.apps.carousel.models import Carousel, LinkTargetType, Slide
+from shuup.front.apps.carousel.plugins import BannerBoxPlugin, CarouselPlugin
+from shuup.testing.factories import get_default_category, get_default_product
+from shuup_tests.front.fixtures import get_jinja_context
+from shuup_tests.simple_cms.utils import create_page
+
+
+@pytest.mark.django_db
+def test_carousel_plugin_form():
+    test_carousel = Carousel.objects.create(name="test")
+    plugin = CarouselPlugin(config={})
+    form_class = plugin.get_editor_form_class()
+    form = form_class(data={"carousel": test_carousel.pk}, plugin=plugin)
+    assert form.is_valid()
+    assert form.get_config() == {"carousel": test_carousel.pk}
+
+
+@pytest.mark.django_db
+def test_carousel_plugin_form_get_context():
+    context = get_jinja_context()
+    test_carousel = Carousel.objects.create(name="test")
+    plugin = CarouselPlugin(config={"carousel": test_carousel.pk})
+    assert plugin.get_context_data(context).get("carousel") == test_carousel
+
+
+@pytest.mark.django_db
+def test_banner_box_plugin():
+    context = get_jinja_context()
+    test_carousel = Carousel.objects.create(name="test")
+    plugin = BannerBoxPlugin(config={"carousel": test_carousel.pk, "title": "Test"})
+    data = plugin.get_context_data(context)
+    assert data.get("carousel") == test_carousel
+    assert data.get("title") == "Test"
+
+
+@pytest.mark.django_db
+def test_image_translations():
+    test_carousel = Carousel.objects.create(name="test")
+    test_image_1 = Image.objects.create(original_filename="slide1.jpg")
+    test_image_2 = Image.objects.create(original_filename="slide2.jpg")
+
+    with translation.override("en"):
+        test_slide = Slide.objects.create(carousel=test_carousel, name="test", image=test_image_1)
+        assert len(test_carousel.slides.all()) == 1
+        assert test_slide.get_translated_field("image").original_filename == "slide1.jpg"
+
+    test_slide.set_current_language("fi")
+    assert test_slide.get_translated_field("image").original_filename == "slide1.jpg"
+    test_slide.image = test_image_2
+    test_slide.save()
+    assert test_slide.get_translated_field("image").original_filename == "slide2.jpg"
+
+    test_slide.set_current_language("en")
+    assert test_slide.get_translated_field("image").original_filename == "slide1.jpg"
+
+    test_slide.set_current_language("jp")
+    assert test_slide.get_translated_field("image").original_filename == "slide1.jpg"
+
+
+@pytest.mark.django_db
+def test_slide_links():
+    test_carousel = Carousel.objects.create(name="test")
+    test_image_1 = Image.objects.create(original_filename="slide1.jpg")
+    with translation.override("en"):
+        test_slide = Slide.objects.create(carousel=test_carousel, name="test", image=test_image_1)
+
+    # Test external link
+    assert len(test_carousel.slides.all()) == 1
+    test_link = "http://example.com"
+    test_slide.external_link = test_link
+    test_slide.save()
+    assert test_slide.get_translated_field("external_link") == test_link
+    assert test_slide.get_link_url() == test_link
+
+    # Test Product url and link priorities
+    test_product = get_default_product()
+    test_slide.product_link = test_product
+    test_slide.save()
+    assert test_slide.get_link_url() == test_link
+    test_slide.external_link = None
+    test_slide.save()
+    assert test_slide.get_link_url().startswith("/p/")  # Close enough...
+
+    # Test Category url and link priorities
+    test_category = get_default_category()
+    test_slide.category_link = test_category
+    test_slide.save()
+    assert test_slide.get_link_url().startswith("/p/")  # Close enough...
+    test_slide.product_link = None
+    test_slide.save()
+    assert test_slide.get_link_url().startswith("/c/")  # Close enough...
+
+    # Test CMS page url and link priorities
+    attrs = {"url": "test"}
+    test_page = create_page(**attrs)
+    test_slide.cms_page_link = test_page
+    test_slide.save()
+    assert test_slide.get_link_url().startswith("/c/")  # Close enough...
+    test_slide.category_link = None
+    test_slide.save()
+    assert test_slide.get_link_url().startswith("/test/")
+
+    # Check that external link overrides everything
+    test_slide.external_link = test_link
+    test_slide.save()
+    assert test_slide.get_link_url() == test_link
+
+
+@pytest.mark.django_db
+def test_visible_manager():
+    test_dt = datetime(2016, 3, 18, 20, 34, 1, 922791)
+    test_carousel = Carousel.objects.create(name="test")
+    test_image = Image.objects.create(original_filename="slide.jpg")
+
+    test_slide = Slide.objects.create(carousel=test_carousel, name="test", image=test_image)
+    assert not list(test_carousel.slides.visible(dt=test_dt))
+
+    # Available since last week
+    test_slide.available_from = test_dt - timedelta(days=7)
+    test_slide.save()
+    assert len(test_carousel.slides.visible(dt=test_dt)) == 1
+
+    # Available until tomorrow
+    test_slide.available_to = test_dt + timedelta(days=1)
+    test_slide.save()
+    assert len(test_carousel.slides.visible(dt=test_dt)) == 1
+
+    # Expired yesterday
+    test_slide.available_to = test_dt - timedelta(days=1)
+    test_slide.save()
+    assert not list(test_carousel.slides.visible(dt=test_dt))
+
+    # Not available until next week
+    test_slide.available_from = test_dt + timedelta(days=7)
+    test_slide.available_to = test_dt + timedelta(days=8)
+    test_slide.save()
+    assert not list(test_carousel.slides.visible(dt=test_dt))
+
+
+@pytest.mark.django_db
+def test_is_visible():
+    test_dt = datetime(2016, 3, 18, 20, 34, 1, 922791)
+    test_carousel = Carousel.objects.create(name="test")
+    test_image = Image.objects.create(original_filename="slide.jpg")
+    test_slide = Slide.objects.create(carousel=test_carousel, name="test", image=test_image)
+    assert not test_slide.is_visible(dt=test_dt)
+
+    # Available since last week
+    test_slide.available_from = test_dt - timedelta(days=7)
+    test_slide.save()
+    assert test_slide.is_visible(dt=test_dt)
+
+    # Available until tomorrow
+    test_slide.available_to = test_dt + timedelta(days=1)
+    test_slide.save()
+    assert test_slide.is_visible(dt=test_dt)
+
+    # Expired yesterday
+    test_slide.available_to = test_dt - timedelta(days=1)
+    test_slide.save()
+    assert not test_slide.is_visible(dt=test_dt)
+
+    # Not available until next week
+    test_slide.available_from = test_dt + timedelta(days=7)
+    test_slide.available_to = test_dt + timedelta(days=8)
+    test_slide.save()
+    assert not test_slide.is_visible(dt=test_dt)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("target_type,expected_target", [
+    (LinkTargetType.CURRENT, "_self"),
+    (LinkTargetType.NEW, "_blank"),
+])
+def test_get_link_target(target_type, expected_target):
+    test_carousel = Carousel.objects.create(name="test")
+    test_image = Image.objects.create(original_filename="slide.jpg")
+    test_slide = Slide.objects.create(carousel=test_carousel, name="test", image=test_image, target=target_type)
+    assert test_slide.get_link_target() == expected_target

--- a/shuup_workbench/settings/base_settings.py
+++ b/shuup_workbench/settings/base_settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = add_enabled_addons(SHUUP_ENABLED_ADDONS_FILE, [
     'shuup.default_tax',
     'shuup.front',
     'shuup.front.apps.auth',
+    'shuup.front.apps.carousel',
     'shuup.front.apps.customer_information',
     'shuup.front.apps.personal_order_history',
     'shuup.front.apps.saved_carts',


### PR DESCRIPTION
Move Shuup Carousel addon to Shuup base under front apps.

Note! Instances using shuup-carousel addon should be updated to use
this new app. There is no migration tools for old carousel and the old
carousels and slides needs to be copied manually to new app before removing
shuup-carousel addon from installed apps.

Modified from commit introduced in https://github.com/shuup/shuup/pull/761 by @shawnadelic 