### PR TITLE
Update URLConf to suppress usage of patterns

### DIFF
--- a/doc/web_api/rest_setup.rst
+++ b/doc/web_api/rest_setup.rst
@@ -25,11 +25,11 @@ Now just add the API to your root urlconf.
 
 .. code-block:: python
 
-   urlpatterns = patterns(
+   urlpatterns = [
        # *snip*
        url(r'^api/', include('shuup.api.urls')),
        # *snip*
-   )
+   ]
 
 
 All done! If you visit the `/api/` URL (as a suitably authenticated user), you should be

--- a/shuup/admin/urls.py
+++ b/shuup/admin/urls.py
@@ -11,7 +11,7 @@ from __future__ import unicode_literals
 import warnings
 
 import django.contrib.auth.views as auth_views
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth import logout as do_logout
 from django.views.decorators.csrf import csrf_exempt
 from django.views.i18n import set_language
@@ -78,4 +78,4 @@ def get_urls():
 
     return tuple(urls)
 
-urlpatterns = patterns('', *get_urls())
+urlpatterns = get_urls()

--- a/shuup/front/apps/auth/urls.py
+++ b/shuup/front/apps/auth/urls.py
@@ -5,7 +5,7 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from shuup.core.utils.maintenance import maintenance_mode_exempt
 
@@ -14,8 +14,7 @@ from .views import (
     RecoverPasswordConfirmView, RecoverPasswordSentView, RecoverPasswordView
 )
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^login/$',
         LoginView.as_view(),
         name='login'),
@@ -34,4 +33,4 @@ urlpatterns = patterns(
     url(r'^recover-password/complete/$',
         maintenance_mode_exempt(RecoverPasswordCompleteView.as_view()),
         name='recover_password_complete'),
-)
+]

--- a/shuup/front/apps/customer_information/urls.py
+++ b/shuup/front/apps/customer_information/urls.py
@@ -5,13 +5,12 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 
 from . import views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^address-book/$', login_required(views.AddressBookView.as_view()),
         name='address_book'),
     url(r'^address-book/edit/(?P<pk>\d+)$', login_required(views.AddressBookEditView.as_view()),
@@ -26,4 +25,4 @@ urlpatterns = patterns(
         name='change_password'),
     url(r'^company/$', login_required(views.CompanyEditView.as_view()),
         name='company_edit'),
-)
+]

--- a/shuup/front/apps/personal_order_history/urls.py
+++ b/shuup/front/apps/personal_order_history/urls.py
@@ -5,15 +5,14 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 
 from . import views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^order-history/$', login_required(views.OrderListView.as_view()),
         name='personal-orders'),
     url(r'^order-history/(?P<pk>.+)/$', login_required(views.OrderDetailView.as_view()),
         name='show-order'),
-)
+]

--- a/shuup/front/apps/registration/urls.py
+++ b/shuup/front/apps/registration/urls.py
@@ -5,17 +5,16 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import (
     activation_complete, ActivationView, registration_complete,
     RegistrationView
 )
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^activate/complete/$', activation_complete, name='registration_activation_complete'),
     url(r'^activate/(?P<activation_key>\w+)/$', ActivationView.as_view(), name='registration_activate'),
     url(r'^register/$', RegistrationView.as_view(), name='registration_register'),
     url(r'^register/complete/$', registration_complete, name='registration_complete'),
-)
+]

--- a/shuup/front/apps/saved_carts/urls.py
+++ b/shuup/front/apps/saved_carts/urls.py
@@ -5,13 +5,12 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 
 from . import views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url('^saved-carts/$', login_required(views.CartListView.as_view()),
         name='saved_cart.list'),
     url('^saved-carts/save/$', login_required(views.CartSaveView.as_view()),
@@ -22,4 +21,4 @@ urlpatterns = patterns(
         name='saved_cart.delete'),
     url('^saved-carts/(?P<pk>.+)/$', login_required(views.CartDetailView.as_view()),
         name='saved_cart.detail')
-)
+]

--- a/shuup/front/apps/simple_search/urls.py
+++ b/shuup/front/apps/simple_search/urls.py
@@ -5,11 +5,10 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import SearchView
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^search/$", SearchView.as_view(), name="product_search"),
-)
+]

--- a/shuup/simple_cms/urls.py
+++ b/shuup/simple_cms/urls.py
@@ -5,13 +5,12 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from shuup.simple_cms.views import PageView
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^(?P<url>.*)/$',
         PageView.as_view(),
         name='cms_page'),
