### PR TITLE
Autopopulate `ShopProduct` categories

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,8 @@ Unrealeased
 Core
 ~~~~
 
+- Add `SHUUP_AUTO_SHOP_PRODUCT_CATEGORIES` option that
+  allows autopopulating categories. Default is `True`.
 - Populate some unfilled customer fields from order
 - Add `is_not_paid` function for `Order` model.
 - Allow zero price payments for zero price orders.

--- a/shuup/admin/modules/categories/forms.py
+++ b/shuup/admin/modules/categories/forms.py
@@ -102,7 +102,10 @@ class CategoryProductForm(forms.Form):
         remove_shop_product_ids = [int(shop_product_id) for shop_product_id in data.get("remove_products", [])]
         for shop_product in ShopProduct.objects.filter(id__in=remove_shop_product_ids):
             if shop_product.primary_category == self.category:
+                if self.category in shop_product.categories.all():
+                    shop_product.categories.remove(self.category)
                 shop_product.primary_category = None
                 shop_product.save()
+
             Product.objects.filter(id=shop_product.product_id).update(category_id=None)
             shop_product.categories.remove(self.category)

--- a/shuup/admin/modules/products/signal_handlers.py
+++ b/shuup/admin/modules/products/signal_handlers.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2016, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.conf import settings
+
+
+def update_categories_post_save(sender, instance, **kwargs):
+    if not getattr(settings, "SHUUP_AUTO_SHOP_PRODUCT_CATEGORIES", False):
+        return
+
+    if not instance.pk or not instance.primary_category:
+        return
+
+    categories = instance.categories.values_list("pk", flat=True)
+    if instance.primary_category.pk not in categories:
+        instance.categories.add(instance.primary_category)
+
+
+def update_categories_through(sender, instance, **kwargs):
+    action = kwargs.get("action", "post_add")
+    if action != "post_add":
+        return
+
+    if not getattr(settings, "SHUUP_AUTO_SHOP_PRODUCT_CATEGORIES", False):
+        return
+
+    if not instance.pk:
+        return
+
+    if not instance.categories.count():
+        return
+
+    if not instance.primary_category:
+        instance.primary_category = instance.categories.first()
+        instance.save()

--- a/shuup/admin/templates/shuup/admin/products/_edit_extra_base_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_extra_base_form.jinja
@@ -5,7 +5,6 @@
 {% call content_block(_("Additional Details"), "fa-file-text") %}
     {{ bs3.field(product_form.barcode) }}
     {{ bs3.field(product_form.gtin) }}
-    {{ bs3.field(product_form.category) }}
     {% call(form, language, map) language_dependent_content_tabs(product_form, tab_id_prefix="additional-language") %}
         {{ bs3.field(product_form[map.variation_name]) }}
         {{ bs3.field(product_form[map.status_text]) }}

--- a/shuup/core/models/_categories.py
+++ b/shuup/core/models/_categories.py
@@ -148,10 +148,12 @@ class Category(MPTTModel, TranslatableModel):
     def soft_delete(self, user=None):
         if not self.status == CategoryStatus.DELETED:
             for shop_product in self.primary_shop_products.all():
+                shop_product.categories.remove(self)
                 shop_product.primary_category = None
                 shop_product.save()
             for shop_product in self.shop_products.all():
                 shop_product.categories.remove(self)
+                shop_product.primary_category = None
                 shop_product.save()
             for product in self.primary_products.all():
                 product.category = None

--- a/shuup/core/settings.py
+++ b/shuup/core/settings.py
@@ -184,3 +184,19 @@ SHUUP_ADDRESS_FIELD_PROPERTIES = {}
 
 #: Indicates maximum days for daily data included to one telemetry request
 SHUUP_MAX_DAYS_IN_TELEMETRY = 180
+
+#: Spec which defines if shop product categories
+#: will be automatically populated on save or
+#: when the shop_product categories change.
+#:
+#: Example A:
+#: shop_product.categories = []
+#: shop_product.primary_category = "A"
+#: shop_product.save()
+#: => "A" will be added to categories
+#:
+#: Example B:
+#: shop_product.primary_category = None
+#: shop_product.categories = ["A", "B"]
+#: => "A" will be made the shop_product.primary_category
+SHUUP_AUTO_SHOP_PRODUCT_CATEGORIES = True

--- a/shuup_tests/admin/test_views.py
+++ b/shuup_tests/admin/test_views.py
@@ -8,13 +8,15 @@
 import json
 
 import pytest
+import six
 from bs4 import BeautifulSoup
 from django.utils.encoding import force_text
 
 from shuup.admin.modules.products.views import ProductEditView
+from shuup.core.models import ShopProduct
 from shuup.testing.factories import (
-    create_random_order, create_random_person, get_default_category,
-    get_default_product, get_default_shop
+    CategoryFactory, create_random_order, create_random_person,
+    get_default_category, get_default_product, get_default_shop
 )
 from shuup.testing.soup_utils import extract_form_fields
 from shuup.testing.utils import apply_request_middleware
@@ -93,3 +95,111 @@ def test_edit_view_adding_messages_to_form_group(rf, admin_user):
 
     assert "base" in errors
     assert "name__en" in errors["base"]
