### PR TITLE
Fix get_shop_configuration templatetag

### DIFF
--- a/shuup/core/templatetags/shuup_common.py
+++ b/shuup/core/templatetags/shuup_common.py
@@ -150,7 +150,7 @@ def get_shop_configuration(context, name, default=None):
     :type default: Any
     """
     from shuup import configuration
-    return configuration.get(context.request.shop, name, default)
+    return configuration.get(context.get("request").shop, name, default)
 
 
 @library.global_function

--- a/shuup/front/apps/registration/templates/shuup/registration/register.jinja
+++ b/shuup/front/apps/registration/templates/shuup/registration/register.jinja
@@ -20,7 +20,9 @@
                     {% for field in form.visible_fields() %}{{ render_field(field) }}{% endfor %}
                     {% if get_shop_configuration("allow_company_registration") %}
                     <p>
-                        <a href="{{ url("shuup:registration_register_company") }}">Register as a company.</a>
+                        <a href="{{ url("shuup:registration_register_company") }}">
+                            {% trans %}Register as a company.{% endtrans %}
+                        </a>
                     </p>
                     {% endif %}
                     <button type="submit" class="btn btn-primary btn-lg btn-block">


### PR DESCRIPTION
`context ` is a jinja's Context class, so context items should be accessed by calling a get method.
make 'Register as a company.' translatable.