### PR TITLE
Fix contact list type filter

### DIFF
--- a/shuup/admin/modules/contacts/views/list.py
+++ b/shuup/admin/modules/contacts/views/list.py
@@ -26,7 +26,7 @@ class ContactTypeFilter(ChoicesFilter):
     def __init__(self):
         super(ContactTypeFilter, self).__init__(choices=[("person", _("Person")), ("company", _("Company"))])
 
-    def filter_queryset(self, queryset, column, value):
+    def filter_queryset(self, queryset, column, value, context):
         if value == "_all":
             return queryset
         model_class = PersonContact


### PR DESCRIPTION
Filtering contacts by type caused
filter_queryset() takes 4 positional arguments but 5 were given
because filter_queryset in ContactTypeFilter was missing
context parameter.