+
+
+@pytest.mark.django_db
+def test_product_edit_view(rf, admin_user, settings):
+    shop = get_default_shop()  # obvious prerequisite
+    product = get_default_product()
+    shop_product = product.get_shop_instance(shop)
+    cat = CategoryFactory()
+
+    assert not shop_product.categories.exists()
+    assert not shop_product.primary_category
+
+    view = ProductEditView.as_view()
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
+    response = view(request, pk=product.pk)
+    response.render()
+
+    content = force_text(response.content)
+    post = extract_form_fields(BeautifulSoup(content))
+
+    post_data = {
+        'shop1-primary_category': [],
+        'shop1-categories': []
+    }
+    post.update(post_data)
+    request = apply_request_middleware(rf.post("/", post), user=admin_user)
+    response = view(request, pk=product.pk)
+
+    shop_product.refresh_from_db()
+    assert not shop_product.categories.exists()
+    assert not shop_product.primary_category
+
+    post_data = {
+        'shop1-default_price_value': 12,
+        'shop1-primary_category': [cat.pk],
+        'shop1-categories': []
+    }
+    post.update(post_data)
+    usable_post = {}
+    for k, v in six.iteritems(post):
+        if not k:
+            continue
+        if not post[k]:
+            continue
+        usable_post[k] = v
+
+    request = apply_request_middleware(rf.post("/", usable_post), user=admin_user)
+    response = view(request, pk=product.pk)
+
+    shop_product = ShopProduct.objects.first()
+    if settings.SHUUP_AUTO_SHOP_PRODUCT_CATEGORIES:
+        assert shop_product.categories.count() == 1
+        assert shop_product.categories.first() == cat
+    else:
+        assert not shop_product.categories.count()
+
+    assert shop_product.primary_category == cat
+
+    post_data = {
+        'shop1-primary_category': [],
+        'shop1-categories': []
+    }
+    usable_post.update(post_data)
+
+    request = apply_request_middleware(rf.post("/", usable_post), user=admin_user)
+    response = view(request, pk=product.pk)
+
+    # empty again
+    shop_product = ShopProduct.objects.first()
+    assert not shop_product.categories.exists()
+    assert not shop_product.primary_category
+
+    post_data = {
+        'shop1-primary_category': [],
+        'shop1-categories': [cat.pk]
+    }
+    usable_post.update(post_data)
+
+    request = apply_request_middleware(rf.post("/", usable_post), user=admin_user)
+    response = view(request, pk=product.pk)
+
+    shop_product = ShopProduct.objects.first()
+    assert shop_product.categories.count() == 1
+    assert shop_product.categories.first() == cat
+    if settings.SHUUP_AUTO_SHOP_PRODUCT_CATEGORIES:
+        assert shop_product.primary_category == cat
+    else:
+        assert not shop_product.primary_category
+
+    cat2 = CategoryFactory()
+
+    post_data = {
+        'shop1-primary_category': [],
+        'shop1-categories': [cat.pk, cat2.pk]
+    }
+    usable_post.update(post_data)
+
+    request = apply_request_middleware(rf.post("/", usable_post), user=admin_user)
+    response = view(request, pk=product.pk)
+
+    shop_product = ShopProduct.objects.first()
+    assert shop_product.categories.count() == 2
+    assert cat in shop_product.categories.all()
+    assert cat2 in shop_product.categories.all()
+    if settings.SHUUP_AUTO_SHOP_PRODUCT_CATEGORIES:
+        assert shop_product.primary_category == cat
+    else:
+        assert not shop_product.primary_category

--- a/shuup_tests/campaigns/test_basket_campaigns.py
+++ b/shuup_tests/campaigns/test_basket_campaigns.py
@@ -397,6 +397,9 @@ def test_product_basket_campaigns():
     # category effect that doesn't match
     effect = DiscountFromCategoryProducts.objects.create(campaign=campaign, category=cat)
     shop_product.categories.remove(cat)
+    shop_product.primary_category = None
+    shop_product.save()
+
     campaign.line_effects.add(effect)
     assert BasketCampaign.get_for_product(shop_product).count() == 0
 

--- a/shuup_tests/campaigns/test_catalog_campaigns.py
+++ b/shuup_tests/campaigns/test_catalog_campaigns.py
@@ -430,6 +430,7 @@ def test_product_catalog_campaigns():
     shop_product.primary_category = cat
     shop_product.save()
     assert CatalogCampaign.get_for_product(shop_product).count() == 1
+    shop_product.categories.remove(cat)
     shop_product.primary_category = None
     shop_product.save()
     assert CatalogCampaign.get_for_product(shop_product).count() == 0
@@ -455,6 +456,7 @@ def test_product_catalog_campaigns():
     sp.save()
 
     assert CatalogCampaign.get_for_product(sp).count() == 1  # matches now
+    sp.categories.remove(cat)
     sp.primary_category = None
     sp.save()
     assert CatalogCampaign.get_for_product(sp).count() == 0  # no match

--- a/shuup_tests/campaigns/test_matcher.py
+++ b/shuup_tests/campaigns/test_matcher.py
@@ -71,6 +71,8 @@ def test_ultrafilter():
     uf.save()
     assert matcher.matches(uf)
     shop_product.categories.remove(category)
+    shop_product.primary_category = None
+    shop_product.save()
     assert not matcher.matches(uf)
     shop_product.primary_category = category
     assert matcher.matches(uf)


### PR DESCRIPTION
Both `Product` and `ShopProduct` have primary category and
shop product also categories. Category setting in `Product` isn't used
in shop front where the categories matter.

This commit introduces `SHUUP_AUTO_SHOP_PRODUCT_CATEGORIES` setting
that enables autopopulation of categories.

Examples with `SHUUP_AUTO_SHOP_PRODUCT_CATEGORIES = True`:
Example A:
```
shop_product.categories = []
shop_product.primary_category = "A"
shop_product.save()
 => "A" will be added to categories
```

Example B:
```
shop_product.primary_category = None
shop_product.categories = ["A", "B"]
=> "A" will be made the shop_product.primary_category
```

* Remove `primary_category` from product editing form
* Add option `SHUUP_AUTO_SHOP_PRODUCT_CATEGORIES` to enable
  autopopulating categories

Refs SH-130