### PR TITLE
Improve product unit handling

### DIFF
--- a/doc/api/shuup.core.utils.rst
+++ b/doc/api/shuup.core.utils.rst
@@ -36,6 +36,14 @@ shuup.core.utils.forms module
     :undoc-members:
     :show-inheritance:
 
+shuup.core.utils.line_unit_mixin module
+---------------------------------------
+
+.. automodule:: shuup.core.utils.line_unit_mixin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 shuup.core.utils.maintenance module
 -----------------------------------
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -43,6 +43,7 @@ Addons
 Front
 ~~~~~
 
+- Basket views: Add display unit support
 - It's now possible to re-order old order from order history
 - It's now possible for addons to extend front main menu using the
   new `front_menu_extender` provide. See :doc:`provides.rst` for more information.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -45,6 +45,7 @@ Addons
 Front
 ~~~~~
 
+- Fix bug: Could no change quantities of unorderable lines in the basket
 - Use display units when rendering product quantities
 - Basket views: Add display unit support
 - It's now possible to re-order old order from order history

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -43,6 +43,7 @@ Addons
 Front
 ~~~~~
 
+- Use display units when rendering product quantities
 - Basket views: Add display unit support
 - It's now possible to re-order old order from order history
 - It's now possible for addons to extend front main menu using the

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unrealeased
 Core
 ~~~~
 
+- Improve OrderSource caching for deserialization speedup
 - Add new product count methods to OrderSource
 - Fix bug in purchase multiple checking of ShopProduct
 - Add unit interface to ShopProduct, OrderLine and SourceLine

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unrealeased
 Core
 ~~~~
 
+- Add DisplayUnit model
 - Rename ``SalesUnit.short_name`` to ``symbol``
 - Improve variation product orderability check performance
 - Add `created_on` and `modified_on` fields for shop

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unrealeased
 Core
 ~~~~
 
+- Fix bug in purchase multiple checking of ShopProduct
 - Add unit interface to ShopProduct, OrderLine and SourceLine
 - Add DisplayUnit model
 - Rename ``SalesUnit.short_name`` to ``symbol``

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unrealeased
 Core
 ~~~~
 
+- Add new product count methods to OrderSource
 - Fix bug in purchase multiple checking of ShopProduct
 - Add unit interface to ShopProduct, OrderLine and SourceLine
 - Add DisplayUnit model

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unrealeased
 Core
 ~~~~
 
+- Add unit interface to ShopProduct, OrderLine and SourceLine
 - Add DisplayUnit model
 - Rename ``SalesUnit.short_name`` to ``symbol``
 - Improve variation product orderability check performance

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unrealeased
 Core
 ~~~~
 
+- Rename ``SalesUnit.short_name`` to ``symbol``
 - Improve variation product orderability check performance
 - Add `created_on` and `modified_on` fields for shop
 - Make shop identifier max length to 128 characters

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -31,6 +31,7 @@ Developing Shuup
 * :doc:`ref/notify_specification`
 * :doc:`ref/prices_and_taxes`
 * :doc:`ref/campaigns`
+* :doc:`ref/units`
 * :doc:`ref/formpart`
 * :doc:`web_api`
 * :doc:`howto/basic_admin_tasks`

--- a/doc/ref/units.rst
+++ b/doc/ref/units.rst
@@ -1,0 +1,104 @@
+Product Units in Shuup
+======================
+
+Commonly web shops sell products which are prepackaged units and their
+quantities are measured in pieces.  However it is sometimes needed to be
+able to sell products in non-integral quantities, like kilograms or
+ounces.  In Shuup, this can be handled with sales units and display
+units.
+
+Each product in Shuup has a sales unit which determines how quantities
+of the product are represented and if non-integral quantities are
+allowed.  However it is possible that the sales unit has an attached
+display unit which overrides the representation part.  This allows, for
+example, the internal quantities to be stored in kilograms but be
+displayed as grams to the customer.
+
+``Product.sales_unit``
+    Sales unit of a `~shuup.core.models.Product`.  Usually a
+    `~shuup.core.models.SalesUnit` object, but can also be ``None``.
+    This is the internal unit which is used to *store* the quantities,
+    like quantities in the order lines or stock amounts.  Quantities
+    shown to the customer should not use the sales unit, but rather a
+    *display unit*, see ShopProduct.display_unit_ and or
+    SalesUnit.display_unit_.
+
+``SalesUnit.name``
+    Name of `~shuup.core.models.SalesUnit`.  Usually shown only in Admin
+    when managing units or when selecting sales unit for a product.
+
+``SalesUnit.symbol``
+    Symbol used when rendering values of the sales unit.
+
+``SalesUnit.decimals``
+    Number of decimals to use for values in this unit.
+
+.. _SalesUnit.display_unit:
+
+``SalesUnit.display_unit``
+    The default display unit of the sales unit.  This property returns a
+    `~shuup.core.models.DisplayUnit` object, which has the sales unit as
+    its internal unit and is marked as a default, or if there is no
+    default display unit for the sales unit, then this will return a
+    proxy object.  The proxy object has the same display unit interface
+    and mirrors the properties of the sales unit, such as symbol and
+    decimals.
+
+.. _ShopProduct.display_unit:
+
+``ShopProduct.display_unit``
+    Display unit of a shop product, a `~shuup.core.models.DisplayUnit`
+    object or ``None``.
+
+``ShopProduct.unit``
+    The unit of the shop product as `~shuup.core.models.UnitInterface`.
+
+``ShopProduct.display_quantity_step``
+    Quantity step of the shop product in the display unit.
+
+``ShopProduct..display_quantity_minimum``
+    Quantity minimum of the shop product in the display unit.
+
+``DisplayUnit.name``
+    Name of the display unit.
+
+``DisplayUnit.symbol``
+    Symbol of the display unit, used when rendering quantity values in
+    the display unit.
+
+``DisplayUnit.internal_unit``
+    The `~shuup.core.models.SalesUnit` object which acts as the internal
+    unit for the display unit.
+
+``DisplayUnit.ratio``
+    Ratio between the display unit and its internal unit.  E.g. if
+    internal unit is a kilogram and display unit is gram, then this
+    should be 0.001.
+
+``DisplayUnit.decimals``
+    Number of decimals to use when representing quantity values in the
+    display unit.
+
+``DisplayUnit.comparison_value``
+    Value to use for comparison purposes.  E.g. if the display unit is a
+    gram with symbol "g" and this is 100, then the unit prices should be
+    rendered as "$5.95 per 100g".
+
+``DisplayUnit.allow_bare_number``
+    If this boolean is true, then values of this unit can be shown
+    without the symbol occasionally.  Usually wanted if the unit is a
+    Piece, i.e. showing just "$5,95" in product listings rather than
+    "$5,95 per pc.".
+
+``DisplayUnit.default``
+    Use this display unit as the default display unit for its internal
+    unit.  If there is several default display units for an internal
+    unit, then its undetermined which will be used.
+
+``UnitInterface``
+    Interface for unit related information and functionality.  Bound to
+    a single display unit and its internal unit.  Can be used for
+    rendering and converting product quantities in the display unit or
+    in the internal unit.  Or for accessing data of either unit.  See
+    the API documentation of the `~shuup.core.models.UnitInterface` for
+    details.

--- a/shuup/admin/__init__.py
+++ b/shuup/admin/__init__.py
@@ -33,6 +33,7 @@ class ShuupAdminAppConfig(AppConfig):
             "shuup.admin.modules.services:PaymentMethodModule",
             "shuup.admin.modules.services:ShippingMethodModule",
             "shuup.admin.modules.attributes:AttributeModule",
+            "shuup.admin.modules.sales_units:DisplayUnitModule",
             "shuup.admin.modules.sales_units:SalesUnitModule",
             "shuup.admin.modules.sales_dashboard:SalesDashboardModule",
             "shuup.admin.modules.shops:ShopModule",

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-21 07:50+0000\n"
+"POT-Creation-Date: 2017-03-18 08:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -1191,6 +1191,9 @@ msgid "Open Orders Value"
 msgstr ""
 
 msgid "Sales Units"
+msgstr ""
+
+msgid "Display Units"
 msgstr ""
 
 msgid "Symbol"

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Sales Units"
 msgstr ""
 
-msgid "Short Name"
+msgid "Symbol"
 msgstr ""
 
 msgid "Allowed decimals"

--- a/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
@@ -26,7 +26,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shuup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-03 09:37+0000\n"
+"POT-Creation-Date: 2017-03-18 08:31+0000\n"
 "PO-Revision-Date: 2017-03-01 13:48+0000\n"
 "Last-Translator: Tuomas Suutari <tuomas.suutari@shoop.io>\n"
 "Language-Team: Finnish (Finland) (http://www.transifex.com/shuup/shuup/"
@@ -1259,6 +1259,9 @@ msgstr "Avoimia tilauksia"
 
 msgid "Sales Units"
 msgstr "Myyntiyksiköt"
+
+msgid "Display Units"
+msgstr "Näyttöyksiköt"
 
 msgid "Symbol"
 msgstr "Symboli"

--- a/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
@@ -853,7 +853,7 @@ msgstr ""
 "Hyvitettävä tili. Hyvittääksesi vapaan määrän, valitse 'Hyvitä vapaa määrä'."
 
 msgid "Quantity"
-msgstr "Lukumäärä"
+msgstr "Määrä"
 
 msgid "The number of units to refund."
 msgstr "Hyvitettävien yksiköiden määrä."

--- a/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
@@ -1260,8 +1260,8 @@ msgstr "Avoimia tilauksia"
 msgid "Sales Units"
 msgstr "Myyntiyksiköt"
 
-msgid "Short Name"
-msgstr "Lyhyt nimi"
+msgid "Symbol"
+msgstr "Symboli"
 
 msgid "Allowed decimals"
 msgstr "Sallitut desimaalit"

--- a/shuup/admin/locale/fi_FI/LC_MESSAGES/djangojs.po
+++ b/shuup/admin/locale/fi_FI/LC_MESSAGES/djangojs.po
@@ -123,7 +123,7 @@ msgid "Text"
 msgstr "Teksti"
 
 msgid "Quantity"
-msgstr "Lukumäärä"
+msgstr "Määrä"
 
 msgid "Unit Price"
 msgstr "Yksikköhinta"

--- a/shuup/admin/locale/it/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/it/LC_MESSAGES/django.po
@@ -907,9 +907,6 @@ msgstr "Valore degli Ordini Aperti"
 msgid "Sales Units"
 msgstr "Unità di Vendita"
 
-msgid "Short Name"
-msgstr "Nome Breve"
-
 msgid "Allowed decimals"
 msgstr "Decimali consentiti"
 

--- a/shuup/admin/locale/ja_JP/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/ja_JP/LC_MESSAGES/django.po
@@ -725,9 +725,6 @@ msgstr ""
 msgid "Sales Units"
 msgstr "販売単位"
 
-msgid "Short Name"
-msgstr "ショートネーム"
-
 msgid "Allowed decimals"
 msgstr "可小数"
 

--- a/shuup/admin/locale/pt_BR/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/pt_BR/LC_MESSAGES/django.po
@@ -799,9 +799,6 @@ msgstr "Valor de Pedidos Abertos"
 msgid "Sales Units"
 msgstr "Unidades de Vendas"
 
-msgid "Short Name"
-msgstr "Nome Abreviado"
-
 msgid "Allowed decimals"
 msgstr "Casas decimais permitidas"
 

--- a/shuup/admin/locale/sv_SE/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/sv_SE/LC_MESSAGES/django.po
@@ -1250,9 +1250,6 @@ msgstr "Värdet av öppna beställningar"
 msgid "Sales Units"
 msgstr "Försäljningsenheter"
 
-msgid "Short Name"
-msgstr "Kort namn"
-
 msgid "Allowed decimals"
 msgstr "Tillåtna decimaler"
 

--- a/shuup/admin/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/zh_Hans/LC_MESSAGES/django.po
@@ -725,9 +725,6 @@ msgstr "转换为父级变体"
 msgid "Sales Units"
 msgstr "销售量"
 
-msgid "Short Name"
-msgstr "简称"
-
 msgid "Allowed decimals"
 msgstr "允许小数"
 

--- a/shuup/admin/modules/orders/views/edit.py
+++ b/shuup/admin/modules/orders/views/edit.py
@@ -136,7 +136,7 @@ def get_line_data_for_edit(shop, line):
             "logicalCount": stock_status.logical_count if stock_status else 0,
             "physicalCount": stock_status.physical_count if stock_status else 0,
             "salesDecimals": line.product.sales_unit.decimals if line.product.sales_unit else 0,
-            "salesUnit": line.product.sales_unit.short_name if line.product.sales_unit else ""
+            "salesUnit": line.product.sales_unit.symbol if line.product.sales_unit else ""
         })
     return base_data
 
@@ -273,7 +273,7 @@ class OrderEditView(CreateOrUpdateView):
             "logicalCount": stock_status.logical_count if stock_status else 0,
             "physicalCount": stock_status.physical_count if stock_status else 0,
             "salesDecimals": product.sales_unit.decimals if product.sales_unit else 0,
-            "salesUnit": product.sales_unit.short_name if product.sales_unit else "",
+            "salesUnit": product.sales_unit.symbol if product.sales_unit else "",
             "purchaseMultiple": shop_product.purchase_multiple,
             "taxClass": {
                 "id": product.tax_class.id,

--- a/shuup/admin/modules/orders/views/refund.py
+++ b/shuup/admin/modules/orders/views/refund.py
@@ -118,7 +118,7 @@ class OrderCreateRefundView(UpdateView):
                 "logicalCount": stock_status.logical_count if stock_status else 0,
                 "physicalCount": stock_status.physical_count if stock_status else 0,
                 "salesDecimals": line.product.sales_unit.decimals if line.product.sales_unit else 0,
-                "salesUnit": line.product.sales_unit.short_name if line.product.sales_unit else ""
+                "salesUnit": line.product.sales_unit.symbol if line.product.sales_unit else ""
             })
         return base_data
 

--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -124,6 +124,7 @@ class ShopProductForm(forms.ModelForm):
             "purchase_multiple",
             "minimum_purchase_quantity",
             "backorder_maximum",
+            "display_unit",
             "limit_shipping_methods",
             "limit_payment_methods",
             "shipping_methods",

--- a/shuup/admin/modules/products/forms/package_forms.py
+++ b/shuup/admin/modules/products/forms/package_forms.py
@@ -55,13 +55,13 @@ class PackageChildForm(forms.Form):
             return stocks
         sales_unit = self.product.sales_unit
         sales_decimals = sales_unit.decimals if sales_unit else 0
-        sales_unit_short_name = sales_unit.short_name if sales_unit else ""
+        sales_unit_symbol = sales_unit.symbol if sales_unit else ""
         for shop_product in self.shop_products:
             for supplier in shop_product.suppliers.all():
                 if supplier in stocks.keys():
                     continue
                 stock_status = supplier.get_stock_status(product_id=self.product.id)
-                stocks[supplier] = (supplier, stock_status, sales_decimals, sales_unit_short_name)
+                stocks[supplier] = (supplier, stock_status, sales_decimals, sales_unit_symbol)
         return stocks
 
     def get_orderability_errors(self):

