### PR TITLE
Send the request object to the Section provides

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unrealeased
 Core
 ~~~~
 
+- Section receives the request object
 - API: added nearby filter for products
 - API: added nearby filter for shops
 - API: add address endpoint

--- a/shuup/admin/base.py
+++ b/shuup/admin/base.py
@@ -230,17 +230,18 @@ class Section(object):
     order = 0
 
     @staticmethod
-    def visible_for_object(obj):
+    def visible_for_object(obj, request):
         """
         Returns whether this sections must be visible for the provided object (e.g. `order`)
         :type model object: e.g. shuup.core.models.Order
+        :type request: HttpRequest
         :return whether this section must be shown in order section list, defaults to false
         :rtype: bool
         """
         return False
 
     @staticmethod
-    def get_context_data(obj):
+    def get_context_data(obj, request):
         """
         Returns additional information to be used in the template
 
@@ -251,6 +252,7 @@ class Section(object):
 
 
         :type object: e.g. shuup.core.models.Order
+        :type request: HttpRequest
         :return additional context data
         :rtype: object|None
         """
@@ -266,8 +268,8 @@ class OrderSection(Section):
         return super(OrderSection, cls).__new__(cls)
 
     @classmethod
-    def visible_for_object(cls, order):
+    def visible_for_object(cls, order, request):
         """
         Support for the deprecated `visible_for_order` function
         """
-        return cls.visible_for_order(order) or super(OrderSection, cls).visible_for_object(order)
+        return cls.visible_for_order(order, request) or super(OrderSection, cls).visible_for_object(order, request)

--- a/shuup/admin/modules/contacts/sections.py
+++ b/shuup/admin/modules/contacts/sections.py
@@ -22,11 +22,11 @@ class BasicInfoContactSection(Section):
     order = 1
 
     @staticmethod
-    def visible_for_object(contact):
+    def visible_for_object(contact, request):
         return True
 
     @staticmethod
