### PR TITLE
Admin: Hide media form parts from product create (SH-516)

### DIFF
--- a/shuup/admin/modules/products/views/edit.py
+++ b/shuup/admin/modules/products/views/edit.py
@@ -159,6 +159,9 @@ class ProductAttributeFormPart(FormPart):
 
 class BaseProductMediaFormPart(FormPart):
     def get_form_defs(self):
+        if not self.object.pk:
+            return
+
         yield TemplatedFormDef(
             self.name,
             self.formset,


### PR DESCRIPTION
Since all product media is now added with AJAX we can't allow merchant to add media through these forms before the actual product is created.

Product basic information still have the dropzone for quick adding the primary image for the product during the creation.