-)
+]

--- a/shuup/testing/checkout_with_login_and_register_urls.py
+++ b/shuup/testing/checkout_with_login_and_register_urls.py
@@ -5,18 +5,17 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.conf import settings
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 
 from shuup.front.views.checkout import CheckoutViewWithLoginAndRegister
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^checkout/$', CheckoutViewWithLoginAndRegister.as_view(), name='checkout'),
     url(r'^checkout/(?P<phase>.+)/$', CheckoutViewWithLoginAndRegister.as_view(), name='checkout'),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^sa/', include('shuup.admin.urls', namespace="shuup_admin", app_name="shuup_admin")),
     url(r'^api/', include('shuup.api.urls')),
     url(r'^', include('shuup.front.urls', namespace="shuup", app_name="shuup")),
-) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/shuup/testing/single_page_checkout_test_urls.py
+++ b/shuup/testing/single_page_checkout_test_urls.py
@@ -5,18 +5,17 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.conf import settings
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 
 from shuup.front.views.checkout import SinglePageCheckoutView
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^checkout/$', SinglePageCheckoutView.as_view(), name='checkout'),
     url(r'^checkout/(?P<phase>.+)/$', SinglePageCheckoutView.as_view(), name='checkout'),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^sa/', include('shuup.admin.urls', namespace="shuup_admin", app_name="shuup_admin")),
     url(r'^api/', include('shuup.api.urls')),
     url(r'^', include('shuup.front.urls', namespace="shuup", app_name="shuup")),
-) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/shuup/testing/single_page_checkout_with_login_and_register_conf.py
+++ b/shuup/testing/single_page_checkout_with_login_and_register_conf.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.conf import settings
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 
@@ -26,12 +26,11 @@ class SinglePageCheckoutViewWithLoginAndRegister(SinglePageCheckoutView):
     empty_phase_spec = "shuup.front.checkout.empty:EmptyPhase"
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^checkout/$', SinglePageCheckoutViewWithLoginAndRegister.as_view(), name='checkout'),
     url(r'^checkout/(?P<phase>.+)/$', SinglePageCheckoutViewWithLoginAndRegister.as_view(), name='checkout'),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^sa/', include('shuup.admin.urls', namespace="shuup_admin", app_name="shuup_admin")),
     url(r'^api/', include('shuup.api.urls')),
     url(r'^', include('shuup.front.urls', namespace="shuup", app_name="shuup")),
-) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/shuup_tests/admin/utils.py
+++ b/shuup_tests/admin/utils.py
@@ -9,14 +9,14 @@ from shuup_tests.utils import replace_urls
 
 
 def get_admin_only_urls():
-    from django.conf.urls import patterns, url, include
+    from django.conf.urls import url, include
     from shuup.admin.urls import get_urls
     class FauxUrlPatternsModule:
         urlpatterns = get_urls()
 
-    return patterns('',
+    return [
         url(r'^sa/', include(FauxUrlPatternsModule, namespace="shuup_admin", app_name="shuup_admin")),
-    )
+    ]
 
 def admin_only_urls():
     return replace_urls(get_admin_only_urls())

--- a/shuup_tests/notify/notification_test_urls.py
+++ b/shuup_tests/notify/notification_test_urls.py
@@ -6,8 +6,8 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns('',
+urlpatterns = [
     url('test/(?P<arg>.+)/$', (lambda: 0), name="test"),
-)
+]

--- a/shuup_workbench/test_urls.py
+++ b/shuup_workbench/test_urls.py
@@ -5,17 +5,16 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.conf import settings
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 
 """
 Modify these only for Shuup tests. For testing modify urls.py instead.
 """
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^sa/', include('shuup.admin.urls', namespace="shuup_admin", app_name="shuup_admin")),
     url(r'^api/', include('shuup.api.urls')),
     url(r'^', include('shuup.front.urls', namespace="shuup", app_name="shuup")),
-) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/shuup_workbench/urls.py
+++ b/shuup_workbench/urls.py
@@ -5,14 +5,13 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.conf import settings
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^sa/', include('shuup.admin.urls', namespace="shuup_admin", app_name="shuup_admin")),
     url(r'^api/', include('shuup.api.urls')),
     url(r'^', include('shuup.front.urls', namespace="shuup", app_name="shuup")),
-) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
In Django 1.10, the patterns function is deprecated, this PR should allow an easier migration to the current version. 