### PR TITLE
Make static file urls more dynamic

### DIFF
--- a/shuup/xtheme/parsing.py
+++ b/shuup/xtheme/parsing.py
@@ -9,10 +9,12 @@ from __future__ import unicode_literals
 
 import pytoml as toml
 import six
+from django.contrib.staticfiles.storage import staticfiles_storage
 from jinja2.ext import Extension
 from jinja2.nodes import Const, EvalContext, ExprStmt, Impossible, Name, Output
 from jinja2.utils import contextfunction
 
+import shuup
 from shuup.xtheme.rendering import render_placeholder
 from shuup.xtheme.view_config import Layout
 
@@ -338,8 +340,18 @@ class PluginExtension(_PlaceholderManagingExtension):
         return noop_node(lineno)
 
 
+class ShuupStaticFilesExtension(Extension):
+    def __init__(self, environment):
+        super(ShuupStaticFilesExtension, self).__init__(environment)
+        environment.globals["static"] = self._static
+
+    def _static(self, path):
+        return "%s?v=%s" % (staticfiles_storage.url(path), shuup.__version__)
+
+
 EXTENSIONS = [
     LayoutPartExtension,
     PlaceholderExtension,
-    PluginExtension
+    PluginExtension,
+    ShuupStaticFilesExtension
 ]

--- a/shuup_tests/browser/front/test_product_view.py
+++ b/shuup_tests/browser/front/test_product_view.py
@@ -9,9 +9,9 @@ import os
 
 import pytest
 from django.core.urlresolvers import reverse
-from django.test import override_settings
 from django.utils.translation import activate
 
+import shuup
 from shuup.core import cache
 from shuup.core.models import ShopProduct
 from shuup.testing.browser_utils import wait_until_condition
@@ -48,6 +48,9 @@ def test_product_descriptions(browser, live_server, settings):
     browser.visit("%s%s" % (live_server, url))
     wait_until_condition(browser, lambda x: x.is_text_present(product.short_description))
     assert product.description in browser.html
+
+    # ensure the version is in static files
+    assert "style.css?v=%s" % shuup.__version__ in browser.html
 
     # product preview
     url = reverse("shuup:xtheme_extra_view", kwargs={"view": "products"})


### PR DESCRIPTION
If your service uses caching engine like incapsula, static files
might be cached many hours after updating Shuup. This change
ties static files to a commit, which means that they will be
always refreshed in cache.

![image](https://cloud.githubusercontent.com/assets/2863405/21634332/20427e0a-d25f-11e6-8b9c-bcaf83e2e11f.png)


No ref