### PR TITLE
Company registration updates

### DIFF
--- a/shuup/admin/modules/settings/consts.py
+++ b/shuup/admin/modules/settings/consts.py
@@ -11,3 +11,4 @@ ORDER_REFERENCE_NUMBER_PREFIX_FIELD = "order_reference_number_prefix"
 ORDER_REFERENCE_NUMBER_METHOD_FIELD = "order_reference_number_method"
 
 ALLOW_COMPANY_REGISTRATION = "allow_company_registration"
+COMPANY_REGISTRATION_REQUIRES_APPROVAL = "company_registration_requires_approval"

--- a/shuup/admin/modules/settings/forms/system.py
+++ b/shuup/admin/modules/settings/forms/system.py
@@ -75,8 +75,11 @@ class RegistrationSettingsForm(BaseSettingsForm):
     title = _("Registration Settings")
     allow_company_registration = forms.BooleanField(
         label=_("Allow company registration"),
-        help_text=_("If you select this, companies can register into your store. "
-                    "Registered companies must be manually approved by admin."), required=False)
+        help_text=_("If you select this, companies can register into your store."), required=False)
+    company_registration_requires_approval = forms.BooleanField(
+        label=_("Company registration requires approval"),
+        help_text=_("Registered companies must be manually approved by admin if this is checked. "
+                    "This option has no effect if company registration is not allowed on your site."), required=False)
 
 
 class OrderSettingsFormPart(BaseSettingsFormPart):

--- a/shuup/front/apps/customer_information/templates/shuup/customer_information/macros/buttons.jinja
+++ b/shuup/front/apps/customer_information/templates/shuup/customer_information/macros/buttons.jinja
@@ -25,13 +25,15 @@
 
 {% macro company_account_button(request) %}
     <div class="btn-group" role="group">
-        <a class="btn btn-primary" href="{{ url("shuup:company_edit") }}">
-            {% if request.is_company_member %}
-                <i class="fa fa-users"></i> {% trans %}Edit company information{% endtrans %}
-            {% else %}
-                <i class="fa fa-link"></i> {% trans %}Link account to company{% endtrans %}
-            {% endif %}
-        </a>
+        {% if get_global_configuration("allow_company_registration") %}
+            <a class="btn btn-primary" href="{{ url("shuup:company_edit") }}">
+                {% if request.is_company_member %}
+                    <i class="fa fa-users"></i> {% trans %}Edit company information{% endtrans %}
+                {% else %}
+                    <i class="fa fa-link"></i> {% trans %}Link account to company{% endtrans %}
+                {% endif %}
+            </a>
+        {% endif %}
     </div>
 {% endmacro %}
 

