### PR TITLE
Admin: Fix bug in media browser upload

### DIFF
--- a/shuup/admin/modules/media/views.py
+++ b/shuup/admin/modules/media/views.py
@@ -94,7 +94,8 @@ class MediaBrowserView(TemplateView):
         return super(MediaBrowserView, self).get(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
-        if request.POST.get("action") == "upload":
+        action = request.POST.get("action") or request.GET.get("action")
+        if action == "upload":
             return self.handle_upload()
 
         # Instead of normal POST variables, the Mithril `m.request()`


### PR DESCRIPTION
Try to get upload action from `request.GET` if action is not available in `request.POST`