### PR TITLE
Fix static files auto-updating URLs

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -72,6 +72,9 @@ Front
 Xtheme
 ~~~~~~
 
+- Revert the query-parameter hack for static files introduced in 1.1.
+  Django's ManifestStaticFilesStorage can be used as a cleaner and more
+  robust way to implement auto-updating URLs for static files.
 - Fix Social Media Links plugin
 - Fix product highlight plugin best selling products
 

--- a/shuup/front/generated_resources.txt
+++ b/shuup/front/generated_resources.txt
@@ -1,3 +1,4 @@
+static/shuup/front/css/owl.video.play.png
 static/shuup/front/css/style.css
 static/shuup/front/fonts/FontAwesome.otf
 static/shuup/front/fonts/fontawesome-webfont.eot

--- a/shuup/front/gulpfile.js
+++ b/shuup/front/gulpfile.js
@@ -34,6 +34,12 @@ gulp.task("less:watch", ["less"], function() {
     gulp.watch(["static_src/less/**/*.less"], ["less"]);
 });
 
+gulp.task("owl-assets", function() {
+    return gulp.src([
+        "bower_components/owl.carousel/dist/assets/owl.video.play.png"
+    ]).pipe(gulp.dest("static/shuup/front/css/"));
+});
+
 gulp.task("js", function() {
     return gulp.src([
         "bower_components/jquery/dist/jquery.js",
@@ -67,7 +73,7 @@ gulp.task("copy_fonts", function() {
     ]).pipe(gulp.dest("static/shuup/front/fonts/"));
 });
 
-gulp.task("default", ["js", "less", "copy_fonts"]);
+gulp.task("default", ["js", "less", "owl-assets", "copy_fonts"]);
 
 gulp.task("watch", ["js:watch", "less:watch"], function() {
 });

--- a/shuup/front/static/.gitignore
+++ b/shuup/front/static/.gitignore
@@ -1,4 +1,2 @@
-*.css
-*.js
-/fonts/
-front/fonts/
+shuup/front/*
+!/shuup/front/img

--- a/shuup/themes/classic_gray/generated_resources.txt
+++ b/shuup/themes/classic_gray/generated_resources.txt
@@ -1,2 +1,4 @@
-static/shuup/classic_gray/pink/style.css
+static/shuup/classic_gray/blue/owl.video.play.png
 static/shuup/classic_gray/blue/style.css
+static/shuup/classic_gray/pink/owl.video.play.png
+static/shuup/classic_gray/pink/style.css

--- a/shuup/themes/classic_gray/gulpfile.js
+++ b/shuup/themes/classic_gray/gulpfile.js
@@ -41,4 +41,13 @@ gulp.task("less:watch", ["less"], function() {
     gulp.watch(["static_src/**/**/*.less"], ["less"]);
 });
 
-gulp.task("default", ["less"]);
+gulp.task("owl-assets", function() {
+    var tasks = folders.map(function(folder) {
+        return gulp.src([
+            "bower_components/owl.carousel/dist/assets/owl.video.play.png"
+        ]).pipe(gulp.dest("static/shuup/classic_gray/" + folder));
+    });
+    return merge(tasks);
+});
+
+gulp.task("default", ["less", "owl-assets"]);

--- a/shuup/xtheme/parsing.py
+++ b/shuup/xtheme/parsing.py
@@ -9,12 +9,10 @@ from __future__ import unicode_literals
 
 import pytoml as toml
 import six
-from django.contrib.staticfiles.storage import staticfiles_storage
 from jinja2.ext import Extension
 from jinja2.nodes import Const, EvalContext, ExprStmt, Impossible, Name, Output
 from jinja2.utils import contextfunction
 
-import shuup
 from shuup.xtheme.rendering import render_placeholder
 from shuup.xtheme.view_config import Layout
 
@@ -340,18 +338,8 @@ class PluginExtension(_PlaceholderManagingExtension):
         return noop_node(lineno)
 
 
-class ShuupStaticFilesExtension(Extension):
-    def __init__(self, environment):
-        super(ShuupStaticFilesExtension, self).__init__(environment)
-        environment.globals["static"] = self._static
-
-    def _static(self, path):
-        return "%s?v=%s" % (staticfiles_storage.url(path), shuup.__version__)
-
-
 EXTENSIONS = [
     LayoutPartExtension,
     PlaceholderExtension,
     PluginExtension,
-    ShuupStaticFilesExtension
 ]

--- a/shuup_tests/browser/front/test_product_view.py
+++ b/shuup_tests/browser/front/test_product_view.py
@@ -11,7 +11,6 @@ import pytest
 from django.core.urlresolvers import reverse
 from django.utils.translation import activate
 
-import shuup
 from shuup.core import cache
 from shuup.core.models import ShopProduct
 from shuup.testing.browser_utils import wait_until_condition
@@ -48,9 +47,6 @@ def test_product_descriptions(browser, live_server, settings):
     browser.visit("%s%s" % (live_server, url))
     wait_until_condition(browser, lambda x: x.is_text_present(product.short_description))
     assert product.description in browser.html
-
-    # ensure the version is in static files
-    assert "style.css?v=%s" % shuup.__version__ in browser.html
 
     # product preview
     url = reverse("shuup:xtheme_extra_view", kwargs={"view": "products"})


### PR DESCRIPTION
Make it possible to use ManifestStaticFilesStorage for implementing
auto-updating URLs for static files and revert the earlier hack which
tried to achieve the same functionality.

See the commit messages for details.