### PR TITLE
Use optional DEFAULT_SHOP_ID setting instead of first shop

### DIFF
--- a/shuup/admin/modules/products/__init__.py
+++ b/shuup/admin/modules/products/__init__.py
@@ -167,7 +167,7 @@ class ProductModule(AdminModule):
 
     def get_model_url(self, object, kind):
         if isinstance(object, Product):
-            shop = Shop.objects.first()
+            shop = Shop.objects.get_default()
             object = object.get_shop_instance(shop)
         return derive_model_url(ShopProduct, "shuup_admin:shop_product", object, kind)
 

--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -105,7 +105,7 @@ class ProductBaseForm(MultiLanguageModelForm):
                 file_id=self.cleaned_data["file"],
                 kind=ProductMediaKind.IMAGE,
             )
-            image.shops.add(Shop.objects.first())
+            image.shops.add(Shop.objects.get_default())
             instance.primary_image = image
             instance.save()
 
@@ -349,7 +349,7 @@ class BaseProductMediaFormSet(BaseModelFormSet):
         kwargs.setdefault("languages", self.languages)
         kwargs.setdefault("product", self.product)
         kwargs.setdefault("allowed_media_kinds", self.allowed_media_kinds)
-        kwargs.setdefault("default_shop", Shop.objects.first().pk)
+        kwargs.setdefault("default_shop", Shop.objects.get_default().pk)
         return self.form_class(**kwargs)
 
 

--- a/shuup/admin/modules/products/views/list.py
+++ b/shuup/admin/modules/products/views/list.py
@@ -70,7 +70,7 @@ class ProductListView(PicotableListView):
 
     def get_queryset(self):
         filter = self.get_filter()
-        shop_id = filter.get("shop", Shop.objects.first().pk)
+        shop_id = filter.get("shop", Shop.objects.get_default().pk)
         qs = ShopProduct.objects.filter(product__deleted=False, shop_id=shop_id)
         q = Q()
         for mode in filter.get("modes", []):

--- a/shuup/admin/modules/shops/__init__.py
+++ b/shuup/admin/modules/shops/__init__.py
@@ -53,7 +53,7 @@ class ShopModule(AdminModule):
 
     def get_help_blocks(self, request, kind):
         if kind == "setup":
-            shop = Shop.objects.first()
+            shop = Shop.objects.get_default()
             yield SimpleHelpBlock(
                 text=_("Add a logo to make your store stand out"),
                 actions=[{

--- a/shuup/admin/views/home.py
+++ b/shuup/admin/views/home.py
@@ -78,7 +78,7 @@ class HomeView(TemplateView):
             })
         else:
             wizard_steps = load_setup_wizard_panes(
-                shop=Shop.objects.first(), request=self.request, visible_only=False)
+                shop=Shop.objects.get_default(), request=self.request, visible_only=False)
             for step in wizard_steps:
                 wizard_actions.append({
                     "text": step.title,

--- a/shuup/campaigns/models/catalog_filters.py
+++ b/shuup/campaigns/models/catalog_filters.py
@@ -96,7 +96,7 @@ class CategoryFilter(CatalogFilter):
 
     def get_matching_shop_products(self):
         shop_products = []
-        shop = Shop.objects.first()
+        shop = Shop.objects.get_default()
         cat_ids = self.categories.all_except_deleted().values_list("pk", flat=True)
         for parent in ShopProduct.objects.filter(categories__id__in=cat_ids).select_related("product"):
             shop_products.append(parent)

--- a/shuup/front/middleware.py
+++ b/shuup/front/middleware.py
@@ -74,7 +74,7 @@ class ShuupFrontMiddleware(object):
 
     def _set_shop(self, request):
         # TODO: Not the best logic :)
-        request.shop = Shop.objects.first()
+        request.shop = Shop.objects.get_default()
         if not request.shop:
             raise ImproperlyConfigured("No shop!")
 


### PR DESCRIPTION
This introduce a minor change on how the default shop is queried. The default behavior stays the same but can be overridden with a DEFAULT_SHOP_ID setting.  

Some parts of the code still use Shop.objects.first() such as the wizard and sample modules which is probably the desired behavior.