### PR TITLE
Translate company registration etc. to Finnish

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -17,6 +17,11 @@ file_filter = shuup/admin/locale/<lang>/LC_MESSAGES/djangojs.po
 source_lang = en
 type = PO
 
+[shuup.api]
+source_lang = en
+file_filter = shuup/api/locale/<lang>/LC_MESSAGES/django.po
+type = PO
+
 [shuup.campaigns]
 file_filter = shuup/campaigns/locale/<lang>/LC_MESSAGES/django.po
 source_lang = en

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-18 08:29+0000\n"
+"POT-Creation-Date: 2017-04-04 10:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -1484,6 +1484,9 @@ msgstr ""
 msgid "The minimum sum that an order needs to reach to be created."
 msgstr ""
 
+msgid "Order Settings"
+msgstr ""
+
 msgid "Order Reference number method"
 msgstr ""
 
@@ -1496,13 +1499,27 @@ msgid ""
 "reference."
 msgstr ""
 
+msgid "Registration Settings"
+msgstr ""
+
+msgid "Allow company registration"
+msgstr ""
+
+msgid ""
+"If you select this, companies can register into your store. Registered "
+"companies must be manually approved by admin."
+msgstr ""
+
 msgid "Settings saved"
 msgstr ""
 
 msgid "Reset Defaults"
 msgstr ""
 
-msgid "Saved successfully"
+msgid "Changes saved successfully"
+msgstr ""
+
+msgid "No changes detected"
 msgstr ""
 
 msgid "Save system settings"
@@ -3336,12 +3353,6 @@ msgid ""
 msgstr ""
 
 msgid "Add component"
-msgstr ""
-
-#, python-format
-msgid ""
-"You can change shop specific order related settings from <a href=\"%(url)s"
-"\">shop configuration</a>."
 msgstr ""
 
 msgid "Order Configuration"

--- a/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
@@ -26,7 +26,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shuup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-18 08:31+0000\n"
+"POT-Creation-Date: 2017-04-04 16:50+0000\n"
 "PO-Revision-Date: 2017-03-01 13:48+0000\n"
 "Last-Translator: Tuomas Suutari <tuomas.suutari@shoop.io>\n"
 "Language-Team: Finnish (Finland) (http://www.transifex.com/shuup/shuup/"
@@ -127,7 +127,7 @@ msgid "Permissions"
 msgstr "Oikeudet"
 
 msgid "Other Settings"
-msgstr "Muut Asetukset"
+msgstr "Muut asetukset"
 
 msgid "Identifier"
 msgstr "Tunniste"
@@ -1570,6 +1570,9 @@ msgstr "Tilauksen nimimiarvo"
 msgid "The minimum sum that an order needs to reach to be created."
 msgstr "Minimiarvo tilaukselle, jotta tilaus voidaan tehdä."
 
+msgid "Order Settings"
+msgstr "Tilausten asetukset"
+
 msgid "Order Reference number method"
 msgstr "Viitenumerometodi"
 
@@ -1588,14 +1591,30 @@ msgstr ""
 "määrästä.<br><br><b>Juokseva kauppakohtainen</b><br>Jokaisella kaupalla on "
 "oma juokseva tilausnumeronsa."
 
+msgid "Registration Settings"
+msgstr "Rekisteröinnin asetukset"
+
+msgid "Allow company registration"
+msgstr "Salli yritysten rekisteröinti"
+
+msgid ""
+"If you select this, companies can register into your store. Registered "
+"companies must be manually approved by admin."
+msgstr ""
+"Jos valitset tämän, yritykset voivat rekisteröityä kauppaasi. Pääkäyttäjän "
+"pitää silti käsin hyväksyä rekisteröidyt yritykset."
+
 msgid "Settings saved"
 msgstr "Asetukset tallennettu"
 
 msgid "Reset Defaults"
 msgstr "Palauta oletukset"
 
