### PR TITLE
Report: change date filter field to DateTime

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unrealeased
 Core
 ~~~~
 
+- Report: change date filter field to DateTime
 - OrderCreator: Dispatch a signal when adding lines to order
 - Enable refunds for order API
 - API: Improved suppliers stock endpoints

--- a/shuup/reports/forms.py
+++ b/shuup/reports/forms.py
@@ -6,7 +6,7 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django import forms
-from django.forms import ChoiceField, DateField, HiddenInput
+from django.forms import ChoiceField, DateTimeField, HiddenInput
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 from enumfields import Enum, EnumField
@@ -44,8 +44,8 @@ class BaseReportForm(forms.Form):
         form_class=ChoiceField, label=_("Date Range"), initial=DateRangeChoices.RUNNING_WEEK, help_text=_(
             "Filter report results by a date range."
         ))
-    start_date = DateField(label=_("Start Date"), required=False, help_text=_("For a custom date range."))
-    end_date = DateField(label=_("End Date"), required=False, help_text=_("For a custom date range."))
+    start_date = DateTimeField(label=_("Start Date"), required=False, help_text=_("For a custom date range."))
+    end_date = DateTimeField(label=_("End Date"), required=False, help_text=_("For a custom date range."))
     writer = forms.ChoiceField(
         label=_("Output Format"), initial="html", choices=[(name, name.title()) for name in sorted(get_writer_names())],
         help_text=_("The format to show the report results.")

--- a/shuup/reports/utils.py
+++ b/shuup/reports/utils.py
@@ -85,7 +85,7 @@ def parse_date_range(value):
         start, end = value[:2]
     else:
         raise ValueError("Can't split date range: %r" % value)
-    date_range = (dates.try_parse_date(start), dates.try_parse_date(end))
+    date_range = (dates.try_parse_datetime(start), dates.try_parse_datetime(end))
     if any(p is None for p in date_range):
         raise ValueError("Invalid date range: %r (parsed as %r)" % (value, date_range))
     return date_range

--- a/shuup/reports/writer.py
+++ b/shuup/reports/writer.py
@@ -11,7 +11,7 @@ from decimal import Decimal
 from pprint import pformat
 
 import six
-from babel.dates import format_date
+from babel.dates import format_datetime
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse
 from django.template.defaultfilters import floatformat
@@ -76,8 +76,8 @@ class ReportWriter(object):
             self.write_heading(
                 "{title} {start} - {end}".format(
                     title=report.title,
-                    start=format_date(report_data["start"], format="short", locale=get_current_babel_locale()),
-                    end=format_date(report_data["end"], format="short", locale=get_current_babel_locale()))
+                    start=format_datetime(report_data["start"], format="short", locale=get_current_babel_locale()),
+                    end=format_datetime(report_data["end"], format="short", locale=get_current_babel_locale()))
             )
             report.ensure_texts()
             self.write_data_table(report, report_data["data"], has_totals=report_data["has_totals"])

--- a/shuup/utils/dates.py
+++ b/shuup/utils/dates.py
@@ -83,6 +83,19 @@ def _parse_date_str(value):
         pass
 
 
+def _parse_datetime_str(value):
+    value = value.strip()
+    for fmt in _date_formats:
+        try:
+            return datetime.datetime.strptime(value, fmt)
+        except:
+            pass
+    try:
+        return datetime.datetime.strptime(value, "%Y-%m-%d %H:%M:%S.%f")
+    except:
+        pass
+
+
 def _parse_time_str(value):
     value = value.strip()
     for fmt in _time_formats:
@@ -115,6 +128,27 @@ def parse_date(value):
     raise ValueError("Unable to parse %s as date (unknown type)." % value)
 
 
+def parse_datetime(value):
+    """
+    Tries to make a datetime out of the value. If impossible, it raises an exception.
+
+    :param value: A value of some ilk.
+    :return: DateTime
+    :rtype: datetime.datetime
+    :raise ValueError:
+    """
+    if isinstance(value, datetime.datetime):
+        return value
+    if isinstance(value, datetime.date):
+        return datetime.datetime.combine(value, datetime.datetime.min.time())
+    elif isinstance(value, six.string_types):
+        date = _parse_datetime_str(value)
+        if not date:
+            raise ValueError("Unable to parse %s as datetime." % value)
+        return date
+    raise ValueError("Unable to parse %s as datetime (unknown type)." % value)
+
+
 def parse_time(value):
     """
     Tries to make a time out of the value. If impossible, it raises an exception.
@@ -134,6 +168,22 @@ def parse_time(value):
             raise ValueError("Unable to parse %s as date." % value)
         return time
     raise ValueError("Unable to parse %s as date (unknown type)." % value)
+
+
+def try_parse_datetime(value):
+    """
+    Tries to make a datetime out of the value. If impossible, returns None.
+
+    :param value: A value of some ilk.
+    :return: Datetime
+    :rtype: datetime.datetime
+    """
+    if value is None:
+        return None
+    try:
+        return parse_datetime(value)
+    except ValueError:
+        return None
 
 
 def try_parse_date(value):

--- a/shuup_tests/utils/test_dates.py
+++ b/shuup_tests/utils/test_dates.py
@@ -7,7 +7,8 @@
 # LICENSE file in the root directory of this source tree.
 
 from datetime import date, datetime
-from shuup.utils.dates import parse_date
+
+from shuup.utils.dates import parse_date, parse_datetime
 
 
 def test_parse_date():
@@ -24,3 +25,18 @@ def test_parse_date():
     assert parse_date(date_fmt1) == expected_date
     assert parse_date(date_fmt2) == expected_date
     assert parse_date(date_fmt3) == expected_date
+
+
+def test_parse_datetime():
+    now = datetime.now()
+    today = date.today()
+
+    date_fmt1 = "2016-12-31"
+    date_fmt2 = "2016-12-31 15:40:34.404540"
+    date_fmt3 = "12/31/2016"
+
+    assert parse_datetime(now) == now
+    assert parse_datetime(today) == datetime.combine(today, datetime.min.time())
+    assert parse_datetime(date_fmt1) == datetime(2016, 12, 31)
+    assert parse_datetime(date_fmt2) == datetime(2016, 12, 31, 15, 40, 34, 404540)
+    assert parse_datetime(date_fmt3) == datetime(2016, 12, 31)


### PR DESCRIPTION
Make it possible to filter objects also by time.

This is useful for filtering orders in a time range inside a single day, for example.