### PR TITLE
Core: Add daily data to telemetry (SH-82 / SH-267)

### DIFF
--- a/shuup/core/settings.py
+++ b/shuup/core/settings.py
@@ -175,3 +175,6 @@ SHUUP_ADDRESS_MODEL_FORM = (
 #: It should be noted, however, that overriding some settings (such as making a
 #: required field non-required) could create other validation issues.
 SHUUP_ADDRESS_FIELD_PROPERTIES = {}
+
+#: Indicates maximum days for daily data included to one telemetry request
+SHUUP_MAX_DAYS_IN_TELEMETRY = 180


### PR DESCRIPTION
* Add daily sales, paid_sales, created products and
created contacts to telemetry data
* Add debug information to telemetry data
* Send telemetry every 24 hours

Example for daily data:
```python
[{
  'orders': 4,
  'paytrail': 11.67,
  'date': '2016-09-15',
  'total_sales': 46.68,
  'stripe': 0,
  'contacts': 197,
  'products': 105,
  'checkoutfi': 0
}]
```

