### PR TITLE
Improve running of the tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,0 @@
-[run]
-branch = True
-omit = *migrations*

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,14 @@ install:
   - pip install tox
   - pip install coveralls
   - pip install codecov
-before_install:
-  - "nvm install 4"
-  - "nvm use 4"
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - "npm install -g selenium-standalone@4.5.3"
-  - "selenium-standalone install"
-  - "selenium-standalone start &"
+#before_install:
+  #- "nvm install 4"
+  #- "nvm use 4"
+  #- "export DISPLAY=:99.0"
+  #- "sh -e /etc/init.d/xvfb start"
+  #- "npm install -g selenium-standalone@4.5.3"
+  #- "selenium-standalone install"
+  #- "selenium-standalone start &"
 script:
   - tox
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
   - pip install -U pip
   - pip install tox
   - pip install coveralls
+  - pip install codecov
 before_install:
   - "nvm install 4"
   - "nvm use 4"
@@ -39,7 +40,9 @@ before_install:
   - "selenium-standalone start &"
 script:
   - tox -e $TOX_ENV
-after_success: test $TOX_ENV = py35-django19-nomigrations && coveralls
+after_success:
+  - coveralls
+  - codecov
 notifications:
   slack:
     secure: mkYYYt9ZQc6vR1aJltnEF1DzZ5xsNmllNcdK8fCwjeK5ZOnB1atujZ08tYxx/t57gaxhMWyJHvKdD0gvyQS6R/pAO2epXY9NqOhPVDEhqtXBpd7wUcEMTQqjSy68FSTjO94O8suC18xB55Cq+KSxm8jJt6zSFsjoffhz+4QIA67rkiNPLmAw2AHYymvVaidWMDe5UUGD7qONmdFI5wx4wOE9veboWDQ49oygiq+c4NFC/d4C108jT7l9ZTko/JF7Bim3VQI0LprGuIH2tZ6TI/3LWEhQX6XXuGr6eXuTF3nQp470yRXRs50Gh+CSY++ZUgFdRfOlg0edHt9m2Lk8j2jfeLgXYWYy1QSCnJDPRzzVIkEP4xaZCcIK7pcckV0Ytn7BP3Y09MDzSvt3+0Cm7ou16shiyy5NqW5DonarN21Mlz9/auZPawsXJqYZVDIZQiM7GLJnpg9wBfgKlPxUZKwi5ttsvrS7iPNK1sSLmICFqukrQlMQnpY5h45uGXsqL7fI7z30Ftld6qIGGVFdFjh3K+4dVXV5XKHnynaR518JvugxLwrNcIWwpyB2I3Ak7AsMzd3IWnY4yrB6pSbVdG0W3zZYXR6GUsYmxICKv5pUVnRKtp2tgOKA3EwgnVjSkJahGPp5bc3xJN8mNOaR33f3kieM5jJcNteEWueX+eA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
 env:
   - TOX_ENV=sanity
   - TOX_ENV=flake8
-  - TOX_ENV=isort
   - TOX_ENV=license_headers
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,19 @@ cache:
     - "$HOME/.cache/pip"
     - "$HOME/.cache/shuup/build_resources"
 env:
-  - TOX_ENV=sanity
-  - TOX_ENV=flake8
-  - TOX_ENV=license_headers
+  - TOXENV=sanity
+  - TOXENV=flake8
+  - TOXENV=license_headers
 matrix:
   include:
-    - python: 2.7
-      env: TOX_ENV=py27-django18-nomigrations
-    - python: 3.4
-      env: TOX_ENV=py34-django18-nomigrations
-    - python: 3.5
-      env: TOX_ENV=py35-django18-nomigrations
-    - python: 2.7
-      env: TOX_ENV=py27-django19-nomigrations
-    - python: 3.4
-      env: TOX_ENV=py34-django19-nomigrations
-    - python: 3.5
-      env: TOX_ENV=py35-django19-nomigrations
+    - {python: 2.7, env: TOXENV=py27-django18-nomigrations}
+    - {python: 3.4, env: TOXENV=py34-django18-nomigrations}
+    - {python: 3.5, env: TOXENV=py35-django18-nomigrations}
+    - {python: 2.7, env: TOXENV=py27-django19-nomigrations}
+    - {python: 3.4, env: TOXENV=py34-django19-nomigrations}
+    - {python: 3.5, env: TOXENV=py35-django19-nomigrations}
     # Browser tests are disabled, since they cause false errors
