### PR TITLE
Admin: Fix bug in media browser upload folders

### DIFF
--- a/shuup/admin/modules/media/views.py
+++ b/shuup/admin/modules/media/views.py
@@ -166,9 +166,8 @@ class MediaBrowserView(TemplateView):
 
     def handle_upload(self):
         request = self.request
-
         try:
-            folder_id = int(request.POST.get("folder_id", 0))
+            folder_id = int(request.POST.get("folder_id") or request.GET.get("folder_id") or 0)
             if folder_id != 0:
                 folder = Folder.objects.get(pk=folder_id)
             else:


### PR DESCRIPTION
Try to get upload folder_id from `request.GET` if not available in `request.POST`