### PR TITLE
Pricing: Avoid rounding multiple times (SH-308)

### DIFF
--- a/shuup/core/models/_order_lines.py
+++ b/shuup/core/models/_order_lines.py
@@ -20,7 +20,6 @@ from shuup.core.pricing import Priceful
 from shuup.core.taxing import LineTax
 from shuup.utils.analog import define_log_model
 from shuup.utils.money import Money
-from shuup.utils.numbers import bankers_round
 from shuup.utils.properties import MoneyProperty, MoneyPropped, PriceProperty
 
 from ._base import ShuupModel
@@ -115,7 +114,7 @@ class OrderLine(MoneyPropped, models.Model, Priceful):
         :rtype: shuup.utils.money.Money
         """
         zero = Money(0, self.order.currency)
-        return sum((x.rounded_amount for x in self.taxes.all()), zero)
+        return sum((x.amount for x in self.taxes.all()), zero)
 
     @property
     def max_refundable_amount(self):
@@ -184,10 +183,6 @@ class OrderLineTax(MoneyPropped, ShuupModel, LineTax):
 
     def __str__(self):
         return "%s: %s on %s" % (self.name, self.amount, self.base_amount)
-
-    @property
-    def rounded_amount(self):
-        return bankers_round(self.amount, 2)
 
 
 OrderLineLogEntry = define_log_model(OrderLine)

--- a/shuup/core/order_creator/_source.py
+++ b/shuup/core/order_creator/_source.py
@@ -689,7 +689,7 @@ class SourceLine(TaxableItem, Priceful):
             for line in self.source.get_final_lines():
                 if line.line_id == self.line_id and line.price == self.price:
                     taxes = line.taxes
-        return sum((x.amount for x in taxes), zero)
+        return sum((ensure_decimal_places(x.amount) for x in taxes), zero)
 
     def _serialize_field(self, key):
         value = getattr(self, key)

--- a/shuup/core/pricing/_priceful_properties.py
+++ b/shuup/core/pricing/_priceful_properties.py
@@ -20,8 +20,8 @@ class PriceRate(object):
         """
         if instance is None:
             return self
-        taxful = instance.taxful_price
-        taxless = instance.taxless_price
+        taxful = instance.raw_taxful_price
+        taxless = instance.raw_taxless_price
         price = getattr(instance, self.price_field)
         return self._convert(taxful, taxless, price)
 


### PR DESCRIPTION
Fix issues with rounding stuff multiple times.

The rounded taxless or taxful total shouldn't be calculated based on rounded values like rounded tax_amount.

The `Priceful.tax_rate` shouldn't never be calculated based on rounded taxless or taxful total.

Priceful properties where the taxfulness is forced with `TaxfulFrom` or `TaxlessFrom` should never be calculated based on rounded taxless or taxful total.

Add `Priceful.raw_taxful_price` and `Priceful.raw_taxless_price` which could be used to calculate the properties mentioned above.

Skip ensuring the `Priceful.price` since the priceful properties should stay untouched until those are shown somewhere. Only `OrderSourceLine` should ensure things to make sure the key components that is saved later to database with certain precision will match.

Ensure decimal limit in `OrderSource.tax_amount` the order source tax amount should have same precision as the order line tax amount does.

At tax summary round line taxless based on values before calculating SUM from those. This is same functionality that is used for order lines. Also the taxless line total in tax summary should match with order taxless total.

At tax summary round line taxful based on the raw based on value. Here we can't use already rounded based on value since we shouldn't add unrouded tax amount to already rounded value. Also the lines total in tax summary should match with order taxful total.