### PR TITLE
Fix bug in picotable mass actions select listed

### DIFF
--- a/shuup/admin/modules/orders/mass_actions.py
+++ b/shuup/admin/modules/orders/mass_actions.py
@@ -43,7 +43,7 @@ class OrderConfirmationPdfAction(PicotableFileMassAction):
 
     def process(self, request, ids):
         if isinstance(ids, six.string_types) and ids == "all":
-            return JsonResponse({"error": ugettext("Selecting all is not supported.")})
+            return JsonResponse({"error": ugettext("Selecting all is not supported.")}, status=400)
         if len(ids) == 1:
             try:
                 response = get_confirmation_pdf(request, ids[0])
@@ -51,7 +51,7 @@ class OrderConfirmationPdfAction(PicotableFileMassAction):
                 return response
             except Exception as e:
                 msg = e.message if hasattr(e, "message") else e
-                return JsonResponse({"error": force_text(msg)})
+                return JsonResponse({"error": force_text(msg)}, status=400)
 
         buff = BytesIO()
         archive = zipfile.ZipFile(buff, 'w', zipfile.ZIP_DEFLATED)
@@ -76,7 +76,7 @@ class OrderConfirmationPdfAction(PicotableFileMassAction):
             response['Content-Disposition'] = 'attachment; filename=order_confirmation_pdf.zip'
             response.write(ret_zip)
             return response
-        return JsonResponse({"errors": errors})
+        return JsonResponse({"errors": errors}, status=400)
 
 
 class OrderDeliveryPdfAction(PicotableFileMassAction):

--- a/shuup/admin/static_src/picotable/picotable.js
+++ b/shuup/admin/static_src/picotable/picotable.js
@@ -617,20 +617,21 @@ const Picotable = (function(m, storage) {
             };
         };
 
-        const itemCount = ctrl.vm.data().pagination.nItems;
-        if (itemCount === 0) {
+        const totalItemCount = ctrl.vm.data().pagination.nItems;
+        if (totalItemCount === 0) {
             return "";
         }
+        const listedItemCount = ctrl.vm.data().items.length;
         const initialMassActions = [
             {key: 0, value: gettext("Select Action")},
             {key: "unselect_all", value: gettext("Clear Selections")},
-            {key: "select_listed", value: gettext("Select All")},
-            {key: "select_all", value: interpolate(gettext("Select All %s Items"), [itemCount])},
+            {key: "select_all", value: gettext("Select All")},
+            {key: "select_listed", value: interpolate(gettext("Select All %s Items"), [listedItemCount])},
         ];
         massActions = initialMassActions.concat(massActions);
 
         return m("div.picotable-mass-actions", [
-            (ctrl.vm.allItemsSelected() ? m("p", interpolate(gettext("All %s Items Selected"), [itemCount])) : null),
+            (ctrl.vm.allItemsSelected() ? m("p", interpolate(gettext("All %s Items Selected"), [totalItemCount])) : null),
             m("select.picotable-mass-action-select.form-control",
                 {
                     id: "mass-action-select" + ctrl.id,
@@ -830,6 +831,13 @@ const Picotable = (function(m, storage) {
                     }
                     setTimeout(function () { URL.revokeObjectURL(downloadUrl); }, 100); // cleanup
                 }
+            } else {
+                ctrl.resetCheckboxes();
+                $(".picotable-mass-action-select").val(0);
+                ctrl.refresh();
+                setTimeout(function() {
+                    window.Messages.enqueue({tags: "error", text: gettext("Something went wrong.")});
+                }, 1000);
             }
         };
         ctrl.doMassAction = function(value) {


### PR DESCRIPTION
"select_all" and "select_listed" keys were wrong way around. Add status code 400 to response if PicotableFileMassAction fails, then we can show error message to user if view doesn't return status code of 200.