### PR TITLE
Front: Fix unicode decode errors in notify events

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -24,6 +24,8 @@ Addons
 Front
 ~~~~~
 
+- Fix unicode decode errors in notify events
+
 Xtheme
 ~~~~~~
 

--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-05 11:58+0000\n"
+"POT-Creation-Date: 2016-09-12 20:42+0000\n"
 "PO-Revision-Date: 2016-08-04 10:51-0700\n"
 "Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
@@ -282,10 +282,6 @@ msgid "Shipment"
 msgstr ""
 
 msgid "Order Shipping Status"
-msgstr ""
-
-#, python-brace-format
-msgid "Possible values: {0}"
 msgstr ""
 
 msgid "Shipment Status"

--- a/shuup/front/notify_events.py
+++ b/shuup/front/notify_events.py
@@ -37,14 +37,8 @@ class ShipmentCreated(Event):
     language = Variable(_("Language"), type=Language)
 
     shipment = Variable(_("Shipment"), type=Model("shuup.Shipment"))
-    shipping_status = Variable(_("Order Shipping Status"),
-                               type=Enum(ShippingStatus),
-                               help_text=_("Possible values: {0}").format(", ".join(
-                                    ["{0}".format(choice) for choice in ShippingStatus])))
-    shipment_status = Variable(_("Shipment Status"),
-                               type=Enum(ShipmentStatus),
-                               help_text=_("Possible values: {0}").format(", ".join(
-                                   ["{0}".format(choice) for choice in ShipmentStatus])))
+    shipping_status = Variable(_("Order Shipping Status"), type=Enum(ShippingStatus))
+    shipment_status = Variable(_("Shipment Status"), type=Enum(ShipmentStatus))
 
 
 class ShipmentDeleted(Event):
@@ -57,10 +51,7 @@ class ShipmentDeleted(Event):
     language = Variable(_("Language"), type=Language)
 
     shipment = Variable(_("Shipment"), type=Model("shuup.Shipment"))
-    shipping_status = Variable(_("Order Shipping Status"),
-                               type=Enum(ShippingStatus),
-                               help_text=_("Possible values: {0}").format(", ".join(
-                                    ["{0}".format(choice) for choice in ShippingStatus])))
+    shipping_status = Variable(_("Order Shipping Status"), type=Enum(ShippingStatus))
 
 
 class PaymentCreated(Event):
@@ -72,10 +63,7 @@ class PaymentCreated(Event):
     customer_phone = Variable(_("Customer Phone"), type=Phone)
     language = Variable(_("Language"), type=Language)
 
-    payment_status = Variable(_("Order Payment Status"),
-                              type=Enum(PaymentStatus),
-                              help_text=_("Possible values: {0}").format(", ".join(
-                                    ["{0}".format(choice) for choice in PaymentStatus])))
+    payment_status = Variable(_("Order Payment Status"), type=Enum(PaymentStatus))
     payment = Variable(_("Payment"), type=Model("shuup.Payment"))
 
 
@@ -88,10 +76,7 @@ class RefundCreated(Event):
     customer_phone = Variable(_("Customer Phone"), type=Phone)
     language = Variable(_("Language"), type=Language)
 
-    payment_status = Variable(_("Order Payment Status"),
-                              type=Enum(PaymentStatus),
-                              help_text=_("Possible values: {0}").format(", ".join(
-                                    ["{0}".format(choice) for choice in PaymentStatus])))
+    payment_status = Variable(_("Order Payment Status"), type=Enum(PaymentStatus))
 
 
 @receiver(order_creator_finished)


### PR DESCRIPTION
Since the translations for help_texts is done while loading the
application the curent language won't affect those. Also at least
in Finnish the help_texts  causes unicode decode errors.

Avoid problems by removing the help_texts for now.