### PR TITLE
Add support pin (SH-301)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -71,6 +71,7 @@ Released on 2016-10-12 09:30pm -0800.
 Core
 ~~~~
 
+- Fetch support id for shops sending telemetry
 - Remove shop languages, category, tax class, service provider and services
   default record creation from `shuup_init` management command
 

--- a/shuup/admin/static_src/base/less/shuup/navigation.less
+++ b/shuup/admin/static_src/base/less/shuup/navigation.less
@@ -285,4 +285,8 @@
         }
     }
 
+    .nav-text {
+        line-height: 60px;
+        color: white;
+    }
 }

--- a/shuup/admin/template_helpers/shuup_admin.py
+++ b/shuup/admin/template_helpers/shuup_admin.py
@@ -16,11 +16,13 @@ from django.core.urlresolvers import NoReverseMatch, reverse
 from django.middleware.csrf import get_token
 from jinja2.utils import contextfunction
 
+from shuup import configuration
 from shuup.admin import menu
 from shuup.admin.breadcrumbs import Breadcrumbs
 from shuup.admin.utils.urls import (
     get_model_url, manipulate_query_string, NoModelUrl
 )
+from shuup.core.telemetry import is_telemetry_enabled
 
 __all__ = ["get_menu_entry_categories", "get_front_url", "get_config", "model_url"]
 
@@ -56,6 +58,14 @@ def get_front_url(context):
         except NoReverseMatch:
             front_url = None
     return front_url
+
+
+@contextfunction
+def get_support_id(context):
+    support_id = None
+    if is_telemetry_enabled():
+        support_id = configuration.get(None, "shuup_support_id")
+    return support_id
 
 
 # TODO: Figure out a more extensible way to deal with this

--- a/shuup/admin/templates/shuup/admin/base/_navigation.jinja
+++ b/shuup/admin/templates/shuup/admin/base/_navigation.jinja
@@ -31,6 +31,9 @@
     <div id="site-search-results" class="site-search-results"></div>
 </div>
 
+{% set support_id=shuup_admin.get_support_id() %}
+{% if support_id %}<p class="nav-text hidden-xs">{% trans %}Support ID: {% endtrans %}{{ support_id }}</p>{% endif %}
+
 {% set front_url=shuup_admin.get_front_url() %}
 {% if front_url %}<a class="nav-btn shop-btn" href="{{ front_url }}" data-toggle="tooltip" data-placement="bottom" title="{% trans %}Visit shop{% endtrans %}"><i class="fa fa-shopping-cart"></i></a>{% endif %}
 

--- a/shuup/core/settings.py
+++ b/shuup/core/settings.py
@@ -141,8 +141,14 @@ SHUUP_ORDER_KNOWN_EXTRA_DATA_KEYS = []
 #: A flag to enable/disable the telemetry system
 SHUUP_TELEMETRY_ENABLED = True
 
+#: The host URL for Shuup's telemetry (statistics) system
+SHUUP_TELEMETRY_HOST_URL = "http://telemetry.shuup.com"
+
 #: The submission URL for Shuup's telemetry (statistics) system
-SHUUP_TELEMETRY_URL = "https://telemetry.shuup.com/collect/"
+SHUUP_TELEMETRY_URL = "%s/collect/" % SHUUP_TELEMETRY_HOST_URL
+
+#: The URL to fetch the Shuup installation support id
+SHUUP_SUPPORT_ID_URL = "%s/support-id" % SHUUP_TELEMETRY_HOST_URL
 
 #: Default cache duration for various caches in seconds
 SHUUP_DEFAULT_CACHE_DURATION = 60 * 30


### PR DESCRIPTION
Save a six digit support id for shuup installations that are sending telemetry and show the id in the admin navbar.
Please merge and deploy shuup.com updates before this.