### PR TITLE
Fix app_label problem in shuup.testing module

### DIFF
--- a/shuup/testing/factories.py
+++ b/shuup/testing/factories.py
@@ -47,7 +47,6 @@ from shuup.utils.filer import filer_image_from_data
 from shuup.utils.money import Money
 
 from .image_generator import generate_image
-from .models import PaymentWithCheckoutPhase
 
 DEFAULT_IDENTIFIER = "default"
 DEFAULT_NAME = "Default"
@@ -305,6 +304,7 @@ def get_custom_payment_processor():
 
 
 def get_payment_processor_with_checkout_phase():
+    from .models import PaymentWithCheckoutPhase
     return _get_service_provider(PaymentWithCheckoutPhase)
 
 


### PR DESCRIPTION
Trying to import anything from `shuup.testing.factories` in tests could result in
```
RuntimeError: Model class
shuup.testing.models._behavior_components.ExpensiveSwedenBehaviorComponent doesn't declare an
explicit app_label and isn't in an application in INSTALLED_APPS
```
if done in a Django 1.9 environment.

The changes in this commit seem to fix it, but if not, at least the problem will be localized to a specific import instead of failing on all factories imports