### PR TITLE
Admin: Fix bug in shop staff member select

### DIFF
--- a/shuup/admin/modules/shops/forms.py
+++ b/shuup/admin/modules/shops/forms.py
@@ -46,8 +46,8 @@ class ShopBaseForm(ProtectedFieldsMixin, ShuupAdminForm):
             help_text=_("Select staff members for this shop."),
             model=get_user_model(),
             initial=initial_members,
-            required=False)
-        staff_members.widget = QuickAddUserMultiSelect()
+            required=False,
+            widget=QuickAddUserMultiSelect())
         staff_members.widget.choices = [(member.pk, force_text(member)) for member in initial_members]
         self.fields["staff_members"] = staff_members
 


### PR DESCRIPTION
It is important that the widget is passed to `Select2MultipleField`
init. Otherwise the attrs is not set correctly and the widget does
never get the data-model attribute.