### PR TITLE
Remove stray period in example command

### DIFF
--- a/doc/howto/getting_started.rst
+++ b/doc/howto/getting_started.rst
@@ -64,7 +64,7 @@ including ``pip`` and ``virtualenv``.
    .. code-block:: shell
 
       python manage.py migrate
-      python.manage.py shuup_init
+      python manage.py shuup_init
 
 Shuup Packages
 --------------


### PR DESCRIPTION
Remove stray period in example command to run shuup_init.