### PR TITLE
Front: Fill search results with words in query (SH-357, SH-254)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -34,6 +34,9 @@ Addons
 Front
 ~~~~~
 
+- For search add default sorting based on distance between product 
+  name and query string
+- Add results from words in query to the search until the limit is reached
 - Enable filtering product lists by price
 - Enable option to filter products with variation values
 - Enable option to modify products queryset in category

--- a/shuup/front/forms/product_list_modifiers.py
+++ b/shuup/front/forms/product_list_modifiers.py
@@ -80,7 +80,9 @@ class SortProductListByName(SimpleProductListModifier):
             ]),
         ]
 
-    def sort_products(self, request, products, sort):
+    def sort_products(self, request, products, data):
+        sort = data.get("sort", "name_a")
+
         def _get_product_name_lowered_stripped(product):
             return product.name.lower().strip()
 
@@ -112,7 +114,9 @@ class SortProductListByPrice(SimpleProductListModifier):
             ]),
         ]
 
-    def sort_products(self, request, products, sort):
+    def sort_products(self, request, products, data):
+        sort = data.get("sort")
+
         def _get_product_price_getter_for_request(request):
             def _get_product_price(product):
                 return product.get_price(request)
@@ -145,7 +149,9 @@ class SortProductListByCreatedDate(SimpleProductListModifier):
             ]),
         ]
 
-    def sort_products(self, request, products, sort):
+    def sort_products(self, request, products, data):
+        sort = data.get("sort")
+
         def _get_product_created_on_datetime(product):
             return product.created_on
 

--- a/shuup/front/utils/sorts_and_filters.py
+++ b/shuup/front/utils/sorts_and_filters.py
@@ -76,7 +76,7 @@ class ProductListFormModifier(six.with_metaclass(abc.ABCMeta)):
         """
         pass
 
-    def sort_products(self, request, products, sort):
+    def sort_products(self, request, products, data):
         """
         Sort products in case sort choices is provided
 
@@ -86,8 +86,8 @@ class ProductListFormModifier(six.with_metaclass(abc.ABCMeta)):
         :param request: Current request
         :param products: Products to sort
         :type products: list[shuup.code.models.Product]
