### PR TITLE
Travis: Add py36, remove py35-django18 and py34-django19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,9 @@ matrix:
   include:
     - {python: 2.7, env: TOXENV=py27-django18-nomigrations}
     - {python: 3.4, env: TOXENV=py34-django18-nomigrations}
-    - {python: 3.5, env: TOXENV=py35-django18-nomigrations}
     - {python: 2.7, env: TOXENV=py27-django19-nomigrations}
-    - {python: 3.4, env: TOXENV=py34-django19-nomigrations}
     - {python: 3.5, env: TOXENV=py35-django19-nomigrations}
+    - {python: 3.6, env: TOXENV=py36-django19-nomigrations}
     # Browser tests are disabled, since they cause false errors
     # - {python: 3.5, env: TOXENV=py35-nomigrations-nocoverage-browser}
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     isort
     license_headers
     sanity
-    {py27,py34,py35}-{django18,django19}-nomigrations
+    {py27,py34,py35,py36}-{django18,django19}-nomigrations
     py35-nomigrations-nocoverage-browser
     py35
 


### PR DESCRIPTION
Shuup should work fine with Python 3.6, so add it to the build matrix.
But since, we don't want the tests take too long, remove couple entries
too.  All supported Python versions (2.7, 3.4, 3.5, 3.6) and Django
versions (1.8, 1.9) are still tested (although not all combinations).