### PR TITLE
Web API: Improve product API

### DIFF
--- a/shuup/api/urls.py
+++ b/shuup/api/urls.py
@@ -20,6 +20,11 @@ class AutoRouter(routers.DefaultRouter):
         for func in get_provide_objects("api_populator"):
             func(router=self)
 
+    def register(self, prefix, viewset, base_name=None):
+        if base_name is None:
+            base_name = prefix.replace('/', '-')
+        super(AutoRouter, self).register(prefix, viewset, base_name)
+
 
 apply_monkeypatch()
 router = AutoRouter()

--- a/shuup/core/models/_attributes.py
+++ b/shuup/core/models/_attributes.py
@@ -523,5 +523,18 @@ class AttributableMixin(object):
         applied_attr.save()
         return applied_attr
 
+    def clear_attribute_value(self, identifier, language=None):
+        avail_attrs = self.get_available_attribute_queryset()
+        attr = avail_attrs.get(identifier=identifier)
+        attr_val = self.attributes.filter(attribute=attr).first()
+        if not attr_val:
+            return
+        if language is None:  # Delete all translations
+            attr_val.delete()
+            return
+        trans = attr_val.translations.filter(language_code=language).first()
+        if trans:
+            trans.delete()
+
 
 AttributeLogEntry = define_log_model(Attribute)


### PR DESCRIPTION
It is now possible to create ShopProducts and attach attributes through
same product API with a single API query.

This supersedes PR #1047 and includes the commit from it.  Difference is
that this also implements updates and partial updates.  And there is
also a fix included for making the API index views point to correct
views.