### PR TITLE
Add create shipment view succeeded signal and event

### DIFF
--- a/shuup/core/models/_orders.py
+++ b/shuup/core/models/_orders.py
@@ -38,7 +38,8 @@ from shuup.core.fields import (
 )
 from shuup.core.pricing import TaxfulPrice, TaxlessPrice
 from shuup.core.signals import (
-    payment_created, refund_created, shipment_created
+    payment_created, refund_created, shipment_created,
+    shipment_created_and_processed
 )
 from shuup.utils.analog import define_log_model, LogEntryKind
 from shuup.utils.dates import local_now, to_aware
@@ -662,6 +663,7 @@ class Order(MoneyPropped, models.Model):
         self.add_log_entry(_(u"Shipment #%d created.") % shipment.id)
         self.update_shipping_status()
         shipment_created.send(sender=type(self), order=self, shipment=shipment)
+        shipment_created_and_processed.send(sender=type(self), order=self, shipment=shipment)
         return shipment
 
     def can_create_refund(self):

--- a/shuup/core/signals.py
+++ b/shuup/core/signals.py
@@ -11,6 +11,7 @@ from django.dispatch import Signal
 get_visibility_errors = Signal(providing_args=["shop_product", "customer"], use_caching=True)
 get_orderability_errors = Signal(providing_args=["shop_product", "customer", "supplier", "quantity"], use_caching=True)
 shipment_created = Signal(providing_args=["order", "shipment"], use_caching=True)
+shipment_created_and_processed = Signal(providing_args=["order", "shipment"], use_caching=True)
 refund_created = Signal(providing_args=["order", "refund_lines"], use_caching=True)
 category_deleted = Signal(providing_args=["category"], use_caching=True)
 shipment_deleted = Signal(providing_args=["shipment"], use_caching=True)

--- a/shuup/front/notify_events.py
+++ b/shuup/front/notify_events.py
@@ -11,7 +11,8 @@ from django.utils.translation import ugettext_lazy as _
 from shuup.core.models import PaymentStatus, ShipmentStatus, ShippingStatus
 from shuup.core.order_creator.signals import order_creator_finished
 from shuup.core.signals import (
-    payment_created, refund_created, shipment_created, shipment_deleted
+    payment_created, refund_created, shipment_created_and_processed,
+    shipment_deleted
 )
 from shuup.notify.base import Event, Variable
 from shuup.notify.typology import Email, Enum, Language, Model, Phone
@@ -101,7 +102,7 @@ def send_order_received_notification(order, **kwargs):
     OrderReceived(**params).run()
 
 
-@receiver(shipment_created)
+@receiver(shipment_created_and_processed)
 def send_shipment_created_notification(order, shipment, **kwargs):
     ShipmentCreated(
         order=order,


### PR DESCRIPTION
Create a new signal which is dispatched after the shipment_created
has dispatched. Connect notify script to this event so you can be sure
that every function connected to shipment_created signal has already
processed and so the shipment contains all information including data
fetched from 3rd party apis for example.