### PR TITLE
Admin: Split help and error texts (SH-80)

### DIFF
--- a/shuup/admin/static_src/base/less/shuup/custom-forms.less
+++ b/shuup/admin/static_src/base/less/shuup/custom-forms.less
@@ -268,6 +268,16 @@ fieldset[disabled] .form-control {
     }
 }
 
+.has-error {
+    .help-block {
+        color: lighten(@text-color, 25%);
+        &.error-block {
+            color:@state-danger-text;
+        }
+    }
+
+}
+
 .error-indicator {
     display: inline-block;
     margin-left: 0.5em;

--- a/shuup/admin/utils/bs3_renderers.py
+++ b/shuup/admin/utils/bs3_renderers.py
@@ -56,3 +56,13 @@ class AdminFieldRenderer(FieldRenderer):
 
         if not self.show_help_block:  # Remove field help to avoid rendering `help-block`
             self.field_help = ''
+
+    def append_to_field(self, html):
+        if self.field_errors:
+            errors = "<br>".join(self.field_errors)
+            html += '<div class="help-block error-block">{error}</div>'.format(error=errors)
+
+        if self.field_help:
+            html += '<span class="help-block">{help}</span>'.format(help=self.field_help)
+
+        return html


### PR DESCRIPTION
For some reason help text was rendered with error text where it was hard to differentiate the two.

* Overwrite `FieldRenderer:append_to_field` in `AdminFieldRenderer` to split help and error texts

Refs SH-80