### PR TITLE
API: fix basket create from order endpoint

### DIFF
--- a/shuup_tests/api/test_basket_api.py
+++ b/shuup_tests/api/test_basket_api.py
@@ -8,6 +8,7 @@
 from __future__ import unicode_literals
 
 import json
+from decimal import Decimal
 
 import pytest
 import six
@@ -26,8 +27,8 @@ from shuup.core.models import (
 from shuup.core.pricing import TaxfulPrice
 from shuup.testing import factories
 from shuup.testing.factories import (
-    create_product, get_default_currency, get_default_supplier,
-    get_random_filer_image
+    create_product, create_random_order, get_default_currency,
+    get_default_product, get_default_supplier, get_random_filer_image
 )
 from shuup_tests.campaigns.test_discount_codes import (
     Coupon, get_default_campaign
@@ -1008,3 +1009,80 @@ def test_basket_with_staff_user(settings):
 
     response = client.get("/api/shuup/basket/{}/".format(basket_data["uuid"]))
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_basket_reorder_staff_user(settings):
+    configure(settings)
+    shop = factories.get_default_shop()
+    factories.get_default_payment_method()
+    factories.get_default_shipping_method()
+    staff_user = User.objects.create(username="staff", is_staff=True)
+
+    client = _get_client(staff_user)
+    person = factories.create_random_person()
+
+    # create an order for the person
+    product = create_product("product", shop=shop, supplier=get_default_supplier(), default_price='12.4')
+    order = create_random_order(customer=person, products=[product], completion_probability=1, shop=shop)
+
+    # create the basket
+    response = client.post("/api/shuup/basket/new/", data={"shop": shop.pk, "customer_id": person.pk}, format="json")
+    # Only stuff linked to shop can create baskets for someone else
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    # Can still add personal baskets
+    staff_person = get_person_contact(staff_user)
+    response = client.post("/api/shuup/basket/new/", data={"shop": shop.pk, "customer_id": staff_person.pk}, format="json")
+    assert response.status_code == status.HTTP_201_CREATED
+    basket_data = json.loads(response.content.decode("utf-8"))
+    basket = Basket.objects.filter(key=basket_data["uuid"].split("-")[1]).first()
+    assert basket.shop == shop
+    assert basket.creator == staff_user
+    assert basket.customer.pk == staff_person.pk
+    response = client.get("/api/shuup/basket/{}/".format(basket_data["uuid"]))
+    assert response.status_code == 200
+
+    # Ok let's link the staff member to the shop and
+    # the basket create for random person should work
+    shop.staff_members.add(staff_user)
+    response = client.post("/api/shuup/basket/new/", data={"shop": shop.pk, "customer_id": person.pk}, format="json")
+    assert response.status_code == status.HTTP_201_CREATED
+    basket_data = json.loads(response.content.decode("utf-8"))
+    basket = Basket.objects.filter(key=basket_data["uuid"].split("-")[1]).first()
+    assert basket.shop == shop
+    assert basket.creator == staff_user
+    assert basket.customer.pk == person.pk
+    response = client.get("/api/shuup/basket/{}/".format(basket_data["uuid"]))
+    assert response.status_code == 200
+
+    # add contents to the basket from a customer order
+    response = client.post('/api/shuup/basket/{}-{}/add_from_order/'.format(shop.pk, basket.key), data={"order": order.pk}, format="json")
+    assert response.status_code == status.HTTP_200_OK
+    basket_data = json.loads(response.content.decode("utf-8"))
+    assert len(basket_data['items']) > 0
+    assert Decimal(basket_data['taxful_total_price']) == order.taxful_total_price_value
+
+    # finally create the order
+    response = client.post('/api/shuup/basket/{}-{}/create_order/'.format(shop.pk, basket.key))
+    assert response.status_code == status.HTTP_201_CREATED
+    response_data = json.loads(response.content.decode("utf-8"))
+    created_order = Order.objects.get(id=response_data['id'])
+    assert created_order.customer == person
+    assert created_order.creator == staff_user
+
+    # create a second customer
+    person2 = factories.create_random_person()
+    # create a basket for customer 2 and try to fill with contents of customer 1 order - it should not be possible
+    response = client.post("/api/shuup/basket/new/", data={"shop": shop.pk, "customer_id": person2.pk}, format="json")
+    assert response.status_code == status.HTTP_201_CREATED
+    basket_data = json.loads(response.content.decode("utf-8"))
+    basket = Basket.objects.filter(key=basket_data["uuid"].split("-")[1]).first()
+    assert basket.shop == shop
+    assert basket.creator == staff_user
+    assert basket.customer.pk == person2.pk
+
+    # add contents to the basket from customer 1 order - error
+    response = client.post('/api/shuup/basket/{}-{}/add_from_order/'.format(shop.pk, basket.key), data={"order": order.pk}, format="json")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert 'invalid order' in response.content.decode("utf-8")


### PR DESCRIPTION
- Set the basket customer when the basket is loaded
- When adding contents to the basket from an existing order, the order customer should either the basket customer or the request customer