### PR TITLE
Campaigns: Fix issue in the multi shop coupons

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -85,6 +85,9 @@ Order Printouts
 Campaigns
 ~~~~~~~~~
 
+- Remove uniqueness from coupon code texts. Instead make sure that one shop
+does not have multiple active basket campaigns with same code.
+
 Customer Group Pricing
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/shuup/campaigns/locale/en/LC_MESSAGES/django.po
+++ b/shuup/campaigns/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-09 11:58+0000\n"
+"POT-Creation-Date: 2017-04-30 01:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -371,6 +371,9 @@ msgstr ""
 msgid "Basket Campaign: %(name)s"
 msgstr ""
 
+msgid "Can not have multiple active campaigns with same code."
+msgstr ""
+
 msgid "usage limit per customer"
 msgstr ""
 
@@ -386,9 +389,6 @@ msgid ""
 msgstr ""
 
 msgid "is active"
-msgstr ""
-
-msgid "Cannot have two same codes active at the same time."
 msgstr ""
 
 msgid "Base Catalog Filter"

--- a/shuup/campaigns/modules.py
+++ b/shuup/campaigns/modules.py
@@ -87,7 +87,8 @@ class BasketCampaignModule(OrderSourceModifierModule):
         )
 
     def can_use_code(self, order_source, code):
-        campaigns = BasketCampaign.objects.filter(active=True, coupon__code__iexact=code, coupon__active=True)
+        campaigns = BasketCampaign.objects.filter(
+            active=True, shop=order_source.shop, coupon__code__iexact=code, coupon__active=True)
         for campaign in campaigns:
             if not campaign.is_available():
                 continue
@@ -95,7 +96,8 @@ class BasketCampaignModule(OrderSourceModifierModule):
         return False
 
     def use_code(self, order, code):
-        campaigns = BasketCampaign.objects.filter(active=True, coupon__code__iexact=code, coupon__active=True)
+        campaigns = BasketCampaign.objects.filter(
+            active=True, shop=order.shop, coupon__code__iexact=code, coupon__active=True)
         for campaign in campaigns:
             campaign.coupon.use(order)
 

--- a/shuup_tests/campaigns/test_basket_campaigns.py
+++ b/shuup_tests/campaigns/test_basket_campaigns.py
@@ -310,7 +310,7 @@ def test_percentage_campaign(rf):
 def test_order_creation_adds_usage(rf, admin_user):
     request, shop, group = initialize_test(rf, False)
 
