### PR TITLE
Core: Fix bug in basket object addresses and methods

### DIFF
--- a/shuup/core/basket/objects.py
+++ b/shuup/core/basket/objects.py
@@ -181,33 +181,39 @@ class BaseBasket(OrderSource):
 
     def _set_value_to_data(self, field_attr, value):
         if hasattr(self, "_data"):
-            self._load()['shipping_address_id'] = getattr(value, "id", None)
+            self._load()[field_attr] = value
 
     def _get_value_from_data(self, field_attr):
         if hasattr(self, "_data") and self._load().get(field_attr):
-            return MutableAddress.objects.filter(id=self._load()[field_attr]).first()
+            return self._load()[field_attr]
 
     @property
     def shipping_address(self):
         if self._shipping_address:
             return self._shipping_address
-        return self._get_value_from_data("shipping_address_id")
+
+        shipping_address_id = self._get_value_from_data("shipping_address_id")
+        if shipping_address_id:
+            return MutableAddress.objects.get(pk=shipping_address_id)
 
     @shipping_address.setter
     def shipping_address(self, value):
         self._shipping_address = value
-        self._set_value_to_data("shipping_address_id", value)
+        self._set_value_to_data("shipping_address_id", getattr(value, "id", None))
 
     @property
     def billing_address(self):
         if self._billing_address:
             return self._billing_address
-        return self._get_value_from_data("billing_address_id")
+
+        billing_address_id = self._get_value_from_data("billing_address_id")
+        if billing_address_id:
+            return MutableAddress.objects.get(pk=billing_address_id)
 
     @billing_address.setter
     def billing_address(self, value):
         self._billing_address = value
-        self._set_value_to_data("billing_address_id", value)
+        self._set_value_to_data("billing_address_id", getattr(value, "id", None))
 
     @property
     def shipping_method(self):

--- a/shuup_tests/api/test_basket_api.py
+++ b/shuup_tests/api/test_basket_api.py
@@ -943,8 +943,23 @@ def test_basket_with_methods(admin_user, settings):
     assert method_data["price"] == shipping_price
     assert method_data["is_available"] == True
 
+    # Make sure that the retrieved basket also has correct methods
+    response = client.get("/api/shuup/basket/{}-{}/".format(shop.pk, basket.key))
+    assert response.status_code == 200
+    response_data = json.loads(response.content.decode("utf-8"))
+    assert response_data["shipping_method"]["id"] == shipping_method.id
+    assert response_data["payment_method"]["id"] == payment_method.id
+
     # Unset payment method
     response = client.post('/api/shuup/basket/{}-{}/set_payment_method/'.format(shop.pk, basket.key), {})
     assert response.status_code == status.HTTP_200_OK
     response_data = json.loads(response.content.decode("utf-8"))
+    assert response_data.get("payment_method") is None
+
+    # Make sure that the retrieved basket also has correct method
+    response = client.get("/api/shuup/basket/{}-{}/".format(shop.pk, basket.key))
+    assert response.status_code == 200
+    response_data = json.loads(response.content.decode("utf-8"))
+    response_data = json.loads(response.content.decode("utf-8"))
+    assert response_data["shipping_method"]["id"] == shipping_method.id
     assert response_data.get("payment_method") is None

--- a/shuup_tests/campaigns/test_discount_codes.py
+++ b/shuup_tests/campaigns/test_discount_codes.py
@@ -124,7 +124,7 @@ def test_campaign_with_coupons1(rf):
     basket = get_basket(request)
 
     assert basket.codes == [dc.code]
-    assert len(basket.get_final_lines()) == 3  # now basket has codes so they will be applied too
+    assert len(basket.get_final_lines()) == 4  # now basket has codes so they will be applied too
     assert OrderLineType.DISCOUNT in [l.type for l in basket.get_final_lines()]
 
     basket.status = status
@@ -164,7 +164,7 @@ def test_campaign_with_coupons2(rf):
     assert [c.upper() for c in basket.codes] != [customer_code]  # they don't match like this
     assert basket.codes == [customer_code]  # they match like this
 
-    assert len(basket.get_final_lines()) == 3  # now basket has codes so they will be applied too
+    assert len(basket.get_final_lines()) == 4  # now basket has codes so they will be applied too
     assert OrderLineType.DISCOUNT in [l.type for l in basket.get_final_lines()]
 
     basket.status = status


### PR DESCRIPTION
Make `_set_value_to_data` and `_get_value_from_data` actually set and get correct values. For addresses and methods always save the method.

Fix campaigns tests since now the service lines is restored from saved data.