### PR TITLE
Core: make basket raise orderability errors

### DIFF
--- a/shuup/front/basket/update_methods.py
+++ b/shuup/front/basket/update_methods.py
@@ -5,4 +5,17 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from shuup.core.basket.update_methods import BasketUpdateMethods  # noqa
+from __future__ import unicode_literals
+
+import six
+from django.contrib import messages
+
+from shuup.core.basket.update_methods import \
+    BasketUpdateMethods as CoreBasketUpdateMethods
+
+
+class BasketUpdateMethods(CoreBasketUpdateMethods):
+    def _handle_orderability_error(self, line, error):
+        error_texts = ", ".join(six.text_type(sub_error) for sub_error in error)
+        message = "%s: %s" % (line.get("text") or line.get("name"), error_texts)
+        messages.warning(self.request, message)

--- a/shuup/front/settings.py
+++ b/shuup/front/settings.py
@@ -28,7 +28,7 @@ SHUUP_BASKET_COMMAND_DISPATCHER_SPEC = (
 #: Spec string for the update method dispatcher used when the basket is updated (usually
 #: on the basket page).
 SHUUP_BASKET_UPDATE_METHODS_SPEC = (
-    "shuup.core.basket.update_methods:BasketUpdateMethods")
+    "shuup.front.basket.update_methods:BasketUpdateMethods")
 
 #: Spec string for the basket class used in the frontend.
 #:


### PR DESCRIPTION
The core basket update methods will raise exception on onderability errors.
Front basket update methods will still save orderability errors in messages framework.

No Refs