### PR TITLE
Fix decimal parsing in ProductPriceView._get_quantity

### DIFF
--- a/shuup/utils/numbers.py
+++ b/shuup/utils/numbers.py
@@ -78,6 +78,15 @@ def parse_decimal_string(s):
     Parses a string (or unicode) that may be embellished
     with spaces and other weirdness into the most probable Decimal.
 
+    >>> assert parse_decimal_string('42') == Decimal(42)
+    >>> assert parse_decimal_string('0') == Decimal(0)
+    >>> assert parse_decimal_string('3.5') == Decimal('3.5')
+    >>> assert parse_decimal_string('') == Decimal(0)
+    >>> assert parse_decimal_string(3.5) == Decimal('3.5')
+    >>> assert parse_decimal_string(-5) == Decimal(-5)
+    >>> assert parse_decimal_string('1e12') == Decimal(112)
+    >>> assert parse_decimal_string(float('inf')) == Decimal('inf')
+
     :param s: Input value
     :type s: str
     :return: Decimal

--- a/shuup/utils/numbers.py
+++ b/shuup/utils/numbers.py
@@ -5,6 +5,8 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
 import re
 from decimal import Decimal, ROUND_HALF_EVEN, ROUND_HALF_UP
 
@@ -69,6 +71,48 @@ def nickel_round(value, quant=Decimal('0.05'), rounding=ROUND_HALF_UP):
 def strip_non_float_chars(s):
     """ Strips characters that aren't part of normal floats. """
     return re.sub("[^-+0123456789.]+", "", six.text_type(s))
+
+
+_simple_decimal_rx = re.compile(r'^[-+]?(\d{1,50}\.\d{0,50}|\.?\d{1,50})$')
+
+raise_exception = object()
+
+
+def parse_simple_decimal(value, error=raise_exception):
+    """
+    Parse simple decimal value from string.
+
+    Simple decimal is basically a string of digits with optional sign
+    and decimal point.  Anything fancy, such as exponent forms, NaN or
+    Infinity is an error.  So are other unallowed characters.  There is
+    also a length limit of 50 digits before and after the decimal point.
+
+    >>> assert parse_simple_decimal('42') == Decimal(42)
+    >>> assert parse_simple_decimal('0') == Decimal(0)
+    >>> assert parse_simple_decimal('3.5') == Decimal('3.5')
+    >>> assert parse_simple_decimal('', None) is None
+    >>> assert parse_simple_decimal(3.5, None ) is None
+    >>> assert parse_simple_decimal(-5, None) is None
+    >>> assert parse_simple_decimal('1e12', None) is None
+    >>> assert parse_simple_decimal(float('inf'), None) is None
+
+    :type value: str
+    :param value: The input value as string
+    :type error: Any
+    :param error: Value to return on error, or by default raise an exception
+    :rtype: Decimal|type(error)
+    :raises ValueError: on errors by default
+    """
+    decoded_value = (
+        value.decode('ascii', errors='replace')
+        if six.PY2 and isinstance(value, bytes)
+        else value)
+    if not isinstance(decoded_value, six.text_type) or (
+            not _simple_decimal_rx.match(decoded_value)):
+        if error is raise_exception:
+            raise ValueError('Cannot parse as simple decimal: %r' % (value,))
+        return error
+    return Decimal(value)
 
 
 def parse_decimal_string(s):

--- a/shuup_tests/front/test_product_price.py
+++ b/shuup_tests/front/test_product_price.py
@@ -5,9 +5,14 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from decimal import Decimal
+
 import pytest
 from django.core.urlresolvers import reverse
 
+from shuup.front.themes.views._product_price import ProductPriceView
 from shuup.testing.factories import create_product, get_default_product, get_default_shop, get_default_supplier
 
 
@@ -52,3 +57,43 @@ def test_variation_product_price(client):
     assert response.context_data["product"] == child
     # product isn't orderable since no supplier
     assert b"no-price" in response.content
+
+
+def test_product_price_get_quantity(rf):
+    view = ProductPriceView()
+    view.request = rf.get('/')
+    assert 'quantity' not in view.request.GET
+
+    def check(input_value, expected_output):
+        view.request.GET = dict(view.request.GET, quantity=input_value)
+        result = view._get_quantity()
+        if expected_output is None:
+            assert result is None
+        else:
+            assert isinstance(result, Decimal)
+            assert result == expected_output
+
+    check('42', 42)
+    check('1.5', Decimal('1.5'))
+    check('3.2441', Decimal('3.2441'))
+    check('0.0000000001', Decimal('0.0000000001'))
+    check('0.000000000001', Decimal('0.000000000001'))
+    check('123456789123456789123456789', 123456789123456789123456789)
+    check('0', 0)
+    check('-100', None)
+    check('', None)
+    check('inf', None)
+    check('nan', None)
+    check('Hello', None)
+    check('1.2.3', None)
+    check('1.2.3.4', None)
+    check('1-2', None)
+    check('1 2 3', None)
+    check('1e30', None)
+    check('1,5', None)
+    check('mämmi', None)
+    check('3€', None)
+    check('\0', None)
+    check('123\0', None)
+    check('123\0456', None)
+    check('\n', None)