--- a/shuup/admin/modules/sales_units/__init__.py
+++ b/shuup/admin/modules/sales_units/__init__.py
@@ -13,7 +13,7 @@ from shuup.admin.base import AdminModule, MenuEntry
 from shuup.admin.menu import STOREFRONT_MENU_CATEGORY
 from shuup.admin.utils.permissions import get_default_model_permissions
 from shuup.admin.utils.urls import derive_model_url, get_edit_and_list_urls
-from shuup.core.models import SalesUnit
+from shuup.core.models import DisplayUnit, SalesUnit
 
 
 class SalesUnitModule(AdminModule):
@@ -45,3 +45,34 @@ class SalesUnitModule(AdminModule):
 
     def get_model_url(self, object, kind):
         return derive_model_url(SalesUnit, "shuup_admin:sales_unit", object, kind)
+
+
+class DisplayUnitModule(AdminModule):
+    name = _("Display Units")
+    breadcrumbs_menu_entry = MenuEntry(name, url="shuup_admin:display_unit.list")
+
+    def get_urls(self):
+        return get_edit_and_list_urls(
+            url_prefix="^display-units",
+            view_template="shuup.admin.modules.sales_units.views.DisplayUnit%sView",
+            name_template="display_unit.%s",
+            permissions=get_default_model_permissions(DisplayUnit)
+        )
+
+    def get_menu_entries(self, request):
+        return [
+            MenuEntry(
+                text=self.name,
+                icon="fa fa-asterisk",
+                url="shuup_admin:display_unit.list",
+                category=STOREFRONT_MENU_CATEGORY,
+                subcategory="settings",
+                ordering=5
+            ),
+        ]
+
+    def get_required_permissions(self):
+        return get_default_model_permissions(DisplayUnit)
+
+    def get_model_url(self, object, kind):
+        return derive_model_url(DisplayUnit, "shuup_admin:display_unit", object, kind)

--- a/shuup/admin/modules/sales_units/views/__init__.py
+++ b/shuup/admin/modules/sales_units/views/__init__.py
@@ -6,7 +6,12 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .edit import SalesUnitEditView
-from .list import SalesUnitListView
+from .edit import DisplayUnitEditView, SalesUnitEditView
+from .list import DisplayUnitListView, SalesUnitListView
 
-__all__ = ["SalesUnitEditView", "SalesUnitListView"]
+__all__ = [
+    "DisplayUnitEditView",
+    "DisplayUnitListView",
+    "SalesUnitEditView",
+    "SalesUnitListView",
+]

--- a/shuup/admin/modules/sales_units/views/edit.py
+++ b/shuup/admin/modules/sales_units/views/edit.py
@@ -9,7 +9,7 @@
 from __future__ import unicode_literals
 
 from shuup.admin.utils.views import CreateOrUpdateView
-from shuup.core.models import SalesUnit
+from shuup.core.models import DisplayUnit, SalesUnit
 from shuup.utils.multilanguage_model_form import MultiLanguageModelForm
 
 
@@ -24,3 +24,16 @@ class SalesUnitEditView(CreateOrUpdateView):
     form_class = SalesUnitForm
     template_name = "shuup/admin/sales_units/edit.jinja"
     context_object_name = "sales_unit"
+
+
+class DisplayUnitForm(MultiLanguageModelForm):
+    class Meta:
+        model = DisplayUnit
+        exclude = ()  # All the fields!
+
+
+class DisplayUnitEditView(CreateOrUpdateView):
+    model = DisplayUnit
+    form_class = DisplayUnitForm
+    template_name = "shuup/admin/sales_units/edit_display_unit.jinja"
+    context_object_name = "display_unit"

--- a/shuup/admin/modules/sales_units/views/list.py
+++ b/shuup/admin/modules/sales_units/views/list.py
@@ -21,7 +21,7 @@ class SalesUnitListView(PicotableListView):
             filter_field="translations__name",
             placeholder=_("Filter by name...")
         )),
-        Column("short_name", _(u"Short Name"), sort_field="translations__short_name", display="short_name"),
+        Column("symbol", _(u"Symbol"), sort_field="translations__symbol", display="symbol"),
         Column("decimals", _(u"Allowed decimals")),
     ]
 

--- a/shuup/admin/modules/sales_units/views/list.py
+++ b/shuup/admin/modules/sales_units/views/list.py
@@ -11,11 +11,10 @@ from django.utils.translation import ugettext_lazy as _
 
 from shuup.admin.utils.picotable import Column, TextFilter
 from shuup.admin.utils.views import PicotableListView
