### PR TITLE
Front menu extender

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -38,6 +38,8 @@ Addons
 Front
 ~~~~~
 
+- It's now possible for addons to extend front main menu using the
+  new `front_menu_extender` provide. See :doc:`provides.rst` for more information.
 - Fix default error handler always returning 200 OK as an HTTP status code.
   Now returns the appropriate status code.
 

--- a/doc/ref/provides.rst
+++ b/doc/ref/provides.rst
@@ -137,6 +137,10 @@ Core
 ``admin_order_section``
     Additional ``Section`` subclasses for Order detail sections.
 
+``front_menu_extender``
+    Additional menu items provided by addons. These should be subclassed from
+    `~shuup.xtheme.extenders.FrontMenuExtender`.
+
 ``front_product_order_form``
     List of order forms which are subclasses of ``ProductOrderForm``. These forms
     are shown on product detail page in front as well as previews etc.

--- a/shuup/themes/classic_gray/templates/classic_gray/shuup/front/macros/theme/navigation.jinja
+++ b/shuup/themes/classic_gray/templates/classic_gray/shuup/front/macros/theme/navigation.jinja
@@ -13,6 +13,7 @@
                     <li{% if request.path == "%s/" % link.url %} class="current"{% endif %}><a href="{{ link.url }}">{{ link.text }}</a></li>
                 {% endfor %}
             {% endif %}
+            {{ xtheme.render_menu_extensions(request) }}
         </ul>
     </div>
 {% endmacro %}

--- a/shuup/xtheme/_theme.py
+++ b/shuup/xtheme/_theme.py
@@ -9,6 +9,7 @@ import logging
 import warnings
 from contextlib import contextmanager
 
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from shuup.apps.provides import (
@@ -17,6 +18,7 @@ from shuup.apps.provides import (
 from shuup.core import cache
 from shuup.utils.deprecation import RemovedInFutureShuupWarning
 from shuup.utils.importing import load
+from shuup.xtheme.extenders import MenuExtenderLocation
 
 log = logging.getLogger(__name__)
 
@@ -324,6 +326,21 @@ class Theme(object):
                 if stylesheet.identifier == self.default_style_identifier:
                     return stylesheet
         return blank
+
+    def render_menu_extensions(self, request, location=MenuExtenderLocation.MAIN_MENU):
+        """
+        Render menu extensions
+
+        Some addons want to provide items to main menu.
+        :param request:
+        :return safe HTML string:
+        """
+        items = []
+        for menu_extender in get_provide_objects("front_menu_extender"):
+            extender = menu_extender()
+            if extender.location == location:
+                items.append(extender.get_rendered_menu_items(request, self))
+        return mark_safe("".join(items))
 
 
 _not_set = object()  # Can't use `None` here.

--- a/shuup/xtheme/extenders.py
+++ b/shuup/xtheme/extenders.py
@@ -1,0 +1,45 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.core.urlresolvers import reverse
+from django.template.loader import get_template
+from django.utils.safestring import mark_safe
+from enumfields import Enum
+
+
+class MenuExtenderLocation(Enum):
+    MAIN_MENU = 1
+    ADMIN_MENU = 2
+    LEFT_MENU = 3
+    FOOTER = 4
+
+
+class FrontMenuExtender(object):
+    location = MenuExtenderLocation.MAIN_MENU
+    items = []
+    menu_item_template = "menu_extension.jinja"
+
+    def _get_template(self, theme):
+        path_template = "shuup/%s/%s"
+        try:
+            template_name = path_template % (theme.template_dir, self.menu_item_template)
+            return get_template(template_name)
+        except:
+            template_name = path_template % ("xtheme", "menu_extension.jinja")  # super safe fallback
+            return get_template(template_name)
+
+    def get_rendered_menu_items(self, request, theme):
+        template = self._get_template(theme)
+        rendered_items = []
+        for item in self.items:
+            try:
+                item["url"] = reverse(item["url"])
+            except:
+                pass  # pass if the url is something like "#"
+
+            rendered_template = template.render(item, request=request)
+            rendered_items.append(rendered_template)
+        return mark_safe("".join(rendered_items))

--- a/shuup/xtheme/templates/shuup/xtheme/menu_extension.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/menu_extension.jinja
@@ -1,0 +1,1 @@
+<li><a href="{{ url }}">{{ title }}</a></li>

--- a/shuup_tests/admin/test_mass_actions.py
+++ b/shuup_tests/admin/test_mass_actions.py
@@ -1,3 +1,9 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
 import csv
 
 import pytest

--- a/shuup_tests/admin/test_order_mass_actions.py
+++ b/shuup_tests/admin/test_order_mass_actions.py
@@ -1,3 +1,9 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
 import json
 
 import pytest

--- a/shuup_tests/browser/front/test_recently_viewed_products.py
+++ b/shuup_tests/browser/front/test_recently_viewed_products.py
@@ -1,3 +1,9 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
 import os
 import pytest
 from django.core.urlresolvers import reverse

--- a/shuup_tests/campaigns/test_caching.py
+++ b/shuup_tests/campaigns/test_caching.py
@@ -1,3 +1,9 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
 import pytest
 from shuup.campaigns.models import CatalogCampaign
 from shuup.campaigns.models import CatalogFilterCachedShopProduct

--- a/shuup_tests/front/test_addressbook.py
+++ b/shuup_tests/front/test_addressbook.py
@@ -1,3 +1,9 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
 import pytest
 import re
 from django.contrib.auth import get_user_model

--- a/shuup_tests/notify/test_action_send_mail.py
+++ b/shuup_tests/notify/test_action_send_mail.py
@@ -1,3 +1,9 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
 import pytest
 
 from shuup.notify.base import Action

--- a/shuup_tests/xtheme/test_extenders.py
+++ b/shuup_tests/xtheme/test_extenders.py
@@ -1,0 +1,27 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from django.core.urlresolvers import reverse
+from shuup.apps.provides import override_provides
+from shuup.testing.factories import get_default_shop
+from shuup.xtheme.extenders import FrontMenuExtender
+from shuup_tests.utils import SmartClient
+
+class TestExtender(FrontMenuExtender):
+    items = [
+        {"url": "shuup:index", "title": "Test Link to Front"}
+    ]
+
+@pytest.mark.django_db
+def test_extender_renders_main_menu(rf):
+    get_default_shop()
+
+    with override_provides("front_menu_extender", ["shuup_tests.xtheme.test_extenders:TestExtender"]):
+        c = SmartClient()
+        soup = c.soup(reverse("shuup:index"))
+        link_texts = [a.text for a in soup.findAll("a")]
+        assert "Test Link to Front" in link_texts


### PR DESCRIPTION
It was not possible for addons to provide objects into front menus.

This PR will add a support for Addons to extend main menus in Shuup Front.