### PR TITLE
API: Update admin order API

### DIFF
--- a/shuup/admin/static_src/base/js/select.js
+++ b/shuup/admin/static_src/base/js/select.js
@@ -17,7 +17,7 @@ function activateSelect($select, model, attrs={}) {
         language: "xx",
         minimumInputLength: 3,
         ajax: {
-            url: "/sa/select",
+            url: window.ShuupAdminConfig.browserUrls.select,
             dataType: "json",
             data: function(params) {
                 return {model: model, search: params.term};

--- a/shuup/admin/template_helpers/shuup_admin.py
+++ b/shuup/admin/template_helpers/shuup_admin.py
@@ -71,6 +71,7 @@ def get_support_id(context):
 
 # TODO: Figure out a more extensible way to deal with this
 BROWSER_URL_NAMES = {
+    "select": "shuup_admin:select",
     "media": "shuup_admin:media.browse",
     "product": "shuup_admin:shop_product.list",
     "contact": "shuup_admin:contact.list",


### PR DESCRIPTION
* Restrict queryset by accessible shops
* Enable searching by email or phone
* Tweak admin select2 to use URL provided by server config