-from shuup.core.models import SalesUnit
+from shuup.core.models import DisplayUnit, SalesUnit
 
 
-class SalesUnitListView(PicotableListView):
-    model = SalesUnit
+class UnitListView(PicotableListView):
     default_columns = [
         Column("name", _(u"Name"), sort_field="translations__name", display="name", filter_config=TextFilter(
             filter_field="translations__name",
@@ -26,4 +25,12 @@ class SalesUnitListView(PicotableListView):
     ]
 
     def get_queryset(self):
-        return SalesUnit.objects.all()
+        return self.model.objects.all()
+
+
+class SalesUnitListView(UnitListView):
+    model = SalesUnit
+
+
+class DisplayUnitListView(UnitListView):
+    model = DisplayUnit

--- a/shuup/admin/templates/shuup/admin/orders/_order_contents.jinja
+++ b/shuup/admin/templates/shuup/admin/orders/_order_contents.jinja
@@ -29,7 +29,7 @@
                         <td>{{ line.sku }}</td>
                         <td>{{ line.text }}</td>
                         <td class="text-right">{{ line.taxless_base_unit_price|money }}</td>
-                        <td class="text-right">{{ line.quantity|number }}</td>
+                        <td class="text-right">{{ line.unit.render_quantity(line.quantity) }}</td>
                         <td class="text-right">{% if line.taxless_discount_amount %}{{ line.taxless_discount_amount|money }}{% else %}-{% endif %}</td>
                         <td class="text-right">{% if line.taxless_discount_amount %}{{ line|discount_percent }}{% else %}-{% endif %}</td>
                         <td class="text-right">{{ line.tax_rate|percent }}</td>

--- a/shuup/admin/templates/shuup/admin/products/_edit_extra_shop_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_extra_shop_form.jinja
@@ -18,6 +18,7 @@
     {{ bs3.field(shop_product_form.purchase_multiple) }}
     {{ bs3.field(shop_product_form.minimum_purchase_quantity) }}
     {{ bs3.field(shop_product_form.backorder_maximum) }}
+    {{ bs3.field(shop_product_form.display_unit) }}
 
     {{ bs3.field(shop_product_form.limit_payment_methods) }}
     {{ bs3.field(shop_product_form.limit_shipping_methods) }}

--- a/shuup/admin/templates/shuup/admin/sales_units/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/sales_units/edit.jinja
@@ -4,7 +4,7 @@
 
 {% block content %}
     {% call single_section_form("sales_unit_form", form) %}
-        {{ language_dependent_content_tabs(form, ["name", "short_name"]) }}
+        {{ language_dependent_content_tabs(form, ["name", "symbol"]) }}
         <div class="form-divider"></div>
         {{ bs3.field(form.decimals) }}
     {% endcall %}

--- a/shuup/admin/templates/shuup/admin/sales_units/edit_display_unit.jinja
+++ b/shuup/admin/templates/shuup/admin/sales_units/edit_display_unit.jinja
@@ -1,0 +1,16 @@
+{% extends "shuup/admin/base.jinja" %}
+{% from "shuup/admin/macros/general.jinja" import single_section_form with context %}
+{% from "shuup/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
+
+{% block content %}
+    {% call single_section_form("display_unit_form", form) %}
+        {{ language_dependent_content_tabs(form, ["name", "symbol"]) }}
+        <div class="form-divider"></div>
+        {{ bs3.field(form.internal_unit) }}
+        {{ bs3.field(form.ratio) }}
+        {{ bs3.field(form.decimals) }}
+        {{ bs3.field(form.comparison_value) }}
+        {{ bs3.field(form.allow_bare_number) }}
+        {{ bs3.field(form.default) }}
+    {% endcall %}
+{% endblock %}

--- a/shuup/campaigns/models/basket_conditions.py
+++ b/shuup/campaigns/models/basket_conditions.py
@@ -38,7 +38,7 @@ class BasketTotalProductAmountCondition(BasketCondition):
         verbose_name=_("product count in basket"), blank=True, null=True, max_digits=36, decimal_places=9)
 
     def matches(self, basket, lines):
-        return (basket.product_count >= self.product_count)
+        return (basket.smart_product_count >= self.product_count)
 
     @property
     def description(self):
@@ -84,7 +84,7 @@ class BasketMaxTotalProductAmountCondition(BasketCondition):
         verbose_name=_("maximum product count in basket"), blank=True, null=True, max_digits=36, decimal_places=9)
 
     def matches(self, basket, lines):
-        return (basket.product_count <= self.product_count)
+        return (basket.smart_product_count <= self.product_count)
 
     @property
     def description(self):

--- a/shuup/core/locale/en/LC_MESSAGES/django.po
+++ b/shuup/core/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-21 07:50+0000\n"
+"POT-Creation-Date: 2017-03-18 09:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -1229,6 +1229,9 @@ msgid ""
 "product price stays above cost."
 msgstr ""
 
+msgid "display unit"
+msgstr ""
+
 msgid "This product has been deleted."
 msgstr ""
 
@@ -2078,6 +2081,9 @@ msgid ""
 "quantities"
 msgstr ""
 
+msgid "sales units"
+msgstr ""
+
 msgid ""
 "The sales unit name to use for products (For example, 'pieces' or 'units'). "
 "Sales units can be set for each product through the product editor view."
@@ -2091,7 +2097,72 @@ msgid ""
 "order invoices."
 msgstr ""
 
-msgid "sales units"
+msgid "Value must be positive and non-zero"
+msgstr ""
+
+msgid "internal unit"
+msgstr ""
+
+msgid "The sales unit that this display unit is linked to."
+msgstr ""
+
+msgid "ratio"
+msgstr ""
+
+msgid ""
+"Size of the display unit in internal unit.  E.g. if internal unit is "
+"kilogram and display unit is gram, ratio is 0.001."
+msgstr ""
+
+msgid ""
+"The number of decimal places to use for values in the display unit.  The "
+"internal values are still rounded based on settings of the internal unit."
+msgstr ""
+
+msgid "comparison value"
+msgstr ""
+
+msgid ""
+"Value to use when displaying unit prices.  E.g. if the display unit is g and "
+"the comparison value is 100, then unit prices are shown per 100g, like: "
+"$2.95 per 100g."
+msgstr ""
+
+msgid "allow bare number"
+msgstr ""
+
+msgid ""
+"If true, values of this unit can be shown without the symbol occasionally.  "
+"Usually wanted if the unit is a piece, so that product listings can show "
+"just '$5.95' rather than '$5.95 per pc.'."
+msgstr ""
+
+msgid "use by default"
+msgstr ""
+
+msgid ""
+"Use this display unit by default when displaying values of the internal unit."
+msgstr ""
+
+msgid "Name of the display unit, e.g. Grams."
+msgstr ""
+
+msgid "An abbreviated name of the display unit, e.g. 'g'."
+msgstr ""
+
+msgid "display units"
+msgstr ""
+
+msgid "Pieces"
+msgstr ""
+
+msgctxt "Symbol for pieces unit"
+msgid "pc."
+msgstr ""
+
+#, python-brace-format
+msgctxt "Display value with unit symbol (with or without space)"
+msgid "{value}{symbol}"
 msgstr ""
 
 msgid "No Choice"

--- a/shuup/core/locale/en/LC_MESSAGES/django.po
+++ b/shuup/core/locale/en/LC_MESSAGES/django.po
@@ -2083,7 +2083,7 @@ msgid ""
 "Sales units can be set for each product through the product editor view."
 msgstr ""
 
-msgid "short name"
+msgid "symbol"
 msgstr ""
 
 msgid ""

--- a/shuup/core/locale/en/LC_MESSAGES/django.po
+++ b/shuup/core/locale/en/LC_MESSAGES/django.po
@@ -1266,16 +1266,16 @@ msgstr ""
 msgid "Product has no sellable children"
 msgstr ""
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s %(unit)s."
+"The product can only be ordered in multiples of {package_size}, for example "
+"{amount}"
 msgstr ""
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s or %(larger_p)s %(unit)s."
+"The product can only be ordered in multiples of {package_size}, for example "
+"{smaller_amount} or {larger_amount}"
 msgstr ""
 
 msgid "variation variable"

--- a/shuup/core/locale/en/LC_MESSAGES/django.po
+++ b/shuup/core/locale/en/LC_MESSAGES/django.po
@@ -1232,6 +1232,14 @@ msgstr ""
 msgid "display unit"
 msgstr ""
 
+msgid "Unit for displaying quantities of this product"
+msgstr ""
+
+msgid ""
+"Invalid display unit: Internal unit of the selected display unit does not "
+"match with the sales unit of the product"
+msgstr ""
+
 msgid "This product has been deleted."
 msgstr ""
 

--- a/shuup/core/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/core/locale/fi_FI/LC_MESSAGES/django.po
@@ -1345,6 +1345,16 @@ msgstr ""
 msgid "display unit"
 msgstr "näyttöyksikkö"
 
+msgid "Unit for displaying quantities of this product"
+msgstr "Yksikkö, jossa tämän tuotteen määrät näytetään"
+
+msgid ""
+"Invalid display unit: Internal unit of the selected display unit does not "
+"match with the sales unit of the product"
+msgstr ""
+"Näyttöyksikkö ei kelpaa: Valitun näyttöyksikön sisäinen yksikkö ei vastaa "
+"tuotteen myyntiyksikköä"
+
 msgid "This product has been deleted."
 msgstr "Tuote on poistettu."
 

--- a/shuup/core/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/core/locale/fi_FI/LC_MESSAGES/django.po
@@ -2286,8 +2286,8 @@ msgstr ""
 "Myyntiyksiköt voidaan asettaa jokaiselle tuotteelle erikseen "
 "tuotemuokkaimesta."
 
-msgid "short name"
-msgstr "lyhyt nimi"
+msgid "symbol"
+msgstr "symboli"
 
 msgid ""
 "An abbreviated name for this sales unit that is shown throughout admin and "

--- a/shuup/core/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/core/locale/fi_FI/LC_MESSAGES/django.po
@@ -1381,21 +1381,20 @@ msgstr "%s ei toimita tuotetta."
 msgid "Product has no sellable children"
 msgstr "Tuotteella ei ole myytäviä lapsia"
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s %(unit)s."
+"The product can only be ordered in multiples of {package_size}, for example "
+"{amount}"
 msgstr ""
-"Tuotetta voi tilata vain %(package_size)s kerrannaisina (esim. %(smaller_p)s "
-"%(unit)s)."
+"Tuotetta voi tilata vain {package_size} kerrannaisina (esim. {amount})."
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s or %(larger_p)s %(unit)s."
+"The product can only be ordered in multiples of {package_size}, for example "
+"{smaller_amount} or {larger_amount}"
 msgstr ""
-"Tuotetta voi tilata vain %(package_size)s kerrannaisina (esim. %(smaller_p)s "
-"tai %(larger_p)s %(unit)s)."
+"Tuotetta voi tilata vain {package_size} kerrannaisina (esim. "
+"{smaller_amount} tai {larger_amount})."
 
 msgid "variation variable"
 msgstr "variaatiomuuttuja"

--- a/shuup/core/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/core/locale/fi_FI/LC_MESSAGES/django.po
@@ -25,7 +25,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shuup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-03 09:37+0000\n"
+"POT-Creation-Date: 2017-03-18 12:25+0000\n"
 "PO-Revision-Date: 2017-03-01 13:49+0000\n"
 "Last-Translator: Tuomas Suutari <tuomas.suutari@shoop.io>\n"
 "Language-Team: Finnish (Finland) (http://www.transifex.com/shuup/shuup/"
@@ -1342,6 +1342,9 @@ msgstr ""
 "eivät voi mennä tämän alle. Tällä asetuksella voit varmistaa, että "
 "tuotettasi ei koskaan myydä liian halvalla."
 
+msgid "display unit"
+msgstr "näyttöyksikkö"
+
 msgid "This product has been deleted."
 msgstr "Tuote on poistettu."
 
@@ -2278,6 +2281,9 @@ msgstr ""
 "suuremmaksi kuin nolla, mikäli tuotteita tällä myyntiyksiköllä voi myydä "
 "osittain."
 
+msgid "sales units"
+msgstr "myyntiyksiköt"
+
 msgid ""
 "The sales unit name to use for products (For example, 'pieces' or 'units'). "
 "Sales units can be set for each product through the product editor view."
@@ -2296,8 +2302,82 @@ msgstr ""
 "Lyhennetty nimi tälle myyntiyksikölle, joka näytetään hallinnassa ja "
 "tilauksilla."
 
-msgid "sales units"
-msgstr "myyntiyksiköt"
+msgid "Value must be positive and non-zero"
+msgstr ""
+
+msgid "internal unit"
+msgstr "sisäinen yksikkö"
+
+msgid "The sales unit that this display unit is linked to."
+msgstr "Myyntiyksikkö, johon tämä näyttöyksikkö on liitetty"
+
+msgid "ratio"
+msgstr "mittasuhde"
+
+msgid ""
+"Size of the display unit in internal unit.  E.g. if internal unit is "
+"kilogram and display unit is gram, ratio is 0.001."
+msgstr ""
+"Näyttöyksikön koko sisäisessä yksikössä. Esim. jos sisäinen yksikkö on "
+"kilogramma ja näyttöyksikkö on gramma, niin mittasuhde on 0,001."
+
+msgid ""
+"The number of decimal places to use for values in the display unit.  The "
+"internal values are still rounded based on settings of the internal unit."
+msgstr ""
+
+msgid "comparison value"
+msgstr "vertailuarvo"
+
+msgid ""
+"Value to use when displaying unit prices.  E.g. if the display unit is g and "
+"the comparison value is 100, then unit prices are shown per 100g, like: "
+"$2.95 per 100g."
+msgstr ""
+"Yksikköhintojen näyttämisessä käytettävä arvo. Esim. jos näyttöyksikkö on g "
+"ja vertailuarvo on 100, niin yksikköhinnat näytetään 100 g kohden, kuten: "
+"2,95 € / 100 g."
+
+msgid "allow bare number"
+msgstr "salli pelkkä luku"
+
+msgid ""
+"If true, values of this unit can be shown without the symbol occasionally.  "
+"Usually wanted if the unit is a piece, so that product listings can show "
+"just '$5.95' rather than '$5.95 per pc.'."
+msgstr ""
+"Jos valittu, niin tämän yksikön arvoja voidaan toisinaan näyttää ilman "
+"symbolia. Halutaan usein silloin, kun yksikkö on kappale, jotta "
+"tuotelistauksissa voidaan näyttää vain '5,95 €' eikä '5,95 € / kpl'."
+
+msgid "use by default"
+msgstr "käytä oletuksena"
+
+msgid ""
+"Use this display unit by default when displaying values of the internal unit."
+msgstr ""
+"Käytä tätä näyttöyksikköä oletuksena näytettäessä sen sisäisen yksikön määriä."
+
+msgid "Name of the display unit, e.g. Grams."
+msgstr "Näyttöyksikö nimi, esim. Gramma."
+
+msgid "An abbreviated name of the display unit, e.g. 'g'."
+msgstr "Näyttöyksikön lyhennetty nimi, esim. 'g'."
+
+msgid "display units"
+msgstr "näyttöyksiköt"
+
+msgid "Pieces"
+msgstr ""
+
+msgctxt "Symbol for pieces unit"
+msgid "pc."
+msgstr "kpl"
+
+#, python-brace-format
+msgctxt "Display value with unit symbol (with or without space)"
+msgid "{value}{symbol}"
+msgstr "{value} {symbol}"
 
 msgid "No Choice"
 msgstr "ei valintaa"

--- a/shuup/core/locale/it/LC_MESSAGES/django.po
+++ b/shuup/core/locale/it/LC_MESSAGES/django.po
@@ -1262,9 +1262,6 @@ msgstr "Clienti Aziende"
 msgid "allowed decimals"
 msgstr "decimali consentiti"
 
-msgid "short name"
-msgstr "nome breve"
-
 msgid "sales unit"
 msgstr "unità di vendita"
 

--- a/shuup/core/locale/it/LC_MESSAGES/django.po
+++ b/shuup/core/locale/it/LC_MESSAGES/django.po
@@ -761,17 +761,17 @@ msgstr "La quantità di acquisto deve essere almeno %d per questo prodotto."
 msgid "The product is not supplied by %s."
 msgstr "Il prodotto non è fornito da %s."
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s %(unit)s."
-msgstr "Il prodotto può essere ordinato solo in ultipli di %(package_size)s, per esempio %(smaller_p)s %(unit)s. "
+"The product can only be ordered in multiples of {package_size}, for example "
+"{amount}"
+msgstr "Il prodotto può essere ordinato solo in ultipli di {package_size}, per esempio {amount}"
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s or %(larger_p)s %(unit)s."
-msgstr "Il prodotto può essere solo ordinato in multipli di %(package_size)s, per esempio %(smaller_p)s or %(larger_p)s %(unit)s."
+"The product can only be ordered in multiples of {package_size}, for example "
+"{smaller_amount} or {larger_amount}"
+msgstr "Il prodotto può essere solo ordinato in multipli di {package_size}, per esempio {smaller_amount} or {larger_amount}"
 
 msgid "variation variable"
 msgstr "variabile di variazione"

--- a/shuup/core/locale/ja_JP/LC_MESSAGES/django.po
+++ b/shuup/core/locale/ja_JP/LC_MESSAGES/django.po
@@ -742,16 +742,16 @@ msgstr ""
 msgid "The product is not supplied by %s."
 msgstr ""
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s %(unit)s."
+"The product can only be ordered in multiples of {package_size}, for example "
+"{amount}"
 msgstr ""
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s or %(larger_p)s %(unit)s."
+"The product can only be ordered in multiples of {package_size}, for example "
+"{smaller_amount} or {larger_amount}"
 msgstr ""
 
 msgid "variation variable"

--- a/shuup/core/locale/ja_JP/LC_MESSAGES/django.po
+++ b/shuup/core/locale/ja_JP/LC_MESSAGES/django.po
@@ -1245,9 +1245,6 @@ msgstr ""
 msgid "allowed decimals"
 msgstr ""
 
-msgid "short name"
-msgstr ""
-
 msgid "sales unit"
 msgstr ""
 

--- a/shuup/core/locale/pt_BR/LC_MESSAGES/django.po
+++ b/shuup/core/locale/pt_BR/LC_MESSAGES/django.po
@@ -1260,9 +1260,6 @@ msgstr "Clientes Empresariais"
 msgid "allowed decimals"
 msgstr "casas decimais permitidas"
 
-msgid "short name"
-msgstr "nome abreviado"
-
 msgid "sales unit"
 msgstr "unidade de vendas"
 

--- a/shuup/core/locale/pt_BR/LC_MESSAGES/django.po
+++ b/shuup/core/locale/pt_BR/LC_MESSAGES/django.po
@@ -759,17 +759,17 @@ msgstr "A quantidade de compra deve ser de pelo menos %d para este produto."
 msgid "The product is not supplied by %s."
 msgstr "O produto não é fornecido por %s."
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s %(unit)s."
-msgstr "O produto só pode ser comprado em múltiplos de %(package_size)s, por exemplo %(smaller_p)s %(unit)s."
+"The product can only be ordered in multiples of {package_size}, for example "
+"{amount}"
+msgstr "O produto só pode ser comprado em múltiplos de {package_size}, por exemplo {amount}"
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s or %(larger_p)s %(unit)s."
-msgstr "O produto só pode ser comprado em múltiplos de %(package_size)s, por exemplo %(smaller_p)s ou %(larger_p)s %(unit)s."
+"The product can only be ordered in multiples of {package_size}, for example "
+"{smaller_amount} or {larger_amount}"
+msgstr "O produto só pode ser comprado em múltiplos de {package_size}, por exemplo {smaller_amount} ou {larger_amount}"
 
 msgid "variation variable"
 msgstr "variável de variação"

--- a/shuup/core/locale/sv_SE/LC_MESSAGES/django.po
+++ b/shuup/core/locale/sv_SE/LC_MESSAGES/django.po
@@ -1352,21 +1352,21 @@ msgstr "Produkten levereras inte av %s."
 msgid "Product has no sellable children"
 msgstr "Produkten har inte underordnade artiklar"
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s %(unit)s."
+"The product can only be ordered in multiples of {package_size}, for example "
+"{amount}"
 msgstr ""
-"Produkten kan endast beställas i satser av %(package_size)s, till exempel "
-"%(smaller_p)s %(unit)s."
+"Produkten kan endast beställas i satser av {package_size}, till exempel "
+"{amount}"
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s or %(larger_p)s %(unit)s."
+"The product can only be ordered in multiples of {package_size}, for example "
+"{smaller_amount} or {larger_amount}"
 msgstr ""
-"Produkten kan endast beställas i satser av %(package_size)s, till exempel "
-"%(smaller_p)s eller %(larger_p)s %(unit)s."
+"Produkten kan endast beställas i satser av {package_size}, till exempel "
+"{smaller_amount} eller {larger_amount}."
 
 msgid "variation variable"
 msgstr "variantvariabel"

--- a/shuup/core/locale/sv_SE/LC_MESSAGES/django.po
+++ b/shuup/core/locale/sv_SE/LC_MESSAGES/django.po
@@ -2294,9 +2294,6 @@ msgstr ""
 "eller 'enheter'). Försäljningsenheter kan ställas in för varje produkt genom "
 "vyn produktredigeraren."
 
-msgid "short name"
-msgstr "kort namn"
-
 msgid ""
 "An abbreviated name for this sales unit that is shown throughout admin and "
 "order invoices."

--- a/shuup/core/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/shuup/core/locale/zh_Hans/LC_MESSAGES/django.po
@@ -1247,9 +1247,6 @@ msgstr "公司客户"
 msgid "allowed decimals"
 msgstr "允许小数"
 
-msgid "short name"
-msgstr "简称"
-
 msgid "sales unit"
 msgstr "销售单位"
 

--- a/shuup/core/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/shuup/core/locale/zh_Hans/LC_MESSAGES/django.po
@@ -742,19 +742,18 @@ msgstr "该产品的购买数量至少为 %d。"
 msgid "The product is not supplied by %s."
 msgstr "%s不供应该产品。"
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s %(unit)s."
-msgstr "该产品只可多个%(package_size)s 订购，例如 %(smaller_p)s %(unit)s。"
+"The product can only be ordered in multiples of {package_size}, for example "
+"{amount}"
+msgstr "该产品只可多个{package_size} 订购，例如 {amount}"
 
-#, python-format
+#, python-brace-format
 msgid ""
-"The product can only be ordered in multiples of %(package_size)s, for "
-"example %(smaller_p)s or %(larger_p)s %(unit)s."
+"The product can only be ordered in multiples of {package_size}, for example "
+"{smaller_amount} or {larger_amount}"
 msgstr ""
-"该产品只可多个%(package_size)s订购，例如%(smaller_p)s 或者 %(larger_p)s "
-"%(unit)s。"
+"该产品只可多个{package_size}订购，例如{smaller_amount} 或者 {larger_amount}"
 
 msgid "variation variable"
 msgstr "变体变量"

--- a/shuup/core/migrations/0028_displayunit.py
+++ b/shuup/core/migrations/0028_displayunit.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shuup', '0027_modify_shop_fields'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='salesunittranslation',
+            old_name='short_name',
+            new_name='symbol',
+        ),
+    ]

--- a/shuup/core/migrations/0028_displayunit.py
+++ b/shuup/core/migrations/0028_displayunit.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations
+import parler.models
+from django.db import migrations, models
+
+import shuup.core.fields
+import shuup.core.models._units
 
 
 class Migration(migrations.Migration):
@@ -15,5 +19,52 @@ class Migration(migrations.Migration):
             model_name='salesunittranslation',
             old_name='short_name',
             new_name='symbol',
+        ),
+        migrations.CreateModel(
+            name='DisplayUnit',
+            fields=[
+                ('id', models.AutoField(
+                    auto_created=True, primary_key=True, serialize=False)),
+                ('internal_unit', models.ForeignKey(
+                    to='shuup.SalesUnit', related_name='display_units')),
+                ('ratio', shuup.core.fields.QuantityField(
+                    default=1, max_digits=36, decimal_places=9, validators=[
+                        shuup.core.models._units.validate_positive_not_zero])),
+                ('decimals', models.PositiveSmallIntegerField(default=0)),
+                ('comparison_value', shuup.core.fields.QuantityField(
+                    default=1, max_digits=36, decimal_places=9, validators=[
+                        shuup.core.models._units.validate_positive_not_zero])),
+                ('allow_bare_number', models.BooleanField(default=False)),
+                ('default', models.BooleanField(default=False)),
+            ],
+            options={
+                'verbose_name_plural': 'display units',
+                'verbose_name': 'display unit',
+            },
+            bases=(parler.models.TranslatableModelMixin, models.Model),
+        ),
+        migrations.CreateModel(
+            name='DisplayUnitTranslation',
+            fields=[
+                ('id', models.AutoField(
+                    auto_created=True, primary_key=True, serialize=False)),
+                ('language_code', models.CharField(max_length=15, db_index=True)),
+                ('name', models.CharField(max_length=150)),
+                ('symbol', models.CharField(max_length=50)),
+                ('master', models.ForeignKey(
+                    to='shuup.DisplayUnit', editable=False,
+                    related_name='translations', null=True)),
+            ],
+            options={
+                'db_table': 'shuup_displayunit_translation',
+                'default_permissions': (),
+                'db_tablespace': '',
+                'managed': True,
+                'verbose_name': 'display unit Translation',
+            },
+        ),
+        migrations.AlterUniqueTogether(
+            name='displayunittranslation',
+            unique_together=set([('language_code', 'master')]),
         ),
     ]

--- a/shuup/core/migrations/0028_displayunit.py
+++ b/shuup/core/migrations/0028_displayunit.py
@@ -67,4 +67,10 @@ class Migration(migrations.Migration):
             name='displayunittranslation',
             unique_together=set([('language_code', 'master')]),
         ),
+        migrations.AddField(
+            model_name='shopproduct',
+            name='display_unit',
+            field=models.ForeignKey(
+                to='shuup.DisplayUnit', blank=True, null=True),
+        ),
     ]

