### PR TITLE
setup.py: Fix/update Trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ LICENSE = 'OSL-3.0'  # https://spdx.org/licenses/
 CLASSIFIERS = """
 Development Status :: 4 - Beta
 Intended Audience :: Developers
-License :: Open Software License 3.0
+License :: OSI Approved
 Natural Language :: English
 Programming Language :: JavaScript
 Programming Language :: Python :: 2

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ DOWNLOAD_URL_TEMPLATE = (
     'v{version}/shuup-{version}-py2.py3-none-any.whl')
 LICENSE = 'OSL-3.0'  # https://spdx.org/licenses/
 CLASSIFIERS = """
-Development Status :: 4 - Beta
+Development Status :: 5 - Production/Stable
 Intended Audience :: Developers
 License :: OSI Approved
 Natural Language :: English

--- a/setup.py
+++ b/setup.py
@@ -54,11 +54,18 @@ Development Status :: 5 - Production/Stable
 Intended Audience :: Developers
 License :: OSI Approved
 Natural Language :: English
+Natural Language :: Chinese (Simplified)
+Natural Language :: Finnish
+Natural Language :: Japanese
+Natural Language :: Portuguese (Brazilian)
 Programming Language :: JavaScript
 Programming Language :: Python :: 2
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3.4
+Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3.6
+Topic :: Internet :: WWW/HTTP :: Dynamic Content
 Topic :: Internet :: WWW/HTTP :: Site Management
 Topic :: Office/Business
 Topic :: Software Development :: Libraries :: Application Frameworks


### PR DESCRIPTION
This PR should allow uploading Shuup to PyPI with Twine.

Also updated some info in the classifiers, e.g. development status.