### PR TITLE
Add 'engines' directive to package.json files

### DIFF
--- a/shuup/admin/package.json
+++ b/shuup/admin/package.json
@@ -10,6 +10,9 @@
   "author": "Shuup Team <shuup@shuup.com>",
   "license": "OSL-3.0",
   "private": true,
+  "engines": {
+    "node" : ">=0.12.0"
+  },
   "dependencies": {
     "autoprefixer-loader": "^3.1.0",
     "babel-core": "^5.8.23",

--- a/shuup/front/package.json
+++ b/shuup/front/package.json
@@ -8,6 +8,9 @@
   },
   "author": "",
   "license": "OSL-3.0",
+  "engines": {
+    "node" : ">=0.12.0"
+  },
   "dependencies": {
     "bower": "^1.8.0",
     "gulp": "^3.9.1",

--- a/shuup/xtheme/package.json
+++ b/shuup/xtheme/package.json
@@ -11,6 +11,9 @@
   "author": "Aarni Koskela <aarni.koskela@shuup.com>",
   "private": true,
   "license": "OSL-3.0",
+  "engines": {
+    "node" : ">=0.12.0"
+  },
   "dependencies": {
     "autoprefixer-loader": "^3.1.0",
     "babel-core": "^5.8.23",


### PR DESCRIPTION
This won't be enforced unless the user has the 'engine-strict' option enabled but it should at least output a warning. 