### PR TITLE
Add allow-root to the bower config in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends python3-minimal python3-virtualenv python3-pip python3-dev python3-pil && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+RUN echo '{ "allow_root": true }' > /root/.bowerrc
 RUN python3 -m virtualenv -p /usr/bin/python3 --system-site-packages /var/www/shuup/venv && \
     /var/www/shuup/venv/bin/pip install -U pip setuptools
 RUN /var/www/shuup/venv/bin/pip install /var/www/shuup/working_copy


### PR DESCRIPTION
By default, bower disallows running it as root. On a traditional system this makes sense: it uses the unix user model to separate bower packages from the system. By not being root, foreign scripts can't really attack the system. In Docker, the separation is provided by the container system, so running foreign scripts as root isn't as much of an issue. By being in a container, foreign scripts can't attack the system.

Allowing root disables the user-based separation model.
Without this change, bower fails with an `ESUDO` error when `docker build` is run.