### PR TITLE
Core: Fix bug in `Order.can_set_complete` (SH-489)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unrealeased
 Core
 ~~~~
 
+- Fix bug in `Order.can_set_complete`
 - Currencies can be now created and edited through admin.
 
 Localization

--- a/shuup/core/models/_orders.py
+++ b/shuup/core/models/_orders.py
@@ -884,10 +884,7 @@ class Order(MoneyPropped, models.Model):
         return (self.status.role == OrderStatusRole.COMPLETE)
 
     def can_set_complete(self):
-        if self.has_products():
-            # order has products, we need to check the fully shipped status
-            return (not self.is_complete()) and self.is_fully_shipped() and (not self.is_canceled())
-        return (not self.is_complete()) and (not self.is_canceled())
+        return not (self.is_complete() or self.is_canceled() or bool(self.get_unshipped_products()))
 
     def is_fully_shipped(self):
         return (self.shipping_status == ShippingStatus.FULLY_SHIPPED)


### PR DESCRIPTION
Allow setting order complete if there is nothing to ship.