### PR TITLE
DefaultTax: filter tax rules correctly

### DIFF
--- a/shuup/default_tax/module.py
+++ b/shuup/default_tax/module.py
@@ -40,13 +40,14 @@ def _get_enabled_tax_rules(taxing_context, tax_class):
     :type taxing_context: shuup.core.taxing.TaxingContext
     :type tax_class: shuup.core.models.TaxClass
     """
-
     tax_rules = TaxRule.objects.may_match_postal_code(
         taxing_context.postal_code).filter(enabled=True, tax_classes=tax_class)
     if taxing_context.customer_tax_group:
         tax_rules = tax_rules.filter(
             Q(customer_tax_groups=taxing_context.customer_tax_group) |
             Q(customer_tax_groups=None))
+    else:
+        tax_rules = tax_rules.filter(customer_tax_groups=None)
     tax_rules = tax_rules.order_by('-override_group', 'priority')
     return tax_rules
 


### PR DESCRIPTION
When tax rule has a specific customer tax group, do not allow contexts with no customer tax groups to match.

In some situations where a tax is only applied to a specific customer group, it is more than necessary to avoid taxing customers that do not belong to that group or which don't even have a group configured.

So, in cases where we have taxes for companies like B2B and also sell to a regular customer with different prices and also allow anonymous ordering, we don't want to tax the anonymous user the same way we tax companies.

To create a tax rule that applies to any customer group, creating a simple rule with no customer tax group will work as expected.

No refs