### PR TITLE
Core: Price rounding change (SH-129)

### DIFF
--- a/shuup/admin/modules/sales_dashboard/dashboard.py
+++ b/shuup/admin/modules/sales_dashboard/dashboard.py
@@ -20,7 +20,6 @@ from shuup.core.pricing import TaxfulPrice
 from shuup.core.utils.query import group_by_period
 from shuup.utils.dates import get_year_and_month_format
 from shuup.utils.i18n import get_current_babel_locale
-from shuup.utils.numbers import bankers_round
 
 
 def get_orders_by_currency(currency):
@@ -47,10 +46,7 @@ class OrderValueChartDashboardBlock(DashboardChartBlock):
         ])
         bar_chart.add_data(
             _("Sales (%(currency)s)") % {"currency": self.currency},
-            [
-                bankers_round(v["sum"], 2)  # TODO: To be fixed in SHUUP-1912
-                for v in aggregate_data.values()
-            ]
+            [v["sum"] for v in aggregate_data.values()]
         )
         return bar_chart
 

--- a/shuup/core/fields/__init__.py
+++ b/shuup/core/fields/__init__.py
@@ -25,6 +25,8 @@ from shuup.utils.i18n import get_current_babel_locale
 
 IdentifierValidator = RegexValidator("[a-z][a-z_]+")
 
+MONEY_FIELD_DECIMAL_PLACES = 9
+
 
 class InternalIdentifierField(models.CharField):
 
@@ -109,7 +111,7 @@ class FormattedDecimalField(models.DecimalField):
 
 class MoneyValueField(FormattedDecimalField):
     def __init__(self, **kwargs):
-        kwargs.setdefault("decimal_places", 9)
+        kwargs.setdefault("decimal_places", MONEY_FIELD_DECIMAL_PLACES)
         kwargs.setdefault("max_digits", 36)
         super(MoneyValueField, self).__init__(**kwargs)
 

--- a/shuup/core/fields/utils.py
+++ b/shuup/core/fields/utils.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import decimal
+
+from shuup.core.fields import MONEY_FIELD_DECIMAL_PLACES
+
+
+def ensure_decimal_places(value):
+    return value.quantize(decimal.Decimal(".1") ** MONEY_FIELD_DECIMAL_PLACES)

--- a/shuup/core/models/_order_lines.py
+++ b/shuup/core/models/_order_lines.py
@@ -20,6 +20,7 @@ from shuup.core.pricing import Priceful
 from shuup.core.taxing import LineTax
 from shuup.utils.analog import define_log_model
 from shuup.utils.money import Money
+from shuup.utils.numbers import bankers_round
 from shuup.utils.properties import MoneyProperty, MoneyPropped, PriceProperty
 
 from ._base import ShuupModel
