### PR TITLE
core/api: Fix JSON fields in Order serialization

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,6 +17,7 @@ Not yet released, still in beta.
 Core
 ~~~~
 
+- Fix serializaiton of JSON fields in Order: Object rather than string
 - Add new shipment_created_and_processed signal
 - Improve OrderSource caching for deserialization speedup
 - Add new product count methods to OrderSource

--- a/shuup/core/api/orders.py
+++ b/shuup/core/api/orders.py
@@ -15,6 +15,7 @@ from django_filters import DateTimeFilter
 from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 from rest_framework import serializers, status
 from rest_framework.decorators import detail_route
+from rest_framework.fields import JSONField
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
@@ -55,6 +56,10 @@ class OrderSerializer(serializers.ModelSerializer):
     billing_address = AddressSerializer(read_only=True)
     shipping_address = AddressSerializer(read_only=True)
     payments = PaymentSerializer(many=True, read_only=True)
+    payment_data = JSONField(read_only=True)
+    shipping_data = JSONField(read_only=True)
+    extra_data = JSONField(read_only=True)
+    codes = JSONField(source='_codes', read_only=True)
 
     class Meta:
         model = Order


### PR DESCRIPTION
The JSON fields of Order (payment_data, shipping_data, extra_data and
codes) should be serialized as objects rather than strings.

Previously the output was like

    {
        "id": 123,
        ...
        "payment_data": "{\"hello\":\"world\"}",
        ...
    }

This fixes the JSON strings to be proper objects, e.g.:

    {
        "id": 123,
        ...
        "payment_data": {
            "hello": "world"
        },
        ...
    }

This makes a bigger difference, if XML serialization is used, since
previously the XML field used to contain JSON string, but this makes it
contain a proper XML object.