### PR TITLE
Use correct model in ProductCrossSellFormSet

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -21,6 +21,7 @@ Localization
 Admin
 ~~~~~
 
+- Fix bug in product cross-sell editview
 - Allow product attribute form extension through provides
 - Make form modifiers reusable. Users of `ShipmentFormModifier`
   should update any references to implement the

--- a/shuup/admin/modules/products/views/edit_cross_sell.py
+++ b/shuup/admin/modules/products/views/edit_cross_sell.py
@@ -18,9 +18,7 @@ from shuup.admin.base import MenuEntry
 from shuup.admin.forms.widgets import ProductChoiceWidget
 from shuup.admin.toolbar import PostActionButton, Toolbar
 from shuup.admin.utils.urls import get_model_url
-from shuup.core.models import (
-    Product, ProductCrossSell, ProductCrossSellType, ProductMedia
-)
+from shuup.core.models import Product, ProductCrossSell, ProductCrossSellType
 
 
 class ProductCrossSellForm(ModelForm):
@@ -49,7 +47,7 @@ class ProductCrossSellFormSet(BaseModelFormSet):
     validate_max = False
     max_num = DEFAULT_MAX_NUM
     absolute_max = DEFAULT_MAX_NUM
-    model = ProductMedia
+    model = ProductCrossSell
     can_delete = True
     can_order = False
     extra = 5


### PR DESCRIPTION
ProductCrossSellFormSet is using wrong model in ProductCrossSellEditView, which can cause errors in some shops. Change ProductCrossSellFormSet model to use ProductCrossSell instead of ProductMedia model.

Now when trying to delete a product from product's cross-sell, form errors are:
[{'id': ['Select a valid choice. That choice is not one of the available choices.']}, {'id': ['Select a valid choice. That choice is not one of the available choices.']},... and nothing happens. After I changed to use ProductCrossSell model everything works correct.