### PR TITLE
Front: Restrict the pagination range to five pages (SH-411)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -31,7 +31,8 @@ Addons
 Front
 ~~~~~
 
-- Enable option to use login and regiser checkout phases 
+- Restrict the paginator to show at most five pages
+- Enable option to use login and register checkout phases
   with vertical checkout process
 - Add checkout view with option to login and register
 - Add is_visible_for_user method for checkout view phase

--- a/shuup/front/template_helpers/general.py
+++ b/shuup/front/template_helpers/general.py
@@ -5,6 +5,9 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+import math
+
+import six
 from django.conf import settings
 from django.core.paginator import Paginator
 from django.utils.translation import get_language, get_language_info, ugettext
@@ -157,9 +160,24 @@ def get_pagination_variables(context, objects, limit):
         current_page = 1
     page = paginator.page(min((current_page or 1), paginator.num_pages))
     variables["page"] = page
+    variables["page_range"] = _get_page_range(current_page, paginator.num_pages)
     variables["objects"] = page.object_list
 
     return variables
+
+
+def _get_page_range(current_page, num_pages, range_gap=5):
+    current_page = min(current_page, num_pages + 1)
+    if current_page <= math.ceil(range_gap / 2):
+        start = 1
+        end = range_gap + 1
+    elif num_pages - math.ceil(range_gap / 2) < current_page:
+        start = num_pages - range_gap + 1
+        end = num_pages + 1
+    else:
+        start = current_page - range_gap // 2
+        end = current_page + range_gap // 2 + 1
+    return six.moves.range(start, min(end, num_pages + 1))
 
 
 @contextfunction

--- a/shuup/front/templates/shuup/front/macros/category.jinja
+++ b/shuup/front/templates/shuup/front/macros/category.jinja
@@ -125,7 +125,7 @@
             </div>
             <div class="clearfix">
                 {% if pagination.is_paginated %}
-                    {{ render_pagination(pagination.page, pagination.paginator) }}
+                    {{ render_pagination(pagination.page, pagination.paginator, pagination.page_range) }}
                 {% endif %}
             </div>
     </div>

--- a/shuup/front/templates/shuup/front/macros/general.jinja
+++ b/shuup/front/templates/shuup/front/macros/general.jinja
@@ -85,7 +85,7 @@
     {% endif %}
 {% endmacro %}
 
-{% macro render_pagination(page, paginator) %}
+{% macro render_pagination(page, paginator, page_range=None) %}
     <script>
         window.PAGE_NUMBER = "{{ page.number }}";
     </script>
@@ -106,7 +106,7 @@
                     </span>
                 </li>
             {% endif %}
-            {% for i in paginator.page_range %}
+            {% for i in page_range or paginator.page_range %}
                 <li id="pagination_page_{{ i }}" class="{% if i == page.number %}active{% endif %}">
                     <a href="#" onclick="refreshFilters({{ i }}); return false;">{{ i }}</a>
                 </li>

--- a/shuup_tests/front/test_general_template_helpers.py
+++ b/shuup_tests/front/test_general_template_helpers.py
@@ -160,25 +160,33 @@ def test_get_pagination_variables():
     vars = {"products": products}
 
     context = get_jinja_context(**vars)
-    variables = general.get_pagination_variables(context, context["products"], limit=4)
+    variables = general.get_pagination_variables(context, context["products"], limit=2)
     assert variables["page"].number == 1
-    assert len(variables["objects"]) == 4
+    assert len(variables["objects"]) == 2
+    assert variables["page_range"][0] == 1
+    assert variables["page_range"][-1] == 5
 
     context = get_jinja_context(path="/?page=5", **vars)
-    variables = general.get_pagination_variables(context, context["products"], limit=4)
+    variables = general.get_pagination_variables(context, context["products"], limit=2)
     assert variables["page"].number == 5
-    assert len(variables["objects"]) == 3
+    assert len(variables["objects"]) == 2
+    assert variables["page_range"][0] == 3
+    assert variables["page_range"][-1] == 7
 
     variables = general.get_pagination_variables(context, context["products"], limit=20)
     assert not variables["is_paginated"]
     assert variables["page"].number == 1
+    assert variables["page_range"][0] == variables["page_range"][-1] == 1
 
     context = get_jinja_context(path="/?page=42", **vars)
     variables = general.get_pagination_variables(context, context["products"], limit=4)
     assert variables["page"].number == 5
     assert len(variables["objects"]) == 3
+    assert variables["page_range"][0] == 1
+    assert variables["page_range"][-1] == 5
 
     vars = {"products": []}
     context = get_jinja_context(path="/", **vars)
     variables = general.get_pagination_variables(context, context["products"], limit=4)
     assert not variables["is_paginated"]
+    assert variables["page_range"][0] == variables["page_range"][-1] == 1


### PR DESCRIPTION
Paginator page range is now a sliding window of five pages
such that the selected page is always shown as the "middle"
value except when on either end of the page range.

Refs SH-411