### PR TITLE
Admin Fix Menu (SH-435, SH-433, SH-436, SH-427)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -23,6 +23,7 @@ Localization
 Admin
 ~~~~~
 
+- Change main menu template and remove ajax loading from main menu.
 - Remove language layer from shop configurations
 - Fix bug in product cross-sell editview
 - Allow product attribute form extension through provides

--- a/shuup/admin/static_src/base/js/main-menu.js
+++ b/shuup/admin/static_src/base/js/main-menu.js
@@ -8,7 +8,6 @@
  */
 $(function() {
     "use strict";
-    var menuLoaded = false;
 
     function openMainNav() {
         $(document.body).addClass("menu-open");
@@ -22,20 +21,8 @@ $(function() {
         return $(document.body).hasClass("menu-open");
     }
 
-    function loadMenu(force) {
-        if (!menuLoaded || force) {
-            $("#main-menu").empty().load(window.ShuupAdminConfig.menuUrl, function() {
-                $("#main-menu .scroll-inner-content").scrollbar("init", {
-                    disableBodyScroll: true
-                });
-            });
-            menuLoaded = true;
-        }
-    }
-
     $("#menu-button").click(function(event) {
         closeAllSubmenus();
-        loadMenu();
         $("#site-search.mobile").removeClass("open"); // Close search if open on mobile
         event.stopPropagation();
         if (mainNavIsOpen()) {
@@ -43,9 +30,6 @@ $(function() {
         } else {
             openMainNav();
         }
-    }).hover(function() {
-        // Start pre-emptively loading the contents of the main menu when the user seems he's about to open it.
-        loadMenu();
     });
 
     function closeAllSubmenus() {
@@ -55,6 +39,7 @@ $(function() {
     }
     $(document).on("click", "#main-menu ul.menu-list > li a", function(e) {
         e.preventDefault();
+        e.stopPropagation();  // do not close submenus
         const target_id = $(this).data("target-id");
         $(".category-submenu").each(function(idx, elem){
             if($(elem).attr("id") != target_id) {
@@ -68,20 +53,21 @@ $(function() {
         const isOpen = $target.hasClass("open");
         $target.toggleClass("open", !isOpen);
     });
-    $(document).ready(function(){
-        loadMenu();
-        if($(window).width() > 768) {
-            openMainNav();
-        }
-    });
-    $(document).on("click", ".category-menu-close", function(e){
+
+    $(window).click(function() {
         closeAllSubmenus();
     });
-    window.onresize = (function() {
-        if($(window).width() > 768) {
-            openMainNav();
+
+    $('.category-submenu').click(function(event){
+        event.stopPropagation();
+        if($(event.target).hasClass("fa-close")) {
+            closeAllSubmenus();
         }
-        else {
+    });
+
+    window.onresize = (function() {
+        closeAllSubmenus();
+        if($(window).width() < 768) {
             closeMainNav();
         }
     });

--- a/shuup/admin/static_src/base/less/shuup/base.less
+++ b/shuup/admin/static_src/base/less/shuup/base.less
@@ -55,12 +55,9 @@ img {
 }
 
 #main-content {
-
-    @media (min-width: @screen-sm-min) {
-        padding: 15px;
-        body.menu-open & {
-            padding-left:88px;
-        }
+    margin-left: 88px;
+    @media (max-width: @screen-sm-min) {
+        margin-left: 0;
     }
 
     &.dashboard { padding: 30px 15px; }

--- a/shuup/admin/static_src/base/less/shuup/main-menu.less
+++ b/shuup/admin/static_src/base/less/shuup/main-menu.less
@@ -215,6 +215,9 @@
 
 .quicklink-submenu {
     background: white;
+    @media (max-width: @screen-sm-min) {
+        max-width: 270px;
+    }
 
     .category-menu-title {
         color: @text-color;
@@ -228,10 +231,27 @@
 
             h3 {
                 font-size: 1.6rem;
-            }
 
+                @media (max-width: @screen-sm-min) {
+                    font-size: 1.2rem;
+                }
+            }
             .btn {
                 display: block;
+
+                @media (max-width: @screen-sm-min) {
+                    font-size: 1.2rem;
+                }
+            }
+            .content-with-logo {
+                @media (max-width: @screen-sm-min) {
+                    margin-left: 0;
+                }
+            }
+            .action {
+               @media (max-width: @screen-sm-min) {
+                    clear: both;
+                }
             }
         }
     }

--- a/shuup/admin/static_src/base/less/shuup/main-menu.less
+++ b/shuup/admin/static_src/base/less/shuup/main-menu.less
@@ -166,6 +166,7 @@
     transition-duration: .3s;
     transition-property: transform;
     transition-timing-function: ease-in-out;
+    padding-bottom: 40px;
 
     &.open {
         transform: translateX(88px);

--- a/shuup/admin/static_src/base/less/shuup/main-menu.less
+++ b/shuup/admin/static_src/base/less/shuup/main-menu.less
@@ -1,18 +1,22 @@
 #main-menu {
     background: @nav-bg;
     position: fixed;
-    left: -88px;
+    left: 0;
     bottom: 0;
     top: 60px;
     width: 88px;
     z-index:1000;
 
-    body.menu-open & {
-        left: 0px;
+    @media (max-width: @screen-sm-min) {
+        left: -88px;
+    }
 
-        @media (max-width: @screen-sm-max) {
-            overflow: hidden;
-        }
+    @media (min-width: @screen-sm-min) {
+        left: 0;
+    }
+
+    body.menu-open & {
+        left: 0;
     }
 
     .scroll-wrapper {
@@ -150,7 +154,8 @@
 }
 
 .category-submenu {
-    top: 0px;
+    z-index: 10;
+    top: 60px;
     position: absolute;
     background: @nav-bg;
     box-shadow: 0 0 3px #000;

--- a/shuup/admin/templates/shuup/admin/base.jinja
+++ b/shuup/admin/templates/shuup/admin/base.jinja
@@ -19,7 +19,7 @@
     <body class="{% block body_class %}{% endblock %} {{ "popup" if request.GET.popup else "" }}">
         {% block top %}
         <header id="top-header">{% include "shuup/admin/base/_navigation.jinja" %}</header>
-        <nav id="main-menu">{# this content is loaded dynamically; see base/_main_menu.jinja #}</nav>
+        {% include "shuup/admin/base/_main_menu.jinja" %}
         {% endblock %}
 
         {% block content_wrap %}

--- a/shuup/admin/templates/shuup/admin/base/_main_menu.jinja
+++ b/shuup/admin/templates/shuup/admin/base/_main_menu.jinja
@@ -2,27 +2,7 @@
 
 {% set categories = shuup_admin.get_menu_entry_categories() %}
 {% set quicklinks = shuup_admin.get_quicklinks() %}
-<div class="scroll-inner-content">
-    <ul class="menu-list">
-        {% if quicklinks %}
-        <li class="quicklinks">
-            <a href="#" data-target-id="quicklinks">
-                <i class="fa fa-bolt"></i>
-                <span class="item-name parent">{% trans %}Quicklinks{% endtrans %}</span>
-            </a>
-        </li>
-        {% endif %}
-        {% for category in categories %}
-        {% set only_entry = (category.entries|first if category.entries|length == 1 else None) %}
-        <li>
-            <a href="{% if not only_entry %}#{% else %}{{ only_entry.url }}{% endif %}" data-target-id="category-{{ category.identifier }}">
-                <i class="{{ category.icon }}"></i>
-                <span class="item-name parent">{{ category.name }}</span>
-            </a>
-        </li>
-        {% endfor %}
-    </ul>
-</div>
+
 {% for category in categories %}
 <div class="category-submenu" id="category-{{ category.identifier }}">
     <div class="category-menu-title">{{ category.name }}</div>
@@ -47,3 +27,26 @@
         {% endfor %}
     </div>
 </div>
+<nav id="main-menu">
+    <div class="scroll-inner-content">
+        <ul class="menu-list">
+            {% if quicklinks %}
+            <li class="quicklinks">
+                <a href="#" data-target-id="quicklinks">
+                    <i class="fa fa-bolt"></i>
+                    <span class="item-name parent">{% trans %}Quicklinks{% endtrans %}</span>
+                </a>
+            </li>
+            {% endif %}
+            {% for category in categories %}
+            {% set only_entry = (category.entries|first if category.entries|length == 1 else None) %}
+            <li>
+                <a href="{% if not only_entry %}#{% else %}{{ only_entry.url }}{% endif %}" data-target-id="category-{{ category.identifier }}">
+                    <i class="{{ category.icon }}"></i>
+                    <span class="item-name parent">{{ category.name }}</span>
+                </a>
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+</nav>

--- a/shuup_tests/browser/admin/test_menu.py
+++ b/shuup_tests/browser/admin/test_menu.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+
+import pytest
+
+from shuup.testing.browser_utils import wait_until_condition
+from shuup.testing.factories import get_default_shop
+from shuup.testing.utils import initialize_admin_browser_test
+
+pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
+
+
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_menu(browser, admin_user, live_server, settings):
+    shop = get_default_shop()
+
+    initialize_admin_browser_test(browser, live_server, settings)
+
+    browser.find_by_css(".menu-list li").first.click()
+    wait_until_condition(browser, lambda x: x.is_text_present("Add a product to see it in your store"))
+
+    # Make sure that the menu is clickable in small devices
+    browser.driver.set_window_size(480, 960)
+    browser.find_by_css("#menu-button").first.click()
+    browser.find_by_css(".menu-list li").first.click()
+    wait_until_condition(browser, lambda x: x.is_text_present("Add a product to see it in your store"))

--- a/shuup_tests/browser/admin/test_order_list.py
+++ b/shuup_tests/browser/admin/test_order_list.py
@@ -39,7 +39,7 @@ def test_orders_list_view(browser, admin_user, live_server, settings):
 def _visit_orders_list_view(browser, live_server):
     url = reverse("shuup_admin:order.list")
     browser.visit("%s%s" % (live_server, url))
-    assert browser.is_text_present("Orders")
+    wait_until_condition(browser, condition=lambda x: x.is_text_present("Orders"))
     wait_until_appeared(browser, ".picotable-item-info")
 
 

--- a/shuup_tests/browser/admin/test_picotable.py
+++ b/shuup_tests/browser/admin/test_picotable.py
@@ -11,7 +11,7 @@ import time
 import pytest
 from django.core.urlresolvers import reverse
 
-from shuup.testing.browser_utils import click_element, wait_until_appeared
+from shuup.testing.browser_utils import click_element, wait_until_appeared, wait_until_condition
 from shuup.testing.factories import create_random_person, get_default_shop
 from shuup.testing.utils import initialize_admin_browser_test
 
@@ -35,7 +35,7 @@ def test_list_view(browser, admin_user, live_server, settings):
 def _visit_contacts_list_view(browser, live_server):
     url = reverse("shuup_admin:contact.list")
     browser.visit("%s%s" % (live_server, url))
-    assert browser.is_text_present("Contacts")
+    wait_until_condition(browser, lambda x: x.is_text_present("Contacts"))
     wait_until_appeared(browser, ".picotable-item-info")
 
 
@@ -95,4 +95,4 @@ def _set_settings(browser):
     browser.find_by_id("id_view_configuration_contact_identifier").click()
     browser.find_by_css(".btn.btn-success").click()
     wait_until_appeared(browser, ".picotable-item-info")
-    assert browser.is_text_present("Internal Identifier")
+    wait_until_condition(browser, lambda x: x.is_text_present("Internal Identifier"))

--- a/shuup_tests/browser/front/test_category_view.py
+++ b/shuup_tests/browser/front/test_category_view.py
@@ -124,12 +124,12 @@ def test_category_product_list(browser, live_server, settings):
     browser = initialize_front_browser_test(browser, live_server)
 
     # check that front page actually loaded
-    assert browser.is_text_present("Welcome to Default!")
+    wait_until_condition(browser, lambda x: x.is_text_present("Welcome to Default!"))
 
     url = reverse("shuup:category", kwargs={"pk": first_cat.pk, "slug": first_cat.slug})
     browser.visit("%s%s" % (live_server, url))
-    assert browser.is_text_present("First Category")
-    assert browser.is_text_present("Sort")
+    wait_until_condition(browser, lambda x: x.is_text_present("First Category"))
+    wait_until_condition(browser, lambda x: x.is_text_present("Sort"))
     assert not browser.is_text_present("Manufacturers")  # Since not in default configuration
     hide_sorts_for_shop(browser, shop)
     show_sorts_for_the_category_only(browser, first_cat)
@@ -155,7 +155,7 @@ def hide_sorts_for_shop(browser, shop):
 def show_sorts_for_the_category_only(browser, category):
     set_configuration(category=category, data={"sort_products_by_name": True})
     browser.reload()
-    assert browser.is_text_present("Sort")
+    wait_until_condition(browser, lambda x: x.is_text_present("Sort"))
     wait_until_condition(browser, lambda x: len(x.find_by_css("#id_sort option")) == 2)
     click_element(browser, "button[data-id='id_sort']")
 
@@ -226,7 +226,7 @@ def manufacturer_filter_test(browser, category, manufacturer):
         }
     )
     browser.reload()
-    assert browser.is_text_present("Manufacturers")
+    wait_until_condition(browser, lambda x: x.is_text_present("Manufacturers"))
     browser.execute_script("$('#manufacturers-%s').click();" % manufacturer.id)
     wait_until_condition(browser, lambda x: len(x.find_by_css(".product-card")) == 1)
 

--- a/shuup_tests/browser/front/test_checkout.py
+++ b/shuup_tests/browser/front/test_checkout.py
@@ -14,8 +14,8 @@ from django.test import override_settings
 from shuup.core.models import OrderStatus, OrderStatusRole
 from shuup.testing.browser_utils import (
     click_element, move_to_element, wait_until_appeared,
-    wait_until_disappeared
-)
+    wait_until_disappeared,
+    wait_until_condition)
 from shuup.testing.factories import (
     create_product, get_default_payment_method, get_default_shipping_method,
     get_default_shop, get_default_supplier
@@ -53,9 +53,9 @@ def test_browser_checkout_horizontal(browser, live_server, settings):
     browser = initialize_front_browser_test(browser, live_server)
 
     # check that front page actually loaded
-    assert browser.is_text_present("Welcome to Default!")
-    assert browser.is_text_present("Newest Products")
-    assert browser.is_text_present(product_name)
+    wait_until_condition(browser, lambda x: x.is_text_present("Welcome to Default!"))
+    wait_until_condition(browser, lambda x: x.is_text_present("Newest Products"))
+    wait_until_condition(browser, lambda x: x.is_text_present(product_name))
 
     click_element(browser, "#product-%s" % product.pk)  # open product from product list
     click_element(browser, "#add-to-cart-button-%s" % product.pk)  # add product to basket
@@ -65,8 +65,8 @@ def test_browser_checkout_horizontal(browser, live_server, settings):
 
     click_element(browser, "#navigation-basket-partial")  # open upper basket navigation menu
     click_element(browser, "a[href='/basket/']")  # click the link to basket in dropdown
-    assert browser.is_text_present("Shopping cart")  # we are in basket page
-    assert browser.is_text_present(product_name)  # product is in basket
+    wait_until_condition(browser, lambda x: x.is_text_present("Shopping cart"))  # we are in basket page
+    wait_until_condition(browser, lambda x: x.is_text_present(product_name))  # product is in basket
 
     click_element(browser, "a[href='/checkout/']") # click link that leads to checkout
 
@@ -86,7 +86,7 @@ def test_browser_checkout_horizontal(browser, live_server, settings):
 
     click_element(browser, "#addresses button[type='submit']")
 
-    assert browser.is_text_present("There were errors on submitted form fields. Please check them and try again.")
+    wait_until_condition(browser, lambda x: x.is_text_present("There were errors on submitted form fields. Please check them and try again."))
 
     # Fill the errors
     browser.fill("shipping-name", customer_name)
@@ -95,32 +95,32 @@ def test_browser_checkout_horizontal(browser, live_server, settings):
     browser.select("shipping-country", customer_country)
 
     click_element(browser, "#addresses button[type='submit']")
-    assert browser.is_text_present("Checkout: Shipping & Payment")
+    wait_until_condition(browser, lambda x: x.is_text_present("Checkout: Shipping & Payment"))
 
-    assert browser.is_text_present(sm.name)  # shipping method name is present
-    assert browser.is_text_present(pm.name)  # payment method name is present
+    wait_until_condition(browser, lambda x: x.is_text_present(sm.name))  # shipping method name is present
+    wait_until_condition(browser, lambda x: x.is_text_present(pm.name))  # payment method name is present
 
     click_element(browser, ".btn.btn-primary.btn-lg.pull-right")  # click "continue" on methods page
 
-    assert browser.is_text_present("Checkout: Confirmation")  # we are indeed in confirmation page
+    wait_until_condition(browser, lambda x: x.is_text_present("Checkout: Confirmation"))  # we are indeed in confirmation page
 
     # See that all expected texts are present
-    assert browser.is_text_present(product_name)
-    assert browser.is_text_present(sm.name)
-    assert browser.is_text_present(pm.name)
-    assert browser.is_text_present("Delivery")
-    assert browser.is_text_present("Billing")
+    wait_until_condition(browser, lambda x: x.is_text_present(product_name))
+    wait_until_condition(browser, lambda x: x.is_text_present(sm.name))
+    wait_until_condition(browser, lambda x: x.is_text_present(pm.name))
+    wait_until_condition(browser, lambda x: x.is_text_present("Delivery"))
+    wait_until_condition(browser, lambda x: x.is_text_present("Billing"))
 
     # check that user information is available
-    assert browser.is_text_present(customer_name)
-    assert browser.is_text_present(customer_street)
-    assert browser.is_text_present(customer_city)
-    assert browser.is_text_present("United States")
+    wait_until_condition(browser, lambda x: x.is_text_present(customer_name))
+    wait_until_condition(browser, lambda x: x.is_text_present(customer_street))
+    wait_until_condition(browser, lambda x: x.is_text_present(customer_city))
+    wait_until_condition(browser, lambda x: x.is_text_present("United States"))
 
     browser.execute_script('document.getElementById("id_accept_terms").checked=true')  # click accept terms
     click_element(browser, ".btn.btn-primary.btn-lg")  # click "place order"
 
-    assert browser.is_text_present("Thank you for your order!")  # order succeeded
+    wait_until_condition(browser, lambda x: x.is_text_present("Thank you for your order!"))  # order succeeded
 
 
 @pytest.mark.urls('shuup.testing.single_page_checkout_test_urls')
@@ -144,9 +144,9 @@ def test_browser_checkout_vertical(browser, live_server, settings):
         # initialize test and go to front page
         browser = initialize_front_browser_test(browser, live_server)
         # check that front page actually loaded
-        assert browser.is_text_present("Welcome to Default!")
-        assert browser.is_text_present("Newest Products")
-        assert browser.is_text_present(product_name)
+        wait_until_condition(browser, lambda x: x.is_text_present("Welcome to Default!"))
+        wait_until_condition(browser, lambda x: x.is_text_present("Newest Products"))
+        wait_until_condition(browser, lambda x: x.is_text_present(product_name))
 
         click_element(browser, "#product-%s" % product.pk)  # open product from product list
         click_element(browser, "#add-to-cart-button-%s" % product.pk)  # add product to basket
@@ -156,8 +156,8 @@ def test_browser_checkout_vertical(browser, live_server, settings):
 
         click_element(browser, "#navigation-basket-partial")  # open upper basket navigation menu
         click_element(browser, "a[href='/basket/']")  # click the link to basket in dropdown
-        assert browser.is_text_present("Shopping cart")  # we are in basket page
-        assert browser.is_text_present(product_name)  # product is in basket
+        wait_until_condition(browser, lambda x: x.is_text_present("Shopping cart"))  # we are in basket page
+        wait_until_condition(browser, lambda x: x.is_text_present(product_name))  # product is in basket
 
         click_element(browser, "a[href='/checkout/']") # click link that leads to checkout
         wait_until_appeared(browser, "h4.panel-title")
@@ -177,7 +177,7 @@ def test_browser_checkout_vertical(browser, live_server, settings):
 
         click_element(browser, "#addresses button[type='submit']")
 
-        assert browser.is_text_present("This field is required.")
+        wait_until_condition(browser, lambda x: x.is_text_present("This field is required."))
 
         # Fill the errors
         browser.fill("shipping-name", customer_name)
@@ -186,29 +186,29 @@ def test_browser_checkout_vertical(browser, live_server, settings):
         browser.select("shipping-country", customer_country)
 
         click_element(browser, "#addresses button[type='submit']")
-        assert browser.is_text_present("Shipping & Payment")
+        wait_until_condition(browser, lambda x: x.is_text_present("Shipping & Payment"))
 
-        assert browser.is_text_present(sm.name)  # shipping method name is present
-        assert browser.is_text_present(pm.name)  # payment method name is present
+        wait_until_condition(browser, lambda x: x.is_text_present(sm.name))  # shipping method name is present
+        wait_until_condition(browser, lambda x: x.is_text_present(pm.name))  # payment method name is present
 
         click_element(browser, ".btn.btn-primary.btn-lg.pull-right")  # click "continue" on methods page
 
-        assert browser.is_text_present("Confirmation")  # we are indeed in confirmation page
+        wait_until_condition(browser, lambda x: x.is_text_present("Confirmation"))  # we are indeed in confirmation page
 
         # See that all expected texts are present
-        assert browser.is_text_present(product_name)
-        assert browser.is_text_present(sm.name)
-        assert browser.is_text_present(pm.name)
-        assert browser.is_text_present("Delivery")
-        assert browser.is_text_present("Billing")
+        wait_until_condition(browser, lambda x: x.is_text_present(product_name))
+        wait_until_condition(browser, lambda x: x.is_text_present(sm.name))
+        wait_until_condition(browser, lambda x: x.is_text_present(pm.name))
+        wait_until_condition(browser, lambda x: x.is_text_present("Delivery"))
+        wait_until_condition(browser, lambda x: x.is_text_present("Billing"))
 
         # check that user information is available
-        assert browser.is_text_present(customer_name)
-        assert browser.is_text_present(customer_street)
-        assert browser.is_text_present(customer_city)
-        assert browser.is_text_present("United States")
+        wait_until_condition(browser, lambda x: x.is_text_present(customer_name))
+        wait_until_condition(browser, lambda x: x.is_text_present(customer_street))
+        wait_until_condition(browser, lambda x: x.is_text_present(customer_city))
+        wait_until_condition(browser, lambda x: x.is_text_present("United States"))
 
         browser.execute_script('document.getElementById("id_accept_terms").checked=true')  # click accept terms
         click_element(browser, ".btn.btn-primary.btn-lg")  # click "place order"
 
-        assert browser.is_text_present("Thank you for your order!")  # order succeeded
+        wait_until_condition(browser, lambda x: x.is_text_present("Thank you for your order!"))  # order succeeded

--- a/shuup_tests/browser/front/test_checkout_with_login_and_register.py
+++ b/shuup_tests/browser/front/test_checkout_with_login_and_register.py
@@ -55,20 +55,20 @@ def test_checkout_with_login_and_register(browser, live_server, settings):
     # Initialize test and go to front page
     browser = initialize_front_browser_test(browser, live_server)
 
-    assert browser.is_text_present("Welcome to Default!")
+    wait_until_condition(browser, lambda x: x.is_text_present("Welcome to Default!"))
     navigate_to_checkout(browser, product)
 
     # Let's assume that after addresses the checkout is normal
-    assert browser.is_text_present("Checkout Method")
+    wait_until_condition(browser, lambda x: x.is_text_present("Checkout Method"))
     guest_ordering_test(browser, live_server)
 
     test_username = "test_username"
     test_email = "test@example.com"
     test_password = "test_password"
-    assert browser.is_text_present("Checkout Method")
+    wait_until_condition(browser, lambda x: x.is_text_present("Checkout Method"))
     register_test(browser, live_server, test_username, test_email, test_password)
 
-    assert browser.is_text_present("Checkout Method")
+    wait_until_condition(browser, lambda x: x.is_text_present("Checkout Method"))
     login_and_finish_up_the_checkout(browser, live_server, test_username, test_email, test_password)
 
 
@@ -93,11 +93,11 @@ def test_single_page_checkout_with_login_and_register(browser, live_server, sett
     # Initialize test and go to front page
     browser = initialize_front_browser_test(browser, live_server)
 
-    assert browser.is_text_present("Welcome to Default!")
+    wait_until_condition(browser, lambda x: x.is_text_present("Welcome to Default!"))
     navigate_to_checkout(browser, product)
 
     # Let's assume that after addresses the checkout is normal
-    assert browser.is_text_present("Checkout Method")
+    wait_until_condition(browser, lambda x: x.is_text_present("Checkout Method"))
     test_username = "test_username"
     test_email = "test@example.com"
     test_password = "test_password"
@@ -107,8 +107,8 @@ def test_single_page_checkout_with_login_and_register(browser, live_server, sett
 
 
 def navigate_to_checkout(browser, product):
-    assert browser.is_text_present("Newest Products")
-    assert browser.is_text_present(product.name)
+    wait_until_condition(browser, lambda x: x.is_text_present("Newest Products"))
+    wait_until_condition(browser, lambda x: x.is_text_present(product.name))
 
     click_element(browser, "#product-%s" % product.pk)  # open product from product list
     click_element(browser, "#add-to-cart-button-%s" % product.pk)  # add product to basket
@@ -118,8 +118,8 @@ def navigate_to_checkout(browser, product):
 
     click_element(browser, "#navigation-basket-partial")  # open upper basket navigation menu
     click_element(browser, "a[href='/basket/']")  # click the link to basket in dropdown
-    assert browser.is_text_present("Shopping cart")  # we are in basket page
-    assert browser.is_text_present(product.name)  # product is in basket
+    wait_until_condition(browser, lambda x: x.is_text_present("Shopping cart"))  # we are in basket page
+    wait_until_condition(browser, lambda x: x.is_text_present(product.name))  # product is in basket
 
     click_element(browser, "a[href='/checkout/']") # click link that leads to checkout
 
@@ -130,13 +130,13 @@ def guest_ordering_test(browser, live_server):
     wait_until_appeared(browser, "div.form-group.passwordinput.required.has-error")
     browser.fill("login-password", "test-password")
     click_element(browser, "button[name='login']")
-    assert browser.is_text_present("Please enter a correct username and password.")
+    wait_until_condition(browser, lambda x: x.is_text_present("Please enter a correct username and password."))
     wait_until_appeared(browser, "div.alert.alert-danger")
 
     click_element(browser, "button[data-id='id_checkout_method_choice-register']")
     click_element(browser, "li[data-original-index='0'] a")
     click_element(browser, "div.clearfix button.btn.btn-primary.btn-lg.pull-right")
-    assert browser.is_text_present("Checkout: Addresses")
+    wait_until_condition(browser, lambda x: x.is_text_present("Checkout: Addresses"))
     url = reverse("shuup:checkout", kwargs={"phase": "checkout_method"})
     browser.visit("%s%s" % (live_server, url))
 
@@ -227,36 +227,36 @@ def login_and_finish_up_the_checkout(browser, live_server, test_username, test_e
     wait_until_appeared(browser, "select[name='shipping-region_code']")
 
     click_element(browser, "#addresses button[type='submit']")
-    assert browser.is_text_present("Shipping & Payment")
+    wait_until_condition(browser, lambda x: x.is_text_present("Shipping & Payment"))
 
     pm = get_default_payment_method()
     sm = get_default_shipping_method()
 
-    assert browser.is_text_present(sm.name)  # shipping method name is present
-    assert browser.is_text_present(pm.name)  # payment method name is present
+    wait_until_condition(browser, lambda x: x.is_text_present(sm.name))  # shipping method name is present
+    wait_until_condition(browser, lambda x: x.is_text_present(pm.name))  # payment method name is present
 
     click_element(browser, ".btn.btn-primary.btn-lg.pull-right")  # click "continue" on methods page
 
-    assert browser.is_text_present("Confirmation")  # we are indeed in confirmation page
+    wait_until_condition(browser, lambda x: x.is_text_present("Confirmation"))  # we are indeed in confirmation page
     product = Product.objects.first()
 
     # See that all expected texts are present
-    assert browser.is_text_present(product.name)
-    assert browser.is_text_present(sm.name)
-    assert browser.is_text_present(pm.name)
-    assert browser.is_text_present("Delivery")
-    assert browser.is_text_present("Billing")
+    wait_until_condition(browser, lambda x: x.is_text_present(product.name))
+    wait_until_condition(browser, lambda x: x.is_text_present(sm.name))
+    wait_until_condition(browser, lambda x: x.is_text_present(pm.name))
+    wait_until_condition(browser, lambda x: x.is_text_present("Delivery"))
+    wait_until_condition(browser, lambda x: x.is_text_present("Billing"))
 
     # check that user information is available
-    assert browser.is_text_present(customer_name)
-    assert browser.is_text_present(customer_street)
-    assert browser.is_text_present(customer_city)
-    assert browser.is_text_present("United States")
+    wait_until_condition(browser, lambda x: x.is_text_present(customer_name))
+    wait_until_condition(browser, lambda x: x.is_text_present(customer_street))
+    wait_until_condition(browser, lambda x: x.is_text_present(customer_city))
+    wait_until_condition(browser, lambda x: x.is_text_present("United States"))
 
     browser.execute_script('document.getElementById("id_accept_terms").checked=true')  # click accept terms
     click_element(browser, ".btn.btn-primary.btn-lg")  # click "place order"
 
-    assert browser.is_text_present("Thank you for your order!")  # order succeeded
+    wait_until_condition(browser, lambda x: x.is_text_present("Thank you for your order!"))  # order succeeded
 
     # Let's make sure the order now has a customer
     assert Order.objects.count() == 1

--- a/shuup_tests/browser/front/test_search_view.py
+++ b/shuup_tests/browser/front/test_search_view.py
@@ -69,7 +69,7 @@ def test_search_product_list(browser, live_server, settings):
     # initialize test and go to front page
     browser = initialize_front_browser_test(browser, live_server)
     # check that front page actually loaded
-    assert browser.is_text_present("Welcome to Default!")
+    wait_until_condition(browser, lambda x: x.is_text_present("Welcome to Default!"))
 
     url = reverse("shuup:product_search")
     browser.visit("%s%s?q=test product" % (live_server, url))


### PR DESCRIPTION
Main menu didn't allow any clicks on mobile size.
The menu was loaded with ajax which caused blinking on load.

In large lists the merchant could not scroll into the last items since they were hidden outside the browser window
Quicklinks menu was way too wide in mobile size, this fix forces it to certain width and alters the styles

* Change the way admin menu is being rendered: show it without ajax
* Fix clicks in mobile size
* Add padding to menu
* Fix quicklinks menu in mobile size

Refs SH-435, SH-433, SH-436, SH-427