### PR TITLE
Add checkout view with register and login phases (SH-376)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -26,6 +26,7 @@ Addons
 Front
 ~~~~~
 
+- Add is_visible_for_user method for checkout view phase
 - Add recently viewed products app
 - Fix/refactor single page checkout view
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -26,6 +26,7 @@ Addons
 Front
 ~~~~~
 
+- Add checkout view with option to login and register
 - Add is_visible_for_user method for checkout view phase
 - Add recently viewed products app
 - Fix/refactor single page checkout view

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -26,6 +26,8 @@ Addons
 Front
 ~~~~~
 
+- Enable option to use login and regiser checkout phases 
+  with vertical checkout process
 - Add checkout view with option to login and register
 - Add is_visible_for_user method for checkout view phase
 - Add recently viewed products app

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,8 @@ Unrealeased
 Core
 ~~~~
 
+- Populate some unfilled customer fields from order
+
 Localization
 ~~~~~~~~~~~~
 

--- a/shuup/front/apps/auth/forms.py
+++ b/shuup/front/apps/auth/forms.py
@@ -35,7 +35,7 @@ class EmailAuthenticationForm(AuthenticationForm):
         self.fields['username'].label = _("Username or email address")
 
     def clean_username(self):
-        username = self.data['username']
+        username = self.cleaned_data['username']
         user_model = get_user_model()
 
         # Note: Always search by username AND by email prevent timing attacks

--- a/shuup/front/checkout/_view_mixin.py
+++ b/shuup/front/checkout/_view_mixin.py
@@ -24,6 +24,9 @@ class CheckoutPhaseViewMixin(object):
     previous_phase = None  # set as an instance variable
     request = None  # exists via being a view
 
+    def is_visible_for_user(self):
+        return bool(self.title)
+
     def is_valid(self):
         return True
 

--- a/shuup/front/checkout/checkout_method.py
+++ b/shuup/front/checkout/checkout_method.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django import forms
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
+from django.utils.translation import ugettext_lazy as _
+from enumfields import Enum
+
+from shuup.front.apps.auth.views import LoginView
+from shuup.front.apps.registration.views import RegistrationNoActivationView
+from shuup.front.checkout import CheckoutPhaseViewMixin
+from shuup.utils.form_group import FormGroup
+
+CHECKOUT_CHOICE_STORAGE_KEY = "checkout_method:checkout_method_choice"
+
+
+class CheckoutMethodChoices(Enum):
+    CHECKOUT_AS_GUEST = 0
+    REGISTER = 1
+
+    class Labels:
+        CHECKOUT_AS_GUEST = _("Checkout as Guest")
+        REGISTER = _("Register")
+
+
+class ChooseToRegisterForm(forms.Form):
+    register = forms.ChoiceField(
+        choices=CheckoutMethodChoices.choices(), initial=CheckoutMethodChoices.REGISTER,
+        label=_("Register with us for future convenience"), required=False
+    )
+
+
+class CheckoutMethodPhase(CheckoutPhaseViewMixin, LoginView):
+    identifier = "checkout_method"
+    title = _("Checkout Method Choice")
+    template_name = "shuup/front/checkout/checkout_method.jinja"
+    login_form_key = "login"
+    checkout_method_choice_key = "checkout_method_choice"
+
+    def get_form(self, form_class=None):
+        form_group = FormGroup(**self.get_form_kwargs())
+        form_group.add_form_def(name=self.login_form_key, form_class=LoginView.form_class, required=False)
+        form_group.add_form_def(name=self.checkout_method_choice_key, form_class=ChooseToRegisterForm, required=False)
+        return form_group
+
+    def is_visible_for_user(self):
+        return bool(not self.request.customer or self.request.customer.is_all_seeing)
+
+    def should_skip(self):
+        return not self.is_visible_for_user()
+
+    def is_valid(self):
+        checkout_method_choice = bool(self.storage.get(CHECKOUT_CHOICE_STORAGE_KEY, None) is not None)
+        return bool(checkout_method_choice or self.request.customer)
+
+    def form_valid(self, form):
+        login_form = form.forms[self.login_form_key]
+        if login_form.cleaned_data:  # TODO: There is probably better way to figure out when to login
+            return super(CheckoutMethodPhase, self).form_valid(login_form)
+        checkout_choice_form = form.forms[self.checkout_method_choice_key]
+        should_register = bool(int(checkout_choice_form.cleaned_data["register"] or 0))
+        self.storage[CHECKOUT_CHOICE_STORAGE_KEY] = should_register
+        self.request.session["checkout_register:%s" % CHECKOUT_CHOICE_STORAGE_KEY] = should_register
+        return HttpResponseRedirect(self.get_success_url())
+
+    def process(self):
+        return
+
+
+class RegisterPhase(CheckoutPhaseViewMixin, RegistrationNoActivationView):
+    identifier = "register"
+    title = _("Register")
+    template_name = "shuup/front/checkout/register.jinja"
+
+    def is_visible_for_user(self):
+        checkout_method_choice_is_registered = bool(self.storage.get(CHECKOUT_CHOICE_STORAGE_KEY, None))
+        return bool(not self.request.customer and checkout_method_choice_is_registered)
+
+    def should_skip(self):
+        return not self.is_visible_for_user()
+
+    def is_valid(self):
+        checkout_method_choice_is_registered = bool(self.storage.get(CHECKOUT_CHOICE_STORAGE_KEY, None))
+        return bool(self.request.customer and checkout_method_choice_is_registered)
+
+    def get_success_url(self, *args, **kwargs):
+        if self.next_phase:
+            return reverse("shuup:checkout", kwargs={"phase": self.next_phase.identifier})
+
+    def process(self):
+        return

