### PR TITLE
Fix simple search results for non public products (SH-225)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -27,6 +27,7 @@ Addons
 Front
 ~~~~~
 
+- Fix bug in simple search with non public products
 - Add carousel app
    - Note! Instances using shuup-carousel addon should be updated to use
      this new app. There is no migration tools for old carousel and the old

--- a/shuup/core/models/_products.py
+++ b/shuup/core/models/_products.py
@@ -151,8 +151,7 @@ class ProductQuerySet(TranslatableQuerySet):
         return qs.exclude(deleted=True)
 
     def _get_qs(self, shop, customer, language, visibility_type):
-        root = (self.language(language) if language else self)
-        qs = root.all()._visible(shop=shop, customer=customer, language=language)
+        qs = self._visible(shop=shop, customer=customer, language=language)
         if customer and customer.is_all_seeing:
             return qs
         else:


### PR DESCRIPTION
Add customer to searchable queryset while fetching product ids for query string. Form cache key from query string, shop and customer to avoid same cached results for every customer/shop.