-    def get_context_data(contact):
+    def get_context_data(contact, request):
         context = {}
 
         context['groups'] = sorted(
@@ -52,12 +52,12 @@ class AddressesContactSection(Section):
     order = 2
 
     @staticmethod
-    def visible_for_object(contact):
+    def visible_for_object(contact, request):
         return (contact.default_shipping_address_id or
                 contact.default_billing_address_id)
 
     @staticmethod
-    def get_context_data(contact):
+    def get_context_data(contact, request):
         return None
 
 
@@ -69,12 +69,12 @@ class OrdersContactSection(Section):
     order = 3
 
     @staticmethod
-    def visible_for_object(contact):
+    def visible_for_object(contact, request):
         return (contact.default_shipping_address_id or
                 contact.default_billing_address_id)
 
     @staticmethod
-    def get_context_data(contact):
+    def get_context_data(contact, request):
         return contact.customer_orders.valid().order_by("-id")
 
 
@@ -86,11 +86,11 @@ class MembersContactSection(Section):
     order = 4
 
     @staticmethod
-    def visible_for_object(contact):
+    def visible_for_object(contact, request):
         return hasattr(contact, 'members')
 
     @staticmethod
-    def get_context_data(contact):
+    def get_context_data(contact, request):
         if contact.members:
             return contact.members.all()
 

--- a/shuup/admin/modules/contacts/views/detail.py
+++ b/shuup/admin/modules/contacts/views/detail.py
@@ -143,10 +143,11 @@ class ContactDetailView(DetailView):
         contact_sections_provides = sorted(get_provide_objects("admin_contact_section"), key=lambda x: x.order)
         for admin_contact_section in contact_sections_provides:
             # Check whether the ContactSection should be visible for the current object
-            if admin_contact_section.visible_for_object(self.object):
+            if admin_contact_section.visible_for_object(self.object, self.request):
                 context["contact_sections"].append(admin_contact_section)
                 # add additional context data where the key is the contact_section identifier
-                context[admin_contact_section.identifier] = admin_contact_section.get_context_data(self.object)
+                section_context = admin_contact_section.get_context_data(self.object, self.request)
+                context[admin_contact_section.identifier] = section_context
 
         return context
 

--- a/shuup/admin/modules/orders/sections.py
+++ b/shuup/admin/modules/orders/sections.py
@@ -22,11 +22,11 @@ class PaymentOrderSection(Section):
     order = 1
 
     @staticmethod
-    def visible_for_object(order):
+    def visible_for_object(order, request):
         return True
 
     @staticmethod
-    def get_context_data(order):
+    def get_context_data(order, request):
         return order.payments.all()
 
 
@@ -38,11 +38,11 @@ class ShipmentSection(Section):
     order = 2
 
     @staticmethod
-    def visible_for_object(order):
+    def visible_for_object(order, request):
         return True
 
     @staticmethod
-    def get_context_data(order):
+    def get_context_data(order, request):
         return Shipment.objects.filter(order=order).order_by("-created_on").all()
 
 
@@ -55,11 +55,11 @@ class LogEntriesOrderSection(Section):
     order = 3
 
     @staticmethod
-    def visible_for_object(order):
+    def visible_for_object(order, request):
         return True
 
     @staticmethod
-    def get_context_data(order):
+    def get_context_data(order, request):
         return OrderLogEntry.objects.filter(target=order).order_by("-created_on").all()[:12]
         # TODO: We're currently trimming to 12 entries, probably need pagination
 
@@ -73,9 +73,9 @@ class AdminCommentSection(Section):
     order = 4
 
     @staticmethod
-    def visible_for_object(order):
+    def visible_for_object(order, request):
         return True
 
     @staticmethod
-    def get_context_data(order):
+    def get_context_data(order, request):
         return None

--- a/shuup/admin/modules/orders/views/detail.py
+++ b/shuup/admin/modules/orders/views/detail.py
@@ -37,10 +37,11 @@ class OrderDetailView(DetailView):
         order_sections_provides = sorted(get_provide_objects("admin_order_section"), key=lambda x: x.order)
         for admin_order_section in order_sections_provides:
             # Check whether the Section should be visible for the current object
-            if admin_order_section.visible_for_object(self.object):
+            if admin_order_section.visible_for_object(self.object, self.request):
                 context["order_sections"].append(admin_order_section)
                 # add additional context data where the key is the order_section identifier
-                context[admin_order_section.identifier] = admin_order_section.get_context_data(self.object)
+                section_context = admin_order_section.get_context_data(self.object, self.request)
+                context[admin_order_section.identifier] = section_context
 
         return context
 

--- a/shuup/admin/modules/products/sections.py
+++ b/shuup/admin/modules/products/sections.py
@@ -21,10 +21,10 @@ class ProductOrdersSection(Section):
     order = 1
 
     @staticmethod
-    def visible_for_object(product):
+    def visible_for_object(product, request):
         return bool(product.pk)
 
     @staticmethod
-    def get_context_data(product):
+    def get_context_data(product, request):
         # TODO: restrict to first 100 orders - do pagination later
         return Order.objects.valid().filter(lines__product_id=product.id).distinct()[:100]

--- a/shuup/admin/modules/products/views/edit.py
+++ b/shuup/admin/modules/products/views/edit.py
@@ -242,8 +242,9 @@ class ProductEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView
         context["tour_complete"] = is_tour_complete("product")
         product_sections_provides = sorted(get_provide_objects("admin_product_section"), key=lambda x: x.order)
         for admin_product_section in product_sections_provides:
-            if admin_product_section.visible_for_object(self.object):
+            if admin_product_section.visible_for_object(self.object, self.request):
                 context["product_sections"].append(admin_product_section)
-                context[admin_product_section.identifier] = admin_product_section.get_context_data(self.object)
+                section_context = admin_product_section.get_context_data(self.object, self.request)
+                context[admin_product_section.identifier] = section_context
 
         return context

--- a/shuup/campaigns/admin_module/sections.py
+++ b/shuup/campaigns/admin_module/sections.py
@@ -19,11 +19,11 @@ class ProductCampaignsSection(Section):
     template = "shuup/campaigns/admin/_product_campaigns.jinja"
 
     @staticmethod
-    def visible_for_object(product):
+    def visible_for_object(product, request):
         return bool(product.pk)
 
     @staticmethod
-    def get_context_data(product):
+    def get_context_data(product, request):
         ctx = {}
         for shop in Shop.objects.all():
             try:

--- a/shuup/order_printouts/admin_module/section.py
+++ b/shuup/order_printouts/admin_module/section.py
@@ -32,11 +32,11 @@ class PrintoutsSection(Section):
     order = 5
 
     @staticmethod
-    def visible_for_object(obj):
+    def visible_for_object(obj, request):
         return True
 
     @staticmethod
-    def get_context_data(obj):
+    def get_context_data(obj, request):
         recipient = None
         if obj.customer:
             recipient = obj.customer.email

--- a/shuup/testing/admin_module/sections.py
+++ b/shuup/testing/admin_module/sections.py
@@ -20,11 +20,11 @@ class MockContactSection(Section):
     order = 9
 
     @staticmethod
-    def visible_for_object(contact):
+    def visible_for_object(contact, request):
         return True
 
     @staticmethod
-    def get_context_data(contact):
+    def get_context_data(contact, request):
         context = {}
         context['mock_context'] = "mock section context data"
         return context


### PR DESCRIPTION
- This will break backwards compatibility but should be necessary for multi-shop feature since some objects could not know the current show without the request.