### PR TITLE
Admin: Fix CreateOrUpdateView success url

### DIFF
--- a/shuup/admin/utils/views.py
+++ b/shuup/admin/utils/views.py
@@ -63,7 +63,7 @@ class CreateOrUpdateView(UpdateView):
         return get_model_url(self.object, kind="new")
 
     def get_success_url(self):
-        next = self.request.GET.get("__next")
+        next = self.request.POST.get("__next")
         try:
             if next == "return":
                 return self.get_return_url()


### PR DESCRIPTION
Retrieve the "next" parameter from POST when generating the success url