### PR TITLE
Select first eligible product image as primary if none is selected

### DIFF
--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -379,7 +379,7 @@ class ProductImageMediaFormSet(ProductMediaFormSet):
                           (form.cleaned_data.get("file") and not form.cleaned_data.get("DELETE"))]
 
         if eligible_forms and not has_primary:
-            # make first form be the primary image as well
-            form_instance = self.forms[0]
+            # make first eligible form be the primary image as well
+            form_instance = eligible_forms[0]
             form_instance.product.primary_image = form_instance.instance
             form_instance.product.save()


### PR DESCRIPTION
For example now if first form happens to be deleted, default product primary
image is not set. So pick default product primary image from eligible forms. 
Eligible forms are already checked but not used.