### PR TITLE
Admin: Fix boolean value presentation errors

### DIFF
--- a/shuup_tests/core/test_attributes.py
+++ b/shuup_tests/core/test_attributes.py
@@ -5,6 +5,8 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
 import datetime
 from decimal import Decimal
 
@@ -32,6 +34,10 @@ def _populate_applied_attribute(aa):
         aa.save()
         assert aa.value is False, "Lies work"
         assert aa.untranslated_string_value == "0", "Integer attributes save string representations"
+        aa.value = None
+        aa.save()
+        assert aa.value is None, "None works"
+        assert aa.untranslated_string_value == "", "Boolean saves None"
         return
 
     if aa.attribute.type == AttributeType.INTEGER:


### PR DESCRIPTION
Since we are using `django.forms.fields.NullBooleanField` in admin
we should return either None, True or False.

While the `Unknown` option (`None`) will never end up in the database
when product attribute is being saved in admin, it is possible to
create this value through API and that causes admin to break.

This commit allows `None` value reading from the numeric_value in
boolean situtiations.