### PR TITLE
Return the appropriate error code in the HTTP response

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -33,6 +33,9 @@ Addons
 Front
 ~~~~~
 
+- Fix default error handler always returning 200 OK as an HTTP status code.
+  Now returns the appropriate status code.
+
 Xtheme
 ~~~~~~
 

--- a/shuup/admin/error_handlers.py
+++ b/shuup/admin/error_handlers.py
@@ -36,4 +36,4 @@ class AdminPageErrorHandler(ErrorPageHandler):
 
     @classmethod
     def handle_error(cls, request, error_status):
-        return render(request, "shuup/admin/errors/{}.jinja".format(error_status))
+        return render(request, "shuup/admin/errors/{}.jinja".format(error_status), status=error_status)

--- a/shuup/front/error_handlers.py
+++ b/shuup/front/error_handlers.py
@@ -30,4 +30,4 @@ class FrontPageErrorHandler(ErrorPageHandler):
 
     @classmethod
     def handle_error(cls, request, error_status):
-        return render(request, "shuup/front/errors/{}.jinja".format(error_status))
+        return render(request, "shuup/front/errors/{}.jinja".format(error_status), status=error_status)


### PR DESCRIPTION
Update the default error handler to return the appropriate HTTP status code.
The status_code variable is passed to the jinja template for rendering the error, but the HTTP status is always left as the default, which is 200.
This fix is applied to both the admin and front error handlers.
The tests have been updated to no longer check for `status_code == 200`, and now check for the appropriate status value.

I have not been able to get the tests running locally.
It would be appreciated if someone could verify the tests pass.