--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-11 17:42+0000\n"
+"POT-Creation-Date: 2016-10-21 01:41+0000\n"
 "PO-Revision-Date: 2016-08-04 10:51-0700\n"
 "Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
@@ -161,6 +161,18 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
+msgid "Checkout as Guest"
+msgstr ""
+
+msgid "Register"
+msgstr ""
+
+msgid "Register with us for future convenience"
+msgstr ""
+
+msgid "Checkout Method Choice"
+msgstr ""
+
 msgid "I accept the terms and conditions"
 msgstr ""
 
@@ -188,21 +200,6 @@ msgid "payment method"
 msgstr ""
 
 msgid "Shipping & Payment"
-msgstr ""
-
-msgid "Company name"
-msgstr ""
-
-msgid "Tax number"
-msgstr ""
-
-msgid "Shipping method"
-msgstr ""
-
-msgid "Payment method"
-msgstr ""
-
-msgid "Please send me marketing correspondence"
 msgstr ""
 
 msgid "Sort products by name"
@@ -257,6 +254,21 @@ msgid "Ordering for filter by category"
 msgstr ""
 
 msgid "Categories"
+msgstr ""
+
+msgid "Limit page size"
+msgstr ""
+
+msgid "Ordering for limit page size"
+msgstr ""
+
+msgid "Products per page"
+msgstr ""
+
+msgid "Filter products by variation"
+msgstr ""
+
+msgid "Ordering for filter by variation"
 msgstr ""
 
 msgid "Filter products by price"
@@ -413,16 +425,19 @@ msgstr ""
 msgid "Checkout"
 msgstr ""
 
+msgid "Checkout: Choose Checkout Method"
+msgstr ""
+
+msgid "Log in"
+msgstr ""
+
+msgid "Forgot your password?"
+msgstr ""
+
 msgid "There are errors"
 msgstr ""
 
-msgid "Errors"
-msgstr ""
-
-msgid "Ordering for a company?"
-msgstr ""
-
-msgid "Please fill out these fields if you are ordering for a company."
+msgid "Checkout: Register"
 msgstr ""
 
 msgid "My Dashboard"
@@ -551,6 +566,12 @@ msgstr ""
 msgid "Billing address"
 msgstr ""
 
+msgid "Ordering for a company?"
+msgstr ""
+
+msgid "Please fill out these fields if you are ordering for a company."
+msgstr ""
+
 msgid "Shipping address"
 msgstr ""
 
@@ -570,6 +591,9 @@ msgid "Delivery method"
 msgstr ""
 
 msgid "Billing"
+msgstr ""
+
+msgid "Payment method"
 msgstr ""
 
 msgid "Add comment"
