### PR TITLE
Make excluded categories optional in CategoryProductsBasketCondition

### DIFF
--- a/shuup/campaigns/migrations/0007_add_excluded_categories.py
+++ b/shuup/campaigns/migrations/0007_add_excluded_categories.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='categoryproductsbasketcondition',
             name='excluded_categories',
-            field=models.ManyToManyField(related_name='_categoryproductsbasketcondition_excluded_categories_+', to='shuup.Category'),
+            field=models.ManyToManyField(blank=True, related_name='_categoryproductsbasketcondition_excluded_categories_+', to='shuup.Category'),
         ),
         migrations.AlterField(
             model_name='categoryproductsbasketcondition',

--- a/shuup/campaigns/models/basket_conditions.py
+++ b/shuup/campaigns/models/basket_conditions.py
@@ -222,7 +222,7 @@ class CategoryProductsBasketCondition(BasketCondition):
     quantity = models.PositiveIntegerField(default=1, verbose_name=_("quantity"))
     categories = models.ManyToManyField(Category, related_name="+", verbose_name=_("categories"))
     excluded_categories = models.ManyToManyField(
-        Category, related_name="+", verbose_name=_("excluded categories"),
+        Category, blank=True, related_name="+", verbose_name=_("excluded categories"),
         help_text=_(
             "If the customer has even a single product in the basket from these categories "
             "this rule won't match thus the campaign cannot be applied to the basket."


### PR DESCRIPTION
Don't require excluded categories in CategoryProductsBasketCondition. Because this change affects only in validation I believe its safe to add this to the migration also.

Or is there some kind of reason why excluded categories is required? People thinks that this is weird to require them.