### PR TITLE
Introduce new provide category "product_context_extra"

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -48,7 +48,8 @@ Front
 
 - Fix bug: Could no change quantities of unorderable lines in the basket
 - Use display units when rendering product quantities
-- Basket views: Add display unit support
+- Add new provide category called `product_context_extra`
+  which can be used to add extra data to the product context.
 - It's now possible to re-order old order from order history
 - It's now possible for addons to extend front main menu using the
   new `front_menu_extender` provide. See :doc:`provides.rst` for more information.

--- a/doc/ref/provides.rst
+++ b/doc/ref/provides.rst
@@ -201,6 +201,10 @@ Core
     `Formdefs <shuup.utils.form_group.FormDef>` for creating payment processors
     (and their service(s)) through the shop setup wizard.
 
+``product_context_extra``
+    Additional context data for the front product views. Provide objects should inherit
+    from `~shuup.front.utils.ProductContextExtra` class.
+
 ``supplier_module``
     Supplier module classes (deriving from `~shuup.core.suppliers.base.BaseSupplierModule`),
     as used by `~shuup.core.models.Supplier`.

--- a/shuup/front/utils/product.py
+++ b/shuup/front/utils/product.py
@@ -67,6 +67,12 @@ def get_product_context(request, product, language=None):
     context["primary_image"] = shop_product.public_primary_image
     context["images"] = shop_product.public_images
     context["order_form"] = _get_order_form(request, context, product, language)
+
+    for provide_object in get_provide_objects("product_context_extra"):
+        provider = provide_object(request, product, language)
+        if provider.provides_extra_context():
+            context.update(provider.extra_context)
+
     return context
 
 
@@ -111,3 +117,26 @@ def get_orderable_variation_children(product, request, variation_variables):
     values = (orderable_variation_children, orderable != 0)
     context_cache.set_cached_value(key, values)
     return values
+
+
+class ProductContextExtra(object):
+
+    def __init__(self, request, product, language, **kwargs):
+        self.request = request
+        self.product = product
+        self.language = language
+
+    def provides_extra_context(self):
+        """
+        Override to add business logic if this module has any context to be added
+        to the product context data.
+        """
+        return (self.extra_context is not None)
+
+    @property
+    def extra_context(self):
+        """
+        Override this property to return wanted information to be added to the product context data.
+        This property should return a dictionary which will be updated to the product context data.
+        """
+        return {}


### PR DESCRIPTION
This provide category can be used to add extra context data to the front product views. Provide objects should inherit from `shuup.front.utils.product.ProductContextExtra` object.
Add test to make sure its working.

This should make it very easy for addons to extend product context data. 