--- a/shuup_tests/utils/test_numbers.py
+++ b/shuup_tests/utils/test_numbers.py
@@ -4,6 +4,7 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+import decimal
 from decimal import Decimal
 
 import pytest
@@ -24,3 +25,27 @@ def test_parse_decimal_string_with_float_input(input_val, expected_val):
     result = parse_decimal_string(input_val)
     assert result == expected_val
 
+
+def test_parse_decimal_string_with_normal_input():
+    assert parse_decimal_string('42') == Decimal(42)
+    assert parse_decimal_string('0') == Decimal(0)
+    assert parse_decimal_string(3.5) == Decimal('3.5')
+    assert parse_decimal_string(-5) == Decimal(-5)
+    assert parse_decimal_string('-5') == Decimal(-5)
+
+
+def test_parse_decimal_string_with_dirty_input():
+    assert parse_decimal_string('1e12') == Decimal(112)
+    assert parse_decimal_string('foo1bar 1x2') == Decimal(112)
+    assert parse_decimal_string('4a bc2def 8g.h5') == Decimal('428.5')
+    assert parse_decimal_string(float('inf')) == Decimal('inf')
+    assert parse_decimal_string(float('-inf')) == Decimal('-inf')
+    assert str(parse_decimal_string(float('nan'))) == str(Decimal('nan'))
+    assert parse_decimal_string('') == Decimal(0)
+    assert parse_decimal_string(' ') == Decimal(0)
+
+
+@pytest.mark.parametrize("value", ['abc', 'inf', '-inf', 'nan'])
+def test_parse_decimal_string_with_unaccepted_input(value):
+    with pytest.raises(decimal.InvalidOperation):
+        parse_decimal_string(value)

--- a/shuup_tests/utils/test_numbers.py
+++ b/shuup_tests/utils/test_numbers.py
@@ -1,15 +1,65 @@
+# -*- coding: utf-8 -*-
 # This file is part of Shuup.
 #
 # Copyright (c) 2012-2017, Shoop Commerce Ltd. All rights reserved.
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
 import decimal
 from decimal import Decimal
 
 import pytest
+import six
 
-from shuup.utils.numbers import parse_decimal_string
+from shuup.utils.numbers import parse_decimal_string, parse_simple_decimal
+
+
+@pytest.mark.parametrize("input_value, expected_result", [
+    ('42', Decimal(42)),
+    ('-13', Decimal(-13)),
+    ('+5', Decimal(5)),
+    ('.2', Decimal('0.2')),
+    ('2.', Decimal('2')),
+    ('inf', None),
+    ('', None),
+    ('+', None),
+    ('-', None),
+    ('++', None),
+    ('--', None),
+    ('1-2', None),
+    (('9' * 51), None),  # Too long
+    ('.' + ('9' * 51), None),  # Too long
+    (('9' * 50), Decimal('9' * 50)),  # Barely fits
+    ('.' + ('0' * 49) + '1', Decimal('0.' + ('0' * 49) + '1')),
+    ('2.5', Decimal('2.5')),
+    ('123.456', Decimal('123.456')),
+    (' 3', None),
+    ('3 ', None),
+    (3, None),
+    (3, None),
+    (0.5, None),
+    (float('inf'), None),
+    ('1e2', None),
+    ('foo', None),
+    ('3ä4', None),
+])
+def test_parse_simple_decimal(input_value, expected_result):
+    if expected_result is not None:
+        result = parse_simple_decimal(input_value)
+        assert result == expected_result
+        assert isinstance(result, Decimal)
+        if six.PY2 and isinstance(input_value, six.text_type):
+            bytes_input = input_value.encode('utf-8')
+            assert parse_simple_decimal(bytes_input) == expected_result
+    else:
+        assert parse_simple_decimal(input_value, None) is None
+        assert parse_simple_decimal(input_value, 0) == 0
+        with pytest.raises(ValueError) as exc_info:
+            parse_simple_decimal(input_value)
+        assert '{}'.format(exc_info.value) == (
+            "Cannot parse as simple decimal: %r" % (input_value,))
 
 
 @pytest.mark.parametrize("input_val, expected_val", [


### PR DESCRIPTION
Commit c7dedea of PR #1068 didn't have proper value validation in the
added _get_quantity method.  Fix this.

Add a new decimal parser for this too, since the parse_decimal_string
silently accepts invalid values.