### PR TITLE
Improve variation orderability check performance

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unrealeased
 Core
 ~~~~
 
+- Improve variation product orderability check performance
 - Add `created_on` and `modified_on` fields for shop
 - Make shop identifier max length to 128 characters
 - Add `staff_members` manytomanyfield for shop
@@ -23,7 +24,7 @@ Admin
 ~~~~~
 
 - Main menu is now updateable through provides.
-- Add new provide category called `order_printouts_delivery_extra_fields` 
+- Add new provide category called `order_printouts_delivery_extra_fields`
   which can be used to add extra rows to order delivery slip.
 - Add new provide category called `admin_order_information` which can be used
   to add extra information rows to order detail page.

--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -278,33 +278,36 @@ class ShopProduct(MoneyPropped, models.Model):
             )
 
         if self.product.mode == ProductMode.SIMPLE_VARIATION_PARENT:
-            sellable = 0
+            sellable = False
             for child_product in self.product.variation_children.all():
-                if child_product.get_shop_instance(self.shop).is_orderable(
+                child_shop_product = child_product.get_shop_instance(self.shop)
+                if child_shop_product.is_orderable(
                         supplier=supplier,
                         customer=customer,
-                        quantity=1,
+                        quantity=child_shop_product.minimum_purchase_quantity,
                         allow_cache=False
                 ):
-                    sellable += 1
-
-            if sellable == 0:
+                    sellable = True
+                    break
+            if not sellable:
                 yield ValidationError(_("Product has no sellable children"), code="no_sellable_children")
-
-        if self.product.mode == ProductMode.VARIABLE_VARIATION_PARENT:
+        elif self.product.mode == ProductMode.VARIABLE_VARIATION_PARENT:
             from shuup.core.models import ProductVariationResult
-            sellable = 0
+            sellable = False
             for combo in self.product.get_all_available_combinations():
                 res = ProductVariationResult.resolve(self.product, combo["variable_to_value"])
-                if res and res.get_shop_instance(self.shop).is_orderable(
+                if not res:
+                    continue
+                child_shop_product = res.get_shop_instance(self.shop)
+                if child_shop_product.is_orderable(
                         supplier=supplier,
                         customer=customer,
-                        quantity=1,
+                        quantity=child_shop_product.minimum_purchase_quantity,
                         allow_cache=False
                 ):
-                    sellable += 1
-
-            if sellable == 0:
+                    sellable = True
+                    break
+            if not sellable:
                 yield ValidationError(_("Product has no sellable children"), code="no_sellable_children")
 
         if self.product.is_package_parent():


### PR DESCRIPTION
Before, the orderability of all variations was checked needlessly.
Now, we only ensure at least one child product is orderable.