--- a/shuup/front/apps/registration/__init__.py
+++ b/shuup/front/apps/registration/__init__.py
@@ -29,10 +29,10 @@ URL names
 """
 
 import django.conf
-from django.db.models.signals import post_save
 from registration.signals import user_activated
 
 from shuup.apps import AppConfig
+from shuup.front.apps.registration.signals import company_contact_activated
 
 
 class RegistrationAppConfig(AppConfig):
@@ -86,7 +86,7 @@ class RegistrationAppConfig(AppConfig):
             # false for HTML mails.
             django.conf.settings.REGISTRATION_EMAIL_HTML = False
 
-        post_save.connect(
+        company_contact_activated.connect(
             send_company_activated_first_time_notification,
             sender=CompanyContact,
         )

--- a/shuup/front/apps/registration/signals.py
+++ b/shuup/front/apps/registration/signals.py
@@ -6,7 +6,10 @@
 # LICENSE file in the root directory of this source tree.
 
 from django.conf import settings
+from django.dispatch import Signal
 from registration.signals import login_user
+
+company_contact_activated = Signal(providing_args=["instance", "request"], use_caching=True)
 
 
 def handle_user_activation(user, **kwargs):

--- a/shuup_tests/front/test_registration.py
+++ b/shuup_tests/front/test_registration.py
@@ -16,10 +16,13 @@ from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 
 from shuup import configuration
+from shuup.admin.modules.contacts.views import ContactDetailView
 from shuup.core.models import CompanyContact
 from shuup.core.models import PersonContact
+from shuup.front.apps.customer_information.views import CompanyEditView
 from shuup.notify.models import Script
 from shuup.testing.factories import get_default_shop
+from shuup.testing.utils import apply_request_middleware
 
 username = "u-%d" % uuid.uuid4().time
 email = "%s@shuup.local" % username
@@ -240,13 +243,16 @@ def test_user_will_be_redirected_to_user_account_page_after_activation(client, r
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("allow_company_registration", (False, True))
-def test_company_registration(django_user_model, client, allow_company_registration):
+@pytest.mark.parametrize("company_registration_requires_approval", (False, True))
+def test_company_registration(django_user_model, client, allow_company_registration,
+                              company_registration_requires_approval, rf, admin_user):
     if "shuup.front.apps.registration" not in settings.INSTALLED_APPS:
         pytest.skip("shuup.front.apps.registration required in installed apps")
 
     get_default_shop()
 
     configuration.set(None, "allow_company_registration", allow_company_registration)
+    configuration.set(None, "company_registration_requires_approval", company_registration_requires_approval)
 
     url = reverse("shuup:registration_register_company")
     Script.objects.create(
@@ -259,17 +265,12 @@ def test_company_registration(django_user_model, client, allow_company_registrat
                 {
                     'fallback_language': {'constant': 'en'},
                     'template_data': {
-                        'pt-br': {'content_type': 'html', 'subject': '', 'body': ''},
                         'en': {
                             'content_type': 'html',
                             'subject': 'Company activated',
-                            'body': '{{customer.pk}} - activated'
+                            'body': 'Company has been approved. '
+                                    'Please activate your account by clicking the link: {{activation_url}}'
                         },
-                        'base': {'content_type': 'html', 'subject': '', 'body': ''},
-                        'it': {'content_type': 'html', 'subject': '', 'body': ''},
-                        'ja': {'content_type': 'html', 'subject': '', 'body': ''},
-                        'zh-hans': {'content_type': 'html', 'subject': '', 'body': ''},
-                        'fi': {'content_type': 'html', 'subject': '', 'body': ''}
                     },
                     'recipient': {'variable': 'customer_email'},
                     'language': {'variable': 'language'},
@@ -296,13 +297,11 @@ def test_company_registration(django_user_model, client, allow_company_registrat
                     {
                         'fallback_language': {'constant': 'en'},
                         'template_data': {
-                            'pt-br': {'content_type': 'html', 'subject': '', 'body': ''},
-                             'en': {'content_type': 'html', 'subject': 'Generic welcome message', 'body': 'Welcome!'},
-                             'base': {'content_type': 'html', 'subject': '', 'body': ''},
-                             'it': {'content_type': 'html', 'subject': '', 'body': ''},
-                             'ja': {'content_type': 'html', 'subject': '', 'body': ''},
-                             'zh-hans': {'content_type': 'html', 'subject': '', 'body': ''},
-                             'fi': {'content_type': 'html', 'subject': '', 'body': ''}
+                             'en': {
+                                 'content_type': 'html',
+                                 'subject': 'Generic welcome message',
+                                 'body': 'Welcome!'
+                             },
                         },
                         'recipient': {'variable': 'customer_email'},
                         'language': {'variable': 'language'},
@@ -311,12 +310,11 @@ def test_company_registration(django_user_model, client, allow_company_registrat
                     {
                         'fallback_language': {'constant': 'en'},
                         'template_data': {
-                            'pt-br': {'content_type': 'plain', 'subject': 'New company registered', 'body': ''},
-                            'en': {'content_type': 'plain', 'subject': 'New company registered', 'body': 'New company registered'},
-                            'it': {'content_type': 'plain', 'subject': 'New company registered', 'body': ''},
-                            'ja': {'content_type': 'plain', 'subject': 'New company registered', 'body': ''},
-                            'zh-hans': {'content_type': 'plain', 'subject': 'New company registered', 'body': ''},
-                            'fi': {'content_type': 'plain', 'subject': 'New company registered', 'body': ''}
+                            'en': {
+                                'content_type': 'plain',
+                                'subject': 'New company registered',
+                                'body': 'New company registered'
+                            },
                         },
                         'recipient': {'constant': 'admin@host.local'},
                         'language': {'constant': 'en'},
@@ -357,15 +355,154 @@ def test_company_registration(django_user_model, client, allow_company_registrat
         company = CompanyContact.objects.get(members__in=[contact])
 
         # one of each got created
-        assert django_user_model.objects.count() == 1
+        assert django_user_model.objects.count() == 2  # admin_user + registered user
         assert PersonContact.objects.count() == 1
         assert CompanyContact.objects.count() == 1
         # and they are innactive
-        assert PersonContact.objects.filter(is_active=False).count() == 1
-        assert CompanyContact.objects.filter(is_active=False).count() == 1
-        assert mail.outbox[0].subject == "Generic welcome message"
-        assert mail.outbox[1].subject == "New company registered"
-        company = CompanyContact.objects.first()
-        company.is_active = True
-        company.save(update_fields=("is_active",))
-        assert mail.outbox[2].subject == "Company activated"
+        if company_registration_requires_approval:
+            assert PersonContact.objects.filter(is_active=False).count() == 1
+            assert CompanyContact.objects.filter(is_active=False).count() == 1
+            assert mail.outbox[0].subject == "Generic welcome message"
+            assert mail.outbox[1].subject == "New company registered"
+            # Activating Company for the first time from admin triggers company_approved_by_admin event
+            request = apply_request_middleware(rf.post("/", {"set_is_active": "1"}), user=admin_user)
+            view_func = ContactDetailView.as_view()
+            response = view_func(request, pk=company.pk)
+            urls = re.findall(
+                'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+',
+                mail.outbox[2].body)
+            assert mail.outbox[2].subject == "Company activated"
+            assert user.registrationprofile.activation_key in urls[0]
+            # User receives link to activate his own account
+            response = client.get(urls[0], follow=True)
+            user.refresh_from_db()
+            assert user.is_active is True
+        else:
+            assert PersonContact.objects.filter(is_active=True).count() == 1
+            assert CompanyContact.objects.filter(is_active=True).count() == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("allow_company_registration", (False, True))
+@pytest.mark.parametrize("company_registration_requires_approval", (False, True))
+def test_create_company_from_customer_dashboard(allow_company_registration, company_registration_requires_approval,
+                                                client, rf, admin_user):
+    if "shuup.front.apps.registration" not in settings.INSTALLED_APPS:
+        pytest.skip("shuup.front.apps.registration required in installed apps")
+
+    get_default_shop()
+    configuration.set(None, "allow_company_registration", allow_company_registration)
+    configuration.set(None, "company_registration_requires_approval", company_registration_requires_approval)
+
+    Script.objects.create(
+        event_identifier="company_registration_received",
+        name="Send Company Registration Received Email",
+        enabled=True,
+        template="company_registration_received_email",
+        _step_data=[
+            {
+                'conditions': [],
+                'next': 'stop',
+                'cond_op': 'all',
+                'actions': [
+                    {
+                        'fallback_language': {'constant': 'en'},
+                        'template_data': {
+                             'en': {
+                                 'content_type': 'html',
+                                 'subject': 'Company Registered',
+                                 'body': 'Waiting approval'
+                             },
+                        },
+                        'recipient': {'variable': 'customer_email'},
+                        'language': {'variable': 'language'},
+                        'identifier': 'send_email'
+                    },
+                ],
+                'enabled': True}],
+    )
+    Script.objects.create(
+        event_identifier="company_approved_by_admin",
+        name="Send Company Activated Email",
+        enabled=True,
+        template="company_activated_email",
+        _step_data=[
+            {'actions': [
+                {
+                    'fallback_language': {'constant': 'en'},
+                    'template_data': {
+                        'en': {
+                            'content_type': 'html',
+                            'subject': 'Company activated',
+                            'body': 'Company has been approved. '
+                                    'Please activate your account by clicking the link: {{activation_url}}'
+                        },
+                    },
+                    'recipient': {'variable': 'customer_email'},
+                    'language': {'variable': 'language'},
+                    'identifier': 'send_email'}
+            ],
+                'enabled': True,
+                'next': 'stop',
+                'conditions': [],
+                'cond_op': 'all'
+            }
+        ]
+    )
+    # This view creates CompanyContact object for already registered user
+    view_func = CompanyEditView.as_view()
+
+    if not allow_company_registration:
+        # If company registration is not allowed,
+        # can't create company contacts from customer dashboard
+        request = apply_request_middleware(rf.get("/"), user=admin_user)
+        response = view_func(request)
+        assert response.status_code == 404
+    else:
+        request = apply_request_middleware(
+            rf.post("/", {
+                'contact-name': "Test company",
+                'contact-name_ext': "test",
+                'contact-tax_number': "12345",
+                'contact-email': "test@example.com",
+                'contact-phone': "123123",
+                'contact-www': "",
+                'billing-name': "testa tesat",
+                'billing-phone': "testa tesat",
+                'billing-email': email,
+                'billing-street': "testa tesat",
+                'billing-street2': "",
+                'billing-postal_code': "12345",
+                'billing-city': "test test",
+                'billing-region': "",
+                'billing-region_code': "",
+                'billing-country': "FI",
+                'shipping-name': "testa tesat",
+                'shipping-phone': "testa tesat",
+                'shipping-email': email,
+                'shipping-street': "testa tesat",
+                'shipping-street2': "",
+                'shipping-postal_code': "12345",
+                'shipping-city': "test test",
+                'shipping-region': "",
+                'shipping-region_code': "",
+                'shipping-country': "FI",
+            }), user=admin_user)
+        response = view_func(request)
+        if company_registration_requires_approval:
+            # CompanyContact was created as inactive but PersonContact stays active
+            assert CompanyContact.objects.filter(is_active=False).count() == 1
+            assert PersonContact.objects.filter(is_active=True).count() == 1
+            assert mail.outbox[0].subject == "Company Registered"
+            # Activate new CompanyContact from admin
+            request = apply_request_middleware(rf.post("/", {"set_is_active": "1"}), user=admin_user)
+            view_func = ContactDetailView.as_view()
+            response = view_func(request, pk=CompanyContact.objects.first().pk)
+            urls = re.findall(
+                'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+',
+                mail.outbox[1].body)
+            assert mail.outbox[1].subject == "Company activated"
+            assert CompanyContact.objects.filter(is_active=True).count() == 1
+        else:
+            assert CompanyContact.objects.filter(is_active=True).count() == 1
+            assert PersonContact.objects.filter(is_active=True).count() == 1


### PR DESCRIPTION
Provide user activation link for the company approved event template
so it can be used to send "Company has been approved" message
containing activation link for the user to activate his account.
This way admin only needs to activate the CompanyContact and it will
trigger the CompanyApproved event which sends the activation link
for the user to activate his own account.

Create a new signal which will be dispatched when the company is
activated through the admin panel. This signal has the request
object which is used to build the activation url. Connect the
send_company_activated_first_time_notification function to this
signal instead of post_save on CompanyContact.

If company registration is not allowed hide the button from customer
dashboard which creates a company contact. Differentiate
company registration allowed and company registration requires approval
settings. If companies are allowed to register, create active or
inactive company/person contacts based on the shop settings.