### PR TITLE
Admin: Fix bug in Picotable sorting with translated models (SH-209)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,6 +18,7 @@ Localization
 Admin
 ~~~~~
 
+- Fix bug in Picotable sorting with translated models
 - Fix bug in services list views columns
 
 Addons

--- a/shuup/admin/utils/picotable.py
+++ b/shuup/admin/utils/picotable.py
@@ -16,7 +16,6 @@ from django.http.response import JsonResponse
 from django.template.defaultfilters import yesno
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import get_language
 
 from shuup.admin.utils.urls import get_model_url, NoModelUrl
 from shuup.utils.dates import try_parse_date
@@ -259,8 +258,6 @@ class Column(object):
 
     def sort_queryset(self, queryset, desc=False):
         order_by = ("-" if desc else "") + self.sort_field
-        if "translations__" in self.sort_field:
-            queryset = queryset.translated(get_language())
         return queryset.order_by(order_by)
 
     def filter_queryset(self, queryset, value):


### PR DESCRIPTION
Using translated manager is not needed and can't be used anymore since the database doesn't contain empty translation for all language codes by default.