-        :param sort: Key to sort with
-        :type sort: str
+        :param data: product list form data
+        :type data: dict
         :return: List of products that might be sorted
         :rtype: list[shuup.code.models.Product]
         """
@@ -216,9 +216,8 @@ def post_filter_products(request, category, products, data):
 
 
 def sort_products(request, category, products, data):
-    sort = data.get("sort", "name_a")
     for extend_obj in _get_active_modifiers(request.shop, category):
-        products = extend_obj.sort_products(request, products, sort)
+        products = extend_obj.sort_products(request, products, data)
     return products
 
 

--- a/shuup_tests/browser/front/test_search_view.py
+++ b/shuup_tests/browser/front/test_search_view.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+
+import pytest
+
+from django.core.urlresolvers import reverse
+from django.utils.translation import activate
+
+from shuup.core import cache
+from shuup.core.models import (
+    Category, CategoryStatus, Manufacturer, Product, ProductMode,
+    ProductVariationVariable, ProductVariationVariableValue, ShopProduct
+)
+from shuup.front.utils.sorts_and_filters import (
+    set_configuration
+)
+from shuup.testing.browser_utils import (
+    click_element, move_to_element, wait_until_condition,
+    wait_until_disappeared
+)
+from shuup.testing.factories import (
+    create_product, get_default_category, get_default_shop,
+    get_default_supplier
+)
+from shuup.testing.utils import initialize_front_browser_test
+
+pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
+
+
+PRODUCT_DATA = [
+    ("Test Product", "sku-1", 123),
+    ("A Test Product", "sku-2", 720),
+    ("XTest Product", "sku-3", 1),
+    ("Test", "sku-4", 42),
+    ("Product", "sku-5", 434),
+    ("Xtest", "sku-6", 3),
+    ("A", "sku-7", 99),
+    ("xtest", "sku-8", 999),
+    ("a", "sku-9", 42),
+    ("test", "sku-10", 53),
+    ("product", "sku-11", 34),
+]
+
+
+def create_orderable_product(name, sku, price):
+    supplier = get_default_supplier()
+    shop = get_default_shop()
+    product = create_product(sku=sku, shop=shop, supplier=supplier, default_price=price, name=name)
+    return product
+
+
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_search_product_list(browser, live_server, settings):
+    activate("en")
+    # initialize
+    cache.clear()
+    shop = get_default_shop()
+
+    for name, sku, price in PRODUCT_DATA:
+        create_orderable_product(name, sku, price=price)
+
+    # initialize test and go to front page
+    browser = initialize_front_browser_test(browser, live_server)
+    # check that front page actually loaded
+    assert browser.is_text_present("Welcome to Default!")
+
+    url = reverse("shuup:product_search")
+    browser.visit("%s%s?q=test product" % (live_server, url))
+
+    wait_until_condition(browser, lambda x: len(x.find_by_css(".product-card")) == 9)
+
+    check_default_ordering(browser)
+    # basic_sorting_test(browser)
+    second_test_query(browser, live_server, url)
+
+
+def check_default_ordering(browser):
+    expected_first_prod_id = "product-%s" % Product.objects.filter(sku="sku-1").first().id
+    wait_until_condition(
+        browser, lambda x: x.find_by_css(".product-card").first["id"] == expected_first_prod_id)
+
+    expected_second_prod_id = "product-%s" % Product.objects.filter(sku="sku-3").first().id
+    wait_until_condition(
+        browser, lambda x: x.find_by_css(".product-card")[1]["id"] == expected_second_prod_id)
+
+    expected_third_prod_id = "product-%s" % Product.objects.filter(sku="sku-2").first().id
+    wait_until_condition(
+        browser, lambda x: x.find_by_css(".product-card")[2]["id"] == expected_third_prod_id)
+
+
+def basic_sorting_test(browser):
+    # Sort from Z to A
+    click_element(browser, "button[data-id='id_sort']")
+    click_element(browser, "li[data-original-index='1'] a")
+    expected_first_prod_id = "product-%s" % Product.objects.filter(sku="sku-3").first().id
+    wait_until_condition(
+        browser, lambda x: x.find_by_css(".product-card").first["id"] == expected_first_prod_id)
+
+    # Sort by price (highest first)
+    click_element(browser, "button[data-id='id_sort']")
+    click_element(browser, "li[data-original-index='3'] a")
+    expected_first_prod_id = "product-%s" % Product.objects.filter(sku="sku-8").first().id
+    wait_until_condition(
+        browser, lambda x: x.find_by_css(".product-card").first["id"] == expected_first_prod_id)
+
+
+    # Sort by price (lowest first)
+    click_element(browser, "button[data-id='id_sort']")
+    click_element(browser, "li[data-original-index='2'] a")
+    expected_first_prod_id = "product-%s" % Product.objects.filter(sku="sku-3").first().id
+    wait_until_condition(
+        browser, lambda x: x.find_by_css(".product-card").first["id"] == expected_first_prod_id)
+
+    # Sort from A to Z
+    click_element(browser, "button[data-id='id_sort']")
+    click_element(browser, "li[data-original-index='0'] a")
+    expected_first_prod_id = "product-%s" % Product.objects.filter(sku="sku-2").first().id
+    wait_until_condition(
+        browser, lambda x: x.find_by_css(".product-card").first["id"] == expected_first_prod_id)
+
+
+def second_test_query(browser, live_server, url):
+    browser.visit("%s%s?q=Test" % (live_server, url))
+    wait_until_condition(browser, lambda x: len(x.find_by_css(".product-card")) == 7)
+    expected_first_prod_id = "product-%s" % Product.objects.filter(sku="sku-4").first().id
+    wait_until_condition(
+        browser, lambda x: x.find_by_css(".product-card").first["id"] == expected_first_prod_id)
+
+    expected_second_prod_id = "product-%s" % Product.objects.filter(sku="sku-10").first().id
+    wait_until_condition(
+        browser, lambda x: x.find_by_css(".product-card")[1]["id"] == expected_second_prod_id)
+
+    expected_third_prod_id = "product-%s" % Product.objects.filter(sku="sku-8").first().id
+    wait_until_condition(
+        browser, lambda x: x.find_by_css(".product-card")[2]["id"] == expected_third_prod_id)
+
+    expected_last_prod_id = "product-%s" % Product.objects.filter(sku="sku-2").first().id
+    wait_until_condition(
+        browser, lambda x: x.find_by_css(".product-card").last["id"] == expected_last_prod_id)


### PR DESCRIPTION
* Pass data for `ProductListFormModifier.sort_products`
* Add search results from words in query string
* Add default sorting based on distance between product name and full query distance
