### PR TITLE
Add admin comment section to admin order module

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,6 +18,8 @@ Localization
 Admin
 ~~~~~
 
+- Add admin comment section to order module
+
 Addons
 ~~~~~~
 

--- a/shuup/admin/__init__.py
+++ b/shuup/admin/__init__.py
@@ -58,6 +58,7 @@ class ShuupAdminAppConfig(AppConfig):
             "shuup.admin.modules.orders.sections:PaymentOrderSection",
             "shuup.admin.modules.orders.sections:LogEntriesOrderSection",
             "shuup.admin.modules.orders.sections:ShipmentSection",
+            "shuup.admin.modules.orders.sections:AdminCommentSection",
         ],
         "admin_contact_section": [
             "shuup.admin.modules.contacts.sections:BasicInfoContactSection",

--- a/shuup/admin/modules/orders/__init__.py
+++ b/shuup/admin/modules/orders/__init__.py
@@ -58,6 +58,12 @@ class OrderModule(AdminModule):
                 permissions=get_default_model_permissions(Order)
             ),
             admin_url(
+                "^orders/(?P<pk>\d+)/update-admin-comment/$",
+                "shuup.admin.modules.orders.views.UpdateAdminCommentView",
+                name="order.update-admin-comment",
+                permissions=get_default_model_permissions(Order)
+            ),
+            admin_url(
                 "^orders/(?P<pk>\d+)/create-refund/$",
                 "shuup.admin.modules.orders.views.OrderCreateRefundView",
                 name="order.create-refund",

--- a/shuup/admin/modules/orders/sections.py
+++ b/shuup/admin/modules/orders/sections.py
@@ -78,3 +78,20 @@ class ShipmentSection(Section):
     @staticmethod
     def get_context_data(order):
         return Shipment.objects.filter(order=order).order_by("-created_on").all()
+
+
+class AdminCommentSection(Section):
+    identifier = "admin_comment"
+    name = _("Admin comment/notes")
+    icon = "fa-comment-o"
+    template = "shuup/admin/orders/_admin_comment.jinja"
+    extra_js = "shuup/admin/orders/_admin_comment_extra_js.jinja"
+    order = 4
+
+    @staticmethod
+    def visible_for_object(order):
+        return True
+
+    @staticmethod
+    def get_context_data(order):
+        return None

--- a/shuup/admin/modules/orders/views/__init__.py
+++ b/shuup/admin/modules/orders/views/__init__.py
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from .detail import OrderDetailView, OrderSetStatusView
-from .edit import OrderEditView
+from .edit import OrderEditView, UpdateAdminCommentView
 from .list import OrderListView
 from .log import NewLogEntryView
 from .payment import OrderCreatePaymentView
@@ -17,5 +17,6 @@ from .shipment import OrderCreateShipmentView, ShipmentDeleteView
 __all__ = [
     "NewLogEntryView", "OrderDetailView", "OrderEditView", "OrderListView",
     "OrderCreatePaymentView", "OrderCreateFullRefundView", "OrderCreateRefundView",
-    "OrderCreateShipmentView", "OrderSetStatusView", "ShipmentDeleteView"
+    "OrderCreateShipmentView", "OrderSetStatusView", "ShipmentDeleteView",
+    "UpdateAdminCommentView"
 ]

--- a/shuup/admin/modules/orders/views/edit.py
+++ b/shuup/admin/modules/orders/views/edit.py
@@ -21,6 +21,7 @@ from django.db.models import Sum
 from django.http.response import HttpResponse, JsonResponse
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext as _
+from django.views.generic import View
 from django_countries import countries
 
 from shuup.admin.modules.orders.json_order_creator import JsonOrderCreator
@@ -410,6 +411,21 @@ class OrderEditView(CreateOrUpdateView):
 
     def handle_finalize(self, request):
         return _handle_or_return_error(self._handle_finalize, request, _("Could not finalize order:"))
+
+
+class UpdateAdminCommentView(View):
+    """
+    Update order's admin comment
+    """
+    def post(self, request, *args, **kwargs):
+        order = Order.objects.get(pk=kwargs["pk"])
+        comment = request.POST["comment"]
+        order.admin_comment = comment
+        order.save()
+
+        return JsonResponse({
+            "comment": order.admin_comment,
+        })
 
 
 def _handle_or_return_error(func, request, error_message):

--- a/shuup/admin/templates/shuup/admin/orders/_admin_comment.jinja
+++ b/shuup/admin/templates/shuup/admin/orders/_admin_comment.jinja
@@ -1,0 +1,12 @@
+<div id="order-admin-comment">
+    <form action="" method="post">
+        <div class="form-group">
+            <label class="control-label" for="admin-comment">{% trans %}Comment{% endtrans %}</label>
+            <textarea class="form-control" id="admin-comment" type="text">{{ order.admin_comment }}</textarea>
+        </div>
+        <div class="form-group text-center">
+            <button class="btn btn-info" href="#">{% trans %}Save comment{% endtrans %}</button>
+        </div>
+        {% csrf_token %}
+    </form>
+</div>

--- a/shuup/admin/templates/shuup/admin/orders/_admin_comment_extra_js.jinja
+++ b/shuup/admin/templates/shuup/admin/orders/_admin_comment_extra_js.jinja
@@ -1,0 +1,21 @@
+<script>
+    (function(){
+        $("#order-admin-comment button").on("click", function(event){
+            event.preventDefault();
+            $.ajax({
+                type: "POST",
+                url: "{{ url('shuup_admin:order.update-admin-comment', pk=order.pk) }}",
+                data: {
+                    "comment": $("#admin-comment").val(),
+                    "csrfmiddlewaretoken": '{{ csrf_token }}',
+                },
+                success: function(data){
+                    $("#admin-comment").val(data["comment"]);
+                },
+                error: function(){
+                    alert("{% trans %}There was an error updating the admin comment.{% endtrans %}")
+                },
+            });
+        });
+    })();
+</script>


### PR DESCRIPTION
Make it possible to update order's admin comment. Add new section to admin order module which displays order's admin comment. Updates admin comment via ajax call to new view which updates the current order object.