### PR TITLE
Fix invalid usages of non-unicode gettext_lazy

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -85,6 +85,8 @@ Regions
 General/miscellaneous
 ~~~~~~~~~~~~~~~~~~~~~
 
+- Fix usages of non-unicode ``gettext_lazy``
+
 SHUUP 1.1.0
 -----------
 

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -562,6 +562,9 @@ msgstr ""
 msgid "Folder %s deleted."
 msgstr ""
 
+msgid "Browse Media"
+msgstr ""
+
 #, python-format
 msgid "%(file)s uploaded to %(folder)s"
 msgstr ""

--- a/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
@@ -613,6 +613,9 @@ msgstr "{num} tiedostoa siirretty kansioon {folder}."
 msgid "Folder %s deleted."
 msgstr "Kansio %s poistettu."
 
+msgid "Browse Media"
+msgstr "Selaa mediaa"
+
 #, python-format
 msgid "%(file)s uploaded to %(folder)s"
 msgstr "%(file)s lähetetty kansioon %(folder)s"

--- a/shuup/admin/locale/sv_SE/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/sv_SE/LC_MESSAGES/django.po
@@ -598,6 +598,9 @@ msgstr "{num} filer flyttade till {folder}."
 msgid "Folder %s deleted."
 msgstr "Mappen %s har tagits bort."
 
+msgid "Browse Media"
+msgstr "Bläddra efter media"
+
 #, python-format
 msgid "%(file)s uploaded to %(folder)s"
 msgstr "%(file)s laddades upp til %(folder)s"

--- a/shuup/admin/modules/content/forms.py
+++ b/shuup/admin/modules/content/forms.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.template import loader as template_loader
 from django.utils import translation
 from django.utils.encoding import force_text
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 
 from shuup import configuration as config
 from shuup.utils import djangoenv

--- a/shuup/admin/modules/media/views.py
+++ b/shuup/admin/modules/media/views.py
@@ -14,7 +14,7 @@ from django.db import IntegrityError
 from django.http.response import JsonResponse
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy as _l
+from django.utils.translation import ugettext_lazy
 from django.views.generic import TemplateView
 from filer.models import File, Folder
 from filer.models.imagemodels import Image
@@ -87,7 +87,7 @@ class MediaBrowserView(TemplateView):
     Most of this is just a JSON API that the Javascript (`static_src/media/browser`) uses.
     """
     template_name = "shuup/admin/media/browser.jinja"
-    title = _l(u"Browse Media")
+    title = ugettext_lazy("Browse Media")
 
     def get_context_data(self, **kwargs):
         context = super(MediaBrowserView, self).get_context_data(**kwargs)

--- a/shuup/core/api/attribute.py
+++ b/shuup/core/api/attribute.py
@@ -6,7 +6,7 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 from parler_rest.fields import TranslatedFieldsField
 from parler_rest.serializers import TranslatableModelSerializer
 from rest_framework.viewsets import ModelViewSet

--- a/shuup/core/api/manufacturer.py
+++ b/shuup/core/api/manufacturer.py
@@ -6,7 +6,7 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 from rest_framework.viewsets import ModelViewSet
 

--- a/shuup/core/api/product_media.py
+++ b/shuup/core/api/product_media.py
@@ -6,7 +6,7 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 from parler_rest.fields import TranslatedFieldsField
 from parler_rest.serializers import TranslatableModelSerializer
 from rest_framework import mixins, serializers, viewsets

--- a/shuup/core/api/tax_class.py
+++ b/shuup/core/api/tax_class.py
@@ -6,7 +6,7 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 from parler_rest.fields import TranslatedFieldsField
 from parler_rest.serializers import TranslatableModelSerializer
 from rest_framework.viewsets import ModelViewSet

--- a/shuup/core/api/units.py
+++ b/shuup/core/api/units.py
@@ -6,7 +6,7 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 from parler_rest.fields import TranslatedFieldsField
 from parler_rest.serializers import TranslatableModelSerializer
 from rest_framework.viewsets import ModelViewSet


### PR DESCRIPTION
The non-unicode version of gettext_lazy shouldn't be used, since on
Python 2 it returns bytes (str) rather than unicode and that might cause
unicode encoding/decoding errors.

Also fix an invalid as-name for ugettext_lazy.  The translation was not
picked-up by makemessages, because the ugettext_lazy was imported with a
name that was unknown to makemessages.  Import the ugettext_lazy with
its original name and rerun makemessages to collect the translation.