### PR TITLE
Front order API

### DIFF
--- a/shuup/front/api/__init__.py
+++ b/shuup/front/api/__init__.py
@@ -5,6 +5,7 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+from shuup.front.api.orders import FrontOrderViewSet
 from shuup.front.api.products import FrontProductViewSet
 
 
@@ -14,3 +15,4 @@ def populate_front_api(router):
     :type router: rest_framework.routers.DefaultRouter
     """
     router.register("shuup/front/products", FrontProductViewSet)
+    router.register("shuup/front/orders", FrontOrderViewSet)

--- a/shuup/front/api/orders.py
+++ b/shuup/front/api/orders.py
@@ -1,0 +1,105 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.translation import ugettext_lazy as _
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import mixins, serializers, viewsets
+
+from shuup.api.mixins import PermissionHelperMixin
+from shuup.core.api.address import AddressSerializer
+from shuup.core.api.orders import OrderFilter, OrderStatusChangeMixin
+from shuup.core.models import get_person_contact, Order, OrderLine, Shop
+
+
+class ShopSerializer(serializers.ModelSerializer):
+    logo = serializers.SerializerMethodField()
+    contact_address = AddressSerializer()
+    options = serializers.JSONField(binary=False, required=False)
+
+    class Meta:
+        model = Shop
+        fields = ("id", "name", "logo", "options", "contact_address")
+
+    def get_logo(self, shop):
+        if shop.logo:
+            return self.context["request"].build_absolute_uri(shop.logo.url)
+
+
+class OrderLineSerializer(serializers.ModelSerializer):
+    image = serializers.SerializerMethodField()
+    taxful_price = serializers.SerializerMethodField()
+
+    class Meta:
+        model = OrderLine
+        fields = "__all__"
+
+    def get_image(self, line):
+        """ Return simply the primary image URL """
+
+        if not line.product:
+            return
+
+        primary_image = line.product.primary_image
+
+        # no image found
+        if not primary_image:
+            # check for variation parent image
+            if not line.product.variation_parent or not line.product.variation_parent.primary_image:
+                return
+
+            primary_image = line.product.variation_parent.primary_image
+
+        if primary_image.external_url:
+            return primary_image.external_url
+        else:
+            return self.context["request"].build_absolute_uri(primary_image.file.url)
+
+    def get_taxful_price(self, line):
+        return line.taxful_price.value
+
+
+class OrderSerializer(serializers.ModelSerializer):
+    shop = ShopSerializer()
+
+    class Meta:
+        model = Order
+        fields = "__all__"
+
+
+class OrderDetailSerializer(serializers.ModelSerializer):
+    lines = OrderLineSerializer(many=True)
+
+    class Meta:
+        model = Order
+        fields = "__all__"
+
+
+class FrontOrderViewSet(PermissionHelperMixin,
+                        OrderStatusChangeMixin,
+                        mixins.ListModelMixin,
+                        mixins.RetrieveModelMixin,
+                        viewsets.GenericViewSet):
+
+    queryset = Order.objects.all()
+    serializer_class = OrderSerializer
+    filter_backends = (DjangoFilterBackend,)
+    filter_class = OrderFilter
+
+    def get_view_name(self):
+        return _("Front Orders")
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return OrderSerializer
+        else:
+            return OrderDetailSerializer
+
+    @classmethod
+    def get_help_text(cls):
+        return _("Retrieve, list, and update order statuses for the current users orders.")
+
+    def get_queryset(self):
+        return self.queryset.filter(customer=get_person_contact(self.request.user))

--- a/shuup_tests/api/test_front_orders_api.py
+++ b/shuup_tests/api/test_front_orders_api.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+import json
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient, force_authenticate
+from shuup.core import cache
+from shuup.core.models import get_person_contact
+from shuup.testing.factories import (
+    create_product, create_random_order, create_random_person,
+    get_default_shop, get_default_supplier
+)
+
+
+def setup_function(fn):
+    cache.clear()
+
+
+@pytest.mark.django_db
+def test_list_no_orders(admin_user):
+    get_default_shop()
+    client = _get_client(admin_user)
+    response = client.get("/api/shuup/front/orders/")
+    response_data = json.loads(response.content.decode("utf-8"))
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response_data) == 0
+
+
+@pytest.mark.django_db
+def test_list_orders(admin_user):
+    shop = get_default_shop()
+    product = create_product("test", shop, get_default_supplier())
+    order = create_random_order(get_person_contact(admin_user), [product])
+    order2 = create_random_order(create_random_person(), [product])
+    client = _get_client(admin_user)
+    response = client.get("/api/shuup/front/orders/")
+    response_data = json.loads(response.content.decode("utf-8"))
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response_data) == 1
+    assert "shop" in response_data[0]
+    assert "contact_address" in response_data[0]["shop"]
+
+
+@pytest.mark.django_db
+def test_retrieve_order(admin_user):
+    shop = get_default_shop()
+    product = create_product("test", shop, get_default_supplier())
+    order = create_random_order(get_person_contact(admin_user), [product])
+    order2 = create_random_order(create_random_person(), [product])
+    client = _get_client(admin_user)
+    response = client.get("/api/shuup/front/orders/{}/".format(order.pk))
+    response_data = json.loads(response.content.decode("utf-8"))
+    assert response.status_code == status.HTTP_200_OK
+    assert response_data["id"] == order.pk
+
+    response = client.get("/api/shuup/front/orders/{}/".format(100))
+    assert response.status_code == 404
+
+    response = client.get("/api/shuup/front/orders/{}/".format(order2.pk))
+    assert response.status_code == 404
+
+
+def _get_client(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client

--- a/shuup_tests/api/test_order_api.py
+++ b/shuup_tests/api/test_order_api.py
@@ -11,11 +11,11 @@ import datetime
 import decimal
 import json
 
-import pytest
 from django.utils.timezone import datetime as dt
+
+import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
-
 from shuup.core import cache
 from shuup.core.models import Order, OrderStatus, PaymentStatus, ShippingStatus
 from shuup.testing.factories import (
@@ -313,9 +313,9 @@ def test_complete_order(admin_user):
     order = create_empty_order(shop=shop)
     order.save()
     client = _get_client(admin_user)
-    response = client.put("/api/shuup/order/%s/complete/" % order.pk)
+    response = client.post("/api/shuup/order/%s/complete/" % order.pk)
     assert response.status_code == 200
-    response = client.put("/api/shuup/order/%s/complete/" % order.pk)
+    response = client.post("/api/shuup/order/%s/complete/" % order.pk)
     assert response.status_code == 400
 
 
@@ -325,9 +325,9 @@ def test_cancel_order(admin_user):
     order = create_empty_order(shop=shop)
     order.save()
     client = _get_client(admin_user)
-    response = client.put("/api/shuup/order/%s/cancel/" % order.pk)
+    response = client.post("/api/shuup/order/%s/cancel/" % order.pk)
     assert response.status_code == 200
-    response = client.put("/api/shuup/order/%s/cancel/" % order.pk)
+    response = client.post("/api/shuup/order/%s/cancel/" % order.pk)
     assert response.status_code == 400
 
 


### PR DESCRIPTION
* Add API that allows users to retrieve their own orders.
* Allow products from a pre-existing order to be added to the basket.

The way errors are handled for APIs is a mess right now. We need to eventually come up with a standard approach that applies across all APIs.