### PR TITLE
Allow registering Shuup to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,8 +128,8 @@ EXTRAS_REQUIRE['everything'] = list(
 
 
 if __name__ == '__main__':
-    if 'register' in sys.argv or 'upload' in sys.argv:
-        raise EnvironmentError('Registering and uploading is blacklisted')
+    if 'upload' in sys.argv:
+        raise EnvironmentError('Uploading is blacklisted')
 
     version = utils.get_version(VERSION, TOPDIR, VERSION_FILE)
     utils.write_version_to_file(version, VERSION_FILE)

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@ DESCRIPTION = 'E-Commerce Platform'
 AUTHOR = 'Shoop Commerce Ltd.'
 AUTHOR_EMAIL = 'shuup@shuup.com'
 URL = 'http://shuup.com/'
+DOWNLOAD_URL_TEMPLATE = (
+    'https://github.com/shuup/shuup/releases/download/'
+    'v{version}/shuup-{version}-py2.py3-none-any.whl')
 LICENSE = 'AGPL-3.0'  # https://spdx.org/licenses/
 CLASSIFIERS = """
 Development Status :: 4 - Beta
@@ -137,6 +140,7 @@ if __name__ == '__main__':
         description=DESCRIPTION,
         long_description=utils.get_long_description(LONG_DESCRIPTION_FILE),
         url=URL,
+        download_url=DOWNLOAD_URL_TEMPLATE.format(version=version),
         author=AUTHOR,
         author_email=AUTHOR_EMAIL,
         license=LICENSE,


### PR DESCRIPTION
It would be convenient if Shuup was in PyPI.  It was not uploaded there
earlier because PSF issued terms that would give PSF and PyPI users too
much permissions for the uploaded packages without accepting the AGPLv3
conditions.

Unfortunately we failed to see back then that it's possible to register
to PyPI without uploading the packages there. (Thanks @jaywink for
pointing this out.)  This PR enables registering Shuup to PyPI with a
download_url which points to the wheel file at Github.

Refs SHUUP-976