-    #- python: 3.5
-    #  env: TOX_ENV=py35-nomigrations-nocoverage-browser
+    # - {python: 3.5, env: TOXENV=py35-nomigrations-nocoverage-browser}
 install:
   - pip install -U pip
   - pip install tox
@@ -39,7 +32,7 @@ before_install:
   - "selenium-standalone install"
   - "selenium-standalone start &"
 script:
-  - tox -e $TOX_ENV
+  - tox
 after_success:
   - coveralls
   - codecov

--- a/_misc/language_twister.py
+++ b/_misc/language_twister.py
@@ -66,5 +66,6 @@ def main():
 
     prj.do(twist_set)
 
+
 if __name__ == '__main__':
     main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,7 @@ order_by_type=false
 skip=migrations
 not_skip=__init__.py
 wrap_length=79
+
+[coverage:run]
+branch = True
+omit = */migrations/*

--- a/shuup/admin/templatetags/shuup_admin.py
+++ b/shuup/admin/templatetags/shuup_admin.py
@@ -24,5 +24,6 @@ class Bootstrap3Namespace(object):
     def form(self, form, **kwargs):
         return mark_safe(FormRenderer(form, **kwargs).render())
 
+
 library.global_function(name="shuup_admin", fn=shuup_admin_template_helpers)
 library.global_function(name="bs3", fn=Bootstrap3Namespace())

--- a/shuup/admin/urls.py
+++ b/shuup/admin/urls.py
@@ -78,4 +78,5 @@ def get_urls():
 
     return tuple(urls)
 
+
 urlpatterns = get_urls()

--- a/shuup/core/fields/tagged_json.py
+++ b/shuup/core/fields/tagged_json.py
@@ -87,6 +87,7 @@ class TagRegistry(object):
                 return info["decoder"](val)
         return obj
 
+
 #: The default tag registry.
 tag_registry = TagRegistry()
 tag_registry.register("$datetime", datetime.datetime, encoder=isoformat, decoder=dateparse.parse_datetime)

--- a/shuup/core/management/commands/shuup_makemigrations.py
+++ b/shuup/core/management/commands/shuup_makemigrations.py
@@ -18,4 +18,5 @@ def new_deconstruct(self):
         del kwargs['verbose_name']
     return name, path, args, kwargs
 
+
 models.Field.deconstruct = new_deconstruct

--- a/shuup/core/models/_categories.py
+++ b/shuup/core/models/_categories.py
@@ -206,4 +206,5 @@ class Category(MPTTModel, TranslatableModel):
         generate_multilanguage_slugs(self, self._get_slug_name)
         return rv
 
+
 CategoryLogEntry = define_log_model(Category)

--- a/shuup/core/pricing/_context.py
+++ b/shuup/core/pricing/_context.py
@@ -32,6 +32,8 @@ class PricingContextable(six.with_metaclass(abc.ABCMeta)):
     pricing context even though it is not a `PricingContext`.
     """
     pass
+
+
 PricingContextable.register(HttpRequest)
 
 

--- a/shuup/front/apps/registration/__init__.py
+++ b/shuup/front/apps/registration/__init__.py
@@ -78,4 +78,5 @@ class RegistrationAppConfig(AppConfig):
             # false for HTML mails.
             django.conf.settings.REGISTRATION_EMAIL_HTML = False
 
+
 default_app_config = "shuup.front.apps.registration.RegistrationAppConfig"

--- a/shuup/front/apps/simple_order_notification/__init__.py
+++ b/shuup/front/apps/simple_order_notification/__init__.py
@@ -19,4 +19,5 @@ class SimpleOrderNotificationAppConfig(AppConfig):
         ]
     }
 
+
 default_app_config = "shuup.front.apps.simple_order_notification.SimpleOrderNotificationAppConfig"

--- a/shuup/front/middleware.py
+++ b/shuup/front/middleware.py
@@ -161,6 +161,7 @@ class ShuupFrontMiddleware(object):
         if request.shop.maintenance_mode and not getattr(request.user, 'is_superuser', False):
             return HttpResponse(loader.render_to_string("shuup/front/maintenance.jinja", request=request), status=503)
 
+
 if (
     "django.contrib.auth" in settings.INSTALLED_APPS and
     "shuup.front.middleware.ShuupFrontMiddleware" in settings.MIDDLEWARE_CLASSES

--- a/shuup/front/urls.py
+++ b/shuup/front/urls.py
@@ -84,6 +84,7 @@ urlpatterns = [
 def _get_extension_urlpatterns(provide_category):
     return chain(*get_provide_objects(provide_category))
 
+
 urlpatterns = list(chain(*(
     _get_extension_urlpatterns("front_urls_pre"),
     urlpatterns,

--- a/shuup/simple_supplier/__init__.py
+++ b/shuup/simple_supplier/__init__.py
@@ -30,4 +30,5 @@ class ShuupSimpleSupplierAppConfig(AppConfig):
         ]
     }
 
+
 default_app_config = "shuup.simple_supplier.ShuupSimpleSupplierAppConfig"

--- a/shuup/testing/__init__.py
+++ b/shuup/testing/__init__.py
@@ -46,4 +46,5 @@ class ShuupTestingAppConfig(AppConfig):
         ],
     }
 
+
 default_app_config = "shuup.testing.ShuupTestingAppConfig"

--- a/shuup_workbench/settings/__init__.py
+++ b/shuup_workbench/settings/__init__.py
@@ -41,4 +41,5 @@ def configure(setup):
 
     return setup
 
+
 globals().update(Setup.configure(configure))

--- a/shuup_workbench/wsgi.py
+++ b/shuup_workbench/wsgi.py
@@ -14,7 +14,7 @@ https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
 """
 
 import os
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "shuup_workbench.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "shuup_workbench.settings")  # noqa
 
 from django.core.wsgi import get_wsgi_application  # noqa (E402)
 application = get_wsgi_application()

--- a/tox.ini
+++ b/tox.ini
@@ -50,21 +50,19 @@ commands =
      {posargs:{env:TEST_ARGS:shuup_tests shuup}}
 
 [testenv:flake8]
-skip_install = True
 deps =
     flake8==3.3.0
+    flake8-isort==2.1.3
+    flake8-polyfill==1.0.1
+    isort==4.2.5
     mccabe==0.6.1
     pep8==1.7.0
     pep8-naming==0.4.1
+    pycodestyle==2.3.1
     pyflakes==1.5.0
-usedevelop = False
-commands = flake8
-
-[testenv:isort]
-deps =
-    isort==4.2.5
+    testfixtures==4.13.5
 usedevelop = True
-commands = isort -sp {toxinidir} -c -rc shuup
+commands = flake8
 
 [testenv:license_headers]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps =
     pytest-cov==2.4.0
     pytest-django==3.1.2
     pytest-splinter==1.8.1
+    pytest-sugar==0.8.0
     selenium==3.0.2
     splinter==0.7.5
     weasyprint==0.34
@@ -45,7 +46,7 @@ usedevelop = {env:USE_DEVELOP:True}
 commands =
     browser: pip install .
     py.test \
-     -ra -v --doctest-modules \
+     -ra --doctest-modules \
      {env:COV_ARGS:--cov shuup --cov-config=.coveragerc} \
      {posargs:{env:TEST_ARGS:shuup_tests shuup}}
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     # BEGIN testing deps
     beautifulsoup4==4.5.3
     html5lib==0.999999999
-    mock==1.0.1
+    mock==2.0.0
     pytest-cache==1.0
     pytest==3.0.6
     pytest-cov==2.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -52,17 +52,17 @@ commands =
 [testenv:flake8]
 skip_install = True
 deps =
-    flake8==2.5.4
-    mccabe==0.5.0
+    flake8==3.3.0
+    mccabe==0.6.1
     pep8==1.7.0
-    pep8-naming==0.3.3
-    pyflakes==1.2.3
+    pep8-naming==0.4.1
+    pyflakes==1.5.0
 usedevelop = False
 commands = flake8
 
 [testenv:isort]
 deps =
-    isort==4.2.2
+    isort==4.2.5
 usedevelop = True
 commands = isort -sp {toxinidir} -c -rc shuup
 


### PR DESCRIPTION
* Add Codecov coverager uploading.
* Use pytest-sugar to make the build outputs prettier.
* Use flake8-isort for import ordering tests.
  - Drops out one extra build job.
  - flake8-isort has better error messages than plain isort
* Update to newer code style checker utils
* Some code style fixes, because newer checkers are more strict
* Make .travis.yml a bit easier to read.
* Comment out nvm and selenium installing.
* Update version of mock