### PR TITLE
Fix issue with stacking filters (SH-284)

### DIFF
--- a/shuup/front/utils/sorts_and_filters.py
+++ b/shuup/front/utils/sorts_and_filters.py
@@ -224,7 +224,9 @@ def sort_products(request, category, products, data):
 
 def get_product_queryset(queryset, request, category, data):
     for extend_obj in _get_active_modifiers(request.shop, category):
-        queryset = extend_obj.get_queryset(queryset, data) or queryset
+        new_queryset = extend_obj.get_queryset(queryset, data)
+        if new_queryset is not None:
+            queryset = new_queryset
     return queryset
 
 

--- a/shuup_tests/browser/front/test_category_view.py
+++ b/shuup_tests/browser/front/test_category_view.py
@@ -261,16 +261,18 @@ def variations_filter_test(browser, category):
     browser.execute_script("$('#variation_size-l').click();")
     wait_until_condition(browser, lambda x: len(x.find_by_css(".product-card")) == 1)
 
+    browser.execute_script("$('#variation_color-brown').click();")  # unselect brown
+
     # Two Big or Black products
-    browser.execute_script("$('#variation_color-brown').click();")
     browser.execute_script("$('#variation_color-black').click();")
     
     wait_until_condition(browser, lambda x: len(x.find_by_css(".product-card")) == 2)
 
+    browser.execute_script("$('#variation_color-black').click();")  # unselect black
+
     # Three Big or Pink products
     browser.execute_script("$('#variation_color-pink').click();")
-    browser.execute_script("$('#variation_color-black').click();")
-    wait_until_condition(browser, lambda x: len(x.find_by_css(".product-card")) == 3)
+    wait_until_condition(browser, lambda x: len(x.find_by_css(".product-card")) == 0)
 
     # One pink product
     browser.execute_script("$('#variation_size-big').click();")


### PR DESCRIPTION
In old implementation, whenever the `get_queryset(...)` returned an
empty queryset or `None`, the old queryset was used.

This caused the following prolem:
* Product A is has manufacturer Y defined
* Product B is a variation with Colors Red and Green
* Now filter to show manufacturer Y and color Red, you will see Product A.

The queryset handling in `get_product_queryset` ignored all the querysets that resulted empty
(alongside the `None` values it should ignore). And when doing so, it
did fallback to the previous queryset, which still had the
previous filters' results in it thus could never end in a situtiation where
nothing was shown.

Refs SH-284