### PR TITLE
Add "name_ext" field to address edit form

### DIFF
--- a/shuup/core/utils/forms.py
+++ b/shuup/core/utils/forms.py
@@ -17,7 +17,7 @@ class MutableAddressForm(forms.ModelForm):
     class Meta:
         model = MutableAddress
         fields = (
-            "name", "phone", "email",
+            "name", "name_ext", "phone", "email",
             "street", "street2", "postal_code", "city",
             "region", "region_code", "country"
         )


### PR DESCRIPTION
The name extension field is displayed on an address if it's filled, however, it isn't editable
Basically this means an address can only be edited partially

Fix this by adding the "name_ext" field to the address edit form

No refs