### PR TITLE
Don't cache service prices in checkout templates

### DIFF
--- a/shuup/front/templates/shuup/front/checkout/method_choice.jinja
+++ b/shuup/front/templates/shuup/front/checkout/method_choice.jinja
@@ -26,7 +26,7 @@
                     <span class="title">
                         <span class="name">{{ service.name }}</span>
                         {% if show_prices() %}
-                            <span class="price">{{ service|price }}</span>
+                            <span class="price">{{ service|price(allow_cache=False) }}</span>
                         {% endif %}
                     </span>
                     <div class="description">


### PR DESCRIPTION
Caching service prices may cause faulty prices when using
Waiving cost behaviour component. If user deletes some products
after passing the Shipping & Payment phase, next time Shipping & Payment
phase will show the cached price which could be the waived price. Though
prices are correct when moving to confirmation view but this has caused
confusion among users.