### PR TITLE
xtheme: Fix Social Media Links plugin

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -72,6 +72,7 @@ Front
 Xtheme
 ~~~~~~
 
+- Fix Social Media Links plugin
 - Fix product highlight plugin best selling products
 
 Classic Gray Theme

--- a/shuup/xtheme/plugins/social_media_links.py
+++ b/shuup/xtheme/plugins/social_media_links.py
@@ -5,9 +5,6 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-import re
-from collections import defaultdict
-
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
@@ -49,19 +46,15 @@ class SocialMediaLinksPluginForm(GenericPluginForm):
         Processed link configuration information is stored and returned as a dictionary
         (``links``).
         """
-        links_dict = defaultdict(dict)
-        cleaned_data = {}
-        precleaned_data = super(SocialMediaLinksPluginForm, self).clean()
-        plugin_fields = [field for (field, value) in self.plugin.fields]
-        for field in plugin_fields:
-            cleaned_data[field] = precleaned_data.pop(field)
-        for link_info in precleaned_data:
-            link_name = re.sub("-ordering", "", link_info)
-            if not link_info.endswith("-ordering"):
-                links_dict[link_name]["url"] = precleaned_data[link_info]
-            else:
-                links_dict[link_name]["ordering"] = precleaned_data[link_info]
-        cleaned_data["links"] = {k: v for (k, v) in links_dict.items() if v.get("url", None)}
+        cleaned_data = super(SocialMediaLinksPluginForm, self).clean()
+        cleaned_data['links'] = {
+            link_name: {
+                'url': cleaned_data.pop(link_name),
+                'ordering': cleaned_data.pop(link_name + '-ordering', 0),
+            }
+            for link_name in self.plugin.icon_classes.keys()
+            if cleaned_data.get(link_name)
+        }
         return cleaned_data
 
 


### PR DESCRIPTION
The SoMe links plugin couldn't be saved because it tried to access the
translated fields incorrectly from the cleaned_data dictionary in its
clean method.

This for-loop

    for field in plugin_fields:
        cleaned_data[field] = precleaned_data.pop(field)

tried to access, e.g. field named "topic" even though there was no such
field in the precleaned_data dictionary.  There was only "topic_*",
"topic_en", "topic_fi", etc.

Fix this by rewriting the clean method to not touch the fields it
doesn't understand, but rather juts rewrite the links, which it knows.