### PR TITLE
core: Fix price display and is_visible caching

### DIFF
--- a/shuup/core/utils/price_display.py
+++ b/shuup/core/utils/price_display.py
@@ -74,7 +74,7 @@ class _ContextFunction(_ContextObject):
 class PriceDisplayFilter(_ContextFilter):
     def __call__(self, context, item, quantity=1, include_taxes=None, allow_cache=True):
         key, val = context_cache.get_cached_value(
-            identifier=self.cache_identifier, item=item, context=context,
+            identifier=self.cache_identifier, item=item, context=context.get('request', context),
             quantity=quantity, include_taxes=include_taxes, name=self.name, allow_cache=allow_cache)
         if val is not None:
             return val
@@ -102,7 +102,7 @@ class PriceDisplayFilter(_ContextFilter):
 class PricePropertyFilter(_ContextFilter):
     def __call__(self, context, item, quantity=1, allow_cache=True):
         key, val = context_cache.get_cached_value(
-            identifier=self.cache_identifier, item=item, context=context,
+            identifier=self.cache_identifier, item=item, context=context.get('request', context),
             quantity=quantity, name=self.name, allow_cache=allow_cache)
         if val is not None:
             return val
@@ -120,7 +120,7 @@ class PricePropertyFilter(_ContextFilter):
 class PricePercentPropertyFilter(_ContextFilter):
     def __call__(self, context, item, quantity=1, allow_cache=True):
         key, val = context_cache.get_cached_value(
-            identifier=self.cache_identifier, item=item, context=context,
+            identifier=self.cache_identifier, item=item, context=context.get('request', context),
             quantity=quantity, name=self.name, allow_cache=allow_cache)
         if val is not None:
             return val
@@ -165,7 +165,7 @@ class PriceRangeDisplayFilter(_ContextFilter):
         """
 
         key, val = context_cache.get_cached_value(
-            identifier=self.cache_identifier, item=product, context=context,
+            identifier=self.cache_identifier, item=product, context=context.get('request', context),
             quantity=quantity, name=self.name, allow_cache=allow_cache)
         if val is not None:
             return val

--- a/shuup/front/template_helpers/product.py
+++ b/shuup/front/template_helpers/product.py
@@ -41,11 +41,12 @@ def get_products_bought_with(context, product, count=5):
 
 @contextfunction
 def is_visible(context, product):
-    key, val = context_cache.get_cached_value(identifier="is_visible", item=product, context=context)
+    request = context["request"]
+
+    key, val = context_cache.get_cached_value(identifier="is_visible", item=product, context=request)
     if val is not None:
         return val
 
-    request = context["request"]
     shop_product = product.get_shop_instance(shop=request.shop, allow_cache=True)
     for error in shop_product.get_visibility_errors(customer=request.customer):  # pragma: no branch
         context_cache.set_cached_value(key, False)


### PR DESCRIPTION
Use the request as the context for the context cache instead of the
Jinja2 context.  This will include the customer and groups in the cache
key.  Without the customer information a wrong price or visibility was
cached and presented to a wrong customer.

This is a cherry-pick of the commit from PR #1127.  Only changed the
commit message a bit to be more detailed.