-    source = seed_source(admin_user)
+    source = seed_source(admin_user, shop)
     source.add_line(
         type=OrderLineType.PRODUCT,
         product=get_default_product(),

--- a/shuup_tests/campaigns/test_coupons.py
+++ b/shuup_tests/campaigns/test_coupons.py
@@ -7,9 +7,12 @@
 # LICENSE file in the root directory of this source tree.
 import pytest
 
+from django.core.exceptions import ValidationError
 from django.utils.encoding import force_text
 
-from shuup.campaigns.models.campaigns import Coupon
+from shuup.campaigns.models.campaigns import BasketCampaign, Coupon
+from shuup.testing import factories
+
 
 @pytest.mark.django_db
 def test_utf8_coupon_force_text(rf):
@@ -20,3 +23,40 @@ def test_utf8_coupon_force_text(rf):
     except UnicodeDecodeError:
         text = ""
     assert text == code
+
+
+@pytest.mark.django_db
+def test_same_codes():
+    shop1 = factories.get_shop(True, "EUR")
+    shop2 = factories.get_shop(True, "USD")
+
+    dc1 = Coupon.objects.create(code="TEST")
+    dc2 = Coupon.objects.create(code="TEST")
+
+
+    BasketCampaign.objects.create(name="test1", active=True, shop_id=shop1.id, coupon_id=dc1.id)
+    with pytest.raises(ValidationError):
+        BasketCampaign.objects.create(name="test1", active=True, shop_id=shop1.id, coupon_id=dc2.id)
+
+    BasketCampaign.objects.create(name="test2", active=True, shop_id=shop2.id, coupon_id=dc2.id)
+    with pytest.raises(ValidationError):
+        BasketCampaign.objects.create(name="test2", active=True, shop_id=shop2.id, coupon_id=dc1.id)
+
+    # Disable one campaigns for dc1 and you should be able to set the code to different campaign again
+    dc3 = Coupon.objects.create(code="TEST")
+    BasketCampaign.objects.filter(coupon=dc1).update(active=False)
+    BasketCampaign.objects.create(name="test1", active=True, shop_id=shop1.id, coupon_id=dc3.id)
+
+    # Try to reactivate the campaign for shop1
+    c = BasketCampaign.objects.filter(coupon=dc1).first()
+    assert c.active == False
+    with pytest.raises(ValidationError):
+        c.active = True
+        c.save()
+
+    # Try to sneak one duplicate code by saving the coupon
+    dc4 = Coupon.objects.create(code="TEST1")
+    BasketCampaign.objects.create(name="test4", active=True, shop_id=shop2.id, coupon_id=dc4.id)
+    with pytest.raises(ValidationError):
+        dc4.code = "TEST"
+        dc4.save()

--- a/shuup_tests/campaigns/test_discount_codes.py
+++ b/shuup_tests/campaigns/test_discount_codes.py
@@ -107,39 +107,6 @@ def test_coupon_amount_limit():
 
 
 @pytest.mark.django_db
-def test_no_two_same_codes_active1():
-    # allow two discount codes with same code as they are inactive
-    dc1 = Coupon.objects.create(code="TEST")
-    dc2 = Coupon.objects.create(code="TEST")
-
-    dc1.active = True
-    dc1.save()
-
-    dc2.active = True
-    with pytest.raises(ValidationError):
-        dc2.save()
-    dc2.code = "changed_code"
-    dc2.save()
-
-@pytest.mark.django_db
-def test_no_two_same_codes_active2():
-    # allow two discount codes with same code as they are inactive
-    dc1 = Coupon.objects.create(code="test")
-    dc2 = Coupon.objects.create(code="TEST")
-
-    assert dc1.code == "test"
-    assert dc2.code == "TEST"
-
-    dc1.active = True
-    dc1.save()
-
-    dc2.active = True
-    with pytest.raises(ValidationError):
-        dc2.save()
-    dc2.code = "changed_code"
-    dc2.save()
-
-@pytest.mark.django_db
 def test_campaign_with_coupons1(rf):
     basket, dc, request, status = _init_basket_coupon_test(rf)
 

--- a/shuup_tests/core/test_order_creator.py
+++ b/shuup_tests/core/test_order_creator.py
@@ -19,9 +19,9 @@ from shuup.core.models import (
 from shuup.core.order_creator import OrderCreator, OrderSource, SourceLine
 from shuup.core.order_creator.constants import ORDER_MIN_TOTAL_CONFIG_KEY
 from shuup.testing.factories import (
-    create_package_product, get_address, get_default_payment_method,
-    get_default_product, get_default_shipping_method, get_default_shop,
-    get_default_supplier, get_initial_order_status
+    create_package_product, get_address, get_default_product, get_default_shop,
+    get_default_supplier, get_initial_order_status, get_payment_method,
+    get_shipping_method
 )
 from shuup.utils.models import get_data_dict
 from shuup_tests.utils.basketish_order_source import BasketishOrderSource
@@ -64,18 +64,19 @@ def test_codes_type_conversion():
     assert source.codes == ["test", "1"]
 
 
-def seed_source(user):
-    source = BasketishOrderSource(get_default_shop())
+def seed_source(user, shop=None):
+    source_shop = shop or get_default_shop()
+    source = BasketishOrderSource(source_shop)
     billing_address = get_address()
     shipping_address = get_address(name="Shippy Doge")
     source.status = get_initial_order_status()
     source.billing_address = billing_address
     source.shipping_address = shipping_address
     source.customer = get_person_contact(user)
-    source.payment_method = get_default_payment_method()
-    source.shipping_method = get_default_shipping_method()
-    assert source.payment_method_id == get_default_payment_method().id
-    assert source.shipping_method_id == get_default_shipping_method().id
+    source.payment_method = get_payment_method(shop)
+    source.shipping_method = get_shipping_method(shop)
+    assert source.payment_method_id == get_payment_method(shop).id
+    assert source.shipping_method_id == get_shipping_method(shop).id
     return source
 
 


### PR DESCRIPTION
Make sure to include source/order shop in to calculations whether the code can be used or not.

Do not limit coupon code to be unique. In multi shops sharing same code like "XMAS" should be pretty common thing.

Instead limit that shop does not have multiple active basket campaigns for same code. Which would make figuring out which code to use pretty hard.

As a side note. Fix the `seed_source` test to allow shop as a parameter to actually guarantee that the source, shipping and payment method shares the same shop. This method is called all over the places so adding this extra in to it might be useful for future when we add more multi shop tests.