### PR TITLE
Fix messages in the administration toolbar

### DIFF
--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -772,10 +772,10 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr ""
 
-msgid "Admin Tools"
+msgid "Administration Tools"
 msgstr ""
 
-msgid "Maintenance"
+msgid "Maintenance mode"
 msgstr ""
 
 msgid "ON"
@@ -784,7 +784,7 @@ msgstr ""
 msgid "OFF"
 msgstr ""
 
-msgid "Admin"
+msgid "Shop Administration"
 msgstr ""
 
 msgid "Tools"
@@ -955,9 +955,6 @@ msgid "Add to cart"
 msgstr ""
 
 msgid "Product is not orderable."
-msgstr ""
-
-msgid "Maintenance mode"
 msgstr ""
 
 msgid "Shop is currently down for maintenance."

--- a/shuup/front/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/front/locale/fi_FI/LC_MESSAGES/django.po
@@ -872,11 +872,11 @@ msgstr "Tuotteet %(start_index)d - %(end_index)d Yhteensä %(count)d"
 msgid "Toggle navigation"
 msgstr "Näytä / piilota navigaatio"
 
-msgid "Admin Tools"
-msgstr "Admintyökalut"
+msgid "Administration Tools"
+msgstr "Hallintatyökalut"
 
-msgid "Maintenance"
-msgstr "Ylläpitotoimenpiteet"
+msgid "Maintenance mode"
+msgstr "Huoltotila"
 
 msgid "ON"
 msgstr "PÄÄLLÄ"
@@ -884,8 +884,8 @@ msgstr "PÄÄLLÄ"
 msgid "OFF"
 msgstr "POIS PÄÄLTÄ"
 
-msgid "Admin"
-msgstr "Pääkäyttäjä"
+msgid "Shop Administration"
+msgstr "Kaupan hallinta"
 
 msgid "Tools"
 msgstr "Työkalut"
@@ -1058,9 +1058,6 @@ msgstr "Lisää ostoskoriin"
 
 msgid "Product is not orderable."
 msgstr "Tuote ei ole tilattavissa"
-
-msgid "Maintenance mode"
-msgstr "Huoltotila"
 
 msgid "Shop is currently down for maintenance."
 msgstr "Kauppa on tällä hetkellä huoltotilassa."

--- a/shuup/front/locale/sv_SE/LC_MESSAGES/django.po
+++ b/shuup/front/locale/sv_SE/LC_MESSAGES/django.po
@@ -865,10 +865,10 @@ msgstr "Artiklarna %(start_index)d till %(end_index)d av %(count)d summan"
 msgid "Toggle navigation"
 msgstr "Visa/göm navigering"
 
-msgid "Admin Tools"
+msgid "Administration Tools"
 msgstr "Administrationsverktyg"
 
-msgid "Maintenance"
+msgid "Maintenance mode"
 msgstr "Underhållsläge"
 
 msgid "ON"
@@ -877,8 +877,8 @@ msgstr "PÅ"
 msgid "OFF"
 msgstr "AV"
 
-msgid "Admin"
-msgstr "Administration"
+msgid "Shop Administration"
+msgstr "Butiks administration"
 
 msgid "Tools"
 msgstr "Verktyg"
@@ -1045,9 +1045,6 @@ msgstr "Lägg i kundvagnen"
 
 msgid "Product is not orderable."
 msgstr "Produkten är inte beställningsbara."
-
-msgid "Maintenance mode"
-msgstr "Underhållsläge"
 
 msgid "Shop is currently down for maintenance."
 msgstr "Butiken är för närvarande nere för underhåll."

--- a/shuup/front/templates/shuup/front/macros/general.jinja
+++ b/shuup/front/templates/shuup/front/macros/general.jinja
@@ -167,9 +167,9 @@
                     <span class="icon-bar"></span>
                 </button>
                 <a class="navbar-brand" href="#">
-                    {% trans %}Admin Tools{% endtrans %}
+                    {% trans %}Administration Tools{% endtrans %}
                     <br>
-                    <small>{% trans %}Maintenance{% endtrans %}:
+                    <small>{% trans %}Maintenance mode{% endtrans %}:
                         {% if request.shop.maintenance_mode %}
                             <span class="maintenance-on">{% trans %}ON{% endtrans %}</span>
                         {% else %}
@@ -182,7 +182,7 @@
             <div class="collapse navbar-collapse" id="admin-tools-menu">
                 <ul class="nav navbar-nav navbar-right">
                     <li>
-                        <a href="{{ url("shuup_admin:dashboard") }}">{% trans %}Admin{% endtrans %}</a>
+                        <a href="{{ url("shuup_admin:dashboard") }}">{% trans %}Shop Administration{% endtrans %}</a>
                     </li>
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle"


### PR DESCRIPTION
Use non-shortened term for Admin*, because term "Admin" is hard to
translate, since it can mean "Administrator" or "Administration".  It's
also nice to be clear what's being administrated; for the translators
and for the users.

Change term "Maintenance" to "Maintenance mode" to reuse its
translation.  The former had incoherent translation in Finnish.