-msgid "Saved successfully"
-msgstr "Tallennettu onnistuneesti"
+msgid "Changes saved successfully"
+msgstr "Muutokset tallennettu onnistuneesti"
+
+msgid "No changes detected"
+msgstr "Ei havaittuja muutoksia"
 
 msgid "Save system settings"
 msgstr "Tallenna järjestelmäasetukset"
@@ -3838,14 +3857,6 @@ msgstr ""
 
 msgid "Add component"
 msgstr "Lisää komponentti"
-
-#, python-format
-msgid ""
-"You can change shop specific order related settings from <a href=\"%(url)s"
-"\">shop configuration</a>."
-msgstr ""
-"Voit vaihtaa kauppakohtaisia tilausasetuksia <a href=\"%(url)s\">kaupan "
-"asetuksista</a>."
 
 msgid "Order Configuration"
 msgstr "Tilauksen asetukset"

--- a/shuup/api/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/api/locale/fi_FI/LC_MESSAGES/django.po
@@ -1,97 +1,104 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Copyright (C) 2015 THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2015.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-01 13:41+0000\n"
+"POT-Creation-Date: 2017-04-04 17:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Last-Translator: Tuomas Suutari <tuomas.suutari@shoop.io>, 2017\n"
+"Language-Team: Finnish (Finland) (https://www.transifex.com/shuup/"
+"teams/55306/fi_FI/)\n"
+"Language: fi_FI\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "API"
-msgstr ""
+msgstr "API"
 
 msgid "Disabled"
-msgstr ""
+msgstr "Pois päältä"
 
 msgid "Admin Users"
-msgstr ""
+msgstr "Pääkäyttäjät"
 
 msgid "Authenticated Users - Read/Write"
-msgstr ""
+msgstr "Tunnistautuneet käyttäjät - Luku/kirjoitus"
 
 msgid "Authenticated Users - Read only"
-msgstr ""
+msgstr "Tunnistautuneet käyttäjät - Vain luku"
 
 msgid "Public Users - Read/Write"
-msgstr ""
+msgstr "Julkiset käyttäjät - Luku/kirjoitus"
 
 msgid "Public Users - Read only"
-msgstr ""
+msgstr "Julkiset käyttäjät - Vain luku"
 
 msgid "API permissions saved"
-msgstr ""
+msgstr "API-oikeudet tallennettu"
 
 msgid "API Permissions"
-msgstr ""
+msgstr "API-oikeudet"
 
 msgid "Configure API permissions"
-msgstr ""
+msgstr "Muokkaa API-oikeuksia"
 
 msgid ""
 "Please, configure the API permission level for each service by selecting the "
 "level below."
-msgstr ""
+msgstr "Asettele API-oikeustaso kullekin palvelulle valitsemalla taso alta."
 
 msgid "Note:"
-msgstr ""
+msgstr "Huomaa:"
 
 msgid "No one can make requests."
-msgstr ""
+msgstr "Kukaan ei pysty tekemään pyyntöjä."
 
 msgid "Admin users"
-msgstr ""
+msgstr "Pääkäyttäjät"
 
 msgid ""
 "Only administrators can make requests to the API to fetch, save, delete or "
 "update data."
 msgstr ""
+"Vain pääkäyttäjät pystyvät tekemään API-pyyntöjä tietojen noutamiseksi, "
+"tallentamiseksi, poistamiseksi tai päivittämiseksi."
 
 msgid "Authenticated users - Read/Write"
-msgstr ""
+msgstr "Tunnistautuneet käyttäjät - Luku/kirjoitus"
 
 msgid "Any authenticated user can fetch, save, delete or update data."
 msgstr ""
+"Kuka tahansa tunnistautunut käyttäjä voi noutaa, tallentaa, poistaa tai "
+"päivittää tietoja."
 
 msgid "Authenticated users - Read"
-msgstr ""
+msgstr "Tunnistautuneet käyttäjät - Luku"
 
 msgid "Any authenticated user can only fetch data."
