### PR TITLE
admin: Add media to service provider form template

### DIFF
--- a/shuup/admin/templates/shuup/admin/service_providers/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/service_providers/edit.jinja
@@ -28,4 +28,5 @@
         });
     </script>
     {% endif %}
+    {{ form.media }}
 {% endblock %}


### PR DESCRIPTION
This allows using Form Assets for the widgets in the form.  See
https://docs.djangoproject.com/en/1.8/topics/forms/media/ for details.