### PR TITLE
Reports: Include start of the day to reports and introduce this week as a date range choice

### DIFF
--- a/shuup/reports/forms.py
+++ b/shuup/reports/forms.py
@@ -21,6 +21,7 @@ class DateRangeChoices(Enum):
     TODAY = "today"
     RUNNING_WEEK = "running_week"
     RUNNING_MONTH = "running_month"
+    THIS_WEEK = "this_week"
     THIS_MONTH = "this_month"
     THIS_YEAR = "this_year"
     ALL_TIME = "all_time"
@@ -30,6 +31,7 @@ class DateRangeChoices(Enum):
         TODAY = _("Today")
         RUNNING_WEEK = _("Running Week (last 7 days)")
         RUNNING_MONTH = _("Running Month (last 30 days)")
+        THIS_WEEK = _("This Week")
         THIS_MONTH = _("This Month")
         THIS_YEAR = _("This Year")
         ALL_TIME = _("All Time")

--- a/shuup_tests/reports/test_parse_date_range_presets.py
+++ b/shuup_tests/reports/test_parse_date_range_presets.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import datetime
+import mock
+import pytest
+import pytz
+
+from shuup.utils import i18n
+from shuup.reports.forms import DateRangeChoices
+from shuup.reports.utils import parse_date_range_preset
+
+
+def test_parse_date_range_presets():
+    locale = i18n.get_current_babel_locale()
+
+    def local_now():
+        return datetime.datetime(2017, 12, 4, 17, 1, tzinfo=pytz.UTC)
+
+    with mock.patch("shuup.utils.dates.local_now", side_effect=local_now):
+        start, end = parse_date_range_preset(DateRangeChoices.TODAY)
+        assert start == local_now().replace(hour=0, minute=0, second=0)
+        assert end == local_now()
+
+        start, end = parse_date_range_preset(DateRangeChoices.RUNNING_WEEK)
+        assert start == local_now().replace(month=11, day=27, hour=0, minute=0, second=0)
+        assert end == local_now()
+
+        start, end = parse_date_range_preset(DateRangeChoices.RUNNING_MONTH)
+        assert start == local_now().replace(month=11, day=4, hour=0, minute=0, second=0)
+        assert end == local_now()
+
+        assert local_now().weekday() == locale.first_week_day
+        start, end = parse_date_range_preset(DateRangeChoices.THIS_WEEK)
+        assert start == local_now().replace(hour=0, minute=0, second=0)
+        assert end == local_now()
+
+        start, end = parse_date_range_preset(DateRangeChoices.THIS_MONTH)
+        assert start == local_now().replace(month=12, day=1, hour=0, minute=0, second=0)
+        assert end == local_now()
+
+        start, end = parse_date_range_preset(DateRangeChoices.THIS_YEAR)
+        assert start == local_now().replace(month=1, day=1, hour=0, minute=0, second=0)
+        assert end == local_now()
+
+        start, end = parse_date_range_preset(DateRangeChoices.ALL_TIME)
+        assert start == local_now().replace(year=2000, hour=0, minute=0, second=0)
+        assert end == local_now()
+
+
+@pytest.mark.parametrize("locale", ["en-US", "fi-FI"])
+def test_parse_date_range_presets_running_week(locale):
+
+    def get_locale():
+        return i18n.get_babel_locale(locale)
+
+    def monday():
+        return datetime.datetime(2017, 12, 4, 17, 1, tzinfo=pytz.UTC)
+
+    def tuesday():
+        return datetime.datetime(2017, 12, 5, 17, 1, tzinfo=pytz.UTC)
+
+    def wednesday():
+        return datetime.datetime(2017, 12, 6, 17, 1, tzinfo=pytz.UTC)
+
+    def thursday():
+        return datetime.datetime(2017, 12, 7, 17, 1, tzinfo=pytz.UTC)
+
+    def friday():
+        return datetime.datetime(2017, 12, 8, 17, 1, tzinfo=pytz.UTC)
+
+    def saturday():
+        return datetime.datetime(2017, 12, 9, 17, 1, tzinfo=pytz.UTC)
+
+    with mock.patch("shuup.utils.i18n.get_current_babel_locale", side_effect=get_locale):
+        for local_now in [monday, tuesday, wednesday, thursday, friday, saturday]:
+            with mock.patch("shuup.utils.dates.local_now", side_effect=local_now):
+                start, end = parse_date_range_preset(DateRangeChoices.THIS_WEEK)
+                assert start == local_now().replace(day=(3 if locale == "en-US" else 4), hour=0, minute=0, second=0)
+                assert start.weekday() == get_locale().first_week_day
+                assert end == local_now()


### PR DESCRIPTION
Since reports doesn't show time but just dates it is convenient to include the start of the day to reports. For example when getting report for last 7 days the last day should be include
fully and not for last hour if the report is run at 11pm.

As a note: No need to set the range to future when choice is today.