### PR TITLE
Give discount for child products also in category products line effect

### DIFF
--- a/shuup/campaigns/models/basket_line_effects.py
+++ b/shuup/campaigns/models/basket_line_effects.py
@@ -151,8 +151,12 @@ class DiscountFromCategoryProducts(BasketLineEffect):
         for line in original_lines:  # Use original lines since we don't want to discount free product lines
             if not line.type == OrderLineType.PRODUCT:
                 continue
-            if line.product.pk not in product_ids:
-                continue
+            if line.product.variation_parent:
+                if line.product.variation_parent.pk not in product_ids and line.product.pk not in product_ids:
+                    continue
+            else:
+                if line.product.pk not in product_ids:
+                    continue
 
             amount = order_source.zero_price.value
             base_price = line.base_unit_price.value * line.quantity


### PR DESCRIPTION
CategoryProductsBasketCondition applies to basket if basket
contains child products that doesn't belong to specified category
but parent does. If this condition was used with
DiscountFromCategoryProducts effect, user didn't get any discount
because DiscountFromCategoryProducts basket line effect only
checks if current product belongs to a specified categories.
Fix this by using different logic if product in the basket is
a child product and then checking if neither parent and child
doesn't belong to given category.