### PR TITLE
Allow zero price payments for deferred orders

### DIFF
--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Order has already been paid"
 msgstr ""
 
-msgid "Only orders which are not paid can be set as paid."
+msgid "Only orders which are not paid or deferred can be set as paid."
 msgstr ""
 
 msgid "Only zero price orders can be set as paid without creating a payment."

--- a/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
@@ -829,8 +829,8 @@ msgstr "Maksu %s luotu"
 msgid "Order has already been paid"
 msgstr "Tilaus on jo maksettu"
 
-msgid "Only orders which are not paid can be set as paid."
-msgstr "Vain maksamattomat tilaukset voidaan asettaa maksetuiksi."
+msgid "Only orders which are not paid or deferred can be set as paid."
+msgstr "Vain maksamattomat tai viivästyneet tilaukset voi asettaa maksetuksi."
 
 msgid "Only zero price orders can be set as paid without creating a payment."
 msgstr ""

--- a/shuup/admin/modules/orders/toolbar.py
+++ b/shuup/admin/modules/orders/toolbar.py
@@ -127,7 +127,8 @@ class CreatePaymentAction(DropdownItem):
 
     @staticmethod
     def visible_for_object(object):
-        return (object.can_create_payment() and not (object.is_not_paid() and not object.taxful_total_price))
+        return (object.can_create_payment() and not (
+            (object.is_not_paid() or object.is_deferred()) and not object.taxful_total_price))
 
 
 class SetPaidAction(PostActionDropdownItem):
@@ -139,7 +140,7 @@ class SetPaidAction(PostActionDropdownItem):
 
     @staticmethod
     def visible_for_object(object):
-        return (object.is_not_paid() and not object.taxful_total_price)
+        return ((object.is_not_paid() or object.is_deferred()) and not object.taxful_total_price)
 
 
 class CreateShipmentAction(DropdownItem):

--- a/shuup/admin/modules/orders/views/payment.py
+++ b/shuup/admin/modules/orders/views/payment.py
@@ -17,7 +17,7 @@ from shuup.admin.toolbar import PostActionButton, Toolbar
 from shuup.admin.utils.forms import add_form_errors_as_messages
 from shuup.admin.utils.urls import get_model_url
 from shuup.core.excs import NoPaymentToCreateException
-from shuup.core.models import Order
+from shuup.core.models import Order, PaymentStatus
 from shuup.utils.money import Money
 
 
@@ -86,9 +86,9 @@ class OrderSetPaidView(DetailView):
     def post(self, request, *args, **kwargs):
         order = self.object = self.get_object()
         error = False
-        if not order.is_not_paid():
+        if order.payment_status not in (PaymentStatus.DEFERRED, PaymentStatus.NOT_PAID):
             error = True
-            messages.error(self.request, _("Only orders which are not paid can be set as paid."))
+            messages.error(self.request, _("Only orders which are not paid or deferred can be set as paid."))
         if order.taxful_total_price:
             error = True
             messages.error(self.request, _("Only zero price orders can be set as paid without creating a payment."))

--- a/shuup/core/models/_orders.py
+++ b/shuup/core/models/_orders.py
@@ -540,6 +540,9 @@ class Order(MoneyPropped, models.Model):
     def is_partially_paid(self):
         return (self.payment_status == PaymentStatus.PARTIALLY_PAID)
 
+    def is_deferred(self):
+        return (self.payment_status == PaymentStatus.DEFERRED)
+
     def is_not_paid(self):
         return (self.payment_status == PaymentStatus.NOT_PAID)
 


### PR DESCRIPTION
If order payment status is not paid or deferred, allow creating zero price
payments. For example some addons can modify order payment status and
in some cases orders with deferred payment status and zero price are
need to be set paid.