### PR TITLE
Fix PersonContact not activated after clicking activate link

### DIFF
--- a/shuup/front/apps/registration/__init__.py
+++ b/shuup/front/apps/registration/__init__.py
@@ -30,7 +30,7 @@ URL names
 
 import django.conf
 from django.db.models.signals import post_save
-from registration.signals import login_user, user_activated
+from registration.signals import user_activated
 
 from shuup.apps import AppConfig
 
@@ -62,7 +62,11 @@ class RegistrationAppConfig(AppConfig):
 
     def ready(self):
         from shuup.core.models import CompanyContact
-        from shuup.front.apps.registration.notify_events import send_company_activated_first_time_notification
+        from .notify_events import send_company_activated_first_time_notification
+        from .signals import handle_user_activation
+
+        user_activated.connect(handle_user_activation)
+
         if not hasattr(django.conf.settings, "ACCOUNT_ACTIVATION_DAYS"):
             # Patch settings to include ACCOUNT_ACTIVATION_DAYS;
             # it's a setting owned by `django-registration-redux`,
@@ -76,9 +80,6 @@ class RegistrationAppConfig(AppConfig):
             # By default, Django-Registration considers this False, but
             # we override it to True. unless otherwise set by the user.
             django.conf.settings.REGISTRATION_AUTO_LOGIN = True
-
-            # connect signal here since the setting value has changed
-            user_activated.connect(login_user)
 
         if not hasattr(django.conf.settings, "REGISTRATION_EMAIL_HTML"):
             # We only provide txt templates out of the box, so default to

--- a/shuup/front/apps/registration/signals.py
+++ b/shuup/front/apps/registration/signals.py
@@ -1,0 +1,21 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2017, Anders Innovations. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from django.conf import settings
+from registration.signals import login_user
+
+
+def handle_user_activation(user, **kwargs):
+    activate_contact_by_user(user)
+    if settings.REGISTRATION_AUTO_LOGIN:
+        login_user(user=user, **kwargs)
+
+
+def activate_contact_by_user(user, **kwargs):
+    contact = user.contact
+    contact.is_active = user.is_active
+    contact.save(update_fields=("is_active",))

--- a/shuup_tests/front/test_registration.py
+++ b/shuup_tests/front/test_registration.py
@@ -185,12 +185,8 @@ def test_user_will_be_redirected_to_user_account_page_after_activation(client):
     body = mail.outbox[-1].body
     urls = re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', body)
     response = client.get(urls[0], follow=True)
-    if settings.SHUUP_REGISTRATION_REQUIRES_ACTIVATION:
-        assert email.encode('utf-8') not in response.content
-        assert reverse('shuup:login') == response.request['PATH_INFO']
-    else:
-        assert email.encode('utf-8') in response.content, 'email should be found from the page.'
-        assert reverse('shuup:customer_edit') == response.request['PATH_INFO'], 'user should be on the account-page.'
+    assert email.encode('utf-8') in response.content, 'email should be found from the page.'
+    assert reverse('shuup:customer_edit') == response.request['PATH_INFO'], 'user should be on the account-page.'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
When user clicked activation link in the email, PersonContact
related to the user was not set to active and user still couldn't
login because PersonContact wasn't active altough the auth user was.
Fix this by activating also the PersonContact when user clicks
activate link.