### PR TITLE
API: add MoneyField and encoder for Money instance

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unrealeased
 Core
 ~~~~
 
+- API: add MoneyField and encoder for Money instances
 - OrderCreator: Dispatch a signal when adding lines to order
 - Enable refunds for order API
 - API: Improved suppliers stock endpoints

--- a/shuup/api/encoders.py
+++ b/shuup/api/encoders.py
@@ -11,12 +11,16 @@ from enum import Enum
 from rest_framework.renderers import JSONRenderer
 from rest_framework.utils import encoders
 
+from shuup.utils.money import Money
+
 LOG = logging.getLogger(__name__)
 
 
 class ExtJSONEncoder(encoders.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, Enum):
+            return obj.value
+        if isinstance(obj, Money):
             return obj.value
         return super(ExtJSONEncoder, self).default(obj)
 

--- a/shuup_tests/api/test_encoder.py
+++ b/shuup_tests/api/test_encoder.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import json
+
+import mock
+import pytest
+from rest_framework import renderers, serializers
+
+from shuup.api.encoders import ExtJSONEncoder
+from shuup.core.models import Order, ShopStatus
+from shuup.testing import factories
+from shuup.utils.money import Money
+
+
+def test_encoder():
+    encoder = ExtJSONEncoder()
+    assert encoder.default(Money(10, "USD")) == 10
+    assert encoder.default(ShopStatus.DISABLED) == ShopStatus.DISABLED.value
+
+
+@pytest.mark.django_db
+def test_money_field_serialize_real_world():
+    shop = factories.get_default_shop()
+    customer = factories.create_random_person("en")
+    supplier = factories.get_default_supplier()
+    product = factories.create_product("test", shop, supplier, "12.42")
+    order = factories.create_random_order(customer, [product], 1, shop)
+
+    class OrderSerializer(serializers.ModelSerializer):
+        taxful_total_price = serializers.ReadOnlyField()
+
+        class Meta:
+            model = Order
+            fields = ["taxful_total_price"]
+
+    data = renderers.JSONRenderer().render(OrderSerializer(order).data).decode("utf-8")
+    assert float(json.loads(data)["taxful_total_price"]) == float(order.taxful_total_price_value)
+
+    # make sure it is being called
+    with mock.patch("shuup.api.encoders.ExtJSONEncoder.default") as mocked_encoder:
+        mocked_encoder.return_value = 1
+        renderers.JSONRenderer().render(OrderSerializer(order).data)
+    mocked_encoder.assert_called()

--- a/shuup_tests/api/test_fields.py
+++ b/shuup_tests/api/test_fields.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from decimal import Decimal
+
+import pytest
+from rest_framework import serializers
+
+from shuup.api.fields import MoneyField
+from shuup.core.fields import MONEY_FIELD_DECIMAL_PLACES
+from shuup.utils.money import Money
+
+
+class TestSerializer(serializers.Serializer):
+    price = MoneyField()
+
+
+class FakeModel(object):
+    price = None
+    def __init__(self, price):
+        self.price = price
+
+
+@pytest.mark.parametrize("value,currency", [
+    (13.24, "USD"),
+    ("13.24", "BRL"),
+    (Decimal(42), "EUR"),
+    (-1, "CAD"),
+    (2, "USD")
+])
+def test_money_field_parse_valid(value, currency):
+    data = {
+        "price": {
+            "currency": currency,
+            "value": value
+        }
+    }
+    serializer = TestSerializer(data=data)
+    assert serializer.is_valid(True)
+
+
+@pytest.mark.parametrize("value,currency", [
+    (13.24, ""),
+    ("", ""),
+    (None, "EUR")
+])
+def test_money_field_parse_invalid(value, currency):
+    data = {"price": {}}
+
+    if value:
+        data["price"]["value"] = value
+    if currency:
+        data["price"]["currency"] = currency
+
+    serializer = TestSerializer(data=data)
+    assert serializer.is_valid() is False
+
+
+@pytest.mark.parametrize("value,currency", [
+    (13.24, "USD"),
+    ("13.24", "BRL"),
+    (Decimal(42), "EUR"),
+    (-1, "CAD"),
+    (2, "USD")
+])
+def test_money_field_serialize(value, currency):
+    serializer = TestSerializer(FakeModel(Money(value, currency)))
+    precision = Decimal(".1") ** MONEY_FIELD_DECIMAL_PLACES
+    assert serializer.data["price"]["value"] == str(Decimal(value).quantize(precision))
+    assert serializer.data["price"]["currency"] == currency

--- a/shuup_tests/utils/test_money.py
+++ b/shuup_tests/utils/test_money.py
@@ -4,10 +4,12 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-import pytest
 import math
-from django.conf import settings
 from decimal import Decimal, ROUND_FLOOR, ROUND_HALF_DOWN
+
+import pytest
+import six
+from django.conf import settings
 from mock import patch
 
 from shuup.utils import babel_precision_provider, money
@@ -155,3 +157,10 @@ def test_set_precision_provider():
 def test_set_precision_provider_with_non_callable():
     with pytest.raises(AssertionError):
         set_precision_provider(3)
+
+
+@pytest.mark.skipif(six.PY2, reason="FIXME: only works with python 3 for now")
+def test_parse_float_str():
+    money = Money(10, "USD")
+    assert float(money) == 10
+    assert str(money) == "10 USD"


### PR DESCRIPTION
- Add MoneyField for serializers that includes the money value and currency
- Add API encoder to Money instance to return only the value of the object

No Refs