### PR TITLE
Filtering products by categories ID

### DIFF
--- a/shuup/core/api/category.py
+++ b/shuup/core/api/category.py
@@ -43,11 +43,10 @@ class CategoryFilter(FilterSet):
     shop = django_filters.ModelChoiceFilter(name="shops",
                                             queryset=Shop.objects.all(),
                                             lookup_expr="exact")
-    is_root = django_filters.CharFilter(name="parent", lookup_expr="isnull")
 
     class Meta:
         model = Category
-        fields = ["id", "parent", "shop", "identifier", "is_root"]
+        fields = ["id", "parent", "shop", "identifier"]
 
 
 class CategoryViewSet(ProtectedModelViewSetMixin, PermissionHelperMixin, viewsets.ModelViewSet):

--- a/shuup/front/api/products.py
+++ b/shuup/front/api/products.py
@@ -276,8 +276,8 @@ class ShopFilter(filters.BaseFilterBackend):
 
 class ProductCategoryFilter(filters.BaseFilterBackend):
     """
-    Filter shop products by categories slug name.
-    `categories` is a comma separed value: ?categories=cat1,cat2,cat3
+    Filter shop products by categories IDs.
+    `categories` is a comma separed value: ?categories=1,2,3,4
     """
     def filter_queryset(self, request, queryset, view):
         categories = request.query_params.get("categories")
@@ -286,7 +286,7 @@ class ProductCategoryFilter(filters.BaseFilterBackend):
 
         category_filters = None
         for category in categories.split(","):
-            category_filter = Q(categories__translations__slug__iexact=category.strip())
+            category_filter = Q(categories__id=category.strip())
             # make OR operator among all categories
             category_filters = (category_filter | category_filters) if category_filters else category_filter
 

--- a/shuup_tests/api/test_front_products_api.py
+++ b/shuup_tests/api/test_front_products_api.py
@@ -206,7 +206,7 @@ def test_products_not_available_shop(admin_user):
     shop_product2.save()
 
     # fetch by category1
-    request = get_request("/api/shuup/front/products/?categories=%s" % category1.slug, admin_user)
+    request = get_request("/api/shuup/front/products/?categories=%d" % category1.id, admin_user)
     response = FrontProductViewSet.as_view({"get": "list"})(request)
     response.render()
     products_data = json.loads(response.content.decode("utf-8"))
@@ -214,12 +214,21 @@ def test_products_not_available_shop(admin_user):
     assert products_data[0]["product_id"] == product1.id
 
     # fetch by category2
-    request = get_request("/api/shuup/front/products/?categories=%s" % category2.slug, admin_user)
+    request = get_request("/api/shuup/front/products/?categories=%d" % category2.id, admin_user)
     response = FrontProductViewSet.as_view({"get": "list"})(request)
     response.render()
     products_data = json.loads(response.content.decode("utf-8"))
     assert len(products_data) == 1
     assert products_data[0]["product_id"] == product2.id
+
+    # fetch by category 1 and 2
+    request = get_request("/api/shuup/front/products/?categories=%d,%d" % (category1.id, category2.id), admin_user)
+    response = FrontProductViewSet.as_view({"get": "list"})(request)
+    response.render()
+    products_data = json.loads(response.content.decode("utf-8"))
+    assert len(products_data) == 2
+    assert products_data[0]["product_id"] == product1.id
+    assert products_data[1]["product_id"] == product2.id
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
- Filtering products by categories ID (which has a db index)
- Removed not working and unnecessary `is_root` filter

**Needs to have Category permission to work.**