--- a/shuup/core/models/__init__.py
+++ b/shuup/core/models/__init__.py
@@ -66,7 +66,7 @@ from ._shops import Shop, ShopStatus
 from ._supplied_products import SuppliedProduct
 from ._suppliers import Supplier, SupplierType
 from ._taxes import CustomerTaxGroup, Tax, TaxClass
-from ._units import SalesUnit
+from ._units import DisplayUnit, PiecesSalesUnit, SalesUnit, UnitInterface
 
 __all__ = [
     "AbstractOrderLine",
@@ -91,6 +91,7 @@ __all__ = [
     "CustomPaymentProcessor",
     "Currency",
     "DefaultOrderStatus",
+    "DisplayUnit",
     "FixedCostBehaviorComponent",
     "get_company_contact",
     "get_currency_precision",
@@ -116,6 +117,7 @@ __all__ = [
     "PaymentUrls",
     "PersistentCacheEntry",
     "PersonContact",
+    "PiecesSalesUnit",
     "PolymorphicShuupModel",
     "PolymorphicTranslatableShuupModel",
     "Product",
@@ -163,6 +165,7 @@ __all__ = [
     "Tax",
     "TaxClass",
     "TranslatableShuupModel",
+    "UnitInterface",
     "WaivingCostBehaviorComponent",
     "WeightBasedPriceRange",
     "WeightBasedPricingBehaviorComponent",

--- a/shuup/core/models/_order_lines.py
+++ b/shuup/core/models/_order_lines.py
@@ -18,6 +18,7 @@ from jsonfield import JSONField
 from shuup.core.fields import MoneyValueField, QuantityField, UnsavedForeignKey
 from shuup.core.pricing import Priceful
 from shuup.core.taxing import LineTax
+from shuup.core.utils.line_unit_mixin import LineWithUnit
 from shuup.utils.analog import define_log_model
 from shuup.utils.money import Money
 from shuup.utils.properties import MoneyProperty, MoneyPropped, PriceProperty
@@ -164,8 +165,14 @@ class AbstractOrderLine(MoneyPropped, models.Model, Priceful):
             self.supplier.module.update_stock(self.product_id)
 
 
-class OrderLine(AbstractOrderLine):
+class OrderLine(LineWithUnit, AbstractOrderLine):
     order = UnsavedForeignKey("Order", related_name='lines', on_delete=models.PROTECT, verbose_name=_('order'))
+
+    # TODO: Store the display and sales unit to OrderLine
+
+    @property
+    def shop(self):
+        return self.order.shop
 
 
 @python_2_unicode_compatible

--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -352,21 +352,21 @@ class ShopProduct(MoneyPropped, models.Model):
             p = (quantity // purchase_multiple)
             smaller_p = max(purchase_multiple, p * purchase_multiple)
             larger_p = max(purchase_multiple, (p + 1) * purchase_multiple)
+            render_qty = self.unit.render_quantity
             if larger_p == smaller_p:
-                message = _('The product can only be ordered in multiples of %(package_size)s, '
-                            'for example %(smaller_p)s %(unit)s.') % {
-                    "package_size": purchase_multiple,
-                    "smaller_p": smaller_p,
-                    "unit": self.product.sales_unit,
-                }
+                message = _(
+                    "The product can only be ordered in multiples of "
+                    "{package_size}, for example {amount}").format(
+                        package_size=render_qty(purchase_multiple),
+                        amount=render_qty(smaller_p))
             else:
-                message = _('The product can only be ordered in multiples of %(package_size)s, '
-                            'for example %(smaller_p)s or %(larger_p)s %(unit)s.') % {
-                    "package_size": purchase_multiple,
-                    "smaller_p": smaller_p,
-                    "larger_p": larger_p,
-                    "unit": self.product.sales_unit,
-                }
+                message = _(
+                    "The product can only be ordered in multiples of "
+                    "{package_size}, for example {smaller_amount} or "
+                    "{larger_amount}").format(
+                        package_size=render_qty(purchase_multiple),
+                        smaller_amount=render_qty(smaller_p),
+                        larger_amount=render_qty(larger_p))
             yield ValidationError(message, code="invalid_purchase_multiple")
 
         for receiver, response in get_orderability_errors.send(

--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -418,9 +418,8 @@ class ShopProduct(MoneyPropped, models.Model):
         Example:
             <input type="number" step="{{ shop_product.quantity_step }}">
         """
-        if self.purchase_multiple:
-            return self.purchase_multiple
-        return self.product.sales_unit.quantity_step
+        step = self.purchase_multiple or self._sales_unit.quantity_step
+        return self._sales_unit.round(step)
 
     @property
     def rounded_minimum_purchase_quantity(self):
@@ -435,7 +434,7 @@ class ShopProduct(MoneyPropped, models.Model):
                 value="{{ shop_product.rounded_minimum_purchase_quantity }}">
 
         """
-        return self.product.sales_unit.round(self.minimum_purchase_quantity)
+        return self._sales_unit.round(self.minimum_purchase_quantity)
 
     @property
     def display_quantity_step(self):

--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -438,6 +438,41 @@ class ShopProduct(MoneyPropped, models.Model):
         return self.product.sales_unit.round(self.minimum_purchase_quantity)
 
     @property
+    def display_quantity_step(self):
+        """
+        Quantity step of this shop product in the display unit.
+
+        Note: This can never be smaller than the display precision.
+        """
+        return max(
+            self.unit.to_display(self.quantity_step),
+            self.unit.display_precision)
+
+    @property
+    def display_quantity_minimum(self):
+        """
+        Quantity minimum of this shop product in the display unit.
+
+        Note: This can never be smaller than the display precision.
+        """
+        return max(
+            self.unit.to_display(self.minimum_purchase_quantity),
+            self.unit.display_precision)
+
+    @property
+    def unit(self):
+        """
+        Unit of this product.
+
+        :rtype: shuup.core.models.UnitInterface
+        """
+        return UnitInterface(self._sales_unit, self.display_unit)
+
+    @property
+    def _sales_unit(self):
+        return self.product.sales_unit or PiecesSalesUnit()
+
+    @property
     def images(self):
         return self.product.media.filter(shops=self.shop, kind=ProductMediaKind.IMAGE).order_by("ordering")
 

--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -348,7 +348,7 @@ class ShopProduct(MoneyPropped, models.Model):
                 yield error
 
         purchase_multiple = self.purchase_multiple
-        if quantity > 0 and purchase_multiple > 1 and (quantity % purchase_multiple) != 0:
+        if quantity > 0 and purchase_multiple > 0 and (quantity % purchase_multiple) != 0:
             p = (quantity // purchase_multiple)
             smaller_p = max(purchase_multiple, p * purchase_multiple)
             larger_p = max(purchase_multiple, (p + 1) * purchase_multiple)

--- a/shuup/core/models/_units.py
+++ b/shuup/core/models/_units.py
@@ -7,37 +7,54 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import with_statement
 
+import warnings
 from decimal import Decimal
 
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
-from parler.models import TranslatableModel, TranslatedFields
+from parler.models import TranslatedField, TranslatedFieldsModel
 
 from shuup.core.fields import InternalIdentifierField
 from shuup.utils.numbers import bankers_round, parse_decimal_string
 
-__all__ = ("SalesUnit",)
+from ._base import TranslatableShuupModel
+
+
+# TODO: (2.0) Remove deprecated SalesUnit.short_name
+class _ShortNameToSymbol(object):
+    def __init__(self, *args, **kwargs):
+        if 'short_name' in kwargs:
+            self._issue_deprecation_warning()
+            kwargs.setdefault('symbol', kwargs.pop('short_name'))
+        super(_ShortNameToSymbol, self).__init__(*args, **kwargs)
+
+    @property
+    def short_name(self):
+        self._issue_deprecation_warning()
+        return self.symbol
+
+    @short_name.setter
+    def short_name(self, value):
+        self._issue_deprecation_warning()
+        self.symbol = value
+
+    def _issue_deprecation_warning(self):
+        warnings.warn(
+            "short_name is deprecated, use symbol instead", DeprecationWarning)
 
 
 @python_2_unicode_compatible
-class SalesUnit(TranslatableModel):
+class SalesUnit(_ShortNameToSymbol, TranslatableShuupModel):
     identifier = InternalIdentifierField(unique=True)
     decimals = models.PositiveSmallIntegerField(default=0, verbose_name=_(u"allowed decimal places"), help_text=_(
         "The number of decimal places allowed by this sales unit."
         "Set this to a value greater than zero if products with this sales unit can be sold in fractional quantities"
     ))
 
-    translations = TranslatedFields(
-        name=models.CharField(max_length=128, verbose_name=_('name'), help_text=_(
-            "The sales unit name to use for products (For example, 'pieces' or 'units'). "
-            "Sales units can be set for each product through the product editor view."
-        )),
-        short_name=models.CharField(max_length=128, verbose_name=_('short name'), help_text=_(
-            "An abbreviated name for this sales unit that is shown throughout admin and order invoices."
-        )),
-    )
+    name = TranslatedField()
+    symbol = TranslatedField()
 
     class Meta:
         verbose_name = _('sales unit')
@@ -68,3 +85,26 @@ class SalesUnit(TranslatableModel):
 
     def round(self, value):
         return bankers_round(parse_decimal_string(value), self.decimals)
+
+
+class SalesUnitTranslation(_ShortNameToSymbol, TranslatedFieldsModel):
+    master = models.ForeignKey(
+        SalesUnit, related_name='translations', null=True, editable=False)
+    name = models.CharField(
+        max_length=128, verbose_name=_('name'), help_text=_(
+            "The sales unit name to use for products (For example, "
+            "'pieces' or 'units'). Sales units can be set for each "
+            "product through the product editor view."))
+    symbol = models.CharField(
+        max_length=128, verbose_name=_("symbol"), help_text=_(
+            "An abbreviated name for this sales unit that is shown "
+            "throughout admin and order invoices."))
+
+    class Meta:
+        # Use same meta options as Parler's defaults to avoid migration
+        unique_together = [('language_code', 'master')]
+        verbose_name = "sales unit Translation"
+        db_table = SalesUnit._meta.db_table + '_translation'
+        db_tablespace = SalesUnit._meta.db_tablespace
+        managed = SalesUnit._meta.managed
+        default_permissions = ()

--- a/shuup/core/models/_units.py
+++ b/shuup/core/models/_units.py
@@ -5,18 +5,23 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from __future__ import with_statement
+from __future__ import unicode_literals
 
 import warnings
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 
+from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from django.utils.encoding import force_text, python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
-from parler.models import TranslatedField, TranslatedFieldsModel
+from django.utils.translation import pgettext
+from parler.models import (
+    TranslatedField, TranslatedFields, TranslatedFieldsModel
+)
 
-from shuup.core.fields import InternalIdentifierField
+from shuup.core.fields import InternalIdentifierField, QuantityField
+from shuup.utils.i18n import format_number
 from shuup.utils.numbers import bankers_round, parse_decimal_string
 
 from ._base import TranslatableShuupModel
@@ -86,6 +91,22 @@ class SalesUnit(_ShortNameToSymbol, TranslatableShuupModel):
     def round(self, value):
         return bankers_round(parse_decimal_string(value), self.decimals)
 
+    @property
+    def display_unit(self):
+        """
+        Default display unit of this sales unit.
+
+        Get a `DisplayUnit` object, which has this sales unit as its
+        internal unit and is marked as a default, or if there is no
+        default display unit for this sales unit, then a proxy object.
+        The proxy object has the same display unit interface and mirrors
+        the properties of the sales unit, such as symbol and decimals.
+
+        :rtype: DisplayUnit
+        """
+        default_display_unit = self.display_units.filter(default=True).first()
+        return default_display_unit or SalesUnitAsDisplayUnit(self)
+
 
 class SalesUnitTranslation(_ShortNameToSymbol, TranslatedFieldsModel):
     master = models.ForeignKey(
@@ -108,3 +129,295 @@ class SalesUnitTranslation(_ShortNameToSymbol, TranslatedFieldsModel):
         db_tablespace = SalesUnit._meta.db_tablespace
         managed = SalesUnit._meta.managed
         default_permissions = ()
+
+
+def validate_positive_not_zero(value):
+    if value <= 0:
+        raise ValidationError(_("Value must be positive and non-zero"))
+
+
+class DisplayUnit(TranslatableShuupModel):
+    internal_unit = models.ForeignKey(
+        SalesUnit, related_name='display_units',
+        verbose_name=_("internal unit"),
+        help_text=_("The sales unit that this display unit is linked to."))
+    ratio = QuantityField(
+        default=1, validators=[validate_positive_not_zero],
+        verbose_name=_("ratio"),
+        help_text=_(
+            "Size of the display unit in internal unit.  E.g. if "
+            "internal unit is kilogram and display unit is gram, "
+            "ratio is 0.001."))
+    decimals = models.PositiveSmallIntegerField(
+        default=0,
+        verbose_name=_("decimal places"),
+        help_text=_(
+            "The number of decimal places to use for values in the "
+            "display unit.  The internal values are still rounded "
+            "based on settings of the internal unit."))
+    comparison_value = QuantityField(
+        default=1, validators=[validate_positive_not_zero],
+        verbose_name=_("comparison value"),
+        help_text=_(
+            "Value to use when displaying unit prices.  E.g. if the "
+            "display unit is g and the comparison value is 100, then "
+            "unit prices are shown per 100g, like: $2.95 per 100g."))
+    allow_bare_number = models.BooleanField(
+        default=False, verbose_name=_("allow bare number"),
+        help_text=_(
+            "If true, values of this unit can be shown without the "
+            "symbol occasionally.  Usually wanted if the unit is a "
+            "piece, so that product listings can show just '$5.95' "
+            "rather than '$5.95 per pc.'."))
+    default = models.BooleanField(
+        default=False, verbose_name=_("use by default"), help_text=_(
+            "Use this display unit by default when displaying "
+            "values of the internal unit."))
+    translations = TranslatedFields(
+        name=models.CharField(
+            max_length=150, verbose_name=_("name"), help_text=_(
+                "Name of the display unit, e.g. Grams.")),
+        symbol=models.CharField(
+            max_length=50, verbose_name=_("symbol"), help_text=_(
+                "An abbreviated name of the display unit, e.g. 'g'.")),
+    )
+
+    class Meta:
+        verbose_name = _("display unit")
+        verbose_name_plural = _("display units")
+
+
+@python_2_unicode_compatible
+class SalesUnitAsDisplayUnit(DisplayUnit):
+    class Meta:
+        abstract = True
+
+    def __init__(self, sales_unit):
+        super(SalesUnitAsDisplayUnit, self).__init__()
+        self.internal_unit = sales_unit
+        self.ratio = Decimal(1)
+        self.decimals = sales_unit.decimals
+        self.comparison_value = Decimal(1)
+        self.allow_bare_number = (sales_unit.decimals == 0)
+        self.default = False
+
+    def _get_pk_val(self, meta=None):
+        return None
+
+    pk = property(_get_pk_val)
+    name = property(lambda self: self.internal_unit.name)
+    symbol = property(lambda self: self.internal_unit.symbol)
+
+    def __str__(self):
+        return force_text(self.name)
+
+
+@python_2_unicode_compatible
+class PiecesSalesUnit(SalesUnit):
+    """
+    Object representing Pieces sales unit.
+
+    Has same API as SalesUnit, but isn't a real model.
+    """
+    class Meta:
+        abstract = True
+
+    def __init__(self):
+        super(PiecesSalesUnit, self).__init__(
+            identifier='_internal_pieces_unit', decimals=0)
+
+    def _get_pk_val(self, meta=None):
+        return None
+
+    pk = property(_get_pk_val)
+    name = _("Pieces")
+    symbol = pgettext("Symbol for pieces unit", "pc.")
+
+    @property
+    def display_unit(self):
+        return SalesUnitAsDisplayUnit(self)
+
+    def __str__(self):
+        return force_text(self.name)
+
+
+class UnitInterface(object):
+    """
+    Interface to unit functions.
+
+    Provides methods for rounding, rendering and converting product
+    quantities in display unit or internal unit.
+    """
+    def __init__(self, internal_unit=None, display_unit=None):
+        """
+        Initialize unit interface.
+
+        :type internal_unit: SalesUnit
+        :type display_unit: DisplayUnit
+        """
+        assert internal_unit is None or display_unit is None or (
+            display_unit.internal_unit == internal_unit), (
+                "Incompatible units: %r, %r" % (internal_unit, display_unit))
+        if display_unit:
+            self.internal_unit = display_unit.internal_unit
+            self.display_unit = display_unit
+        else:
+            self.internal_unit = internal_unit or PiecesSalesUnit()
+            self.display_unit = self.internal_unit.display_unit
+        assert self.display_unit.internal_unit == self.internal_unit
+
+    @property
+    def symbol(self):
+        """
+        Symbol of the display unit.
+
+        :rtype: str
+        """
+        return self.display_unit.symbol or PiecesSalesUnit.symbol
+
+    def get_symbol(self, allow_empty=True):
+        """
+        Get symbol of the display unit or empty if it is not needed.
+
+        :rtype: str
+        """
+        if allow_empty and self.allow_bare_number and (
+                self.display_unit.comparison_value == 1):
+            return ''
+        return self.symbol
+
+    @property
+    def internal_symbol(self):
+        """
+        Symbol of the internal unit.
+
+        :rtype: str
+        """
+        return self.internal_unit.symbol
+
+    @property
+    def allow_bare_number(self):
+        """
+        Allow showing values without the unit symbol.
+
+        :rtype: bool
+        """
+        return self.display_unit.allow_bare_number
+
+    @property
+    def display_precision(self):
+        """
+        Smallest possible non-zero quantity in the display unit.
+        """
+        return Decimal('0.1') ** self.display_unit.decimals
+
+    def render_quantity(self, quantity, force_symbol=False):
+        """
+        Render (internal unit) quantity in the display unit.
+
+        The value is converted from the internal unit to the display
+        unit and then localized.  The display unit symbol is added if
+        needed.
+
+        :type quantity: Decimal
+        :param quantity: Quantity to render, in internal unit
+        :type force_symbol: bool
+        :param force_symbol: Make sure that the symbol is rendered
+        :rtype: str
+        :return: Rendered quantity in display unit.
+        """
+        display_quantity = self.to_display(quantity)
+        value = format_number(display_quantity, self.display_unit.decimals)
+        symbol = self.get_symbol(allow_empty=(not force_symbol))
+        if not symbol:
+            return value
+        return _get_value_symbol_template().format(value=value, symbol=symbol)
+
+    def render_quantity_internal(self, quantity, force_symbol=False):
+        """
+        Render quantity (in internal unit) in the internal unit.
+
+        The value is rounded, localized and the internal unit symbol is
+        added if needed.
+
+        :type quantity: Decimal
+        :param quantity: Quantity to render, in internal unit
+        :type force_symbol: bool
+        :param force_symbol: Make sure that the symbol is rendered
+        :rtype: str
+        :return: Rendered quantity in internal unit.
+        """
+        rounded = _round_to_digits(
+            Decimal(quantity), self.internal_unit.decimals, ROUND_HALF_UP)
+        value = format_number(rounded, self.internal_unit.decimals)
+        if not force_symbol and self.allow_bare_number:
+            return value
+        symbol = self.internal_unit.symbol
+        return _get_value_symbol_template().format(value=value, symbol=symbol)
+
+    def to_display(self, quantity, rounding=ROUND_HALF_UP):
+        """
+        Convert quantity from internal unit to display unit.
+
+        :type quantity: Decimal
+        :param quantity: Quantity to convert, in internal unit
+        :rtype: Decimal
+        :return: Converted quantity, in display unit
+        """
+        value = Decimal(quantity) / self.display_unit.ratio
+        return _round_to_digits(value, self.display_unit.decimals, rounding)
+
+    def from_display(self, display_quantity, rounding=ROUND_HALF_UP):
+        """
+        Convert quantity from display unit to internal unit.
+
+        :type quantity: Decimal
+        :param quantity: Quantity to convert, in display unit
+        :rtype: Decimal
+        :return: Converted quantity, in internal unit
+        """
+        value = Decimal(display_quantity) * self.display_unit.ratio
+        return _round_to_digits(value, self.internal_unit.decimals, rounding)
+
+    def get_per_values(self, force_symbol=False):
+        """
+        Get "per" quantity and "per" text according to the display unit.
+
+        Useful when rendering unit prices, e.g.::
+
+          (per_qty, per_text) = unit.get_per_values(force_symbol=True)
+          price = product.get_price(quantity=per_qty)
+          unit_price_text = _("{price} per {per_text}").format(
+              price=price, per_text=per_text)
+
+        :rtype: (Decimal, str)
+        :return:
+          Quantity (in internal unit) and text to use as the unit in
+          unit prices
+        """
+        symbol = self.get_symbol(allow_empty=(not force_symbol))
+        without_value = (self.display_unit.comparison_value == 1)
+        per_qty = self.comparison_quantity
+        per_text = (symbol if without_value else self.render_quantity(per_qty))
+        return (per_qty, per_text)
+
+    @property
+    def comparison_quantity(self):
+        """
+        Quantity (in internal unit) to use as the unit in unit prices.
+
+        :rtype: Decimal
+        :return: Quantity, in internal unit
+        """
+        return self.from_display(self.display_unit.comparison_value)
+
+
+def _get_value_symbol_template():
+    return pgettext(
+        "Display value with unit symbol (with or without space)",
+        "{value}{symbol}")
+
+
+def _round_to_digits(value, digits, rounding=ROUND_HALF_UP):
+    precision = Decimal('1.' + ('1' * digits))
+    return value.quantize(precision, rounding=rounding)

--- a/shuup/core/order_creator/_source.py
+++ b/shuup/core/order_creator/_source.py
@@ -28,6 +28,7 @@ from shuup.core.models import (
 )
 from shuup.core.pricing import Price, Priceful, TaxfulPrice, TaxlessPrice
 from shuup.core.taxing import should_calculate_taxes_automatically, TaxableItem
+from shuup.core.utils.line_unit_mixin import LineWithUnit
 from shuup.utils.decorators import non_reentrant
 from shuup.utils.i18n import format_money, is_existing_language
 from shuup.utils.money import Money
@@ -554,7 +555,7 @@ class LineSource(Enum):
     DISCOUNT_MODULE = 4
 
 
-class SourceLine(TaxableItem, Priceful):
+class SourceLine(TaxableItem, Priceful, LineWithUnit):
     """
     Line of OrderSource.
 

--- a/shuup/core/utils/line_unit_mixin.py
+++ b/shuup/core/utils/line_unit_mixin.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2017, Anders Innovations. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from django.core.exceptions import ObjectDoesNotExist
+
+from shuup.core.models._units import PiecesSalesUnit, UnitInterface
+
+
+class LineWithUnit(object):
+    @property
+    def unit(self):
+        """
+        Unit of this line.
+
+        :rtype: UnitInterface
+        """
+        # TODO: Store the sales unit and display unit to the line
+        if not self.product or not self.product.sales_unit:
+            return UnitInterface(PiecesSalesUnit())
+        try:
+            shop_product = self.product.get_shop_instance(self.shop)
+        except ObjectDoesNotExist:
+            return UnitInterface(self.product.sales_unit)
+        return shop_product.unit

--- a/shuup/front/apps/saved_carts/templates/shuup/saved_carts/cart_detail.jinja
+++ b/shuup/front/apps/saved_carts/templates/shuup/saved_carts/cart_detail.jinja
@@ -32,6 +32,7 @@
                 <tbody>
                 {% for line in lines %}
                     {% set product = line.product %}
+                    {% set unit = line.product.get_shop_instance(request.shop).unit -%}
                     {% set image = product.primary_image %}
                     {% if not image and product.variation_parent %}
                         {% set image = product.variation_parent.primary_image %}
@@ -40,7 +41,7 @@
                     <tr>
                         <td>{% if thumbnail %}<img src="{{ thumbnail }}" alt="{{ product.name }}">{% endif %}</td>
                         <td><a href="{{ shuup.urls.model_url(line.product) }}">{{ product.name }}</a></td>
-                        <td class="text-right">{{ line.quantity }}</td>
+                        <td class="text-right">{{ unit.render_quantity(line.quantity) }}</td>
                         {% if show_prices() %}
                         <td class="text-right">{{ line.product|price }}</td>
                         {% endif %}

--- a/shuup/front/apps/saved_carts/views.py
+++ b/shuup/front/apps/saved_carts/views.py
@@ -68,7 +68,7 @@ class CartSaveView(View):
             return JsonResponse({"ok": False}, status=403)
         if not title:
             return JsonResponse({"ok": False, "error": force_text(_("Please enter a basket title."))}, status=400)
-        if basket.product_count == 0:
+        if basket.is_empty:
             return JsonResponse({"ok": False, "error": force_text(_("Cannot save an empty basket."))}, status=400)
         saved_basket = StoredBasket(
             shop=basket.shop,
@@ -80,7 +80,7 @@ class CartSaveView(View):
             persistent=True,
             title=title,
             data=basket.storage.load(basket=basket),
-            product_count=basket.product_count)
+            product_count=basket.smart_product_count)
         saved_basket.save()
         saved_basket.products = set(basket.product_ids)
         return JsonResponse({"ok": True}, status=200)

--- a/shuup/front/basket/commands.py
+++ b/shuup/front/basket/commands.py
@@ -21,7 +21,10 @@ from shuup.utils.numbers import parse_decimal_string
 
 
 # TODO: Refactor handle_add, it's too complex
-def handle_add(request, basket, product_id, quantity=1, supplier_id=None, **kwargs):  # noqa (C901)
+def handle_add(  # noqa (C901)
+        request, basket, product_id,
+        quantity=1, unit_type='internal',
+        supplier_id=None, **kwargs):
     """
     Handle adding a product to the basket.
 
@@ -47,6 +50,8 @@ def handle_add(request, basket, product_id, quantity=1, supplier_id=None, **kwar
 
     try:
         quantity = parse_decimal_string(quantity)
+        if unit_type == 'display':
+            quantity = shop_product.unit.from_display(quantity)
         if not product.sales_unit.allow_fractions:
             if quantity % 1 != 0:
                 msg = _(
@@ -102,7 +107,9 @@ def handle_add(request, basket, product_id, quantity=1, supplier_id=None, **kwar
     }
 
 
-def handle_add_var(request, basket, product_id, quantity=1, **kwargs):
+def handle_add_var(
+        request, basket, product_id,
+        quantity=1, unit_type='internal', **kwargs):
     """
     Handle adding a complex variable product into the basket by resolving the combination variables.
     This actually uses `kwargs`, expecting `var_XXX=YYY` to exist there, where `XXX` is the PK
@@ -118,7 +125,9 @@ def handle_add_var(request, basket, product_id, quantity=1, **kwargs):
     if not var_product:
         raise ValidationError(_(u"This variation is not available."), code="invalid_variation_combination")
     # and hand it off to handle_add like we're used to
-    return handle_add(request=request, basket=basket, product_id=var_product.pk, quantity=quantity)
+    return handle_add(
+        request=request, basket=basket, product_id=var_product.pk,
+        quantity=quantity, unit_type=unit_type)
 
 
 def handle_del(request, basket, line_id, **kwargs):

--- a/shuup/front/basket/commands.py
+++ b/shuup/front/basket/commands.py
@@ -102,7 +102,7 @@ def handle_add(  # noqa (C901)
     basket.add_product(**add_product_kwargs)
 
     return {
-        'ok': basket.product_count,
+        'ok': basket.smart_product_count,
         'added': quantity
     }
 

--- a/shuup/front/basket/commands.py
+++ b/shuup/front/basket/commands.py
@@ -185,3 +185,4 @@ def handle_update(request, basket, **kwargs):
     if basket_changed:  # pragma: no branch
         basket.clean_empty_lines()
         basket.dirty = True
+        basket.uncache()

--- a/shuup/front/basket/storage.py
+++ b/shuup/front/basket/storage.py
@@ -168,7 +168,7 @@ class DatabaseBasketStorage(BasketStorage):
         stored_basket.data = data
         stored_basket.taxless_total_price = basket.taxless_total_price_or_none
         stored_basket.taxful_total_price = basket.taxful_total_price_or_none
-        stored_basket.product_count = basket.product_count
+        stored_basket.product_count = basket.smart_product_count
         stored_basket.customer = (basket.customer or None)
         stored_basket.orderer = (basket.orderer or None)
         stored_basket.creator = real_user_or_none(basket.creator)

--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -655,9 +655,6 @@ msgstr ""
 msgid "There was an error adding the product to the basket"
 msgstr ""
 
-msgid "Qty"
-msgstr ""
-
 msgid "Remove product from basket"
 msgstr ""
 

--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-02-24 13:59+0000\n"
+"POT-Creation-Date: 2017-03-18 09:48+0000\n"
 "PO-Revision-Date: 2016-08-04 10:51-0700\n"
 "Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
@@ -658,9 +658,6 @@ msgstr ""
 msgid "Qty"
 msgstr ""
 
-msgid "Quantity"
-msgstr ""
-
 msgid "Remove product from basket"
 msgstr ""
 
@@ -849,6 +846,12 @@ msgid "Files"
 msgstr ""
 
 msgid "Product"
+msgstr ""
+
+msgid "Unit Price"
+msgstr ""
+
+msgid "Quantity"
 msgstr ""
 
 msgid "excl. tax"

--- a/shuup/front/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/front/locale/fi_FI/LC_MESSAGES/django.po
@@ -753,9 +753,6 @@ msgstr "Tuote lisätty koriin"
 msgid "There was an error adding the product to the basket"
 msgstr "Virhe lisättäessä tuotetta koriin"
 
-msgid "Quantity"
-msgstr "Määrä"
-
 msgid "Remove product from basket"
 msgstr "Poista tuote ostoskorista"
 
@@ -952,6 +949,9 @@ msgstr "Tuote"
 
 msgid "Unit Price"
 msgstr "Yksikköhinta"
+
+msgid "Quantity"
+msgstr "Määrä"
 
 msgid "excl. tax"
 msgstr "ei sis. veroja"

--- a/shuup/front/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/front/locale/fi_FI/LC_MESSAGES/django.po
@@ -25,7 +25,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shuup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-03 09:37+0000\n"
+"POT-Creation-Date: 2017-03-18 09:48+0000\n"
 "PO-Revision-Date: 2017-03-01 13:53+0000\n"
 "Last-Translator: Tuomas Suutari <tuomas.suutari@shoop.io>\n"
 "Language-Team: Finnish (Finland) (http://www.transifex.com/shuup/shuup/"
@@ -952,6 +952,9 @@ msgstr "Tiedostot"
 
 msgid "Product"
 msgstr "Tuote"
+
+msgid "Unit Price"
+msgstr "Yksikköhinta"
 
 msgid "excl. tax"
 msgstr "ei sis. veroja"

--- a/shuup/front/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/front/locale/fi_FI/LC_MESSAGES/django.po
@@ -753,9 +753,6 @@ msgstr "Tuote lisätty koriin"
 msgid "There was an error adding the product to the basket"
 msgstr "Virhe lisättäessä tuotetta koriin"
 
-msgid "Qty"
-msgstr "Määrä"
-
 msgid "Quantity"
 msgstr "Määrä"
 

--- a/shuup/front/static_src/js/update_price.js
+++ b/shuup/front/static_src/js/update_price.js
@@ -15,7 +15,8 @@ window.updatePrice = function updatePrice(productId) {
     var data = {
         // In case productId is not available try to fallback to first input with correct name
         id: productId ? productId : $("input[name=product_id]").val(),
-        quantity: $quantity.val()
+        quantity: $quantity.val(),
+        unitType: $("#product-unit-type-" + productId).val()
     };
 
     var $simpleVariationSelect = $("#product-variations-" + productId);

--- a/shuup/front/static_src/less/front/basket.less
+++ b/shuup/front/static_src/less/front/basket.less
@@ -57,15 +57,13 @@
             }
         }
         .quantity {
-            @media (max-width: @screen-xs-max) {
-                float: left;
-            }
+            float: left;
             label {
                 display: inline-block;
                 margin-right: 5px;
             }
             .form-control {
-                width: 75px;
+                width: 100px;
                 display: inline-block;
             }
         }

--- a/shuup/front/templates/shuup/front/macros/basket.jinja
+++ b/shuup/front/templates/shuup/front/macros/basket.jinja
@@ -53,6 +53,7 @@
             {% endif %}
             <div class="quantity">
                 {% if product %}
+                    {% set unit = shop_product.unit %}
                     {% if line.can_change_quantity %}
                     <div class="input-group">
                         <div class="input-group-addon">
@@ -61,15 +62,20 @@
                         <input
                             id="qty_{{ line.line_id }}"
                             type="number"
-                            name="q_{{ line.line_id }}"
+                            name="dq_{{ line.line_id }}"
                             size="2"
                             class="line_quantity form-control"
-                            step="{{ shop_product.quantity_step }}"
-                            value="{{ line.quantity }}"
-                            min="{{ shop_product.rounded_minimum_purchase_quantity }}">
+                            step="{{ shop_product.display_quantity_step }}"
+                            value="{{ unit.to_display(line.quantity) }}"
+                            min="{{ shop_product.display_quantity_minimum }}">
+                        <div class="input-group-addon sales-unit">
+                            {{ unit.symbol }}
+                        </div>
                     </div>
                     {% else %}
-                        <div class="">{{ _("Quantity") }}: {{ line.quantity }}</div>
+                        <div class="">
+                            {{ unit.render_quantity(line.quantity, force_symbol=True) }}
+                        </div>
                     {% endif %}
                 {% endif %}
             </div>

--- a/shuup/front/templates/shuup/front/macros/basket.jinja
+++ b/shuup/front/templates/shuup/front/macros/basket.jinja
@@ -56,9 +56,6 @@
                     {% set unit = shop_product.unit %}
                     {% if line.can_change_quantity %}
                     <div class="input-group">
-                        <div class="input-group-addon">
-                            {% trans %}Qty{% endtrans %}
-                        </div>
                         <input
                             id="qty_{{ line.line_id }}"
                             type="number"

--- a/shuup/front/templates/shuup/front/macros/basket.jinja
+++ b/shuup/front/templates/shuup/front/macros/basket.jinja
@@ -7,8 +7,8 @@
             <input name="command" type="hidden" value="update">
             {% csrf_token %}
             {{ render_basket_lines(basket) }}
+            {{ render_unorderable_basket_lines(basket) }}
         </form>
-        {{ render_unorderable_basket_lines(basket) }}
         {{ render_coupon_div(basket) }}
         {{ render_basket_summary(basket) }}
     </div>

--- a/shuup/front/templates/shuup/front/macros/navigation.jinja
+++ b/shuup/front/templates/shuup/front/macros/navigation.jinja
@@ -159,7 +159,7 @@
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                 <i class="menu-icon fa fa-shopping-cart"></i>
                 <span class="hidden-xs">{% trans %}Cart{% endtrans %}</span>
-                <span>({{ basket.product_count }})</span>
+                <span>({{ basket.smart_product_count }})</span>
                 <i class="dropdown-icon fa fa-angle-down"></i>
             </a>
             <div class="dropdown-menu cart">

--- a/shuup/front/templates/shuup/front/macros/navigation.jinja
+++ b/shuup/front/templates/shuup/front/macros/navigation.jinja
@@ -185,8 +185,8 @@
                             {% for line in lines %}
                                 <tr>
                                     <td>
-                                        {% set line_url = shuup.urls.get_url(line.product) %}
-                                        {{ line.quantity|number }} &times;
+                                        {% set line_url = shuup.urls.model_url(line.product) %}
+                                        {{ line.unit.render_quantity(line.quantity) }} &times;
                                         {% if line_url %}
                                             <a href="{{ line_url }}">{{ line.text }}</a>
                                         {% else %}

--- a/shuup/front/templates/shuup/front/macros/order.jinja
+++ b/shuup/front/templates/shuup/front/macros/order.jinja
@@ -112,6 +112,9 @@
                         </td>
                         <td class="text-right">
                             {{ line.taxful_discounted_unit_price|money }}
+                            {% if line.unit.to_display(1) != 1 %}
+                                / {{ line.unit.internal_symbol }}
+                            {% endif %}
                             {% if line.tax_amount %}
                                 <br>
                                 <small class="text-muted">
@@ -126,7 +129,7 @@
                             {% endif %}
                         </td>
                         <td class="text-right">
-                            {{ line.quantity|number }}
+                            {{ line.unit.render_quantity(line.quantity) }}
                         </td>
                         <td class="text-right">
                             <span class="line-total">{{ line.taxful_price|money }}</span>
@@ -143,7 +146,11 @@
     {% set quantity_map = product.get_package_child_to_quantity_map() %}
     <ul class="package-children">
         {% for child in package_children %}
-            <li><small><em>{{ quantity_map[child]|int }} &times; {{ child }}</em></small></li>
+            {%- set unit = child.get_shop_instance(request.shop).unit -%}
+            <li><small><em>
+                {{- unit.render_quantity(quantity_map[child]) }}
+                &times; {{ child -}}
+            </em></small></li>
         {% endfor %}
     </ul>
 {% endmacro %}

--- a/shuup/front/templates/shuup/front/macros/order.jinja
+++ b/shuup/front/templates/shuup/front/macros/order.jinja
@@ -66,7 +66,7 @@
                 <tr>
                     <th></th>
                     <th class="text-left">{% trans %}Product{% endtrans %}</th>
-                    <th class="text-right">{% trans %}Price{% endtrans %}</th>
+                    <th class="text-right">{% trans %}Unit Price{% endtrans %}</th>
                     <th class="text-right">{% trans %}Quantity{% endtrans %}</th>
                     <th class="text-right">{% trans %}Total{% endtrans %}</th>
                 </tr>

--- a/shuup/front/templates/shuup/front/macros/product.jinja
+++ b/shuup/front/templates/shuup/front/macros/product.jinja
@@ -51,14 +51,16 @@ Inheritance order for product macors:
 
 {% macro render_product_price(product, show_units=True) %}
     {% if show_prices() %}
+        {%- set unit = product.get_shop_instance(request.shop).unit -%}
+        {%- set (per_qty, per_text) = unit.get_per_values(show_units) -%}
         <div class="price-line">
             <span class="lead">
                 {%- if product.is_variation_parent() -%}
-                    {% set (min_price, max_price) = product|price_range %}
+                    {% set (min_price, max_price) = product|price_range(per_qty) %}
                     {% if min_price == max_price %}
                         {% if product|is_discounted -%}
                         <small class="text-muted original-price original"><s>
-                            {{- product|base_price -}}
+                            {{- product|base_price(per_qty) -}}
                         </s></small>
                         {%- endif %}
                         <strong>{{ min_price }}</strong>
@@ -68,13 +70,13 @@ Inheritance order for product macors:
                 {%- else -%}
                     {% if product|is_discounted -%}
                         <small class="text-muted original-price original"><s>
-                            {{- product|base_price -}}
+                            {{- product|base_price(per_qty) -}}
                         </s></small>
                     {%- endif %}
-                    <strong>{{ product|price }}</strong>
+                    <strong>{{ product|price(per_qty) }}</strong>
                 {%- endif -%}
-                {%- if show_units -%}
-                    <small> / {{ product.sales_unit.symbol }}</small>
+                {%- if per_text -%}
+                    <small> / {{ per_text }}</small>
                 {%- endif -%}
             </span>
         </div>

--- a/shuup/front/templates/shuup/front/macros/product.jinja
+++ b/shuup/front/templates/shuup/front/macros/product.jinja
@@ -74,7 +74,7 @@ Inheritance order for product macors:
                     <strong>{{ product|price }}</strong>
                 {%- endif -%}
                 {%- if show_units -%}
-                    <small> / {{ product.sales_unit.short_name }}</small>
+                    <small> / {{ product.sales_unit.symbol }}</small>
                 {%- endif -%}
             </span>
         </div>

--- a/shuup/front/templates/shuup/front/macros/product_information.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_information.jinja
@@ -138,5 +138,7 @@
 
 {% macro product_line(product, quantity) %}
     {% set u = url("shuup:product", pk=product.pk, slug=product.slug) %}
-    <a href="{{ u }}">{{ product.name }}</a> &times; {{ quantity|int }}
+    {% set unit = product.get_shop_instance(request.shop).unit %}
+    {{ unit.render_quantity(quantity) }} &times;
+    <a href="{{ u }}">{{ product.name }}</a>
 {% endmacro %}

--- a/shuup/front/templates/shuup/front/macros/product_ordering.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_ordering.jinja
@@ -134,7 +134,7 @@
             min="{{ shop_product.rounded_minimum_purchase_quantity }}"
             onchange="updatePrice('{{ product_id }}')"
             >
-            <span class="input-group-addon sales-unit">{{ shop_product.product.sales_unit.short_name }}</span>
+            <span class="input-group-addon sales-unit">{{ shop_product.product.sales_unit.symbol }}</span>
         </div>
     </div>
 {% endmacro %}
@@ -155,7 +155,7 @@
             {% if product|is_discounted(quantity) %}
             (<s>{{ product|base_unit_price(quantity) }}</s>)
             {% endif %}
-            {{ product|discounted_unit_price(quantity) }}/{{ product.sales_unit.short_name }}
+            {{ product|discounted_unit_price(quantity) }}/{{ product.sales_unit.symbol }}
         </span>
     </div>
 {% endmacro %}

--- a/shuup/front/templates/shuup/front/macros/product_ordering.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_ordering.jinja
@@ -121,6 +121,7 @@
     {% else %}
         {%- set product_id = shop_product.product.pk -%}
     {% endif %}
+    {% set unit = shop_product.unit %}
     <div class="form-group amount">
         <label for="product-quantity-{{ product_id }}">{% trans %}Quantity{% endtrans %}</label>
         <div class="input-group">
@@ -129,12 +130,17 @@
             class="form-control"
             name="quantity"
             id="product-quantity-{{ product_id }}"
-            step="{{ shop_product.quantity_step }}"
-            value="{{ quantity }}"
-            min="{{ shop_product.rounded_minimum_purchase_quantity }}"
+            step="{{ shop_product.display_quantity_step }}"
+            value="{{ unit.to_display(quantity) }}"
+            min="{{ shop_product.display_quantity_minimum }}"
             onchange="updatePrice('{{ product_id }}')"
             >
-            <span class="input-group-addon sales-unit">{{ shop_product.product.sales_unit.symbol }}</span>
+            <input
+                type="hidden" id="product-unit-type-{{ product_id }}"
+                name="unit_type" value="display">
+            <span class="input-group-addon sales-unit">
+                {{- unit.symbol -}}
+            </span>
         </div>
     </div>
 {% endmacro %}

--- a/shuup/simple_supplier/admin_module/views.py
+++ b/shuup/simple_supplier/admin_module/views.py
@@ -84,17 +84,17 @@ class StocksListView(PicotableListView):
 def get_adjustment_success_message(stock_adjustment):
     arguments = {
         "delta": stock_adjustment.delta,
-        "unit_short_name": stock_adjustment.product.sales_unit.short_name,
+        "unit_symbol": stock_adjustment.product.sales_unit.symbol,
         "product_name": stock_adjustment.product.name,
         "supplier_name": stock_adjustment.supplier.name
     }
     if stock_adjustment.delta > 0:
         return _(
-            "Added %(delta)s %(unit_short_name)s for product %(product_name)s stock (%(supplier_name)s)"
+            "Added %(delta)s %(unit_symbol)s for product %(product_name)s stock (%(supplier_name)s)"
         ) % arguments
     else:
         return _(
-            "Removed %(delta)s %(unit_short_name)s from product %(product_name)s stock (%(supplier_name)s)"
+            "Removed %(delta)s %(unit_symbol)s from product %(product_name)s stock (%(supplier_name)s)"
         ) % arguments
 
 

--- a/shuup/simple_supplier/locale/en/LC_MESSAGES/django.po
+++ b/shuup/simple_supplier/locale/en/LC_MESSAGES/django.po
@@ -43,13 +43,13 @@ msgstr ""
 
 #, python-format
 msgid ""
-"Added %(delta)s %(unit_short_name)s for product %(product_name)s stock "
+"Added %(delta)s %(unit_symbol)s for product %(product_name)s stock "
 "(%(supplier_name)s)"
 msgstr ""
 
 #, python-format
 msgid ""
-"Removed %(delta)s %(unit_short_name)s from product %(product_name)s stock "
+"Removed %(delta)s %(unit_symbol)s from product %(product_name)s stock "
 "(%(supplier_name)s)"
 msgstr ""
 

--- a/shuup/simple_supplier/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/simple_supplier/locale/fi_FI/LC_MESSAGES/django.po
@@ -82,7 +82,7 @@ msgid "Purchase price per unit (%(currency_name)s)"
 msgstr "Ostohinta per yksikkö (%(currency_name)s)"
 
 msgid "Quantity"
-msgstr "Lukumäärä"
+msgstr "Määrä"
 
 msgid "Only non-zero values can be added to stock."
 msgstr "Varastoarvon pitää olla suurempi kuin nolla."

--- a/shuup/simple_supplier/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/simple_supplier/locale/fi_FI/LC_MESSAGES/django.po
@@ -49,19 +49,19 @@ msgstr "Muuta varastosaldoa"
 
 #, python-format
 msgid ""
-"Added %(delta)s %(unit_short_name)s for product %(product_name)s stock "
+"Added %(delta)s %(unit_symbol)s for product %(product_name)s stock "
 "(%(supplier_name)s)"
 msgstr ""
-"Lisättiin %(delta)s %(unit_short_name)s tuotteelle %(product_name)s "
-"varastoon (%(supplier_name)s)"
+"Lisättiin %(delta)s %(unit_symbol)s tuotteelle %(product_name)s varastoon "
+"(%(supplier_name)s)"
 
 #, python-format
 msgid ""
-"Removed %(delta)s %(unit_short_name)s from product %(product_name)s stock "
+"Removed %(delta)s %(unit_symbol)s from product %(product_name)s stock "
 "(%(supplier_name)s)"
 msgstr ""
-"Poistettiin %(delta)s %(unit_short_name)s tuotteelta %(product_name)s "
-"varastosta (%(supplier_name)s)"
+"Poistettiin %(delta)s %(unit_symbol)s tuotteelta %(product_name)s varastosta "
+"(%(supplier_name)s)"
 
 #, python-format
 msgid "Alert limit for product %(product_name)s set to %(value)s."

--- a/shuup/simple_supplier/locale/it/LC_MESSAGES/django.po
+++ b/shuup/simple_supplier/locale/it/LC_MESSAGES/django.po
@@ -45,15 +45,15 @@ msgstr "Modifica disponibilità"
 
 #, python-format
 msgid ""
-"Added %(delta)s %(unit_short_name)s for product %(product_name)s stock "
+"Added %(delta)s %(unit_symbol)s for product %(product_name)s stock "
 "(%(supplier_name)s)"
-msgstr "Aggiunti %(delta)s %(unit_short_name)s per il prodotto %(product_name)s scorte (%(supplier_name)s)"
+msgstr "Aggiunti %(delta)s %(unit_symbol)s per il prodotto %(product_name)s scorte (%(supplier_name)s)"
 
 #, python-format
 msgid ""
-"Removed %(delta)s %(unit_short_name)s from product %(product_name)s stock "
+"Removed %(delta)s %(unit_symbol)s from product %(product_name)s stock "
 "(%(supplier_name)s)"
-msgstr "Rimossi %(delta)s %(unit_short_name)s per il prodotto dalle scorte di %(product_name)s (%(supplier_name)s)"
+msgstr "Rimossi %(delta)s %(unit_symbol)s per il prodotto dalle scorte di %(product_name)s (%(supplier_name)s)"
 
 #, python-format
 msgid "Alert limit for product %(product_name)s set to %(value)s."

--- a/shuup/simple_supplier/locale/ja_JP/LC_MESSAGES/django.po
+++ b/shuup/simple_supplier/locale/ja_JP/LC_MESSAGES/django.po
@@ -47,13 +47,13 @@ msgstr ""
 
 #, python-format
 msgid ""
-"Added %(delta)s %(unit_short_name)s for product %(product_name)s stock "
+"Added %(delta)s %(unit_symbol)s for product %(product_name)s stock "
 "(%(supplier_name)s)"
 msgstr ""
 
 #, python-format
 msgid ""
-"Removed %(delta)s %(unit_short_name)s from product %(product_name)s stock "
+"Removed %(delta)s %(unit_symbol)s from product %(product_name)s stock "
 "(%(supplier_name)s)"
 msgstr ""
 

--- a/shuup/simple_supplier/locale/pt_BR/LC_MESSAGES/django.po
+++ b/shuup/simple_supplier/locale/pt_BR/LC_MESSAGES/django.po
@@ -47,15 +47,15 @@ msgstr "Ajustar estoque"
 
 #, python-format
 msgid ""
-"Added %(delta)s %(unit_short_name)s for product %(product_name)s stock "
+"Added %(delta)s %(unit_symbol)s for product %(product_name)s stock "
 "(%(supplier_name)s)"
-msgstr "Adicionado %(delta)s %(unit_short_name)s ao estoque do produto %(product_name)s (%(supplier_name)s)"
+msgstr "Adicionado %(delta)s %(unit_symbol)s ao estoque do produto %(product_name)s (%(supplier_name)s)"
 
 #, python-format
 msgid ""
-"Removed %(delta)s %(unit_short_name)s from product %(product_name)s stock "
+"Removed %(delta)s %(unit_symbol)s from product %(product_name)s stock "
 "(%(supplier_name)s)"
-msgstr "Removido %(delta)s %(unit_short_name)s do estoque do produto %(product_name)s (%(supplier_name)s)"
+msgstr "Removido %(delta)s %(unit_symbol)s do estoque do produto %(product_name)s (%(supplier_name)s)"
 
 msgid "Not allowed"
 msgstr "Não permitido"

--- a/shuup/simple_supplier/locale/sv_SE/LC_MESSAGES/django.po
+++ b/shuup/simple_supplier/locale/sv_SE/LC_MESSAGES/django.po
@@ -44,18 +44,18 @@ msgstr "Justera lager"
 
 #, python-format
 msgid ""
-"Added %(delta)s %(unit_short_name)s for product %(product_name)s stock "
+"Added %(delta)s %(unit_symbol)s for product %(product_name)s stock "
 "(%(supplier_name)s)"
 msgstr ""
-"Tillagda %(delta)s %(unit_short_name)s för produkten %(product_name)s i "
+"Tillagda %(delta)s %(unit_symbol)s för produkten %(product_name)s i "
 "lageret (%(supplier_name)s)"
 
 #, python-format
 msgid ""
-"Removed %(delta)s %(unit_short_name)s from product %(product_name)s stock "
+"Removed %(delta)s %(unit_symbol)s from product %(product_name)s stock "
 "(%(supplier_name)s)"
 msgstr ""
-"Borttagna %(delta)s %(unit_short_name)s från produkten %(product_name)s i "
+"Borttagna %(delta)s %(unit_symbol)s från produkten %(product_name)s i "
 "lageret (%(supplier_name)s)"
 
 #, python-format

--- a/shuup/simple_supplier/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/shuup/simple_supplier/locale/zh_Hans/LC_MESSAGES/django.po
@@ -48,13 +48,13 @@ msgstr "调整库存"
 
 #, python-format
 msgid ""
-"Added %(delta)s %(unit_short_name)s for product %(product_name)s stock "
+"Added %(delta)s %(unit_symbol)s for product %(product_name)s stock "
 "(%(supplier_name)s)"
 msgstr ""
 
 #, python-format
 msgid ""
-"Removed %(delta)s %(unit_short_name)s from product %(product_name)s stock "
+"Removed %(delta)s %(unit_symbol)s from product %(product_name)s stock "
 "(%(supplier_name)s)"
 msgstr ""
 

--- a/shuup/simple_supplier/utils.py
+++ b/shuup/simple_supplier/utils.py
@@ -92,7 +92,7 @@ def get_stock_information_html(supplier, product):
     context = {
         "div_id": get_stock_information_div_id(supplier, product),
         "sales_decimals": product.sales_unit.decimals if product.sales_unit else 0,
-        "sales_unit": product.sales_unit.short_name if product.sales_unit else "",
+        "sales_unit": product.sales_unit.symbol if product.sales_unit else "",
         "stock": stock
     }
     if "shuup.notify" in settings.INSTALLED_APPS:

--- a/shuup/testing/factories.py
+++ b/shuup/testing/factories.py
@@ -116,7 +116,7 @@ class SalesUnitFactory(DjangoModelFactory):
         model = SalesUnit
 
     name = fuzzy.FuzzyText(length=12, prefix="Sales Unit ")
-    short_name = fuzzy.FuzzyText(length=6, prefix="SU ")
+    symbol = fuzzy.FuzzyText(length=6, prefix="SU ")
 
 
 class CategoryFactory(DjangoModelFactory):
@@ -479,7 +479,7 @@ def get_default_sales_unit():
             identifier=DEFAULT_IDENTIFIER,
             decimals=0,
             name=DEFAULT_NAME,
-            short_name=DEFAULT_NAME[:3].lower()
+            symbol=DEFAULT_NAME[:3].lower()
         )
         assert str(unit) == DEFAULT_NAME
     return unit

--- a/shuup/utils/i18n.py
+++ b/shuup/utils/i18n.py
@@ -10,7 +10,7 @@ import babel
 import babel.numbers
 from babel import UnknownLocaleError
 from babel.dates import format_datetime
-from babel.numbers import format_currency
+from babel.numbers import format_currency, format_decimal, parse_pattern
 from django.apps import apps
 from django.utils import translation
 from django.utils.lru_cache import lru_cache
@@ -56,6 +56,17 @@ def get_current_babel_locale(fallback="en-US-POSIX"):
                 "Failed to get current babel locale (lang=%s)" %
                 (translation.get_language(),))
     return locale
+
+
+def format_number(value, digits=None):
+    locale = get_current_babel_locale()
+    if digits is None:
+        return format_decimal(value, locale=locale)
+    (min_digits, max_digits) = (
+        digits if isinstance(digits, tuple) else (digits, digits))
+    format = locale.decimal_formats.get(None)
+    pattern = parse_pattern(format)  # type: babel.numbers.NumberPattern
+    return pattern.apply(value, locale, force_frac=(min_digits, max_digits))
 
 
 def format_percent(value, digits=0):

--- a/shuup_tests/api/test_products_api.py
+++ b/shuup_tests/api/test_products_api.py
@@ -657,8 +657,8 @@ def test_create_complete_product(admin_user):
     ###### 4) create sales unit
     sales_unit_data = {
         "translations": {
-            "en": {"name": "Kilo", "short_name": "KG"},
-            "pt-br": {"name": "Quilo", "short_name": "KGz"},
+            "en": {"name": "Kilo", "symbol": "KG"},
+            "pt-br": {"name": "Quilo", "symbol": "KGz"},
         },
         "decimals": 2
     }

--- a/shuup_tests/api/test_sales_unit_api.py
+++ b/shuup_tests/api/test_sales_unit_api.py
@@ -30,7 +30,7 @@ def test_sales_unit_api(admin_user):
 
     sales_unit_data = {
         "translations": {
-            "en": {"name": "Kilo", "short_name": "KG"}
+            "en": {"name": "Kilo", "symbol": "KG"}
         },
         "decimals": 2
     }
@@ -40,11 +40,11 @@ def test_sales_unit_api(admin_user):
     assert response.status_code == status.HTTP_201_CREATED
     sales_unit = SalesUnit.objects.first()
     assert sales_unit.name == sales_unit_data["translations"]["en"]["name"]
-    assert sales_unit.short_name == sales_unit_data["translations"]["en"]["short_name"]
+    assert sales_unit.symbol == sales_unit_data["translations"]["en"]["symbol"]
     assert sales_unit.decimals == sales_unit_data["decimals"]
 
     sales_unit_data["translations"]["en"]["name"] = "Pound"
-    sales_unit_data["translations"]["en"]["short_name"] = "PD"
+    sales_unit_data["translations"]["en"]["symbol"] = "PD"
     sales_unit_data["decimals"] = 3
 
     response = client.put("/api/shuup/sales_unit/%d/" % sales_unit.id,
@@ -53,21 +53,21 @@ def test_sales_unit_api(admin_user):
     assert response.status_code == status.HTTP_200_OK
     sales_unit = SalesUnit.objects.first()
     assert sales_unit.name == sales_unit_data["translations"]["en"]["name"]
-    assert sales_unit.short_name == sales_unit_data["translations"]["en"]["short_name"]
+    assert sales_unit.symbol == sales_unit_data["translations"]["en"]["symbol"]
     assert sales_unit.decimals == sales_unit_data["decimals"]
 
     response = client.get("/api/shuup/sales_unit/%d/" % sales_unit.id)
     assert response.status_code == status.HTTP_200_OK
     data = json.loads(response.content.decode("utf-8"))
     assert sales_unit.name == data["translations"]["en"]["name"]
-    assert sales_unit.short_name == data["translations"]["en"]["short_name"]
+    assert sales_unit.symbol == data["translations"]["en"]["symbol"]
     assert sales_unit.decimals == data["decimals"]
 
     response = client.get("/api/shuup/sales_unit/")
     assert response.status_code == status.HTTP_200_OK
     data = json.loads(response.content.decode("utf-8"))
     assert sales_unit.name == data[0]["translations"]["en"]["name"]
-    assert sales_unit.short_name == data[0]["translations"]["en"]["short_name"]
+    assert sales_unit.symbol == data[0]["translations"]["en"]["symbol"]
     assert sales_unit.decimals == data[0]["decimals"]
 
     response = client.delete("/api/shuup/sales_unit/%d/" % sales_unit.id)
@@ -75,7 +75,7 @@ def test_sales_unit_api(admin_user):
     assert SalesUnit.objects.count() == 0
 
     # create a product and relate it to a sales unit
-    sales_unit = SalesUnit.objects.create(name="Kilo", short_name="KG")
+    sales_unit = SalesUnit.objects.create(name="Kilo", symbol="KG")
     product = create_product("product with sales unit", sales_unit=sales_unit)
 
     # shouldn't be possible to delete a sales_unit with a related product

--- a/shuup_tests/core/test_foreignkeys.py
+++ b/shuup_tests/core/test_foreignkeys.py
@@ -38,7 +38,7 @@ def test_manufacturer_removal():
 @pytest.mark.django_db
 def test_sales_unit_removal():
     product = get_product()
-    sales_unit = SalesUnit.objects.create(name="test", short_name="te")
+    sales_unit = SalesUnit.objects.create(name="test", symbol="te")
     product.sales_unit = sales_unit
     product.save()
     with pytest.raises(ProtectedError):

--- a/shuup_tests/core/test_sales_unit.py
+++ b/shuup_tests/core/test_sales_unit.py
@@ -24,6 +24,24 @@ def test_sales_unit_decimals():
 
 
 @pytest.mark.django_db
+def test_sales_unit_short_name():
+    # test the deprecated compatibility property
+    assert SalesUnit(symbol="kg").short_name == "kg"
+    assert SalesUnit(short_name="kg").symbol == "kg"
+    unit = SalesUnit()
+    unit.short_name = "oz"
+    assert unit.symbol == "oz"
+    en_sales_units = SalesUnit.objects.language("en")
+    unit2 = en_sales_units.create(decimals=1, name="Gram", short_name="g")
+    assert unit2.name == "Gram"
+    assert unit2.symbol == "g"
+    unit3 = en_sales_units.get(pk=unit2.pk)
+    unit3.set_current_language('en')
+    assert unit3.name == "Gram"
+    assert unit3.symbol == "g"
+
+
+@pytest.mark.django_db
 @override_settings(**{"LANGUAGES": (("en", "en"), ("fi", "fi"))})
 def test_sales_unit_str():
     unit = SalesUnit()

--- a/shuup_tests/core/test_units.py
+++ b/shuup_tests/core/test_units.py
@@ -1,0 +1,327 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from decimal import Decimal
+
+import pytest
+from django.utils import translation
+from django.utils.translation.trans_real import translation as get_trans
+
+from shuup.core.models import (
+    DisplayUnit, SalesUnit, PiecesSalesUnit, UnitInterface)
+from shuup.core.models._units import SalesUnitAsDisplayUnit
+
+
+def nbsp(x):
+    """
+    Convert space to non-breaking space.
+    """
+    return x.replace(" ", "\xa0")
+
+
+def test_unit_interface_smoke():
+    gram = get_g_in_kg_unit(decimals=4, display_decimals=1)
+    assert gram.symbol == 'g'
+    assert gram.internal_symbol == 'kg'
+    assert gram.to_display(Decimal('0.01')) == 10
+    assert gram.from_display(10) == Decimal('0.01')
+    assert gram.render_quantity(Decimal('0.01')) == '10.0g'
+    assert gram.comparison_quantity == Decimal('0.1')
+
+
+def test_unit_interface_init_without_args():
+    unit = UnitInterface()
+    assert isinstance(unit.internal_unit, PiecesSalesUnit)
+    assert isinstance(unit.display_unit, SalesUnitAsDisplayUnit)
+    assert unit.display_unit.internal_unit == unit.internal_unit
+
+
+def test_unit_interface_init_from_internal_unit():
+    sales_unit = SalesUnit(name="Test", symbol="tst")
+    unit = UnitInterface(sales_unit)
+    assert unit.internal_unit == sales_unit
+    assert isinstance(unit.display_unit, SalesUnitAsDisplayUnit)
+    assert unit.display_unit.internal_unit == sales_unit
+
+
+def test_unit_interface_init_from_display_unit():
+    sales_unit = SalesUnit(name="Test", symbol="tst")
+    display_unit = DisplayUnit(name="Test2", symbol="t2",
+                               internal_unit=sales_unit)
+    unit = UnitInterface(display_unit=display_unit)
+    assert unit.display_unit == display_unit
+    assert unit.internal_unit == sales_unit
+
+
+@pytest.mark.django_db
+def test_unit_interface_init_with_non_default_display_unit():
+    sales_unit = SalesUnit.objects.create(name="Test", symbol="tst")
+    default_du = DisplayUnit.objects.create(
+        name="Default Display Unit", symbol="ddu",
+        internal_unit=sales_unit, default=True)
+    non_default_du = DisplayUnit.objects.create(
+        name="Non-default Display Unit", symbol="ndu",
+        internal_unit=sales_unit, default=False)
+    assert sales_unit.display_unit == default_du
+    unit = UnitInterface(sales_unit, non_default_du)
+    assert unit.internal_unit == sales_unit
+    assert unit.display_unit == non_default_du
+    assert unit.internal_unit.display_unit == default_du
+
+
+def test_unit_interface_init_unit_compatibility_check():
+    su1 = SalesUnit(identifier="SU1", symbol="su1")
+    su2 = SalesUnit(identifier="SU2", symbol="su2")
+    du = DisplayUnit(name="DU", symbol="du", internal_unit=su1)
+    UnitInterface(su1, du)  # OK
+    with pytest.raises(AssertionError) as exc_info:
+        UnitInterface(su2, du)
+    assert str(exc_info.value) == (
+        "Incompatible units: <SalesUnit:None-SU2>, <DisplayUnit:None>")
+
+
+def test_unit_interface_display_precision():
+    sales_unit = SalesUnit(symbol="t")
+    assert UnitInterface(display_unit=DisplayUnit(
+        internal_unit=sales_unit,
+        decimals=9)).display_precision == Decimal('0.000000001')
+    assert UnitInterface(display_unit=DisplayUnit(
+        internal_unit=sales_unit,
+        decimals=4)).display_precision == Decimal('0.0001')
+    assert UnitInterface(display_unit=DisplayUnit(
+        internal_unit=sales_unit,
+        decimals=2)).display_precision == Decimal('0.01')
+    assert UnitInterface(display_unit=DisplayUnit(
+        internal_unit=sales_unit,
+        decimals=0)).display_precision == Decimal('1')
+
+
+def test_unit_interface_to_display():
+    gram3 = get_g_in_kg_unit(decimals=3, display_decimals=0)
+    assert gram3.to_display(Decimal('0.01')) == 10
+    assert gram3.to_display(Decimal('0.001')) == 1
+    assert gram3.to_display(Decimal('0.0005')) == 1
+    assert gram3.to_display(Decimal('0.000499')) == 0
+    assert gram3.to_display(Decimal('-1')) == -1000
+    assert gram3.to_display(Decimal('-0.1234')) == -123
+    assert gram3.to_display(Decimal('-0.1235')) == -124
+
+
+def test_unit_interface_to_display_small_display_prec():
+    gram6 = get_g_in_kg_unit(decimals=6, display_decimals=1)
+    assert gram6.to_display(Decimal('0.01')) == 10
+    assert gram6.to_display(Decimal('0.001')) == 1
+    assert gram6.to_display(Decimal('0.0005')) == Decimal('0.5')
+    assert gram6.to_display(Decimal('0.000499')) == Decimal('0.5')
+    assert gram6.to_display(Decimal('0.0001234')) == Decimal('0.1')
+    assert gram6.to_display(Decimal('0.0001235')) == Decimal('0.1')
+    assert gram6.to_display(Decimal('12.3456789')) == Decimal('12345.7')
+
+
+def test_unit_interface_to_display_float():
+    gram3 = get_g_in_kg_unit(decimals=3, display_decimals=0)
+    assert gram3.to_display(0.01) == 10
+
+
+def test_unit_interface_to_display_str():
+    gram3 = get_g_in_kg_unit(decimals=3, display_decimals=0)
+    assert gram3.to_display('0.01') == 10
+
+
+def test_unit_interface_from_display():
+    gram3 = get_g_in_kg_unit(decimals=3, display_decimals=0)
+    assert gram3.from_display(1234) == Decimal('1.234')
+    assert gram3.from_display(Decimal('123.456')) == Decimal('0.123')
+    assert gram3.from_display(Decimal('123.5')) == Decimal('0.124')
+    assert gram3.from_display(Decimal('124.5')) == Decimal('0.125')
+
+
+def test_unit_interface_from_display_small_display_prec():
+    gram6 = get_g_in_kg_unit(decimals=6, display_decimals=1)
+    assert gram6.from_display(123) == Decimal('0.123')
+    assert gram6.from_display(Decimal('123.456')) == Decimal('0.123456')
+    assert gram6.from_display(Decimal('123.4565')) == Decimal('0.123457')
+
+
+def test_unit_interface_from_display_float():
+    gram6 = get_g_in_kg_unit(decimals=6, display_decimals=3)
+    assert gram6.from_display(123.456) == Decimal('0.123456')
+
+
+def test_unit_interface_from_display_str():
+    gram6 = get_g_in_kg_unit(decimals=6, display_decimals=3)
+    assert gram6.from_display('123.456') == Decimal('0.123456')
+
+
+def test_unit_interface_render_quantity():
+    gram3 = get_g_in_kg_unit(decimals=3, display_decimals=0)
+    with translation.override('en'):
+        assert gram3.render_quantity(123) == '123,000g'
+        assert gram3.render_quantity(1234567) == '1,234,567,000g'
+        assert gram3.render_quantity(0.123) == '123g'
+        assert gram3.render_quantity('0.0521') == '52g'
+        assert gram3.render_quantity('0.0525') == '53g'
+        assert gram3.render_quantity('0.0535') == '54g'
+
+
+def test_unit_interface_render_quantity_pieces():
+    pcs = UnitInterface(PiecesSalesUnit())
+    with translation.override('en'):
+        assert pcs.render_quantity(123) == '123'
+        assert pcs.render_quantity(1234567) == '1,234,567'
+        assert pcs.render_quantity(0.123) == '0'
+        assert pcs.render_quantity('52.1') == '52'
+        assert pcs.render_quantity('52.5') == '53'
+        assert pcs.render_quantity('53.5') == '54'
+        assert pcs.render_quantity(123, force_symbol=True) == '123pc.'
+
+
+def test_unit_interface_render_quantity_small_display_prec():
+    gram6 = get_g_in_kg_unit(decimals=6, display_decimals=1)
+    with translation.override(None):
+        assert gram6.render_quantity(Decimal('12.3456789')) == '12345.7g'
+
+
+def test_unit_interface_render_quantity_translations():
+    # Let's override some translations, just to be sure
+    for lang in ['en', 'pt-br', 'hi', 'hy']:
+        get_trans(lang).merge(ValueSymbolTranslationWithoutSpace)
+    for lang in ['fi']:
+        get_trans(lang).merge(ValueSymbolTranslationWithSpace)
+
+    gram = get_g_in_kg_unit(decimals=7, display_decimals=4)
+    qty = Decimal('4321.1234567')
+    with translation.override(None):
+        assert gram.render_quantity(qty) == '4321123.4567g'
+    with translation.override('en'):
+        assert gram.render_quantity(qty) == '4,321,123.4567g'
+    with translation.override('fi'):
+        assert gram.render_quantity(qty) == nbsp('4 321 123,4567 g')
+    with translation.override('pt-br'):
+        assert gram.render_quantity(qty) == '4.321.123,4567g'
+    with translation.override('hi'):
+        assert gram.render_quantity(qty) == '43,21,123.4567g'
+    with translation.override('hy'):
+        assert gram.render_quantity(qty) == '4321123,4567g'
+
+
+trans_key = (
+    'Display value with unit symbol (with or without space)'
+    '\x04'  # Gettext context separator
+    '{value}{symbol}')
+
+
+class ValueSymbolTranslationWithSpace(object):
+    _catalog = {trans_key: nbsp('{value} {symbol}')}
+
+
+class ValueSymbolTranslationWithoutSpace(object):
+    _catalog = {trans_key: '{value}{symbol}'}
+
+
+def test_unit_interface_render_quantity_internal_kg():
+    gram3 = get_g_in_kg_unit(decimals=3, display_decimals=1)
+    with translation.override('en'):
+        assert gram3.render_quantity_internal(123) == '123.000kg'
+        assert gram3.render_quantity_internal(1234567) == '1,234,567.000kg'
+        assert gram3.render_quantity_internal(0.123) == '0.123kg'
+        assert gram3.render_quantity_internal('0.0521') == '0.052kg'
+        assert gram3.render_quantity_internal('0.0525') == '0.053kg'
+        assert gram3.render_quantity_internal('0.0535') == '0.054kg'
+
+
+def test_unit_interface_render_quantity_internal_pieces():
+    pcs = UnitInterface(PiecesSalesUnit())
+    with translation.override('en'):
+        assert pcs.render_quantity_internal(123) == '123'
+        assert pcs.render_quantity_internal(1234567) == '1,234,567'
+        assert pcs.render_quantity_internal(0.123) == '0'
+        assert pcs.render_quantity_internal('52.1') == '52'
+        assert pcs.render_quantity_internal('52.5') == '53'
+        assert pcs.render_quantity_internal('53.5') == '54'
+        assert pcs.render_quantity_internal(123, force_symbol=True) == '123pc.'
+
+
+def test_unit_interface_get_per_values():
+    pcs = UnitInterface(PiecesSalesUnit())
+    gram = get_g_in_kg_unit(decimals=3, display_decimals=1)
+    gram.display_unit.comparison_value = 100
+    with translation.override('en'):
+        assert pcs.get_per_values() == (1, '')
+        assert pcs.get_per_values(force_symbol=True) == (1, 'pc.')
+        assert gram.get_per_values() == (Decimal('0.1'), '100.0g')
+
+
+def get_g_in_kg_unit(decimals, display_decimals, comparison=100):
+    return UnitInterface(display_unit=DisplayUnit(
+            internal_unit=get_kilogram_sales_unit(decimals=decimals),
+            ratio=Decimal('0.001'),
+            decimals=display_decimals,
+            symbol='g',
+            comparison_value=comparison))
+
+
+def get_kilogram_sales_unit(decimals):
+    return SalesUnit(name="Kilograms", symbol='kg', decimals=decimals)
+
+
+def test_sales_unit_as_display_unit():
+    sales_unit = SalesUnit(decimals=3)
+    display_unit = SalesUnitAsDisplayUnit(sales_unit)
+    assert display_unit.internal_unit == sales_unit
+    assert display_unit.ratio == 1
+    assert display_unit.decimals == sales_unit.decimals
+    assert display_unit.comparison_value == 1
+    assert display_unit.allow_bare_number is False
+    assert display_unit.default is False
+    assert display_unit.pk is None
+    assert display_unit == display_unit
+
+    # Name and symbol should be "lazy" to allow language switch
+    sales_unit.set_current_language('en')
+    sales_unit.symbol = "Kg"
+    sales_unit.name = "Kilogram"
+    assert display_unit.name == sales_unit.name
+    assert display_unit.symbol == sales_unit.symbol
+    assert '{}'.format(display_unit) == sales_unit.name
+    sales_unit.set_current_language('fi')
+    sales_unit.name = "kilogramma"
+    sales_unit.symbol = "kg"
+    assert display_unit.name == sales_unit.name
+    assert display_unit.symbol == sales_unit.symbol
+    assert '{}'.format(display_unit) == sales_unit.name
+
+
+def test_sales_unit_as_display_unit_allow_bare_number():
+    each = SalesUnit(decimals=0, symbol='ea.')
+    kg = SalesUnit(decimals=3, symbol='kg')
+    assert SalesUnitAsDisplayUnit(each).allow_bare_number is True
+    assert SalesUnitAsDisplayUnit(kg).allow_bare_number is False
+
+
+def test_pieces_sales_unit():
+    pcs = PiecesSalesUnit()
+    assert pcs.identifier == '_internal_pieces_unit'
+    with translation.override(None):
+        assert pcs.name == "Pieces"
+        assert pcs.symbol == "pc."
+        assert '{}'.format(pcs) == "Pieces"
+    assert isinstance(pcs.display_unit, SalesUnitAsDisplayUnit)
+    assert pcs.display_unit.internal_unit == pcs
+
+
+def test_kg_in_oz():
+    kg_oz = UnitInterface(display_unit=DisplayUnit(
+        internal_unit=get_kilogram_sales_unit(decimals=9),
+        ratio=Decimal('0.028349523'),
+        decimals=3, symbol='oz'))
+    assert kg_oz.comparison_quantity == Decimal('0.028349523')
+    assert kg_oz.render_quantity('0.028349523') == '1.000oz'
+    assert kg_oz.render_quantity(1) == '35.274oz'
+    assert kg_oz.render_quantity(0.001) == '0.035oz'
+    assert kg_oz.from_display(Decimal('0.001')) == Decimal('0.000028350')
+    assert kg_oz.to_display(Decimal('0.000028350')) == approx('0.001')
+
+
+def approx(value):
+    return pytest.approx(Decimal(value), abs=Decimal('0.1')**7)

--- a/shuup_tests/front/test_basket.py
+++ b/shuup_tests/front/test_basket.py
@@ -151,6 +151,7 @@ def test_basket_orderability_change(rf):
     assert len(basket.get_lines()) == 1
     assert len(basket.get_unorderable_lines()) == 0
     product.soft_delete()
+    basket.uncache()
     assert basket.dirty
     assert len(basket.get_lines()) == 0
     assert len(basket.get_unorderable_lines()) == 1
@@ -197,14 +198,17 @@ def test_basket_package_product_orderability_change(rf):
     assert len(basket.get_unorderable_lines()) == 0
 
     supplier.adjust_stock(child.id, -1)
-    assert basket.dirty
+
+    # Orderability is already cached, we need to uncache to force recheck
+    basket.uncache()
 
     # After reducing stock to 1, should only be stock for one
     assert len(basket.get_lines()) == 1
     assert len(basket.get_unorderable_lines()) == 1
 
     supplier.adjust_stock(child.id, -1)
-    assert basket.dirty
+
+    basket.uncache()
 
     # After reducing stock to 0, should be stock for neither
     assert len(basket.get_lines()) == 0


### PR DESCRIPTION
Currently product has only one sales unit which is used in Admin and
Front.  Make it possible to have a separate display unit for a product
to allow having product quantities being rendered in different unit than
the values stored in the database.  This is documented in the added
units.rst file, which I recommended checking before going to details of
this PR.

There is many related fixes and improvements too.  Won't go to details
here.  The commit messages should contain the reasons for each change.