### PR TITLE
Admin: Picotable column fixes (SH-408)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -25,6 +25,7 @@ Localization
 Admin
 ~~~~~
 
+- Fix picotable aggregate columns
 - Allow setting productless order as completed
 - Change main menu template and remove ajax loading from main menu.
 - Remove language layer from shop configurations

--- a/shuup/admin/modules/settings/__init__.py
+++ b/shuup/admin/modules/settings/__init__.py
@@ -76,7 +76,10 @@ class ViewSettings(object):
             column = self._get_column(field)
             if column:
                 columns.append(column)
-
+        table_columns = set([col.id for col in columns])
+        for default_column in self.default_columns:
+            if default_column.id not in table_columns and default_column.id != "select":
+                columns.append(default_column)
         return columns
 
     def _get_translated_column(self, field):

--- a/shuup/admin/modules/settings/views/__init__.py
+++ b/shuup/admin/modules/settings/views/__init__.py
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 import six
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import resolve, reverse
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import FormView
@@ -23,9 +23,11 @@ class ListSettingsView(FormView):
 
     def dispatch(self, request, *args, **kwargs):
         module_str = "%s:%s" % (request.GET.get("module"), request.GET.get("model"))
-        self.return_url = request.GET.get("return_url")
+        self.return_url = reverse("shuup_admin:%s.list" % request.GET.get("return_url"))
+        match = resolve(self.return_url)
+        default_columns = load("%s:%s" % (match.func.__module__, match.func.__name__)).default_columns
         self.model = load(module_str)
-        self.settings = ViewSettings(self.model, [])
+        self.settings = ViewSettings(self.model, default_columns)
         return super(ListSettingsView, self).dispatch(request, *args, **kwargs)
 
     def get_form(self, form_class=None):
@@ -45,7 +47,7 @@ class ListSettingsView(FormView):
         for col, val in six.iteritems(form.cleaned_data):
             self.settings.set_config(col, val, use_key=True)
         messages.success(self.request, _("Settings saved"), fail_silently=True)
-        return HttpResponseRedirect(reverse("shuup_admin:%s.list" % self.return_url))
+        return HttpResponseRedirect(self.return_url)
 
     def get_context_data(self, **kwargs):
         context = super(ListSettingsView, self).get_context_data(**kwargs)

--- a/shuup/admin/utils/views.py
+++ b/shuup/admin/utils/views.py
@@ -174,9 +174,9 @@ class PicotableListView(PicotableViewMixin, ListView):
 
         if self.mass_actions:
             if self.settings.columns:
-                # settings.columns never have this empty one
+                # settings.columns never have selects
                 self.columns = [
-                    Column("select", "", display="", sortable=False, linked=False),  # empty column for selects
+                    Column("select", "", display="", sortable=False, linked=False, class_name="text-center"),
                 ] + self.settings.columns
             else:
                 self.columns = self.default_columns


### PR DESCRIPTION
* Center the select column
* Show default columns that don't necessarily belong to the table (ie aggregate columns, etc) and ensure they are selectable

Refs SH-408