### PR TITLE
Remove position fixed from top panels on mobile devices.

### DIFF
--- a/shuup/admin/static_src/base/less/shuup/base.less
+++ b/shuup/admin/static_src/base/less/shuup/base.less
@@ -61,6 +61,9 @@ img {
     @media (max-width: @screen-sm-min) {
         margin-left: 0;
     }
+    @media (max-width: @screen-xs-max) {
+        margin-top: 0 !important;
+    }
 
     &.dashboard { padding: 30px 15px; }
 

--- a/shuup/admin/static_src/base/less/shuup/support-navigation.less
+++ b/shuup/admin/static_src/base/less/shuup/support-navigation.less
@@ -5,7 +5,9 @@
     width: 100%;
     padding-left: 107px;
     border-bottom: 1px solid #ddd;
-
+    @media (max-width: @screen-xs-max) {
+        position: inherit;
+    }
 }
 body {
     &.popup {


### PR DESCRIPTION
Top panel takes 50% of screen space on a phone making viewing anything in shuup admin quite challenging.
Make top panel not fixed for smaller mobile devices.