-msgstr ""
+msgstr "Kuka tahansa tunnistautunut käyttäjä voi noutaa tietoja."
 
 msgid "Public users - Read/Write"
-msgstr ""
+msgstr "Julkiset käyttäjät - Luku/kirjoitus"
 
 msgid "Any user (authenticated or not) can fetch, save, delete or update data."
 msgstr ""
+"Kuka tahansa (tunnistautunut tai ei) voi noutaa, tallentaa, poistaa tai "
+"päivittää tietoja."
 
 msgid "Use this with caution."
-msgstr ""
+msgstr "Käytä tätä varoen."
 
 msgid "Public users - Read"
-msgstr ""
+msgstr "Julkiset käyttäjät - Luku"
 
 msgid "Any user (authenticated or not) can only fetch data."
-msgstr ""
+msgstr "Kuka tahansa (tunnistautunut tai ei) voi noutaa tietoja."
 
 msgid "Save"
-msgstr ""
+msgstr "Tallenna"

--- a/shuup/front/apps/registration/forms.py
+++ b/shuup/front/apps/registration/forms.py
@@ -6,14 +6,28 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import six
-from django import forms
 from django.contrib.auth.forms import User, UserCreationForm
 from django.utils.translation import ugettext_lazy as _
-from django_countries import countries
-from django_countries.widgets import CountrySelectWidget
 from registration.users import UsernameField
 
 from shuup.core.models import CompanyContact, MutableAddress, PersonContact
+
+
+def _form_field_from(model, field_name, **kwargs):
+    return model._meta.get_field(field_name).formfield(**kwargs)
+
+
+def _address_field(field_name, **kwargs):
+    return _form_field_from(MutableAddress, field_name, **kwargs)
+
+
+def _person_field(field_name, **kwargs):
+    kwargs.setdefault('help_text', None)
+    return _form_field_from(PersonContact, field_name, **kwargs)
+
+
+def _company_field(field_name, **kwargs):
+    return _form_field_from(CompanyContact, field_name, **kwargs)
 
 
 class CompanyRegistrationForm(UserCreationForm):
