### PR TITLE
Fix ProductCrossSellsPlugin with invalid type

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -212,6 +212,7 @@ Front
 Xtheme
 ~~~~~~
 
+- Fix bug: ProductCrossSellsPlugin caused server errors occasionally
 - Allow layout to be rearranged in xtheme editor through drag and drop
 - Add highlight plugin for category products
 - Use rich text editor for text plugin

--- a/shuup/xtheme/plugins/products.py
+++ b/shuup/xtheme/plugins/products.py
@@ -76,7 +76,7 @@ class ProductCrossSellsPlugin(TemplatedPlugin):
             # Map initial config string to enum type
             try:
                 type = map_relation_type(relation_type)
-            except AttributeError:
+            except LookupError:
                 type = ProductCrossSellType.RELATED
             config["type"] = type
         super(ProductCrossSellsPlugin, self).__init__(config)
@@ -88,7 +88,7 @@ class ProductCrossSellsPlugin(TemplatedPlugin):
         relation_type = self.config.get("type")
         try:
             type = map_relation_type(relation_type)
-        except AttributeError:
+        except LookupError:
             type = ProductCrossSellType.RELATED
         return {
             "request": context["request"],

--- a/shuup_tests/xtheme/test_cross_sell_plugin.py
+++ b/shuup_tests/xtheme/test_cross_sell_plugin.py
@@ -42,3 +42,12 @@ def test_cross_sell_plugin_accepts_initial_config_as_string_or_enum():
 
     plugin = ProductCrossSellsPlugin({"type": ProductCrossSellType.RECOMMENDED})
     assert plugin.config["type"] == ProductCrossSellType.RECOMMENDED
+
+
+def test_cross_sell_plugin_with_invalid_type():
+    plugin = ProductCrossSellsPlugin({"type": "foobar"})
+    assert plugin.config['type'] == ProductCrossSellType.RELATED
+
+    plugin.config['type'] = 'foobar'
+    context_data = plugin.get_context_data({'request': 'REQUEST'})
+    assert context_data['type'] == ProductCrossSellType.RELATED


### PR DESCRIPTION
Fix following bug: If the "type" paramater is invalid in the config, the
cross sells plugin causes internal server error.

The fix was to simply catch a correct exception type.

The invalid value could end up in the config e.g. after changing the
plugin type from ProductHighlightPlugin to ProductCrossSellsPlugin in
the Xtheme editor.