### PR TITLE
Fix issue with faulty filters

### DIFF
--- a/shuup/front/static_src/js/category.js
+++ b/shuup/front/static_src/js/category.js
@@ -77,6 +77,10 @@ $(function() {
     });
 
     $.each(window.PRODUCT_LIST_FILTERS, function(idx, key) {
+        if($("#id_" + key).parent(".form-group").hasClass("has-error")) {
+            const host_str = '//' + location.host + location.pathname;
+            window.location.href = host_str;
+        }
         $("#id_" + key).on("change", function() {
             window.refreshFilters(window.PAGE_NUMBER);
         });


### PR DESCRIPTION
If customer has page loaded and filters are being changed by admin, it causes an error that won't go away

Add forced reload to the page if form causes error

Refs SH-284, SH-345