### PR TITLE
Admin: Filter variation parents for select view

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -49,6 +49,7 @@ Core
 Admin
 ~~~~~
 
+- Add option to filter variation parents for product select view
 - Fix home view help blocks filtering objects by the current shop
 - Fix bug: Filter category parent choices based on current shop
 - Add middleware to select and set the current shop in the request

--- a/shuup/admin/views/select.py
+++ b/shuup/admin/views/select.py
@@ -102,6 +102,12 @@ class MultiselectAjaxView(TemplateView):
                 ProductMode.NORMAL
             ])
 
+        if search_mode and search_mode == "sellable_mode_only" and issubclass(cls, Product):
+            qs = qs.exclude(mode__in=[
+                ProductMode.SIMPLE_VARIATION_PARENT,
+                ProductMode.VARIABLE_VARIATION_PARENT,
+            ])
+
         qs = qs.distinct()
         return [{"id": obj.id, "name": force_text(obj)} for obj in qs[:self.result_limit]]
 


### PR DESCRIPTION
Allow fetching only "sellable" product modes through admin ajax select view.