### PR TITLE
Report: consider the timezone when grouping order dates

### DIFF
--- a/shuup/default_reports/reports/sales.py
+++ b/shuup/default_reports/reports/sales.py
@@ -8,6 +8,7 @@
 import itertools
 
 from babel.dates import format_date
+from django.utils.timezone import localtime
 from django.utils.translation import ugettext_lazy as _
 
 from shuup.core.pricing import TaxfulPrice, TaxlessPrice
@@ -32,7 +33,7 @@ class SalesReport(OrderReportMixin, ShuupReportBase):
     ]
 
     def extract_date(self, entity):
-        return entity.order_date.date()
+        return localtime(entity.order_date).date()
 
     def get_data(self):
         orders = self.get_objects().order_by("-order_date")

--- a/shuup/default_reports/reports/sales_per_hour.py
+++ b/shuup/default_reports/reports/sales_per_hour.py
@@ -8,6 +8,7 @@
 import itertools
 
 import six
+from django.utils.timezone import localtime
 from django.utils.translation import ugettext_lazy as _
 
 from shuup.default_reports.forms import OrderReportForm
@@ -24,12 +25,11 @@ class SalesPerHour(OrderReportMixin, ShuupReportBase):
     schema = [
         {"key": "hour", "title": _("Hour")},
         {"key": "order_amount", "title": _("Order Amount")},
-        {"key": "total_sales", "title": _("Total Sales")},
-
+        {"key": "total_sales", "title": _("Total Sales")}
     ]
 
     def date_hour(self, timestamp):
-        return timestamp.strftime("%H")
+        return localtime(timestamp).strftime("%H")
 
     def get_data(self, **kwargs):
         orders = self.get_objects()

--- a/shuup_tests/default_reports/test_default_reports.py
+++ b/shuup_tests/default_reports/test_default_reports.py
@@ -13,7 +13,12 @@ from decimal import Decimal
 
 import pytest
 import six
+from babel.dates import format_date
+from django.test.utils import override_settings
+from django.utils.dateparse import parse_datetime
 from django.utils.encoding import force_text
