### PR TITLE
Introduce provided order information

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -22,6 +22,8 @@ Localization
 Admin
 ~~~~~
 
+- Add new provide category called `admin_order_information` which can be used
+  to add extra information rows to order detail page.
 - Use select2 multiple field for shop staff members
 - Fix bug in "Select All" mass action
 - Fix bug in product choice widget

--- a/doc/ref/provides.rst
+++ b/doc/ref/provides.rst
@@ -82,6 +82,10 @@ Core
     Allows providing extension for the product attribute form in admin.
     Should implement the `~shuup.admin.form_modifier.FormModifier` interface.
 
+``admin_order_information``
+    Additional information rows for Order detail page. Provide objects should inherit
+    from `~shuup.admin.modules.orders.utils.OrderInformation` class.
+
 ``admin_product_form_part``
     Additional ``FormPart`` classes for Product editing.
     (This is used by pricing modules, for instance.) See :doc:`example <../howto/new_tab>`.

--- a/shuup/admin/modules/orders/utils.py
+++ b/shuup/admin/modules/orders/utils.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+class OrderInformation(object):
+    order = 1
+    title = "default"
+
+    def __init__(self, order, **kwargs):
+        self.order = order
+
+    def provides_info(self):
+        """
+        Override to add business logic if the order should show this information row.
+        """
+        return (self.information is not None)
+
+    @property
+    def information(self):
+        """
+        Override this property to return wanted information about the order.
+        """
+        return None

--- a/shuup/admin/modules/orders/views/detail.py
+++ b/shuup/admin/modules/orders/views/detail.py
@@ -34,6 +34,13 @@ class OrderDetailView(DetailView):
         context["title"] = force_text(self.object)
         context["order_sections"] = []
 
+        provided_information = []
+        for provided_info in sorted(get_provide_objects("admin_order_information"), key=lambda x: x.order):
+            info = provided_info(self.object)
+            if info.provides_info():
+                provided_information.append((info.title, info.information))
+        context["provided_information"] = provided_information
+
         order_sections_provides = sorted(get_provide_objects("admin_order_section"), key=lambda x: x.order)
         for admin_order_section in order_sections_provides:
             # Check whether the Section should be visible for the current object

--- a/shuup/admin/templates/shuup/admin/orders/detail.jinja
+++ b/shuup/admin/templates/shuup/admin/orders/detail.jinja
@@ -46,6 +46,11 @@
                             {% if tracking_codes %}
                                 {{ info_row(_("Tracking codes"), render_objects(tracking_codes)) }}
                             {% endif %}
+                            {% if provided_information %}
+                                {% for title, info in provided_information %}
+                                    {{ info_row(title, info) }}
+                                {% endfor %}
+                            {% endif %}
                         </dl>
                     </div>
                 </div>


### PR DESCRIPTION
This provide category is used to add extra info rows into Order detail page. Provide objects should inherit from `shuup.admin.modules.orders.utils.OrderInformation` class. Classes inheriting `OrderInformation` are turned into info rows by using the title variable as row title and information property as row data. Includes test for checking that info rows can be added to the Order detail page.