### PR TITLE
Fixes to Finnish translations

### DIFF
--- a/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
@@ -39,7 +39,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Home"
-msgstr "Koti"
+msgstr "Etusivu"
 
 #, python-format
 msgid ""
@@ -578,7 +578,7 @@ msgid "Decimal places"
 msgstr "Desimaalipaikat"
 
 msgid "Customers Dashboard"
-msgstr "Asiakkaiden ohjausnäkymä"
+msgstr "Asiakkuuksien hallintapaneeli"
 
 msgid "Active customers"
 msgstr "Aktiivisia asiakkaita"
@@ -1230,7 +1230,7 @@ msgid "Convert to Variation Parent"
 msgstr "Muunna variaatioisännäksi"
 
 msgid "Sales Dashboard"
-msgstr "Myynnin ohjausnäkymä"
+msgstr "Myynnin hallintapaneeli"
 
 msgid "Sales per Month (past 12 months)"
 msgstr "Kuukausittainen myynti (viimeiset 12 kuukautta)"
@@ -1960,10 +1960,10 @@ msgid "Menu"
 msgstr "Valikko"
 
 msgid "Dashboard"
-msgstr "Kojelauta"
+msgstr "Hallintapaneeli"
 
 msgid "Go home"
-msgstr "Mene kotiin"
+msgstr "Mene etusivulle"
 
 msgid "Search for"
 msgstr "Etsi"

--- a/shuup/front/apps/customer_information/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/front/apps/customer_information/locale/fi_FI/LC_MESSAGES/django.po
@@ -68,10 +68,10 @@ msgid "Address Status"
 msgstr "Osoitteen tila"
 
 msgid "Home"
-msgstr "Koti"
+msgstr "Etusivu"
 
 msgid "Dashboard"
-msgstr "Kojelauta"
+msgstr "Hallintapaneeli"
 
 msgid "General Information"
 msgstr "Yleiset tiedot"

--- a/shuup/front/apps/personal_order_history/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/front/apps/personal_order_history/locale/fi_FI/LC_MESSAGES/django.po
@@ -52,7 +52,7 @@ msgid "Status"
 msgstr "Tila"
 
 msgid "Total price"
-msgstr "Hinta yhteensä"
+msgstr "Kokonaishinta"
 
 msgid "Details"
 msgstr "Tiedot"
@@ -132,10 +132,10 @@ msgid "Details of order %(identifier)s"
 msgstr "Tilauksen %(identifier)s tiedot"
 
 msgid "Home"
-msgstr "Koti"
+msgstr "Etusivu"
 
 msgid "Dashboard"
-msgstr "Kojelauta"
+msgstr "Hallintapaneeli"
 
 msgid "Order History"
 msgstr "Tilaushistoria"

--- a/shuup/front/apps/saved_carts/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/front/apps/saved_carts/locale/fi_FI/LC_MESSAGES/django.po
@@ -24,10 +24,10 @@ msgid "Saved Carts"
 msgstr "Tallennetut ostoskorit"
 
 msgid "Home"
-msgstr "Koti"
+msgstr "Etusivu"
 
 msgid "Dashboard"
-msgstr "Tilin hallinta"
+msgstr "Hallintapaneeli"
 
 msgid "My Saved Carts"
 msgstr "Tallennetut korini"

--- a/shuup/front/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/front/locale/fi_FI/LC_MESSAGES/django.po
@@ -446,10 +446,10 @@ msgid "data"
 msgstr "data"
 
 msgid "taxless total price"
-msgstr "veroton hinta yhteensä"
+msgstr "veroton kokonaishinta"
 
 msgid "taxful total price"
-msgstr "verollinen hinta yhteensä"
+msgstr "verollinen kokonaishinta"
 
 msgid "currency"
 msgstr "valuutta"
@@ -670,13 +670,13 @@ msgid "There are errors"
 msgstr "Virhe"
 
 msgid "My Dashboard"
-msgstr "Kojelauta"
+msgstr "Hallintapaneelini"
 
 msgid "Dashboard"
-msgstr "Kojelauta"
+msgstr "Hallintapaneeli"
 
 msgid "Home"
-msgstr "Koti"
+msgstr "Etusivu"
 
 msgid "Bad Request"
 msgstr "Epäkelpo pyyntö"
@@ -960,7 +960,7 @@ msgid "Products ordered"
 msgstr "Tilatut tuotteet"
 
 msgid "Tax breakdown"
-msgstr "Verojen erittely"
+msgstr "Veroerittely"
 
 msgid "Tax"
 msgstr "Vero"
@@ -969,7 +969,7 @@ msgid "Tax percentage"
 msgstr "Veroprosentti"
 
 msgid "Based on amount"
-msgstr "Perustuu määrään"
+msgstr "Veron peruste"
 
 msgid "Amount of tax"
 msgstr "Veron määrä"

--- a/shuup/simple_cms/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/simple_cms/locale/fi_FI/LC_MESSAGES/django.po
@@ -205,4 +205,4 @@ msgid "Extras"
 msgstr "Extrat"
 
 msgid "Home"
-msgstr "Koti"
+msgstr "Etusivu"

--- a/shuup/themes/classic_gray/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/themes/classic_gray/locale/fi_FI/LC_MESSAGES/django.po
@@ -41,7 +41,7 @@ msgid "This theme has no special settings to configure."
 msgstr "Tällä teemalla ei ole muokattavia lisäasetuksia."
 
 msgid "Home"
-msgstr "Koti"
+msgstr "Etusivu"
 
 #, python-format
 msgid "Welcome to %(shop_name)s!"


### PR DESCRIPTION
Unify the following translations:
 * Home = Etusivu
 * Dashboard = Hallintapaneeli
 * Total price = Kokonaishinta
 * Tax breakdown = Veroerittely
 * Based on price = Veron peruste