@@ -621,12 +645,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-msgid "Log in"
-msgstr ""
-
-msgid "Forgot your password?"
-msgstr ""
-
 msgid "New user? Register here!"
 msgstr ""
 
@@ -673,6 +691,9 @@ msgid "Total including tax"
 msgstr ""
 
 msgid "Company"
+msgstr ""
+
+msgid "Tax number"
 msgstr ""
 
 msgid "Preview"

--- a/shuup/front/templates/shuup/front/checkout/_horizontal_phases.jinja
+++ b/shuup/front/templates/shuup/front/checkout/_horizontal_phases.jinja
@@ -7,7 +7,7 @@
     {% block checkout_phase_bar %}
         {% if view and view.phases %}
         <ul class="nav nav-pills nav-justified">
-            {% for phase in view.phases if phase.title %}
+            {% for phase in view.phases if phase.is_visible_for_user() %}
             <li {% if phase.is_current %}class="active"{% endif %}>
                 <a href="{{ url("shuup:checkout", phase=phase.identifier) }}">{{ loop.index }}. {{ phase.title }}</a>
             </li>

--- a/shuup/front/templates/shuup/front/checkout/_vertical_phases.jinja
+++ b/shuup/front/templates/shuup/front/checkout/_vertical_phases.jinja
@@ -1,4 +1,5 @@
 {% if request.is_ajax() %}
+    {%- import "shuup/front/macros/general.jinja" as macros with context -%}
     {%- import "shuup/front/macros/checkout.jinja" as checkout_macros with context -%}
 {% else %}
     {% extends "shuup/front/base.jinja" %}
@@ -57,12 +58,16 @@
             if (!data.includes("csrfmiddlewaretoken")) {  // no csrftoken no post
                 return false;
             }
+            const currentPhase = window.currentPhase;
             $.ajax({
                 type: "post",
                 url: "/checkout/" + window.currentPhase + "/",
                 data: data,
                 success: function (response) {
                     $("#ajax_content").html(response);
+                    if (currentPhase != window.currentPhase && form.hasClass("single-page-refresh-after")) {
+                        location.reload();
+                    }
                 }
             });
         };
