### PR TITLE
Check that product children are available for the current shop

### DIFF
--- a/shuup/admin/modules/products/views/edit.py
+++ b/shuup/admin/modules/products/views/edit.py
@@ -85,10 +85,7 @@ class ShopProductFormPart(FormPart):
 
     def __init__(self, request, object=None):
         super(ShopProductFormPart, self).__init__(request, object)
-        shop_queryset = Shop.objects.filter(status=ShopStatus.ENABLED)
-        if getattr(self.request.user, "is_superuser", False):
-            shop_queryset = shop_queryset.filter(staff_members=self.request.user)
-        self.shops = shop_queryset
+        self.shops = [request.session['admin_shop']]
 
     def get_shop_instance(self, shop):
         try:

--- a/shuup/admin/modules/products/views/edit.py
+++ b/shuup/admin/modules/products/views/edit.py
@@ -26,8 +26,7 @@ from shuup.admin.utils.tour import is_tour_complete
 from shuup.admin.utils.views import CreateOrUpdateView
 from shuup.apps.provides import get_provide_objects
 from shuup.core.models import (
-    Product, ProductType, SalesUnit, Shop, ShopProduct, ShopStatus, Supplier,
-    TaxClass
+    Product, ProductType, SalesUnit, Shop, ShopProduct, Supplier, TaxClass
 )
 
 from .toolbars import EditProductToolbar
@@ -228,17 +227,17 @@ class ProductEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView
         orderability_errors = []
 
         if self.object.pk:
-            for shop in Shop.objects.all():
-                try:
-                    shop_product = self.object.get_shop_instance(shop)
-                    orderability_errors.extend(
-                        ["%s: %s" % (shop.name, msg.message)
-                         for msg in shop_product.get_orderability_errors(
-                            supplier=None,
-                            quantity=shop_product.minimum_purchase_quantity,
-                            customer=None)])
-                except ObjectDoesNotExist:
-                    orderability_errors.extend(["%s: %s" % (shop.name, _("Product is not available."))])
+            shop = Shop.objects.get_current(self.request)
+            try:
+                shop_product = self.object.get_shop_instance(shop)
+                orderability_errors.extend(
+                    ["%s: %s" % (shop.name, msg.message)
+                        for msg in shop_product.get_orderability_errors(
+                        supplier=None,
+                        quantity=shop_product.minimum_purchase_quantity,
+                        customer=None)])
+            except ObjectDoesNotExist:
+                orderability_errors.extend(["%s: %s" % (shop.name, _("Product is not available."))])
         context["orderability_errors"] = orderability_errors
         context["product_sections"] = []
         context["tour_key"] = "product"

--- a/shuup/core/models/_shops.py
+++ b/shuup/core/models/_shops.py
@@ -30,6 +30,9 @@ def _get_default_currency():
 
 
 class ShopManager(TranslatableManager):
+    def get_current(self, request):
+        return request.session['admin_shop']
+
     def get_for_user(self, user):
         qs = self.get_queryset()
         if user.is_superuser:

--- a/shuup_tests/simple_supplier/test_simple_supplier.py
+++ b/shuup_tests/simple_supplier/test_simple_supplier.py
@@ -19,6 +19,7 @@ from shuup.simple_supplier.admin_module.views import (process_alert_limit,
                                                       process_stock_adjustment)
 from shuup.simple_supplier.models import StockAdjustment, StockCount
 from shuup.simple_supplier.notify_events import AlertLimitReached
+from shuup.testing.utils import apply_request_middleware
 from shuup.testing.factories import (create_order_with_product, create_product,
                                      get_default_shop)
 from shuup_tests.simple_supplier.utils import get_simple_supplier
@@ -80,8 +81,7 @@ def test_supplier_with_stock_counts(rf, admin_user, settings):
     quantity = random.randint(100, 600)
     supplier.adjust_stock(product.pk, quantity)
     adjust_quantity = random.randint(100, 600)
-    request = rf.get("/")
-    request.user = admin_user
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
     request.POST = {
         "purchase_price": decimal.Decimal(32.00),
         "delta": adjust_quantity
@@ -120,8 +120,7 @@ def test_admin_form(rf, admin_user):
     supplier = get_simple_supplier()
     shop = get_default_shop()
     product = create_product("simple-test-product", shop, supplier)
-    request = rf.get("/")
-    request.user = admin_user
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
     frm = SimpleSupplierForm(product=product, request=request)
     # Form contains 1 product even if the product is not stocked
     assert len(frm.products) == 1
@@ -152,11 +151,9 @@ def test_new_product_admin_form_renders(rf, client, admin_user):
     Make sure that no exceptions are raised when creating a new product
     with simple supplier enabled
     """
-    request = rf.get("/")
-    request.user = admin_user
-    request.session = client.session
-    view = ProductEditView.as_view()
     shop = get_default_shop()
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
+    view = ProductEditView.as_view()
     supplier = get_simple_supplier()
     supplier.stock_managed = True
     supplier.save()
@@ -179,8 +176,7 @@ def test_alert_limit_view(rf, admin_user):
     assert not sc.alert_limit
 
     test_alert_limit = decimal.Decimal(10)
-    request = rf.get("/")
-    request.user = admin_user
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
     request.method = "POST"
     request.POST = {
         "alert_limit": test_alert_limit,


### PR DESCRIPTION
This prevents an error when checking orderability when some child products are not available in a shop