@@ -114,7 +115,7 @@ class OrderLine(MoneyPropped, models.Model, Priceful):
         :rtype: shuup.utils.money.Money
         """
         zero = Money(0, self.order.currency)
-        return sum((x.amount for x in self.taxes.all()), zero)
+        return sum((x.rounded_amount for x in self.taxes.all()), zero)
 
     @property
     def max_refundable_amount(self):
@@ -183,6 +184,10 @@ class OrderLineTax(MoneyPropped, ShuupModel, LineTax):
 
     def __str__(self):
         return "%s: %s on %s" % (self.name, self.amount, self.base_amount)
+
+    @property
+    def rounded_amount(self):
+        return bankers_round(self.amount, 2)
 
 
 OrderLineLogEntry = define_log_model(OrderLine)

--- a/shuup_tests/core/test_rounding.py
+++ b/shuup_tests/core/test_rounding.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from decimal import Decimal
+
+from shuup.core.models import OrderLine
+from shuup.core.models import OrderLineType
+from shuup.core.models import Shop
+from shuup.core.models import ShopStatus
+from shuup.testing.factories import create_empty_order
+from shuup.utils.numbers import bankers_round
+from shuup_tests.utils.basketish_order_source import BasketishOrderSource
+
+PRICE_SPEC = [
+    ([1,2,3,4]),
+    ([1,2,3,6]),
+    ([1,2,3,8]),
+    ([1.23223, 12.24442, 42.26233]),
+    ([1223.46636, 13.24655, 411.234554]),
+    ([101.74363, 12.99346, 4222.57422]),
+    ([112.93549, 199.2446, 422.29234]),
+    ([1994.49654, 940.23452, 425.24566]),
+    ([1994.496541234566, 940.2345298765, 425.2456612334]),  # Those prices that will be cut when put in DB
+]
+
+
+@pytest.mark.parametrize("prices", PRICE_SPEC)
+@pytest.mark.django_db
+def test_rounding(prices):
+    expected = 0
+    for p in prices:
+        expected += bankers_round(p, 2)
+
+    order = create_empty_order(prices_include_tax=False)
+    order.save()
+    currency = order.shop.currency
+    for x, price in enumerate(prices):
+        ol = OrderLine(
+            order=order,
+            type=OrderLineType.OTHER,
+            quantity=1,
+            text="Thing",
+            ordering=x,
+            base_unit_price=order.shop.create_price(price)
+        )
+        ol.save()
+    order.cache_prices()
+    for x, order_line in enumerate(order.lines.all().order_by("ordering")):
+        price = Decimal(prices[x]).quantize(Decimal(".1") ** 9)
+
+        # make sure prices are in database with original precision
+        assert order_line.base_unit_price == order.shop.create_price(price)
+
+        # make sure the line taxless price is rounded
+        assert order_line.taxless_price == order.shop.create_price(bankers_round(price, 2))
+
+        # make sure the line price is rounded
+        assert order_line.price == order.shop.create_price(price)
+
+    # make sure order total is rounded
+    assert order.taxless_total_price == order.shop.create_price(bankers_round(expected, 2))
+
+
+@pytest.mark.parametrize("prices", PRICE_SPEC)
+@pytest.mark.django_db
+def test_order_source_rounding(prices):
+    shop = Shop.objects.create(
+        name="test",
+        identifier="test",
+        status=ShopStatus.ENABLED,
+        public_name="test",
+        prices_include_tax=False
+    )
+    expected = 0
+    for p in prices:
+        expected += bankers_round(p, 2)
+
+    source = BasketishOrderSource(shop)
+    for x, price in enumerate(prices):
+        source.add_line(
+            type=OrderLineType.OTHER,
+            quantity=1,
+            text=x,
+            base_unit_price=source.create_price(price),
+            ordering=x,
+        )
+
+    for x, order_source in enumerate(source.get_lines()):
+        price = Decimal(prices[x]).quantize(Decimal(".1") ** 9)
+
+        # make sure prices are in database with original precision
+        assert order_source.base_unit_price == source.shop.create_price(price)
+
+        # make sure the line taxless price is rounded
+        assert order_source.taxless_price == source.shop.create_price(bankers_round(price, 2))
+
+        # make sure the line price is rounded
+        assert order_source.price == source.shop.create_price(price)
+
+    # make sure order total is rounded
+    assert source.taxless_total_price == source.shop.create_price(bankers_round(expected, 2))

--- a/shuup_tests/functional/test_tax_system.py
+++ b/shuup_tests/functional/test_tax_system.py
@@ -88,7 +88,7 @@ def test_stacked_tax_taxful_price():
             assert isinstance(line, SourceLine)
             assert line.taxes
             assert line.taxful_price == TaxfulPrice(20, 'EUR')
-            assert_almost_equal(line.taxless_price, TaxlessPrice("18.518518", 'EUR'))
+            assert_almost_equal(line.taxless_price, TaxlessPrice("18.52", 'EUR'))
             source.uncache()
 
             # Let's move out to a taxless location.


### PR DESCRIPTION
* Round priceful taxless and taxful prices into two decimals
* Round taxes to two decimals when getting order line tax
amount.
* Limit source line base_unit_price and discount_amount to
9 decimals like it is in order line
* Limit priceful price to 9 decimals
* Remove uneccessary rounding while calculating order totals

One option would have been to round priceful price to two decimals,
but it will cause problems when calculating other price components
like discount rate since all the other price components would be
with full precision.

All spots with rounding to two decimals can be changed to round
based on currency decimals later.

See the extra test for refunds which will not be solved by
this PR in case that is a problem. I think we shouldn't refund
with higher precision that the currency allows.