+from django.utils.timezone import localtime, now
+from pytz import timezone
 
 from shuup.apps.provides import override_provides
 from shuup.core.models import (
@@ -37,9 +42,12 @@ from shuup.testing.factories import (
     OrderLineType, UserFactory
 )
 from shuup.testing.utils import apply_request_middleware
+from shuup.utils.i18n import get_current_babel_locale
 from shuup_tests.core.test_basic_order import create_order
 from shuup_tests.reports.test_reports import initialize_report_test
 from shuup_tests.utils.basketish_order_source import BasketishOrderSource
+
+from .utils import create_orders_for_dates
 
 
 class InfoTest(object):
@@ -908,3 +916,75 @@ def test_refunds_report(rf):
 
     for k, v in expected_data.items():
         assert data[k] == v
+
+
+@pytest.mark.parametrize("server_timezone", ["America/Los_Angeles", "America/Sao_Paulo"])
+@pytest.mark.django_db
+def test_sales_report_timezone(server_timezone):
+    with override_settings(TIME_ZONE = server_timezone):
+        """
+        TIME TABLE
+
+        | identifier  | ISO 8859-1                | UTC                 | America/Los_Angeles | America/Sao_Paulo   |
+        | first_date  | 2017-10-01T23:50:00+03:00 | 2017-10-01 20:50:00 | 2017-10-01 13:50:00 | 2017-10-01 17:50:00 |
+        | second_date | 2017-10-02T17:13:00+10:00 | 2017-10-02 07:13:00 | 2017-10-02 00:13:00 | 2017-10-02 04:13:00 |
+        | third_date  | 2017-10-02T22:04:44-01:00 | 2017-10-02 23:04:44 | 2017-10-02 16:04:44 | 2017-10-02 20:04:44 |
+        | forth_date  | 2017-10-02T23:04:44-05:00 | 2017-10-03 04:04:44 | 2017-10-02 21:04:44 | 2017-10-03 01:04:44 |
+        """
+
+        first_date = parse_datetime("2017-10-01T23:50:00+03:00")
+        second_date = parse_datetime("2017-10-02T17:13:00+10:00")
+        third_date = parse_datetime("2017-10-02T22:04:44-01:00")
+        forth_date = parse_datetime("2017-10-02T23:04:44-05:00")
+
+        inited_data = create_orders_for_dates([first_date, second_date, third_date, forth_date], as_paid=True)
+        assert Order.objects.count() == 4
+
+        first_date_local = first_date.astimezone(timezone(server_timezone))
+        second_date_local = second_date.astimezone(timezone(server_timezone))
+        third_date_local = third_date.astimezone(timezone(server_timezone))
+        forth_date_local = forth_date.astimezone(timezone(server_timezone))
+
+        data = {
+            "report": SalesReport.get_name(),
+            "shop": inited_data["shop"].pk,
+            "start_date": first_date_local.isoformat(),
+            "end_date": second_date_local.isoformat(),
+        }
+        report = SalesReport(**data)
+        report_data = report.get_data()["data"]
+        assert len(report_data) == 2
+
+        # the orders should be rendered as localtime
+        assert report_data[0]["date"] == format_date(second_date_local, locale=get_current_babel_locale())
+        assert report_data[1]["date"] == format_date(first_date_local, locale=get_current_babel_locale())
+
+        # includes the 3rd order
+        data.update({
+            "start_date": first_date_local.isoformat(),
+            "end_date": third_date_local.isoformat()
+        })
+        report = SalesReport(**data)
+        report_data = report.get_data()["data"]
+        assert len(report_data) == 2
+
+        assert report_data[0]["date"] == format_date(second_date_local, locale=get_current_babel_locale())
+        assert report_data[1]["date"] == format_date(first_date_local, locale=get_current_babel_locale())
+
+        # includes the 4th order - here the result is different for Los_Angeles and Sao_Paulo
+        data.update({
+            "start_date": first_date_local.isoformat(),
+            "end_date": forth_date_local.isoformat()
+        })
+        report = SalesReport(**data)
+        report_data = report.get_data()["data"]
+
+        if server_timezone == "America/Los_Angeles":
+            assert len(report_data) == 2
+            assert report_data[0]["date"] == format_date(second_date_local, locale=get_current_babel_locale())
+            assert report_data[1]["date"] == format_date(first_date_local, locale=get_current_babel_locale())
+        else:
+            assert len(report_data) == 3
+            assert report_data[0]["date"] == format_date(forth_date_local, locale=get_current_babel_locale())
+            assert report_data[1]["date"] == format_date(second_date_local, locale=get_current_babel_locale())
+            assert report_data[2]["date"] == format_date(first_date_local, locale=get_current_babel_locale())

--- a/shuup_tests/default_reports/utils.py
+++ b/shuup_tests/default_reports/utils.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import random
+
+from shuup.testing.factories import (
+    create_order_with_product, create_product, create_random_person,
+    get_default_shop, get_default_supplier
+)
+
+
+def create_orders_for_dates(dates, as_paid=False):
+    shop = get_default_shop()
+    supplier = get_default_supplier()
+    customer = create_random_person()
+    products = []
+
+    for i in range(20):
+        sku = "test-%s" % random.randint(10000, 999999)
+        price = random.randint(1, 11) * 5
+        product = create_product(sku, shop, supplier, price)
+        products.append(product)
+
+    orders = []
+    for date in dates:
+        product = random.choice(products)
+        sp = product.get_shop_instance(shop)
+
+        quantity = random.randint(0, 10)
+        order = create_order_with_product(product, supplier, quantity, sp.default_price, shop=shop)
+        order.order_date = date
+        order.customer = customer
+        order.save()
+
+        if as_paid:
+            order.create_payment(order.taxful_total_price)
+
+        orders.append(order)
+
+    return {
+        "created_products": products,
+        "created_orders": orders,
+        "shop": shop,
+        "customer": customer,
+        "orders": orders
+    }


### PR DESCRIPTION
The order dates should be localized to the current timezone configuration before using that to group.