### PR TITLE
Admin: Ensure default language tab is shown first (SH-448)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,6 +20,7 @@ Localization
 Admin
 ~~~~~
 
+- Ensure `PARLER_DEFAULT_LANGUAGE_CODE` is the first tab in multilingual tab forms
 - Show help text as popovers
 - Add admin walkthrough
 

--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -147,7 +147,9 @@ class ShopProductForm(forms.ModelForm):
 
 class ProductAttributesForm(forms.Form):
     def __init__(self, **kwargs):
-        self.languages = to_language_codes(kwargs.pop("languages", ()))
+        self.default_language = kwargs.pop(
+            "default_language", getattr(settings, "PARLER_DEFAULT_LANGUAGE_CODE"))
+        self.languages = to_language_codes(kwargs.pop("languages", ()), self.default_language)
         self.language_names = dict((lang, get_language_name(lang)) for lang in self.languages)
         self.product = kwargs.pop("product")
         self.attributes = self.product.get_available_attribute_queryset()
@@ -295,7 +297,9 @@ class BaseProductMediaFormSet(BaseModelFormSet):
 
     def __init__(self, *args, **kwargs):
         self.product = kwargs.pop("product")
-        self.languages = to_language_codes(kwargs.pop("languages", ()))
+        self.default_language = kwargs.pop(
+            "default_language", getattr(settings, "PARLER_DEFAULT_LANGUAGE_CODE"))
+        self.languages = to_language_codes(kwargs.pop("languages", ()), self.default_language)
         kwargs.pop("empty_permitted")  # this is unknown to formset
         super(BaseProductMediaFormSet, self).__init__(*args, **kwargs)
 

--- a/shuup_tests/admin/test_product_attributes_form.py
+++ b/shuup_tests/admin/test_product_attributes_form.py
@@ -36,7 +36,9 @@ def test_product_attributes_form():
 
     # English is missing on purpose from the languages list; it'll still be available
     # for `genre` as it has an extant value.
-    paf = ProductAttributesForm(product=product, languages=("fi", "sv"))
+    paf = ProductAttributesForm(product=product, languages=("fi", "sv"), default_language="sv")
+    assert paf.languages[0] == "sv"
+
     assert compare_partial_dicts(paf.initial, {  # Check that things get loaded.
         "bogomips": 6400,
         "genre__fi": "Kauhu",
@@ -53,7 +55,7 @@ def test_product_attributes_form():
         "awesome": "True",
         "important_datetime": make_aware(datetime.datetime(2000, 1, 1, 1, 2, 3), utc)
     })
-    paf = ProductAttributesForm(product=product, languages=("fi", "sv"), data=form_data)
+    paf = ProductAttributesForm(product=product, languages=("fi", "sv"), default_language="sv", data=form_data)
     paf.full_clean()
     assert not paf.errors
     paf.save()

--- a/shuup_tests/admin/test_product_module.py
+++ b/shuup_tests/admin/test_product_module.py
@@ -49,6 +49,7 @@ def test_product_edit_view_works_at_all(rf, admin_user):
         with admin_only_urls():
             view_func = ProductEditView.as_view()
             response = view_func(request, pk=product.pk)
+            response.render()
             assert (product.sku in response.rendered_content)  # it's probable the SKU is there
             response = view_func(request, pk=None)  # "new mode"
             assert response.rendered_content  # yeah, something gets rendered

--- a/shuup_tests/utils/test_multilanguage_model_form.py
+++ b/shuup_tests/utils/test_multilanguage_model_form.py
@@ -31,6 +31,7 @@ def test_default_language_finnish():
     shop.save()
 
     shop_form = ShopBaseForm(instance=shop, languages=settings.LANGUAGES)
+    assert shop_form.languages[0] == "fi"
     data = get_form_data(shop_form, prepared=True)
     assert data.get("name__en") == test_name_en
     assert not data.get("name__fi")


### PR DESCRIPTION
Ensure `PARLER_DEFAULT_LANGUAGE_CODE` is the first tab
in multilingual tab forms.

Refs SH-448