### PR TITLE
Admin: Remove language layer for shops (SH-369)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -23,6 +23,7 @@ Localization
 Admin
 ~~~~~
 
+- Remove language layer from shop configurations
 - Fix bug in product cross-sell editview
 - Allow product attribute form extension through provides
 - Make form modifiers reusable. Users of `ShipmentFormModifier`

--- a/shuup/admin/modules/shops/views/__init__.py
+++ b/shuup/admin/modules/shops/views/__init__.py
@@ -8,6 +8,6 @@
 
 from .edit import ShopEditView, ShopEnablerView
 from .list import ShopListView
-from .wizard import ShopLanguagesWizardPane, ShopWizardPane
+from .wizard import ShopWizardPane
 
-__all__ = ["ShopEditView", "ShopEnablerView", "ShopLanguagesWizardPane", "ShopListView", "ShopWizardPane"]
+__all__ = ["ShopEditView", "ShopEnablerView", "ShopListView", "ShopWizardPane"]

--- a/shuup/admin/modules/shops/views/edit.py
+++ b/shuup/admin/modules/shops/views/edit.py
@@ -15,7 +15,6 @@ from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext as _
 from django.views.generic import View
 
-from shuup import configuration
 from shuup.admin.form_part import (
     FormPart, FormPartsViewMixin, SaveFormPartsMixin, TemplatedFormDef
 )
@@ -39,7 +38,7 @@ class ShopBaseFormPart(FormPart):
             required=True,
             kwargs={
                 "instance": self.object,
-                "languages": configuration.get(self.object, "languages", settings.LANGUAGES)
+                "languages": settings.LANGUAGES
             }
         )
 

--- a/shuup/admin/modules/shops/views/wizard.py
+++ b/shuup/admin/modules/shops/views/wizard.py
@@ -8,41 +8,13 @@
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
-from shuup import configuration
 from shuup.admin.modules.shops.forms import (
-    ShopAddressWizardForm, ShopLanguagesWizardForm, ShopWizardForm
+    ShopAddressWizardForm, ShopWizardForm
 )
 from shuup.admin.views.wizard import (
     TemplatedWizardFormDef, WizardFormDef, WizardPane
 )
 from shuup.core.models import TaxClass
-
-
-class ShopLanguagesWizardPane(WizardPane):
-    identifier = "languages"
-    text = _("Please select the languages supported by your shop")
-
-    def visible(self):
-        return not configuration.get(self.object, "languages", None)
-
-    def get_form_defs(self):
-        return [
-            WizardFormDef(
-                name="shop_languages",
-                extra_js="shuup/admin/shops/_change_languages_script.jinja",
-                form_class=ShopLanguagesWizardForm,
-                kwargs={
-                    "initial": {
-                        "languages": configuration.get(self.object, "languages", [settings.LANGUAGE_CODE])
-                    }
-                }
-            )
-        ]
-
-    def form_valid(self, form):
-        languages = form["shop_languages"].cleaned_data.get("languages")
-        shop_languages = [(code, name) for code, name in settings.LANGUAGES if code in languages]
-        configuration.set(self.object, "languages", shop_languages)
 
 
 class ShopWizardPane(WizardPane):
