### PR TITLE
Product admin - Shipping mode translations

### DIFF
--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -3648,3 +3648,9 @@ msgstr ""
 #, python-format
 msgid "Couldn't get selections for %s."
 msgstr ""
+
+msgid "not shipped( non-deliverable )"
+msgstr "not shipped"
+
+msgid "shipped( deliverable )"
+msgstr "shipped"

--- a/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/fi_FI/LC_MESSAGES/django.po
@@ -4115,3 +4115,9 @@ msgstr "Julkaise kauppa"
 #, python-format
 msgid "Couldn't get selections for %s."
 msgstr "%s valintoja ei voitu hakea"
+
+msgid "not shipped( non-deliverable )"
+msgstr "ei toimitettava"
+
+msgid "shipped( deliverable )"
+msgstr "toimitettava"

--- a/shuup/admin/locale/it/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/it/LC_MESSAGES/django.po
@@ -1842,3 +1842,9 @@ msgstr "Pubblica Negozio"
 #, python-format
 msgid "Couldn't get selections for %s."
 msgstr "Non posso prendere la selezione per %s."
+
+msgid "not shipped( non-deliverable )"
+msgstr "non spedito"
+
+msgid "shipped( deliverable )"
+msgstr "spedito"

--- a/shuup/admin/locale/ja_JP/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/ja_JP/LC_MESSAGES/django.po
@@ -1481,3 +1481,9 @@ msgstr ""
 #, python-format
 msgid "Couldn't get selections for %s."
 msgstr ""
+
+msgid "not shipped( non-deliverable )"
+msgstr "not shipped"
+
+msgid "shipped( deliverable )"
+msgstr "shipped"

--- a/shuup/admin/locale/pt_BR/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/pt_BR/LC_MESSAGES/django.po
@@ -1606,3 +1606,9 @@ msgstr "Apenas um %(model)s permitido."
 #, python-format
 msgid "Couldn't get selections for %s."
 msgstr "Não foi possível obter seleções para %s."
+
+msgid "not shipped( non-deliverable )"
+msgstr "não enviado"
+
+msgid "shipped( deliverable )"
+msgstr "enviado"

--- a/shuup/admin/locale/sv_SE/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/sv_SE/LC_MESSAGES/django.po
@@ -4191,3 +4191,9 @@ msgstr "Publicera butik"
 #, python-format
 msgid "Couldn't get selections for %s."
 msgstr "Det gick inte att få alternativ för %s."
+
+msgid "not shipped( non-deliverable )"
+msgstr "ej levererad"
+
+msgid "shipped( deliverable )"
+msgstr "levererad"

--- a/shuup/admin/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/zh_Hans/LC_MESSAGES/django.po
@@ -1491,3 +1491,9 @@ msgstr "只允许一个 %(model)s。"
 #, python-format
 msgid "Couldn't get selections for %s."
 msgstr ""
+
+msgid "not shipped( non-deliverable )"
+msgstr "未发货"
+
+msgid "shipped( deliverable )"
+msgstr "已发货"

--- a/shuup/core/models/_products.py
+++ b/shuup/core/models/_products.py
@@ -90,8 +90,8 @@ class ShippingMode(Enum):
     SHIPPED = 1
 
     class Labels:
-        NOT_SHIPPED = _('not shipped')
-        SHIPPED = _('shipped')
+        NOT_SHIPPED = _('not shipped( non-deliverable )')
+        SHIPPED = _('shipped( deliverable )')
 
 
 class ProductVerificationMode(Enum):


### PR DESCRIPTION
Add a own translation for shipping mode as "shipped(deliverable)" and "not shipped(not deliverable)"

#1175 