### PR TITLE
Scroll up after submitting checkout phase form

### DIFF
--- a/shuup/front/templates/shuup/front/checkout/_vertical_phases.jinja
+++ b/shuup/front/templates/shuup/front/checkout/_vertical_phases.jinja
@@ -65,6 +65,7 @@
                 data: data,
                 success: function (response) {
                     $("#ajax_content").html(response);
+                    window.scrollTo(0, $("#ajax_content").offset().top);
                     if (currentPhase != window.currentPhase && form.hasClass("single-page-refresh-after")) {
                         location.reload();
                     }


### PR DESCRIPTION
When user clicks continue in vertical checkout view to move into next phase, scrolls html document up little bit to prevent the user to skip any new information. 

New phase content is fetched via ajax and inserted html content but for example if user has scrolled to the bottom of the html document, some of the new phase content is possibly inserted out of the user's screen and it is easily skipped. 

This fix scrolls document up after moving to new phase so that user doesn't accidentally miss any phase information like shipping or payment methods for example.