### PR TITLE
Make it possible to override person contact form properties

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -56,6 +56,8 @@ Addons
 Front
 ~~~~~
 
+- Add SHUUP_PERSON_CONTACT_FIELD_PROPERTIES setting which can be used
+  to change person contact form field properties
 - Fix caching of ``shuup.product.is_visible`` template function
 - Checkout: Fix method phase attribute population
 - Send registration activation e-mail via notify event

--- a/shuup/front/apps/customer_information/forms.py
+++ b/shuup/front/apps/customer_information/forms.py
@@ -6,6 +6,7 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django import forms
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from enumfields import EnumField
@@ -28,6 +29,11 @@ class PersonContactForm(forms.ModelForm):
         for field in ("first_name", "last_name", "email"):
             self.fields[field].required = True
         self.initial["language"] = self.instance.language
+
+        field_properties = settings.SHUUP_PERSON_CONTACT_FIELD_PROPERTIES
+        for field, properties in field_properties.items():
+            for prop in properties:
+                setattr(self.fields[field], prop, properties[prop])
 
     def save(self, commit=True):
         self.instance.language = self.cleaned_data["language"]

--- a/shuup/front/settings.py
+++ b/shuup/front/settings.py
@@ -67,3 +67,16 @@ SHUUP_FRONT_DEFAULT_SORT_CONFIGURATION = {
 #:
 #: Cache duration in seconds for front template helpers. Default 30 minutes.
 SHUUP_TEMPLATE_HELPERS_CACHE_DURATION = 60*30
+
+#: A dictionary defining properties to override the default field properties of the
+#: person contact form. Should map the field name (as a string) to a dictionary
+#: containing the overriding Django form field properties, as in the following
+#: example which makes the gender field hidden:
+#:
+#: SHUUP_PERSON_CONTACT_FIELD_PROPERTIES = {
+#:    "gender": {"widget": forms.HiddenInput()}
+#: }
+#:
+#: It should be noted, however, that overriding some settings (such as making a
+#: required field non-required) could create other validation issues.
+SHUUP_PERSON_CONTACT_FIELD_PROPERTIES = {}


### PR DESCRIPTION
Add new setting called SHUUP_PERSON_CONTACT_FIELD_PROPERTIES
which can be used the way as SHUUP_ADDRESS_FIELD_PROPERTIES
setting to override form field properties. You can specify a
dict containing the field name as the key and the value is a
another dict containing the field properties and their new values.