### PR TITLE
Admin: Add object created signal (SH-219)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,6 +18,7 @@ Localization
 Admin
 ~~~~~
 
+- Add object created signal
 - Enable region codes for contact addresses
 - Enable region codes for order editor
 

--- a/shuup/admin/modules/orders/views/edit.py
+++ b/shuup/admin/modules/orders/views/edit.py
@@ -24,6 +24,7 @@ from django.utils.translation import ugettext as _
 from django_countries import countries
 
 from shuup.admin.modules.orders.json_order_creator import JsonOrderCreator
+from shuup.admin.signals import object_created
 from shuup.admin.toolbar import Toolbar
 from shuup.admin.utils.urls import get_model_url
 from shuup.admin.utils.views import CreateOrUpdateView
@@ -396,6 +397,7 @@ class OrderEditView(CreateOrUpdateView):
                 creator=request.user,
                 ip_address=request.META.get("REMOTE_ADDR"),
             )
+            object_created.send(sender=Order, object=order)
             messages.success(request, _("Order %(identifier)s created.") % vars(order))
         return JsonResponse({
             "success": True,

--- a/shuup/admin/signals.py
+++ b/shuup/admin/signals.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from django.dispatch import Signal
+
+object_created = Signal(providing_args=["object"], use_caching=True)

--- a/shuup/admin/utils/views.py
+++ b/shuup/admin/utils/views.py
@@ -17,6 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.generic import ListView, UpdateView
 
 from shuup.admin.modules.settings import ViewSettings
+from shuup.admin.signals import object_created
 from shuup.admin.toolbar import (
     get_default_edit_toolbar, NewActionButton, SettingsActionButton, Toolbar
 )
@@ -94,6 +95,8 @@ class CreateOrUpdateView(UpdateView):
         # * django.views.generic.edit.FormMixin#form_valid
         is_new = (not self.object.pk)
         self.save_form(form)
+        if is_new:
+            object_created.send(sender=type(self.object), object=self.object)
         add_create_or_change_message(self.request, self.object, is_new=is_new)
         return HttpResponseRedirect(self.get_success_url())
 

--- a/shuup_tests/browser/admin/test_product_create.py
+++ b/shuup_tests/browser/admin/test_product_create.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+
+import pytest
+
+from django.core.urlresolvers import reverse
+from django.utils.translation import activate
+
+from shuup.admin.signals import object_created
+from shuup.core.models import Product
+from shuup.testing.browser_utils import click_element, wait_until_appeared
+from shuup.testing.factories import (
+    create_product, get_default_product_type, get_default_sales_unit,
+    get_default_shop, get_default_tax_class
+)
+from shuup.testing.utils import initialize_admin_browser_test
+
+pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
+OBJECT_CREATED_LOG_IDENTIFIER = "object_created_signal_handled"
+
+
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_product_create(browser, admin_user, live_server):
+    activate("en")
+    shop = get_default_shop()
+    get_default_product_type()
+    get_default_sales_unit()
+    get_default_tax_class()
+    object_created.connect(_add_custom_product_created_message, sender=Product, dispatch_uid="object_created_signal_test")
+    initialize_admin_browser_test(browser, live_server)
+
+    url = reverse("shuup_admin:product.new")
+    browser.visit("%s%s" % (live_server, url))
+    sku = "testsku"
+    name = "Some product name"
+    price_value = 10
+
+    browser.fill("base-sku", sku)
+    browser.fill("base-name__en", name)
+    browser.fill("shop%s-default_price_value" % shop.pk, price_value)
+
+    click_element(browser, "button[form='product_form']")
+    wait_until_appeared(browser, "div[class='message success']")
+    Product.objects.filter(sku=sku).first().log_entries.filter(identifier=OBJECT_CREATED_LOG_IDENTIFIER).count() == 1
+    object_created.disconnect(sender=Product, dispatch_uid="object_created_signal_test")
+
+
+def _add_custom_product_created_message(sender, object, **kwargs):
+    assert sender == Product
+    object.add_log_entry("Custom object created signal handled", identifier=OBJECT_CREATED_LOG_IDENTIFIER)


### PR DESCRIPTION
Signal is fired from CreateOrUpdateView form_valid when in new mode. Also add the same signal for order created view.

This is needed since some of the admin forms has multiple saves before the object is "complete" so using the post_save signal created parameter is not optimal. For example contact creation.