### PR TITLE
Set zero sum orders as paid on creation

### DIFF
--- a/shuup/core/models/_orders.py
+++ b/shuup/core/models/_orders.py
@@ -229,7 +229,7 @@ class Order(MoneyPropped, models.Model):
     payment_data = JSONField(blank=True, null=True, verbose_name=_('payment data'))
 
     shipping_method = UnsavedForeignKey(
-        "ShippingMethod", related_name='shipping_orders',  blank=True, null=True,
+        "ShippingMethod", related_name='shipping_orders', blank=True, null=True,
         default=None, on_delete=models.PROTECT,
         verbose_name=_('shipping method'))
     shipping_method_name = models.CharField(
@@ -529,10 +529,9 @@ class Order(MoneyPropped, models.Model):
 
         if insufficient_stocks:
             formatted_counts = [_("%(name)s (physical stock: %(quantity)s)") % {
-                    "name": force_text(name),
-                    "quantity": force_text(quantity)
-                }
-                for (name, quantity) in insufficient_stocks.items()]
+                "name": force_text(name),
+                "quantity": force_text(quantity)
+            } for (name, quantity) in insufficient_stocks.items()]
             raise Problem(
                 _("Insufficient physical stock count for following products: %(product_counts)s") % {
                     "product_counts": ", ".join(formatted_counts)

--- a/shuup/core/order_creator/_creator.py
+++ b/shuup/core/order_creator/_creator.py
@@ -222,7 +222,12 @@ class OrderProcessor(object):
 
         # Then do all the caching one more time!
         order.cache_prices()
-        order.save()
+
+        if order.get_total_paid_amount() >= order.taxful_total_price.amount:
+            order._set_paid()  # also calls save
+        else:
+            order.save()
+
         return order
 
     def _assign_code_usages(self, order_source, order):


### PR DESCRIPTION
It isn't possible to create payments on orders with zero as their total price
However, said orders should still be marked as fully paid

Circumvent the issue by marking zero sum orders as paid on creation