### PR TITLE
tox.ini: Update BeautifulSoup4 and pin html5lib

### DIFF
--- a/shuup_tests/reports/test_reports.py
+++ b/shuup_tests/reports/test_reports.py
@@ -156,9 +156,10 @@ def test_reporting(rf):
         assert response.status_code == 200
 
         soup = BeautifulSoup(response.render().content)
-        assert force_text(TestSalesReport.title) in str(soup)
-        assert str(expected_taxless_total) in str(soup)
-        assert str(expected_taxful_total) in str(soup)
+        soup_text = force_text(soup)
+        assert force_text(TestSalesReport.title) in soup_text
+        assert str(expected_taxless_total) in soup_text
+        assert str(expected_taxful_total) in soup_text
 
 
 @pytest.mark.django_db

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,8 @@ deps =
     django19: django>=1.9,<1.10
     # Do not remove the following BEGIN/END comments. setup.py uses them
     # BEGIN testing deps
-    beautifulsoup4==4.4.0
+    beautifulsoup4==4.5.3
+    html5lib==0.999999999
     mock==1.0.1
     pytest-cache==1.0
     pytest==2.8.4


### PR DESCRIPTION
BeautifulSoup4 4.4.0 does not work with recent html5lib (0.99999999 or
newer), so update it to newer version which works better.

Also pin html5lib so we don't get such surprises anymore.