### PR TITLE
Updated the full_clean of the xtheme PluginForm to allow plugin data …

### DIFF
--- a/shuup/xtheme/plugins/forms.py
+++ b/shuup/xtheme/plugins/forms.py
@@ -66,7 +66,7 @@ class PluginForm(forms.Form):
         """
         super(PluginForm, self).full_clean()
         for name in self.fields:
-            if name in self.data:
+            if self.cleaned_data.get(name, None) is not None:
                 continue
             if self.fields[name].initial is not None:
                 self.cleaned_data[name] = self.fields[name].initial

--- a/shuup/xtheme/plugins/forms.py
+++ b/shuup/xtheme/plugins/forms.py
@@ -66,7 +66,7 @@ class PluginForm(forms.Form):
         """
         super(PluginForm, self).full_clean()
         for name in self.fields:
-            if self.cleaned_data.get(name, None) is not None:
+            if name in self.cleaned_data:
                 continue
             if self.fields[name].initial is not None:
                 self.cleaned_data[name] = self.fields[name].initial

--- a/shuup_tests/front/test_carousel.py
+++ b/shuup_tests/front/test_carousel.py
@@ -27,11 +27,11 @@ def test_carousel_plugin_form():
     checks = [
         (
             {},
-            {"carousel": None, "active": True}
+            {"carousel": None, "active": False}
         ),
         (
             {"carousel": test_carousel.pk},
-            {"carousel": test_carousel.pk, "active": True}
+            {"carousel": test_carousel.pk, "active": False}
         ),
         (
             {"carousel": test_carousel.pk, "active": False},


### PR DESCRIPTION
I wasn't able to update existing plugin using the xtheme editor though I was able to create new ones. I discovered that the full_clean method of the PluginForm had the line 

```
    def full_clean(self):
        """
        Use initial values as defaults for cleaned data
        """
        super(PluginForm, self).full_clean()
        for name in self.fields:
            if name in self.data:
                continue
            if self.fields[name].initial is not None:
                self.cleaned_data[name] = self.fields[name].initial
        self.cleaned_data

```
For instance, the value for name for Carousel plugin is 'carousel' but the corresponding key in the raw form data is 'plugin-carousel'. This check would consistently fail for existing plugin config. New plugins can be created but existing ones can't be edited and updated.

My change simply checks for the updated fields in the cleaned_data rather than the underlying form data. That is

`name in self.cleaned_data:`

Another way of addressing the problem is to prefix the name with the plugin prefix and check for the key in the raw data as below

`"%s-%s" % (self.prefix, name) in self.data:`

After making this change, the unit test for carousel did not pass. I noticed that the test was expecting the value for active to default to True which seems counter-intuitive to me. I think active is not supplied, then the corresponding config value should default to False ( and this is what the existing carousel codes implements). So I changed the checks to reflect this. 

Secondly, I updated the unit test for carousel (test_carousel) to reflect the intuitive expectation of active in config should be set to True when active is not selected in the form. 