### PR TITLE
Fix registration while ordering

### DIFF
--- a/shuup/front/checkout/_view_mixin.py
+++ b/shuup/front/checkout/_view_mixin.py
@@ -45,9 +45,12 @@ class CheckoutPhaseViewMixin(object):
     def reset(self):
         self.storage.reset()
 
-    def get_success_url(self):
+    def get_success_url(self, *args, **kwargs):
         if self.next_phase:
             return reverse("shuup:checkout", kwargs={"phase": self.next_phase.identifier})
+        next_obj = super(CheckoutPhaseViewMixin, self)
+        if hasattr(next_obj, 'get_success_url'):
+            return next_obj.get_success_url(*args, **kwargs)
 
     def get_url(self, request):
         return reverse("shuup:checkout", kwargs={"phase": self.identifier})


### PR DESCRIPTION
Django registration redux calls get_success_url like:

    success_url = self.get_success_url(new_user)

which resulted in:

    TypeError: get_success_url() takes 1 positional argument but 2 were given

Fix this error by accepting args and kwargs in CheckoutPhaseViewMixin
get_success_url method. Also call super if there is no next phase set.