### PR TITLE
Front: Show variation parents in highlight plugin (PP-49)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -37,6 +37,7 @@ Addons
 Front
 ~~~~~
 
+- Show variation parents in highlight plugins
 - Fallback to variation parent image for variation children
   in basket, checkout and saved carts.
 - Fix search result styling for products with long names

--- a/shuup/front/utils/product_statistics.py
+++ b/shuup/front/utils/product_statistics.py
@@ -26,13 +26,13 @@ def get_best_selling_product_info(shop_ids, cutoff_days=30):
             OrderLine.objects
             .filter(
                 order__shop_id__in=shop_ids,
-                order__order_date__gte=cutoff_date
+                order__order_date__gte=cutoff_date,
+                type=OrderLineType.PRODUCT
             )
-            .exclude(product=None)
             .values("product")
             .annotate(n=Sum("quantity"))
             .order_by("-n")[:100]
-            .values_list("product", "n")
+            .values_list("product", "product__variation_parent_id", "n")
         )
         cache.set(cache_key, sales_data, 3 * 60 * 60)  # three hours
     return sales_data

--- a/shuup_tests/front/test_general_template_helpers.py
+++ b/shuup_tests/front/test_general_template_helpers.py
@@ -128,19 +128,39 @@ def test_best_selling_products_with_multiple_orders():
     # Third product outsold by first two products
     assert product_3 not in general.get_best_selling_products(context, n_products=n_products)
 
+    children = [create_product("SimpleVarChild-%d" % x, supplier=supplier, shop=shop) for x in range(5)]
+    for child in children:
+        child.link_to_parent(product_3)
+        create_order_with_product(child, supplier, quantity=1, taxless_base_unit_price=price, shop=shop)
+    cache.clear()
+    # Third product now sold in greatest quantity
+    assert product_3 == general.get_best_selling_products(context, n_products=n_products)[0]
+
 
 @pytest.mark.django_db
 def test_get_newest_products():
-    populate_if_required()
+    supplier = get_default_supplier()
+    shop = get_default_shop()
+    products = [create_product("sku-%d" % x, supplier=supplier, shop=shop) for x in range(2)]
+    children = [create_product("SimpleVarChild-%d" % x, supplier=supplier, shop=shop) for x in range(2)]
+    for child in children:
+        child.link_to_parent(products[0])
     context = get_jinja_context()
-    assert len(list(general.get_newest_products(context, n_products=4))) == 4
+    # only 2 parent products exist
+    assert len(list(general.get_newest_products(context, n_products=10))) == 2
 
 
 @pytest.mark.django_db
 def test_get_random_products():
-    populate_if_required()
+    supplier = get_default_supplier()
+    shop = get_default_shop()    
+    products = [create_product("sku-%d" % x, supplier=supplier, shop=shop) for x in range(2)]
+    children = [create_product("SimpleVarChild-%d" % x, supplier=supplier, shop=shop) for x in range(2)]
+    for child in children:
+        child.link_to_parent(products[0])
     context = get_jinja_context()
-    assert len(list(general.get_random_products(context, n_products=4))) == 4
+    # only 2 parent products exist
+    assert len(list(general.get_random_products(context, n_products=10))) == 2
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Show variation parents in product highlight plugins to avoid the variants from flooding the results.

thanks to @tulimaki and @Pikkupomo for their input!

Refs PP-49