### PR TITLE
Attribute form extension (SH-278)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,6 +20,9 @@ Localization
 Admin
 ~~~~~
 
+- Make form modifiers reusable. Users of `ShipmentFormModifier`
+  should update any references to implement the
+  `shuup.admin.form_modifier.FormModifier` interface instead
 - Add mass actions to products list
 - Add mass actions to orders list
 - Add mass actions to contacts list

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,6 +20,7 @@ Localization
 Admin
 ~~~~~
 
+- Allow product attribute form extension through provides
 - Make form modifiers reusable. Users of `ShipmentFormModifier`
   should update any references to implement the
   `shuup.admin.form_modifier.FormModifier` interface instead

--- a/doc/provides.rst
+++ b/doc/provides.rst
@@ -76,9 +76,7 @@ Core
 
 ``admin_extend_create_shipment_form``
     Allows providing extension for shipment creation in admin.
-    Should implement the
-    `~shuup.admin.modules.orders.views.shipment.ShipmentFormModifier`
-    interface.
+    Should implement the `~shuup.admin.form_modifier.FormModifier` interface.
 
 ``admin_product_form_part``
     Additional ``FormPart`` classes for Product editing.
@@ -105,7 +103,7 @@ Core
     `~shuup.core.pricing.DiscountModule` for pricing system.
 
 ``front_extend_product_list_form``
-    Allows providing extension for product list form. Should implement the 
+    Allows providing extension for product list form. Should implement the
     `~shuup.front.utils.sorts_and_filters.ProductListFormModifier`
     interface.
 

--- a/doc/provides.rst
+++ b/doc/provides.rst
@@ -78,6 +78,10 @@ Core
     Allows providing extension for shipment creation in admin.
     Should implement the `~shuup.admin.form_modifier.FormModifier` interface.
 
+``admin_extend_attribute_form``
+    Allows providing extension for the product attribute form in admin.
+    Should implement the `~shuup.admin.form_modifier.FormModifier` interface.
+
 ``admin_product_form_part``
     Additional ``FormPart`` classes for Product editing.
     (This is used by pricing modules, for instance.)

--- a/shuup/admin/form_modifier.py
+++ b/shuup/admin/form_modifier.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import abc
+
+import six
+from django.contrib import messages
+from django.db.transaction import atomic
+
+from shuup.apps.provides import get_provide_objects
+from shuup.utils.excs import Problem
+
+
+class FormModifier(six.with_metaclass(abc.ABCMeta)):
+    def get_extra_fields(self, object=None):
+        """
+        Extra fields for creation view.
+
+        :param object: Object linked to form
+        :type object: django.db.models.Model
+        :return: List of extra fields that should be added to form.
+        Tuple should contain field name and Django form field.
+        :rtype: list[(str,django.forms.Field)]
+        """
+        pass
+
+    def clean_hook(self, form):
+        """
+        Extra clean for creation form.
+
+        This hook will be called in `~Django.forms.Form.clean` method of
+        the form, after calling parent clean.  Implementor of this hook
+        may call `~Django.forms.Form.add_error` to add errors to form or
+        modify the ``form.cleaned_data`` dictionary.
+
+        :param form: Form that is currently cleaned
+        :type form: django.forms.Form
+        :rtype: None
+        """
+        pass
+
+    def form_valid_hook(self, form, object):
+        """
+        Extra form valid handler for creation view.`
+
+        :param form: Form that is currently handled
+        :type form: django.forms.Form
+        :param object: object linked to form
+        :type object: django.db.models.Model
+        :rtype: None
+        """
+        pass
+
+
+class ModifiableFormMixin(object):
+    form_modifier_provide_key = None
+
+    def clean(self):
+        cleaned_data = super(ModifiableFormMixin, self).clean()
+        for extend_class in get_provide_objects(self.form_modifier_provide_key):
+            extend_class().clean_hook(self)
+        return cleaned_data
+
+
+class ModifiableViewMixin(object):
+    def add_extra_fields(self, form, object=None):
+        for extend_class in get_provide_objects(form.form_modifier_provide_key):
+            for field_key, field in extend_class().get_extra_fields(object) or []:
+                form.fields[field_key] = field
+
+    def get_form(self):
+        form = super(ModifiableViewMixin, self).get_form(self.form_class)
+        self.add_extra_fields(form, self.object)
+        return form
+
+    def form_valid_hook(self, form, object):
+        has_extension_errors = False
+        for extend_class in get_provide_objects(form.form_modifier_provide_key):
+            try:
+                extend_class().form_valid_hook(form, object)
+            except Problem as problem:
+                has_extension_errors = True
+                messages.error(self.request, problem)
+        return has_extension_errors
+
+    @atomic
+    def form_valid(self, form):
+        response = super(ModifiableViewMixin, self).form_valid(form)
+        has_extension_errors = self.form_valid_hook(form, self.object)
+
+        if has_extension_errors:
+            return self.form_invalid(form)
+        else:
+            return response

