### PR TITLE
Auth: Enable user to configure emails sent by auth app to use HTML

### DIFF
--- a/shuup/front/apps/auth/forms.py
+++ b/shuup/front/apps/auth/forms.py
@@ -6,11 +6,12 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from django import forms
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
-from django.core.mail import send_mail
+from django.core.mail.message import EmailMessage
 from django.db.models import Q
 from django.template import loader
 from django.utils.encoding import force_bytes
@@ -117,6 +118,8 @@ class RecoverPasswordForm(forms.Form):
         }
         subject = loader.render_to_string(self.subject_template_name, context)
         subject = ''.join(subject.splitlines())  # Email subject *must not* contain newlines
-        email = loader.render_to_string(self.email_template_name, context, request=self.request)
-        send_mail(subject, email, self.from_email, [user_to_recover.email])
+        body = loader.render_to_string(self.email_template_name, context, request=self.request)
+        email = EmailMessage(from_email=self.from_email, subject=subject, body=body, to=[user_to_recover.email])
+        email.content_subtype = settings.SHUUP_AUTH_EMAIL_CONTENT_SUBTYPE
+        email.send()
         return True

--- a/shuup/front/apps/auth/settings.py
+++ b/shuup/front/apps/auth/settings.py
@@ -1,0 +1,12 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+#: Require email-based activation for users?
+#:
+#: Configures the content subtype of the emails sent by Auth app
+#: Set `html` if your template is HTML-based
+#:
+SHUUP_AUTH_EMAIL_CONTENT_SUBTYPE = 'plain'


### PR DESCRIPTION
A setting was created to make it possible to change EmailMessage
content_subtype from plain text to whatever is needed, especially html.