### PR TITLE
Fix product highlight plugin best selling products

### DIFF
--- a/shuup/xtheme/plugins/products.py
+++ b/shuup/xtheme/plugins/products.py
@@ -43,7 +43,7 @@ class ProductHighlightPlugin(TemplatedPlugin):
         if type == "newest":
             products = get_newest_products(context, count, orderable_only)
         elif type == "best_selling":
-            products = get_best_selling_products(context, count, orderable_only)
+            products = get_best_selling_products(context, count, orderable_only=orderable_only)
         elif type == "random":
             products = get_random_products(context, count, orderable_only)
         else:


### PR DESCRIPTION
ProductHighlightPlugin uses get_best_selling_products function
if type best_selling is selected. Plugin passed arguments
without keywords and so some arguments got assigned to
wrong parameters. Fix this by passing orderable_only with keyword.