### PR TITLE
Taxes: Fix default tax bugs (SH-341)

### DIFF
--- a/shuup/default_tax/models.py
+++ b/shuup/default_tax/models.py
@@ -17,7 +17,7 @@ from shuup.utils.patterns import Pattern, pattern_matches
 
 class TaxRuleQuerySet(models.QuerySet):
     def may_match_postal_code(self, postalcode):
-        null = Q(_postal_codes_min__isnull=True)
+        null = Q(Q(_postal_codes_min__isnull=True) | Q(_postal_codes_min=""))
         in_range = Q()
         if postalcode:
             in_range = Q(_postal_codes_min__lte=postalcode, _postal_codes_max__gte=postalcode)
@@ -86,10 +86,9 @@ class TaxRule(models.Model):
         return True
 
     def save(self, *args, **kwargs):
-        if self.postal_codes_pattern:
-            min_value, max_value = Pattern(self.postal_codes_pattern).get_alphabetical_limits()
-            self._postal_codes_min = min_value
-            self._postal_codes_max = max_value
+        min_value, max_value = Pattern(self.postal_codes_pattern).get_alphabetical_limits()
+        self._postal_codes_min = min_value
+        self._postal_codes_max = max_value
         return super(TaxRule, self).save(*args, **kwargs)
 
     def __str__(self):

--- a/shuup/utils/patterns.py
+++ b/shuup/utils/patterns.py
@@ -80,7 +80,7 @@ class Pattern(object):
         return any(self._test_piece(piece, target) for piece in self.positive_pieces)
 
     def get_alphabetical_limits(self):
-        if self.negative_pieces:
+        if self.negative_pieces or self.pattern_text == "*":
             return (None, None)
         all_values = set()
         for min_value, max_value in self.positive_pieces:

--- a/shuup_tests/default_tax/test_default_tax.py
+++ b/shuup_tests/default_tax/test_default_tax.py
@@ -182,6 +182,21 @@ def test_rule_min_max():
     postal_code = None
     assert TaxRule.objects.may_match_postal_code(postal_code).count() == 1
 
+@pytest.mark.django_db
+def test_wildcard_postalcode():
+    tax = create_tax("test-1", rate=Decimal("0.12"))
+    tax.save()
+    rule = TaxRule.objects.create(postal_codes_pattern="*", tax=tax)
+
+    for postal_code in ["", None, "12333", "test"]:
+        assert TaxRule.objects.may_match_postal_code(postal_code).count() == 1
+
+    rule.postal_codes_pattern = ""
+    rule.save()
+
+    assert rule._postal_codes_min is None
+    assert rule._postal_codes_max is None
+
 
 @pytest.mark.django_db
 def test_rule_admin(rf, admin_user):


### PR DESCRIPTION
If postal code was a wildcard it was never matched to anything (except a '*'). When postal code was changed to empty it was never changed in database level and caused non matching rules.