### PR TITLE
Handle registration activation email sending via notify scripts

### DIFF
--- a/shuup/front/apps/registration/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/apps/registration/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-06 14:48+0000\n"
+"POT-Creation-Date: 2017-05-15 12:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -29,6 +29,12 @@ msgid "Customer"
 msgstr ""
 
 msgid "Customer Email"
+msgstr ""
+
+msgid "Activation URL"
+msgstr ""
+
+msgid "Is User Active"
 msgstr ""
 
 msgid "Company Registration Received"

--- a/shuup/front/apps/registration/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/front/apps/registration/locale/fi_FI/LC_MESSAGES/django.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shuup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-06 14:48+0000\n"
+"POT-Creation-Date: 2017-05-15 12:11+0000\n"
 "PO-Revision-Date: 2017-02-10 11:15+0000\n"
 "Last-Translator: Janne Tammi <janne@shuup.com>\n"
 "Language-Team: Finnish (Finland) (http://www.transifex.com/shuup/shuup/"
@@ -44,6 +44,12 @@ msgstr "Asiakas"
 
 msgid "Customer Email"
 msgstr "Asiakkaan sähköpostiosoite"
+
+msgid "Activation URL"
+msgstr "Aktivointi-URL"
+
+msgid "Is User Active"
+msgstr "Onko Käyttäjä Aktiivinen"
 
 msgid "Company Registration Received"
 msgstr "Yrityksen rekisteröityminen vastaanotettu"

--- a/shuup/front/apps/registration/locale/sv_SE/LC_MESSAGES/django.po
+++ b/shuup/front/apps/registration/locale/sv_SE/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shuup\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-06 14:48+0000\n"
+"POT-Creation-Date: 2017-05-15 12:12+0000\n"
 "PO-Revision-Date: 2017-04-06 17:50+0300\n"
 "Last-Translator: Frank Wickström <frwickst@gmail.com>\n"
 "Language-Team: Swedish (Sweden) (http://www.transifex.com/shuup/shuup/"
@@ -30,6 +30,12 @@ msgstr "Kund"
 
 msgid "Customer Email"
 msgstr "Kundens e-post"
+
+msgid "Activation URL"
+msgstr "Aktivering URL"
+
+msgid "Is User Active"
+msgstr "Är Användaren Aktiv"
 
 msgid "Company Registration Received"
 msgstr "Registrering av företag mottaget"

--- a/shuup/front/apps/registration/views.py
+++ b/shuup/front/apps/registration/views.py
@@ -51,7 +51,7 @@ class RegistrationNoActivationView(RegistrationViewMixin, simple_views.Registrat
 
 
 class RegistrationWithActivationView(RegistrationViewMixin, default_views.RegistrationView):
-    pass
+    SEND_ACTIVATION_EMAIL = False
 
 
 class RegistrationView(View):


### PR DESCRIPTION
Disable the default user registration activation email sending.
Extend the RegistrationReceived event so that it can include
activation url. Then this event can be used to send customized
activation email to registered user.