### PR TITLE
Specify minimum Node version compatible with Shuup

### DIFF
--- a/doc/howto/getting_started_dev.rst
+++ b/doc/howto/getting_started_dev.rst
@@ -15,7 +15,7 @@ Getting Started with Shuup Development
 Requirements
 ------------
 * Python 2.7.9+/3.4+. https://www.python.org/download/.
-* Node.js. https://nodejs.org/en/download/
+* Node.js (v0.12 or above). https://nodejs.org/en/download/
 * Any database supported by Django.
 
 Installation for Shuup Development

--- a/shuup_setup_utils/nodejs_verify.py
+++ b/shuup_setup_utils/nodejs_verify.py
@@ -23,7 +23,7 @@ So, in short, to continue:
 """.strip()
 
 NO_NODE_WHATSOEVER = """
-You need to install Node.js (version 0.10 or newer) to continue.
+You need to install Node.js (version 0.12 or newer) to continue.
 Please see
   https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager
 for instructions relevant to your system.


### PR DESCRIPTION
Add the minimum version of Node required to build the resources (v0.10 isn't compatible anymore).