### PR TITLE
New provide category for adding extra fields to the order delivery pr…

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -22,6 +22,8 @@ Localization
 Admin
 ~~~~~
 
+- Add new provide category called `order_printouts_delivery_extra_fields` 
+  which can be used to add extra rows to order delivery slip.
 - Add new provide category called `admin_order_information` which can be used
   to add extra information rows to order detail page.
 - Use select2 multiple field for shop staff members

--- a/doc/ref/provides.rst
+++ b/doc/ref/provides.rst
@@ -156,6 +156,10 @@ Core
 ``notify_script_template``
     Notification framework `~shuup.notify.base.ScriptTemplate` classes.
 
+``order_printouts_delivery_extra_fields``
+    Additional information rows for order delivery printout. Provide objects should inherit
+    from `~shuup.order_printouts.utils.PrintoutDeliveryExtraInformation` class.
+
 ``order_source_modifier_module``
     `~shuup.core.order_creator.OrderSourceModifierModule` for modifying
     order source, e.g. in its

--- a/shuup/order_printouts/admin_module/views.py
+++ b/shuup/order_printouts/admin_module/views.py
@@ -12,6 +12,7 @@ from django.http import HttpResponse, JsonResponse
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
+from shuup.apps.provides import get_provide_objects
 from shuup.core.models import Order, OrderLine, OrderLineType, Shipment
 from shuup.utils.pdf import html_to_pdf, render_html_to_pdf
 
@@ -77,6 +78,14 @@ def _get_delivery_html(request, order, shipment, html_mode=False):
         "footer": _get_footer_information(order.shop),
         "html_mode": html_mode
     }
+
+    provided_information = {}
+    for provided_info in sorted(get_provide_objects("order_printouts_delivery_extra_fields")):
+        info = provided_info(order, shipment)
+        if info.provides_extra_fields():
+            provided_information.update(info.extra_fields)
+    context['extra_fields'] = provided_information
+
     return render_to_string("shuup/order_printouts/admin/delivery_pdf.jinja", context=context, request=request)
 
 

--- a/shuup/order_printouts/templates/shuup/order_printouts/admin/delivery_pdf.jinja
+++ b/shuup/order_printouts/templates/shuup/order_printouts/admin/delivery_pdf.jinja
@@ -1,6 +1,6 @@
 {% extends "shuup/order_printouts/admin/order_base.jinja" %}
 {% block information %}
-    {{ macros.shipment_information_table(order, shipment) }}
+    {{ macros.shipment_information_table(order, shipment, extra_fields) }}
 {% endblock %}
 {% block content %}
     <br>

--- a/shuup/order_printouts/templates/shuup/order_printouts/admin/macros.jinja
+++ b/shuup/order_printouts/templates/shuup/order_printouts/admin/macros.jinja
@@ -35,7 +35,7 @@
     </table>
 {% endmacro %}
 
-{% macro shipment_information_table(order, shipment) %}
+{% macro shipment_information_table(order, shipment, extra_fields=None) %}
     <table>
         <tr>
             <td>{% trans %}Identifier{% endtrans %}</td>
@@ -49,6 +49,14 @@
             <td>{% trans %}Order date{% endtrans %}</td>
             <td>{{ order.order_date|localtime|date("j.n.Y H:i") }}</td>
         </tr>
+        {% if extra_fields %}
+            {% for field_name, field_value in extra_fields.items() %}
+                <tr>
+                    <td>{{ field_name }}</td>
+                    <td>{{ field_value }}</td>
+                </tr>
+            {% endfor %}
+        {% endif %}
     </table>
 {% endmacro %}
 

--- a/shuup/order_printouts/utils.py
+++ b/shuup/order_printouts/utils.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+class PrintoutDeliveryExtraInformation(object):
+    order = 1
+
+    def __init__(self, order, shipment, **kwargs):
+        self.order = order
+        self.shipment = shipment
+
+    def provides_extra_fields(self):
+        """
+        Override to add business logic if this module has any extra fields to add
+        to the delivery printout.
+        """
+        return (self.extra_fields is not None)
+
+    @property
+    def extra_fields(self):
+        """
+        Override this property to return wanted information about the order.
+        This property should return a dictionary of field names and values
+        which will be rendered to the order delivery printout.
+        """
+        return {}

--- a/shuup_tests/order_printouts/test_printouts.py
+++ b/shuup_tests/order_printouts/test_printouts.py
@@ -7,12 +7,26 @@
 # LICENSE file in the root directory of this source tree.
 import pytest
 
-from shuup.order_printouts.admin_module.views import get_confirmation_pdf, get_delivery_pdf
+from shuup.apps.provides import override_provides
+from shuup.order_printouts.utils import PrintoutDeliveryExtraInformation
+from shuup.order_printouts.admin_module.views import (
+    get_confirmation_pdf, get_delivery_pdf, get_delivery_html
+)
 from shuup.testing.factories import (
     create_order_with_product, create_product, get_default_shop, get_default_supplier
 )
 from shuup.testing.utils import apply_request_middleware
 from shuup.utils.importing import load
+
+
+class TestPrintoutDeliveryExtraFields(PrintoutDeliveryExtraInformation):
+
+    @property
+    def extra_fields(self):
+        return {
+            "Phone": "123456789",
+            "Random": "row"
+        }
 
 
 @pytest.mark.django_db
@@ -32,3 +46,26 @@ def test_printouts(rf):
     assert response.status_code == 200
     response = get_confirmation_pdf(request, order.id)
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_adding_extra_fields_to_the_delivery(rf):
+    try:
+        import weasyprint
+    except ImportError:
+        pytest.skip()
+
+    shop = get_default_shop()
+    supplier = get_default_supplier()
+    product = create_product("simple-test-product", shop)
+    order = create_order_with_product(product, supplier, 6, 6, shop=shop)
+    shipment = order.create_shipment_of_all_products(supplier)
+    request = rf.get("/")
+
+    with override_provides("order_printouts_delivery_extra_fields", [
+        "shuup_tests.order_printouts.test_printouts:TestPrintoutDeliveryExtraFields",
+    ]):
+        response = get_delivery_html(request, shipment.id)
+        assert response.status_code == 200
+        assert "123456789" in response.content.decode()
+        assert "Random" in response.content.decode()


### PR DESCRIPTION
…intout

Add new provide category called "order_printouts_delivery_extra_fields". This
provide category can be used to add custom information to the order delivery
printout. By default these extra fields are rendered into the shipment
information table.