### PR TITLE
Core: Remove `clean_language_codes` from language field

### DIFF
--- a/shuup/core/fields/__init__.py
+++ b/shuup/core/fields/__init__.py
@@ -153,7 +153,6 @@ class LanguageFieldMixin(object):
 
 class LanguageField(LanguageFieldMixin, models.CharField):
     def __init__(self, *args, **kwargs):
-        self.clean_language_codes()
         kwargs.setdefault("max_length", 10)
         kwargs["choices"] = [(code, code) for code in sorted(self.LANGUAGE_CODES)]
         super(LanguageField, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Cleaning the extincted languages in field init will cause
slowness at least in migrations and it is not necessary there.