### PR TITLE
Admin: Fix bug in object created signal (SH-219 / SH-231)

### DIFF
--- a/shuup/admin/form_part.py
+++ b/shuup/admin/form_part.py
@@ -7,6 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 from django.http import HttpResponseRedirect
 
+from shuup.admin.signals import object_created
 from shuup.admin.utils.urls import get_model_url
 from shuup.admin.utils.views import add_create_or_change_message
 from shuup.apps.provides import get_provide_objects
@@ -88,7 +89,8 @@ class SaveFormPartsMixin(object):
                 self.object = retval
                 for form_part in form_parts:
                     form_part.object = self.object
-
+        if is_new:
+            object_created.send(sender=type(self.object), object=self.object)
         add_create_or_change_message(self.request, self.object, is_new)
 
         if hasattr(self, "get_success_url"):

--- a/shuup_tests/browser/admin/test_product_create.py
+++ b/shuup_tests/browser/admin/test_product_create.py
@@ -48,7 +48,8 @@ def test_product_create(browser, admin_user, live_server):
 
     click_element(browser, "button[form='product_form']")
     wait_until_appeared(browser, "div[class='message success']")
-    Product.objects.filter(sku=sku).first().log_entries.filter(identifier=OBJECT_CREATED_LOG_IDENTIFIER).count() == 1
+    product = Product.objects.filter(sku=sku).first()
+    assert product.log_entries.filter(identifier=OBJECT_CREATED_LOG_IDENTIFIER).count() == 1
     object_created.disconnect(sender=Product, dispatch_uid="object_created_signal_test")
 
 


### PR DESCRIPTION
Also send signal from saved form parts when object is created. Fix product created test to actually fail when signal is not fired.