### PR TITLE
front: Fix re-ordering

### DIFF
--- a/shuup/front/apps/personal_order_history/templates/shuup/personal_order_history/macros/buttons.jinja
+++ b/shuup/front/apps/personal_order_history/templates/shuup/personal_order_history/macros/buttons.jinja
@@ -1,7 +1,9 @@
 {% macro render_action_buttons(order) %}
+{% if order_is_reorderable %}
     <div class="pull-right inline">
         <a class="btn btn-success" href="{{ url("shuup:reorder-order", pk=order.pk) }}">
             <i class="fa fa-plus"></i> {% trans %}Add all products to cart{% endtrans %}
         </a>
     </div>
+{% endif %}
 {% endmacro %}


### PR DESCRIPTION
When adding products from an order to basket, don't add child lines or
subscriptions.

Child lines are excluded because otherwise package contents are added
twice.  Subscriptions are excluded because those don't use normal
checkout flow.