@@ -30,62 +44,34 @@ class CompanyRegistrationForm(UserCreationForm):
 
     """
     required_css_class = 'required'
-    email = forms.EmailField(label=_("E-mail"))
+    email = _form_field_from(User, 'email')
 
-    contact_first_name = forms.CharField(max_length=255, label=_("First Name"))
-    contact_last_name = forms.CharField(max_length=255, label=_("Last Name"))
-    contact_phone = forms.CharField(
-        label=_('Phone'), max_length=64, help_text=_("The primary phone number for the address."))
-    contact_street = forms.CharField(
-        label=_('Street'), max_length=255, help_text=_("The street address."))
-    contact_street2 = forms.CharField(
-        label=_('Street (2)'), required=False, max_length=255,
-        help_text=_("An additional street address line."))
-    contact_street3 = forms.CharField(
-        label=_('Street (3)'), required=False, max_length=255,
-        help_text=_("Any additional street address line."))
-    contact_postal_code = forms.CharField(
-        label=_('Postal Code'), max_length=64, help_text=_("The address postal/zip code."))
-    contact_city = forms.CharField(label=_('City'), max_length=255, help_text=_("The address city."))
-    contact_region_code = forms.CharField(
-        label=_('Region Code'), required=False, max_length=16,
-        help_text=_("The address region, province, or state."))
-    contact_region = forms.CharField(
-        label=_('Region'), required=False, max_length=64,
-        help_text=_("The address region, province, or state."))
-    contact_country = forms.ChoiceField(choices=countries, label=_("Country"), widget=CountrySelectWidget)
-    company_name = forms.CharField(
-        label=_('Name'), max_length=255, help_text=_("The name for the address."))
-    company_name_ext = forms.CharField(
-        label=_('Name Extension'), required=False, max_length=255,
-        help_text=_(
-            "Any other text to display along with the address. "
-            "This could be department names (for companies) or titles (for people)."))
-    company_www = forms.URLField(max_length=128, required=False, label=_("Web Address"))
-    company_tax_number = forms.CharField(
-        label=_('Tax Number'), max_length=32,
-        help_text=_("The business tax number. For example, EIN in US or VAT code in Europe."))
-    company_email = forms.EmailField(
-        label=_('Email'), max_length=128, help_text=_("The primary email for the address."))
-    company_phone = forms.CharField(
-        label=_('Phone'), max_length=64, help_text=_("The primary phone number for the address."))
-    company_street = forms.CharField(
-        label=_('Street'), max_length=255, help_text=_("The street address."))
-    company_street2 = forms.CharField(
-        label=_('Street (2)'), max_length=255, help_text=_("An additional street address line."), required=False)
-    company_street3 = forms.CharField(
-        label=_('Street (3)'), required=False, max_length=255,
-        help_text=_("Any additional street address line."))
-    company_postal_code = forms.CharField(
-        label=_('Postal Code'), max_length=64, help_text=_("The address postal/zip code."))
-    company_city = forms.CharField(label=_('City'), max_length=255, help_text=_("The address city."))
-    company_region_code = forms.CharField(
-        label=_('Region Code'), required=False, max_length=16,
-        help_text=_("The address region, province, or state."))
-    company_region = forms.CharField(
-        label=_('Region'), required=False, max_length=64,
-        help_text=_("The address region, province, or state."))
-    company_country = forms.ChoiceField(choices=countries, label=_("Country"), widget=CountrySelectWidget)
+    contact_first_name = _person_field('first_name', required=True)
+    contact_last_name = _person_field('last_name', required=True)
+    contact_phone = _address_field('phone', required=True, help_text=None)
+    contact_street = _address_field('street')
+    contact_street2 = _address_field('street2')
+    contact_street3 = _address_field('street3')
+    contact_postal_code = _address_field('postal_code')
+    contact_city = _address_field('city')
+    contact_region_code = _address_field('region_code')
+    contact_region = _address_field('region')
+    contact_country = _address_field('country')
+
+    company_name = _company_field('name', help_text=_("Name of the company"))
+    company_name_ext = _company_field('name_ext')
+    company_www = _company_field('www', help_text=None)
+    company_tax_number = _company_field('tax_number')
+    company_email = _company_field('email')
+    company_phone = _company_field('phone', help_text=None)
+    company_street = _address_field('street')
+    company_street2 = _address_field('street2')
+    company_street3 = _address_field('street3')
+    company_postal_code = _address_field('postal_code')
+    company_city = _address_field('city')
+    company_region_code = _address_field('region_code')
+    company_region = _address_field('region')
+    company_country = _address_field('country')
 
     class Meta:
         model = User

--- a/shuup/front/apps/registration/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/apps/registration/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-11 17:29+0000\n"
+"POT-Creation-Date: 2017-04-04 16:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -19,10 +19,25 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
+msgid "Name of the company"
+msgstr ""
+
 msgid "Registration Received"
 msgstr ""
 
+msgid "Customer"
+msgstr ""
+
 msgid "Customer Email"
+msgstr ""
+
+msgid "Company Registration Received"
+msgstr ""
+
+msgid "Company Approved"
+msgstr ""
+
+msgid "Company has been activated."
 msgstr ""
 
 msgid "Send Registration Received Email"
@@ -39,16 +54,60 @@ msgstr ""
 msgid "{{ order.shop }} - Welcome!"
 msgstr ""
 
+msgid "Send Company Registration Received Email"
+msgstr ""
+
+msgid "Send email when a user registers as a company."
+msgstr ""
+
+msgid "Send Company Activated Email"
+msgstr ""
+
+msgid "Notify company's contact person that company account is activated"
+msgstr ""
+
+msgid ""
+"This script will send an email to the user or to any configured email right "
+"after a company is activated."
+msgstr ""
+
 msgid "Account activation"
 msgstr ""
 
 msgid "Account activation failed."
 msgstr ""
 
+msgid "Register as a Company"
+msgstr ""
+
+msgid "Company Registration"
+msgstr ""
+
+msgid "Login information"
+msgstr ""
+
+msgid "The information you will log in with."
+msgstr ""
+
+msgid "Contact information"
+msgstr ""
+
+msgid "Contact information for primary company contact"
+msgstr ""
+
+msgid "Company information"
+msgstr ""
+
+msgid "Company billing information"
+msgstr ""
+
 msgid "Register"
 msgstr ""
 
 msgid "Registration"
+msgstr ""
+
+msgid "Register as a company."
 msgstr ""
 
 msgid "Activation successful!"

--- a/shuup/front/apps/registration/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/front/apps/registration/locale/fi_FI/LC_MESSAGES/django.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shuup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-03 09:37+0000\n"
+"POT-Creation-Date: 2017-04-04 16:16+0000\n"
 "PO-Revision-Date: 2017-02-10 11:15+0000\n"
 "Last-Translator: Janne Tammi <janne@shuup.com>\n"
 "Language-Team: Finnish (Finland) (http://www.transifex.com/shuup/shuup/"
@@ -33,11 +33,26 @@ msgstr ""
 "Generated-By: Babel 2.1.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+msgid "Name of the company"
+msgstr "Yrityksen nimi"
+
 msgid "Registration Received"
 msgstr "Rekisteröityminen vastaanotettu"
 
+msgid "Customer"
+msgstr "Asiakas"
+
 msgid "Customer Email"
 msgstr "Asiakkaan sähköpostiosoite"
+
+msgid "Company Registration Received"
+msgstr "Yrityksen rekisteröityminen vastaanotettu"
+
+msgid "Company Approved"
+msgstr "Yritystili hyväksytty"
+
+msgid "Company has been activated."
+msgstr "Yritys on aktivoitu."
 
 msgid "Send Registration Received Email"
 msgstr "Lähetä \"Rekisteröityminen vastaanotettu\" -sähköposti"
@@ -49,11 +64,30 @@ msgid ""
 "This script will send an email to the user or to any configured email right "
 "after a user get registered."
 msgstr ""
-"Tämä scripti lähettää sähköpostin käyttäjälle tai konfiguroiduille "
+"Tämä komentosarja lähettää sähköpostin käyttäjälle tai konfiguroiduille "
 "sähköposteille välittömästi käyttäjän rekisteröitymisen jälkeen."
 
 msgid "{{ order.shop }} - Welcome!"
 msgstr "{{ order.shop }} - Tervetuloa!"
+
+msgid "Send Company Registration Received Email"
+msgstr "Lähetä \"Yrityksen rekisteröityminen vastaanotettu\" -sähköposti"
+
+msgid "Send email when a user registers as a company."
+msgstr "Lähetä sähköposti kun käyttäjä rekisteröityy yrityksenä."
+
+msgid "Send Company Activated Email"
+msgstr "Lähetä \"Yritys aktivoitu\" -sähköposti"
+
+msgid "Notify company's contact person that company account is activated"
+msgstr "Ilmoita yrityksen yhteyshenkilölle, että yritys on aktivoitu"
+
+msgid ""
+"This script will send an email to the user or to any configured email right "
+"after a company is activated."
+msgstr ""
+"Tämä komentosarja lähettää sähköpostin käyttäjälle tai konfiguroiduille "
+"sähköposteille, kun yritystili aktivoidaan."
 
 msgid "Account activation"
 msgstr "Tilin aktivointi"
@@ -61,11 +95,38 @@ msgstr "Tilin aktivointi"
 msgid "Account activation failed."
 msgstr "Tilin aktivointi epäonnistui"
 
+msgid "Register as a Company"
+msgstr "Rekisteröidy yrityksenä"
+
+msgid "Company Registration"
+msgstr "Yritysrekisteröityminen"
+
+msgid "Login information"
+msgstr "Kirjautumistiedot"
+
+msgid "The information you will log in with."
+msgstr "Tiedot joilla kirjaudutaan sisään."
+
+msgid "Contact information"
+msgstr "Yhteystiedot"
+
+msgid "Contact information for primary company contact"
+msgstr "Yrityksen pääyhteyshenkilön yhteystiedot"
+
+msgid "Company information"
+msgstr "Yrityksen tiedot"
+
+msgid "Company billing information"
+msgstr "Yrityksen laskutustiedot"
+
 msgid "Register"
 msgstr "Rekisteröidy"
 
 msgid "Registration"
 msgstr "Rekisteröityminen"
+
+msgid "Register as a company."
+msgstr "Rekisteröidy yrityksenä."
 
 msgid "Activation successful!"
 msgstr "Aktivointi onnistui!"

--- a/shuup/front/apps/registration/notify_events.py
+++ b/shuup/front/apps/registration/notify_events.py
@@ -102,7 +102,7 @@ CompanyActivatedEmailScriptTemplate = generic_send_email_script_template_factory
     identifier="company_activated_email",
     event=CompanyApproved,
     name=_("Send Company Activated Email"),
-    description=_("Notify company's contact person that compny account is activated"),
+    description=_("Notify company's contact person that company account is activated"),
     help_text=_("This script will send an email to the user or to any configured email "
                 "right after a company is activated."),
     initial=dict(

--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-18 09:48+0000\n"
+"POT-Creation-Date: 2017-04-04 10:53+0000\n"
 "PO-Revision-Date: 2016-08-04 10:51-0700\n"
 "Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
@@ -422,6 +422,12 @@ msgid "Customer Email"
 msgstr ""
 
 msgid "Customer Phone"
+msgstr ""
+
+msgid "Shop Email"
+msgstr ""
+
+msgid "Shop Phone"
 msgstr ""
 
 msgid "Language"

--- a/shuup/front/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/front/locale/fi_FI/LC_MESSAGES/django.po
@@ -25,7 +25,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shuup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-18 09:48+0000\n"
+"POT-Creation-Date: 2017-04-04 10:53+0000\n"
 "PO-Revision-Date: 2017-03-01 13:53+0000\n"
 "Last-Translator: Tuomas Suutari <tuomas.suutari@shoop.io>\n"
 "Language-Team: Finnish (Finland) (http://www.transifex.com/shuup/shuup/"
@@ -480,6 +480,12 @@ msgstr "Asiakkaan sähköposti"
 
 msgid "Customer Phone"
 msgstr "Asiakkaan puhelinnumero"
+
+msgid "Shop Email"
+msgstr "Kaupan sähköpostiosoite"
+
+msgid "Shop Phone"
+msgstr "Kaupan puhelinnumero"
 
 msgid "Language"
 msgstr "Kieli"

--- a/shuup/front/templates/shuup/front/macros/checkout.jinja
+++ b/shuup/front/templates/shuup/front/macros/checkout.jinja
@@ -42,7 +42,7 @@
     <div class="well">
         <fieldset>
             {% if saved_address_form and saved_address_form.fields.addresses.choices|count > 1 %}
-                {{ render_address_form(None, saved_address_form, "saved_shpping") }}
+                {{ render_address_form(None, saved_address_form, "saved_shipping") }}
             {% endif %}
             {{ render_address_form(_("Shipping address"), shipping_form, "shipping", ship_to_billing_checkbox) }}
         </fieldset>


### PR DESCRIPTION
Make the company registration form more DRY (to reduce number of
to-be-translated messages) and translate it to Finnish.

Add also "shuup.api" to Transifex configuration and translate it to
Finnish.

Translate a couple other found untranslated messages too.