### PR TITLE
Change FreeProductLine quantity field type to QuantityField

### DIFF
--- a/shuup/campaigns/migrations/0008_freeproductline_quantity_to_quantityfield.py
+++ b/shuup/campaigns/migrations/0008_freeproductline_quantity_to_quantityfield.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import shuup.core.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('campaigns', '0007_add_excluded_categories'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='freeproductline',
+            name='quantity',
+            field=shuup.core.fields.QuantityField(decimal_places=9, default=1, verbose_name='quantity', max_digits=36),
+        ),
+    ]

--- a/shuup/campaigns/models/basket_line_effects.py
+++ b/shuup/campaigns/models/basket_line_effects.py
@@ -9,7 +9,7 @@ import random
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from shuup.core.fields import MoneyValueField
+from shuup.core.fields import MoneyValueField, QuantityField
 from shuup.core.models import (
     Category, OrderLineType, PolymorphicShuupModel, Product
 )
@@ -38,7 +38,7 @@ class FreeProductLine(BasketLineEffect):
     model = Product
     name = _("Free Product(s)")
 
-    quantity = models.PositiveIntegerField(default=1, verbose_name=_("quantity"))
+    quantity = QuantityField(default=1, verbose_name=_("quantity"))
     products = models.ManyToManyField(Product, verbose_name=_("product"))
 
     @property


### PR DESCRIPTION
Change FreeProductLine basket line effects quantity field
to QuantityField type because product units can have decimal
values. Add validation to FreeProductLine quantity field
so that quantity must be divisible with the product unit
step.