@@ -82,7 +87,7 @@
             $("form").on("submit", function(e) {
                 if (window.currentPhase !== "confirm") {
                     e.preventDefault();
-                    window.submitCheckoutPhaseForm($("#" + window.currentPhase));
+                    window.submitCheckoutPhaseForm($(this));
                 }
             });
             $("a[href^='#phase']").on("click", function(e) {

--- a/shuup/front/templates/shuup/front/checkout/_vertical_phases.jinja
+++ b/shuup/front/templates/shuup/front/checkout/_vertical_phases.jinja
@@ -16,7 +16,7 @@
                  id="accordion"
                  role="tablist"
                  aria-multiselectable="true">
-                {% for phase in view.phases if phase.title %}
+                {% for phase in view.phases if phase.is_visible_for_user() %}
                 <div class="panel panel-primary">
                     <div class="panel-heading" role="tab" id="headingOne">
                         <h4 class="panel-title">

--- a/shuup/front/templates/shuup/front/checkout/checkout_method.jinja
+++ b/shuup/front/templates/shuup/front/checkout/checkout_method.jinja
@@ -1,0 +1,39 @@
+{% extends "shuup/front/checkout/_base.jinja" %}
+
+{% block title %}Checkout Method{% endblock %}
+{% block content_title %}{% trans %}Checkout: Choose Checkout Method{% endtrans %}{% endblock %}
+
+{% block checkout_phase_content %}
+    <div class="row">
+        {% set forms = form.forms %}
+        <div class="col-md-6">
+            <form class="single-page-refresh-after" role="form" method="post" action="">
+                {% csrf_token %}
+                {% set login_form = forms["login"] %}
+                {% for error in login_form.non_field_errors() %}
+                    {{ macros.alert(error, mode="danger") }}
+                {% endfor %}
+                {% for f in login_form.hidden_fields() %}{{ f }}{% endfor %}
+                {{ macros.render_field(login_form.username) }}
+                {{ macros.render_field(login_form.password) }}
+                <button type="submit" class="btn btn-primary btn-block" name="login">
+                    <i class="fa fa-sign-in"></i> {% trans %}Log in{% endtrans %}
+                </button>
+                <hr>
+                <a href="{{ url("shuup:recover_password") }}">
+                    {% trans %}Forgot your password?{% endtrans %}
+                </a>
+            </form>
+        </div>
+        <div class="col-md-6">
+            <form role="form" method="post" action="">
+                {% csrf_token %}
+                {% set method_form = forms["checkout_method_choice"] %}
+                {{ macros.render_field(method_form.register) }}
+                {{ checkout_macros.default_buttons() }}
+            </form>
+            {% placeholder "checkout_method_choice_right" %}{% endplaceholder %}
+        </div>
+    </div>
+    {% placeholder "checkout_method_choice_bottom" %}{% endplaceholder %}
+{% endblock %}

--- a/shuup/front/templates/shuup/front/checkout/register.jinja
+++ b/shuup/front/templates/shuup/front/checkout/register.jinja
@@ -1,0 +1,13 @@
+{% extends "shuup/front/checkout/_base.jinja" %}
+
+{% block title %}Register{% endblock %}
+{% block content_title %}{% trans %}Checkout: Register{% endtrans %}{% endblock %}
+
+{% block checkout_phase_content %}
+    <form class="single-page-refresh-after" role="form" method="post" action="" id="register">
+        {% csrf_token %}
+        {% for field in form.hidden_fields() %}{{ field|safe }}{% endfor %}
+        {% for field in form.visible_fields() %}{{ macros.render_field(field) }}{% endfor %}
+        {{ checkout_macros.default_buttons() }}
+    </form>
+{% endblock %}

--- a/shuup/front/views/checkout.py
+++ b/shuup/front/views/checkout.py
@@ -61,6 +61,19 @@ class SinglePageCheckoutView(DefaultCheckoutView):
     process_class = VerticalCheckoutProcess
 
 
+class CheckoutViewWithLoginAndRegister(BaseCheckoutView):
+    phase_specs = [
+        "shuup.front.checkout.checkout_method:CheckoutMethodPhase",
+        "shuup.front.checkout.checkout_method:RegisterPhase",
+        "shuup.front.checkout.addresses:AddressesPhase",
+        "shuup.front.checkout.methods:MethodsPhase",
+        "shuup.front.checkout.methods:ShippingMethodPhase",
+        "shuup.front.checkout.methods:PaymentMethodPhase",
+        "shuup.front.checkout.confirm:ConfirmPhase",
+    ]
+    empty_phase_spec = "shuup.front.checkout.empty:EmptyPhase"
+
+
 def get_checkout_view():
     view = cached_load("SHUUP_CHECKOUT_VIEW_SPEC")
     if hasattr(view, "as_view"):  # pragma: no branch

--- a/shuup/testing/checkout_with_login_and_register_urls.py
+++ b/shuup/testing/checkout_with_login_and_register_urls.py
@@ -1,0 +1,22 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.conf import settings
+from django.conf.urls import include, patterns, url
+from django.conf.urls.static import static
+from django.contrib import admin
+
+from shuup.front.views.checkout import CheckoutViewWithLoginAndRegister
+
+urlpatterns = patterns(
+    '',
+    url(r'^checkout/$', CheckoutViewWithLoginAndRegister.as_view(), name='checkout'),
+    url(r'^checkout/(?P<phase>.+)/$', CheckoutViewWithLoginAndRegister.as_view(), name='checkout'),
+    url(r'^admin/', include(admin.site.urls)),
+    url(r'^sa/', include('shuup.admin.urls', namespace="shuup_admin", app_name="shuup_admin")),
+    url(r'^api/', include('shuup.api.urls')),
+    url(r'^', include('shuup.front.urls', namespace="shuup", app_name="shuup")),
+) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/shuup/testing/single_page_checkout_with_login_and_register_conf.py
+++ b/shuup/testing/single_page_checkout_with_login_and_register_conf.py
@@ -1,0 +1,36 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.conf import settings
+from django.conf.urls import include, patterns, url
+from django.conf.urls.static import static
+from django.contrib import admin
+
+from shuup.front.views.checkout import SinglePageCheckoutView
+
+
+class SinglePageCheckoutViewWithLoginAndRegister(SinglePageCheckoutView):
+    phase_specs = [
+        "shuup.front.checkout.checkout_method:CheckoutMethodPhase",
+        "shuup.front.checkout.checkout_method:RegisterPhase",
+        "shuup.front.checkout.addresses:AddressesPhase",
+        "shuup.front.checkout.methods:MethodsPhase",
+        "shuup.front.checkout.methods:ShippingMethodPhase",
+        "shuup.front.checkout.methods:PaymentMethodPhase",
+        "shuup.front.checkout.confirm:ConfirmPhase",
+    ]
+    empty_phase_spec = "shuup.front.checkout.empty:EmptyPhase"
+
+
+urlpatterns = patterns(
+    '',
+    url(r'^checkout/$', SinglePageCheckoutViewWithLoginAndRegister.as_view(), name='checkout'),
+    url(r'^checkout/(?P<phase>.+)/$', SinglePageCheckoutViewWithLoginAndRegister.as_view(), name='checkout'),
+    url(r'^admin/', include(admin.site.urls)),
+    url(r'^sa/', include('shuup.admin.urls', namespace="shuup_admin", app_name="shuup_admin")),
+    url(r'^api/', include('shuup.api.urls')),
+    url(r'^', include('shuup.front.urls', namespace="shuup", app_name="shuup")),
+) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/shuup_tests/browser/front/test_checkout_with_login_and_register.py
+++ b/shuup_tests/browser/front/test_checkout_with_login_and_register.py
@@ -72,6 +72,40 @@ def test_checkout_with_login_and_register(browser, live_server, settings):
     login_and_finish_up_the_checkout(browser, live_server, test_username, test_email, test_password)
 
 
+@override_settings(SHUUP_REGISTRATION_REQUIRES_ACTIVATION=False)
+@pytest.mark.urls('shuup.testing.single_page_checkout_with_login_and_register_conf')
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_single_page_checkout_with_login_and_register(browser, live_server, settings):
+    # initialize
+    product_name = "Test Product"
+    get_default_shop()
+    pm = get_default_payment_method()
+    sm = get_default_shipping_method()
+    product = create_orderable_product(product_name, "test-123", price=100)
+    OrderStatus.objects.create(
+        identifier="initial",
+        role=OrderStatusRole.INITIAL,
+        name="initial",
+        default=True
+    )
+
+    # Initialize test and go to front page
+    browser = initialize_front_browser_test(browser, live_server)
+
+    assert browser.is_text_present("Welcome to Default!")
+    navigate_to_checkout(browser, product)
+
+    # Let's assume that after addresses the checkout is normal
+    assert browser.is_text_present("Choose Checkout Method")
+    test_username = "test_username"
+    test_email = "test@example.com"
+    test_password = "test_password"
+    register_test(browser, live_server, test_username, test_email, test_password)
+
+    login_and_finish_up_the_checkout(browser, live_server, test_username, test_email, test_password)
+
+
 def navigate_to_checkout(browser, product):
     assert browser.is_text_present("Newest Products")
     assert browser.is_text_present(product.name)

--- a/shuup_tests/browser/front/test_checkout_with_login_and_register.py
+++ b/shuup_tests/browser/front/test_checkout_with_login_and_register.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+import pytest
+
+from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
+
+from shuup.core.models import (
+    Order, OrderStatus, OrderStatusRole, PersonContact, Product
+)
+from shuup.testing.browser_utils import (
+    click_element, wait_until_appeared, wait_until_condition,
+    wait_until_disappeared
+)
+from shuup.testing.factories import (
+    create_product, get_default_payment_method, get_default_shipping_method,
+    get_default_shop, get_default_supplier
+)
+from shuup.testing.utils import initialize_front_browser_test
+
+pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
+
+
+def create_orderable_product(name, sku, price):
+    supplier = get_default_supplier()
+    shop = get_default_shop()
+    product = create_product(sku=sku, shop=shop, supplier=supplier, default_price=price, name=name)
+    return product
+
+
+@override_settings(SHUUP_REGISTRATION_REQUIRES_ACTIVATION=False)
+@pytest.mark.urls('shuup.testing.checkout_with_login_and_register_urls')
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_checkout_with_login_and_register(browser, live_server, settings):
+    # initialize
+    product_name = "Test Product"
+    get_default_shop()
+    pm = get_default_payment_method()
+    sm = get_default_shipping_method()
+    product = create_orderable_product(product_name, "test-123", price=100)
+    OrderStatus.objects.create(
+        identifier="initial",
+        role=OrderStatusRole.INITIAL,
+        name="initial",
+        default=True
+    )
+
+    # Initialize test and go to front page
+    browser = initialize_front_browser_test(browser, live_server)
+
+    assert browser.is_text_present("Welcome to Default!")
+    navigate_to_checkout(browser, product)
+
+    # Let's assume that after addresses the checkout is normal
+    assert browser.is_text_present("Checkout: Choose Checkout Method")
+    guest_ordering_test(browser, live_server)
+
+    test_username = "test_username"
+    test_email = "test@example.com"
+    test_password = "test_password"
+    assert browser.is_text_present("Checkout: Choose Checkout Method")
+    register_test(browser, live_server, test_username, test_email, test_password)
+
+    assert browser.is_text_present("Checkout: Choose Checkout Method")
+    login_and_finish_up_the_checkout(browser, live_server, test_username, test_email, test_password)
+
+
+def navigate_to_checkout(browser, product):
+    assert browser.is_text_present("Newest Products")
+    assert browser.is_text_present(product.name)
+
+    click_element(browser, "#product-%s" % product.pk)  # open product from product list
+    click_element(browser, "#add-to-cart-button-%s" % product.pk)  # add product to basket
+
+    wait_until_appeared(browser, ".cover-wrap")
+    wait_until_disappeared(browser, ".cover-wrap")
+
+    click_element(browser, "#navigation-basket-partial")  # open upper basket navigation menu
+    click_element(browser, "a[href='/basket/']")  # click the link to basket in dropdown
+    assert browser.is_text_present("Shopping cart")  # we are in basket page
+    assert browser.is_text_present(product.name)  # product is in basket
+
+    click_element(browser, "a[href='/checkout/']") # click link that leads to checkout
+
+
+def guest_ordering_test(browser, live_server):
+    browser.fill("login-username", "test-username")
+    click_element(browser, "button[name='login']")
+    wait_until_appeared(browser, "div.form-group.passwordinput.required.has-error")
+    browser.fill("login-password", "test-password")
+    click_element(browser, "button[name='login']")
+    assert browser.is_text_present("Please enter a correct username and password.")
+    wait_until_appeared(browser, "div.alert.alert-danger")
+
+    click_element(browser, "button[data-id='id_checkout_method_choice-register']")
+    click_element(browser, "li[data-original-index='0'] a")
+    click_element(browser, "div.clearfix button.btn.btn-primary.btn-lg.pull-right")
+    assert browser.is_text_present("Checkout: Addresses")
+    url = reverse("shuup:checkout", kwargs={"phase": "checkout_method"})
+    browser.visit("%s%s" % (live_server, url))
+
+
+def register_test(browser, live_server, test_username, test_email, test_password):
+    click_element(browser, "button[data-id='id_checkout_method_choice-register']")
+    click_element(browser, "li[data-original-index='1'] a")
+    click_element(browser, "div.clearfix button.btn.btn-primary.btn-lg.pull-right")
+    wait_until_condition(browser, lambda x: x.is_text_present("Register"))
+
+    browser.find_by_id("id_username").fill(test_username)
+    browser.find_by_id("id_email").fill(test_email)
+    browser.find_by_id("id_password1").fill(test_password)
+    browser.find_by_id("id_password2").fill("typo-%s" % test_password)
+    click_element(browser, "div.clearfix button.btn.btn-primary.btn-lg.pull-right")
+    wait_until_appeared(browser, "div.form-group.passwordinput.required.has-error")
+
+    browser.find_by_id("id_password1").fill(test_password)
+    browser.find_by_id("id_password2").fill(test_password)
+    click_element(browser, "div.clearfix button.btn.btn-primary.btn-lg.pull-right")
+
+    wait_until_condition(browser, lambda x: x.is_text_present("Addresses"))
+    # Reload here just in case since there might have been reload with JS
+    # which might cause issues with tests since the elements is in cache
+    browser.reload()
+
+    # Log out and go back to checkout choice phase
+    click_element(browser, "div.top-nav i.menu-icon.fa.fa-user")
+    click_element(browser, "a[href='/logout/']")
+
+    # Ensure that the language is still english. It seems that the language might change
+    # during the logout.
+    browser.find_by_id("language-changer").click()
+    browser.find_by_xpath('//a[@class="language"]').first.click()
+
+    # There is no products on basket anymore so let's add one
+    product = Product.objects.first()
+    product_url = reverse("shuup:product", kwargs={"pk": product.pk, "slug": product.slug})
+    browser.visit("%s%s" % (live_server, product_url))
+    click_element(browser, "#add-to-cart-button-%s" % product.pk)  # add product to basket
+
+    wait_until_appeared(browser, ".cover-wrap")
+    wait_until_disappeared(browser, ".cover-wrap")
+
+    browser.visit("%s%s" % (live_server, "/checkout/"))
+
+
+def login_and_finish_up_the_checkout(browser, live_server, test_username, test_email, test_password):
+    browser.fill("login-username", test_email)
+    browser.fill("login-password", test_password)
+    click_element(browser, "button[name='login']")
+
+    wait_until_condition(browser, lambda x: x.is_text_present("Addresses"), timeout=100)
+    # Reload here just in case since there might have been reload with JS
+    # which might cause issues with tests since the elements is in cache
+    browser.reload()
+
+    # This should be first order upcoming
+    assert Order.objects.count() == 0
+
+    # Fnish the checkout
+    customer_name = "Test Tester"
+    customer_street = "Test Street"
+    customer_city = "Test City"
+    customer_region = "CA"
+    customer_country = "US"
+
+    # Fill all necessary information
+    browser.fill("billing-name", customer_name)
+    browser.fill("billing-street", customer_street)
+    browser.fill("billing-city", customer_city)
+    browser.select("billing-country", customer_country)
+    wait_until_appeared(browser, "select[name='billing-region_code']")
+    browser.select("billing-region_code", customer_region)
+
+    click_element(browser, "#addresses button[type='submit']")
+
+    wait_until_condition(browser, lambda x: x.is_text_present("This field is required."))
+
+    browser.fill("shipping-name", customer_name)
+    browser.fill("shipping-street", customer_street)
+    browser.fill("shipping-city", customer_city)
+    browser.select("shipping-country", customer_country)
+
+    click_element(browser, "#addresses button[type='submit']")
+    assert browser.is_text_present("Shipping & Payment")
+
+    pm = get_default_payment_method()
+    sm = get_default_shipping_method()
+
+    assert browser.is_text_present(sm.name)  # shipping method name is present
+    assert browser.is_text_present(pm.name)  # payment method name is present
+
+    click_element(browser, ".btn.btn-primary.btn-lg.pull-right")  # click "continue" on methods page
+
+    assert browser.is_text_present("Confirmation")  # we are indeed in confirmation page
+    product = Product.objects.first()
+
+    # See that all expected texts are present
+    assert browser.is_text_present(product.name)
+    assert browser.is_text_present(sm.name)
+    assert browser.is_text_present(pm.name)
+    assert browser.is_text_present("Delivery")
+    assert browser.is_text_present("Billing")
+
+    # check that user information is available
+    assert browser.is_text_present(customer_name)
+    assert browser.is_text_present(customer_street)
+    assert browser.is_text_present(customer_city)
+    assert browser.is_text_present("United States")
+
+    browser.execute_script('document.getElementById("id_accept_terms").checked=true')  # click accept terms
+    click_element(browser, ".btn.btn-primary.btn-lg")  # click "place order"
+
+    assert browser.is_text_present("Thank you for your order!")  # order succeeded
+
+    # Let's make sure the order now has a customer
+    assert Order.objects.count() == 1
+    order = Order.objects.first()
+    assert order.customer == PersonContact.objects.filter(user__username=test_username).first()
+    assert order.customer.name == customer_name
+    assert order.customer.default_shipping_address is not None
+    assert order.customer.default_billing_address is not None
+    assert order.customer.user.username == test_username


### PR DESCRIPTION
* Core: Populate some unfilled customer fields from order
* Front: Add is_visible_for_user method for checkout view phase
* Front: Add checkout view with option to login and register
* Front: Enable login and register phases for vertical process