@@ -62,7 +34,7 @@ class ShopWizardPane(WizardPane):
                 form_class=ShopWizardForm,
                 kwargs={
                     "instance": self.object,
-                    "languages": configuration.get(self.object, "languages", settings.LANGUAGES)
+                    "languages": settings.LANGUAGES
                 }
             ),
             WizardFormDef(

--- a/shuup/front/template_helpers/general.py
+++ b/shuup/front/template_helpers/general.py
@@ -15,7 +15,6 @@ from django.utils.translation import get_language, get_language_info, ugettext
 from jinja2.utils import contextfunction
 from mptt.templatetags.mptt_tags import cache_tree_children
 
-from shuup import configuration
 from shuup.core.models import Category, Manufacturer, Product, Supplier
 from shuup.front.utils.product_statistics import get_best_selling_product_info
 from shuup.front.utils.views import cache_product_things
@@ -196,9 +195,8 @@ def _get_page_range(current_page, num_pages, range_gap=5):
 
 @contextfunction
 def get_shop_language_choices(context):
-    request = context["request"]
     languages = []
-    for code, name in configuration.get(request.shop, "languages", settings.LANGUAGES):
+    for code, name in settings.LANGUAGES:
         lang_info = get_language_info(code)
         name_in_current_lang = ugettext(name)
         local_name = lang_info["name_local"]

--- a/shuup/testing/factories.py
+++ b/shuup/testing/factories.py
@@ -27,7 +27,6 @@ from faker.utils.loading import find_available_locales
 from filer.models import imagemodels
 from six import BytesIO
 
-from shuup import configuration
 from shuup.core.defaults.order_statuses import create_default_order_statuses
 from shuup.core.models import (
     AnonymousContact, Attribute, AttributeType, AttributeVisibility, Category,
@@ -401,8 +400,6 @@ def get_default_shop():
             public_name=DEFAULT_NAME
         )
         assert str(shop) == DEFAULT_NAME
-    if not configuration.get(shop, "languages"):
-        configuration.set(shop, "languages", settings.LANGUAGES)
     return shop
 
 

--- a/shuup_tests/admin/test_shop_edit.py
+++ b/shuup_tests/admin/test_shop_edit.py
@@ -38,7 +38,6 @@ def test_protected_fields():
     shop_form = ShopBaseForm(data=data, instance=shop, languages=settings.LANGUAGES)
     _test_cleanliness(shop_form)
     shop_form.save()
-    assert ConfigurationItem.objects.filter(shop=shop, key="languages").first().value == list(map(list, settings.LANGUAGES))
 
     # Now let's make it protected!
     create_product(printable_gibberish(), shop=shop, supplier=get_default_supplier())

--- a/shuup_tests/admin/test_wizard.py
+++ b/shuup_tests/admin/test_wizard.py
@@ -49,28 +49,6 @@ def test_get_wizard_no_panes(rf, settings):
 
 
 @pytest.mark.django_db
-def test_languages_wizard_pane(rf, admin_user, settings):
-    settings.SHUUP_SETUP_WIZARD_PANE_SPEC = [
-        "shuup.admin.modules.shops.views:ShopLanguagesWizardPane"
-    ]
-    shop = get_default_shop()
-    configuration.set(shop, "languages", None)
-    assert not configuration.get(shop, "languages", None)
-    fields = _extract_fields(rf, admin_user)
-    fields["shop_languages-languages"] = []
-    request = rf.post("/", data=fields)
-    response = WizardView.as_view()(request)
-    # fields are missing
-    assert response.status_code == 400
-
-    fields["shop_languages-languages"] = ["en", "fi"]
-    request = rf.post("/", data=fields)
-    response = WizardView.as_view()(request)
-    assert response.status_code == 200
-    assert len(configuration.get(shop, "languages", None)) == 2
-
-
-@pytest.mark.django_db
 def test_shop_wizard_pane(rf, admin_user, settings):
     settings.SHUUP_SETUP_WIZARD_PANE_SPEC = [
         "shuup.admin.modules.shops.views:ShopWizardPane"

--- a/shuup_workbench/settings/base_settings.py
+++ b/shuup_workbench/settings/base_settings.py
@@ -192,7 +192,6 @@ REST_FRAMEWORK = {
 }
 
 SHUUP_SETUP_WIZARD_PANE_SPEC = [
-    "shuup.admin.modules.shops.views:ShopLanguagesWizardPane",
     "shuup.admin.modules.shops.views:ShopWizardPane",
     "shuup.admin.modules.service_providers.views.PaymentWizardPane",
     "shuup.admin.modules.service_providers.views.CarrierWizardPane",


### PR DESCRIPTION
Doing changes logic around settings like LANGUAGE, LANGUAGES and
PARLER_DEFAULT_LANGUAGE_CODE will not work correctly without
actually change these settings and reload the application.

Also changing these settings can be done different ways depending
on project needs so this will be not provided from Shuup base.
