### PR TITLE
Provide mechanism to validate uploaded wheels

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -8,6 +8,7 @@
 -e .
 alabaster==0.7.8
 babel==2.3.4
+cryptography==1.7.1
 django-bootstrap3==6.2.2
 django-countries==3.4.1
 django-enumfields==0.7.4
@@ -28,6 +29,8 @@ fake-factory==0.5.3
 imagesize==0.7.1
 jinja2==2.8
 jsonfield==1.0.3
+keyring==10.2
+keyrings.alt==2.0
 Markdown==2.6.6
 MarkupSafe==0.23
 pillow==3.2.0
@@ -35,6 +38,7 @@ Pygments==2.1.3
 pytoml==0.1.8
 pytz==2016.4
 requests==2.10.0
+secretstorage==2.3.1
 six==1.10.0
 snowballstemmer==1.2.1
 Sphinx==1.4.1

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ utils.add_exclude_patters([
 REQUIRES = [
     'pillow>=3.4.2,<4',
     'Babel>=2.2,<3',
+    'cryptography==1.7.1',
     'Django>=1.8,<1.10',
     'django-bootstrap3>=6.1,<7',
     'django-countries>=3.3,<4',
@@ -98,11 +99,14 @@ REQUIRES = [
     'fake-factory>=0.5.0,<0.5.4',
     'Jinja2>=2.8,<2.9',
     'jsonfield>=1.0,<2',
+    'keyring==10.2',
+    'keyrings.alt==2.0',
     'Markdown>=2.6,<3',
     'openpyxl==2.3.5',
     'pytoml>=0.1.0,<0.2',
     'pytz>=2015.4',
     'requests>=2.7,<3',
+    'secretstorage==2.3.1',
     'six>=1.9,<2',
     'unicodecsv==0.14.1',
     'xlrd==1.0.0'

--- a/shuup/addons/admin_module/views/upload.py
+++ b/shuup/addons/admin_module/views/upload.py
@@ -14,6 +14,7 @@ import traceback
 import zipfile
 
 from django import forms
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http.response import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
@@ -109,7 +110,13 @@ class AddonUploadConfirmView(FormView):
         self.template_name = "shuup/admin/addons/upload_complete.jinja"
         context = {}
         try:
-            installer.install_package(self.get_addon_path())
+            addon_path = self.get_addon_path()
+            if hasattr(settings, 'WHEEL_USER'):
+                # Do not import at the top as it would introduce extra
+                # dependencies to the project.
+                from shuup.addons.verify import verify_wheel
+                verify_wheel(addon_path)
+            installer.install_package(addon_path)
         except Exception:
             context["error"] = traceback.format_exc()
             context["success"] = False

--- a/shuup/addons/verify.py
+++ b/shuup/addons/verify.py
@@ -1,0 +1,40 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import json
+
+import keyring
+from django.conf import settings
+from wheel import signatures
+from wheel.install import WheelFile
+from wheel.util import native
+
+
+class WheelValidationFailed(Exception):
+    pass
+
+
+def verify_wheel(wheelfile):
+    wf = WheelFile(wheelfile)
+    sig_name = wf.distinfo_name + '/RECORD.jws'
+    try:
+        sig = json.loads(native(wf.zipfile.open(sig_name).read()))
+    except KeyError:
+        raise WheelValidationFailed("This wheel is not signed")
+    verified = signatures.verify(sig)
+
+    try:
+        vk = verified[0][0]['jwk']['vk']
+    except (KeyError, IndexError, ValueError):
+        raise WheelValidationFailed("Invalid signature")
+
+    if vk != settings.WHEEL_USER:
+        raise WheelValidationFailed("Wheel validation failed")
+
+    kr = keyring.get_keyring()
+    password = kr.get_password("wheel", settings.WHEEL_USER)
+    if password != settings.WHEEL_PASSWORD:
+        raise WheelValidationFailed("Wheel validation failed")

--- a/shuup/apps/settings.py
+++ b/shuup/apps/settings.py
@@ -109,9 +109,10 @@ def validate_templates_configuration():
 
 def reload_apps():
     import django
+    from django.contrib.staticfiles.finders import get_finder
     # Clear cache for any AppDirectoriesFinder instance.
     # This should be done before Django apps is reloaded.
-    django.contrib.staticfiles.finders.get_finder.cache_clear()
+    get_finder.cache_clear()
 
     _KNOWN_SETTINGS.clear()
     django.apps.apps.app_configs.clear()

--- a/shuup/front/templates/shuup/front/checkout/_vertical_phases.jinja
+++ b/shuup/front/templates/shuup/front/checkout/_vertical_phases.jinja
@@ -65,6 +65,7 @@
                 data: data,
                 success: function (response) {
                     $("#ajax_content").html(response);
+                    window.scrollTo(0, $("#ajax_content").offset().top);
                     if (currentPhase != window.currentPhase && form.hasClass("single-page-refresh-after")) {
                         location.reload();
                     }


### PR DESCRIPTION
This optionally enables Wheel validation for addon uploads.
To enable it, WHEEL_USER and WHEEL_PASSWORD have to be provided

WHEEL_USER should be set to the value of vk when running `wheel keygen`
on the machine used to build and sign wheels.
WHEEL_PASSWORD should be the value returned by:
    ``keyring get wheel WHEEL_USER``
where WHEEL_USER matches the value of the previously aquired vk.

It is also necessary to properly set up the keyring backend in:
~/.local/share/python_keyring/keyringrc.cfg:

```
[backend]
default-keyring=keyrings.alt.file.PlaintextKeyring
```

The same keyring used when building the wheels should be copied to:
~/.local/share/python_keyring/keyring_pass.cfg

Ref: MAR-19