--- a/shuup/admin/modules/attributes/views/edit.py
+++ b/shuup/admin/modules/attributes/views/edit.py
@@ -7,18 +7,21 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 
+from shuup.admin.form_modifier import ModifiableFormMixin, ModifiableViewMixin
 from shuup.admin.utils.views import CreateOrUpdateView
 from shuup.core.models import Attribute
 from shuup.utils.multilanguage_model_form import MultiLanguageModelForm
 
 
-class AttributeForm(MultiLanguageModelForm):
+class AttributeForm(ModifiableFormMixin, MultiLanguageModelForm):
+    form_modifier_provide_key = "admin_extend_attribute_form"
+
     class Meta:
         model = Attribute
         exclude = ()  # All the fields!
 
 
-class AttributeEditView(CreateOrUpdateView):
+class AttributeEditView(ModifiableViewMixin, CreateOrUpdateView):
     model = Attribute
     form_class = AttributeForm
     template_name = "shuup/admin/attributes/edit.jinja"

--- a/shuup_tests/admin/test_shipment_creator.py
+++ b/shuup_tests/admin/test_shipment_creator.py
@@ -6,24 +6,25 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 
-import pytest
 import re
 
+import pytest
 from bs4 import BeautifulSoup
 from django import forms
 
+from shuup.admin.form_modifier import FormModifier
 from shuup.admin.modules.orders.views.shipment import (
-    FORM_MODIFIER_PROVIDER_KEY, OrderCreateShipmentView, ShipmentFormModifier
+    OrderCreateShipmentView, ShipmentForm
 )
 from shuup.apps.provides import override_provides
 from shuup.core.excs import NoShippingAddressException
-
 from shuup.core.models import Order
 from shuup.testing.factories import (
     create_order_with_product, create_product, get_default_shop,
     get_default_supplier
 )
 from shuup.testing.utils import apply_request_middleware
+
 
 @pytest.mark.django_db
 def test_shipment_creating_view_get(rf, admin_user):
@@ -79,7 +80,7 @@ def test_extending_shipment_with_extra_fields(rf, admin_user):
         product, supplier, quantity=quantity, taxless_base_unit_price=1, shop=shop)
 
     extend_form_class = "shuup_tests.admin.test_shipment_creator.ShipmentFormModifierTest"
-    with override_provides(FORM_MODIFIER_PROVIDER_KEY, [extend_form_class]):
+    with override_provides(ShipmentForm.form_modifier_provide_key, [extend_form_class]):
         request = apply_request_middleware(rf.get("/"), user=admin_user)
         view = OrderCreateShipmentView.as_view()
         response = view(request, pk=order.pk).render()
@@ -102,7 +103,7 @@ def test_extending_shipment_clean_hook(rf, admin_user):
         product, supplier, quantity=quantity, taxless_base_unit_price=1, shop=shop)
 
     extend_form_class = "shuup_tests.admin.test_shipment_creator.ShipmentFormModifierTest"
-    with override_provides(FORM_MODIFIER_PROVIDER_KEY, [extend_form_class]):
+    with override_provides(ShipmentForm.form_modifier_provide_key, [extend_form_class]):
         data = {
             "q_%s" % product.pk: 1,
             "supplier": supplier.pk,
@@ -126,7 +127,7 @@ def test_extending_shipment_form_valid_hook(rf, admin_user):
         product, supplier, quantity=quantity, taxless_base_unit_price=1, shop=shop)
 
     extend_form_class = "shuup_tests.admin.test_shipment_creator.ShipmentFormModifierTest"
-    with override_provides(FORM_MODIFIER_PROVIDER_KEY, [extend_form_class]):
+    with override_provides(ShipmentForm.form_modifier_provide_key, [extend_form_class]):
         phone_number = "+358911"
         data = {
             "q_%s" % product.pk: 1,
@@ -149,7 +150,7 @@ def test_extending_shipment_form_valid_hook(rf, admin_user):
         assert shipment.products.first().product_id == product.id
 
 
-class ShipmentFormModifierTest(ShipmentFormModifier):
+class ShipmentFormModifierTest(FormModifier):
     def get_extra_fields(self, order):
         return [("phone", forms.CharField(label="Phone", max_length=64, required=False))]
 
@@ -174,13 +175,13 @@ def test_shipment_creating_with_no_shipping_address(rf, admin_user):
     supplier = get_default_supplier()
     product = create_product(sku="test-sku", shop=shop, supplier=supplier, default_price=3.33)
     order = create_order_with_product(product, supplier, quantity=1, taxless_base_unit_price=1, shop=shop)
-    
-    # remove shipping address 
+
+    # remove shipping address
     order.shipping_address = None
     order.save()
 
     with pytest.raises(NoShippingAddressException):
         order.create_shipment_of_all_products()
-    
+
     # order should not have any shipments since it should have thrown an exception
     assert order.shipments.count() == 0


### PR DESCRIPTION
Refactor `ShipmentFormModifier`  to make it reusable
Allow the attribute form extension

Refs SH-278