### PR TITLE
Update npm-shrinkwrap.json files

### DIFF
--- a/shuup/admin/npm-shrinkwrap.json
+++ b/shuup/admin/npm-shrinkwrap.json
@@ -1,9002 +1,7426 @@
 {
   "name": "shuup.admin",
   "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
-    "autoprefixer-loader": {
-      "version": "3.1.0",
-      "from": "https://registry.npmjs.org/autoprefixer-loader/-/autoprefixer-loader-3.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/autoprefixer-loader/-/autoprefixer-loader-3.1.0.tgz",
-      "dependencies": {
-        "autoprefixer": {
-          "version": "6.2.3",
-          "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
-          "dependencies": {
-            "postcss-value-parser": {
-              "version": "3.2.3",
-              "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
-            },
-            "normalize-range": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
-            },
-            "num2fraction": {
-              "version": "1.2.2",
-              "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-            },
-            "browserslist": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
-            },
-            "caniuse-db": {
-              "version": "1.0.30000386",
-              "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz"
-            }
-          }
-        },
-        "loader-utils": {
-          "version": "0.2.12",
-          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "json5": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-            }
-          }
-        },
-        "postcss": {
-          "version": "5.0.14",
-          "from": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
-          "dependencies": {
-            "supports-color": {
-              "version": "3.1.2",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-            }
-          }
-        },
-        "postcss-safe-parser": {
-          "version": "1.0.4",
-          "from": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-1.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-1.0.4.tgz"
-        }
+    "@gulp-sourcemaps/map-sources": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
+      "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
+      "requires": {
+        "normalize-path": "2.1.1",
+        "through2": "2.0.3"
       }
     },
-    "babel-core": {
-      "version": "5.8.34",
-      "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.34.tgz",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.34.tgz",
+    "Base64": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg="
+    },
+    "accord": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/accord/-/accord-0.28.0.tgz",
+      "integrity": "sha512-sPF34gqHegaCSryKf5wHJ8wREK1dTZnHmC9hsB7D8xjntRdd30DXDPKf0YVIcSvnXJmcYu5SCvZRz28H++kFhQ==",
+      "requires": {
+        "convert-source-map": "1.5.1",
+        "glob": "7.1.2",
+        "indx": "0.2.3",
+        "lodash.clone": "4.5.0",
+        "lodash.defaults": "4.2.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.merge": "4.6.1",
+        "lodash.partialright": "4.2.1",
+        "lodash.pick": "4.4.0",
+        "lodash.uniq": "4.5.0",
+        "resolve": "1.7.0",
+        "semver": "5.5.0",
+        "uglify-js": "2.8.29",
+        "when": "3.7.8"
+      },
       "dependencies": {
-        "babel-plugin-constant-folding": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
-        },
-        "babel-plugin-dead-code-elimination": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
-        },
-        "babel-plugin-eval": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
-        },
-        "babel-plugin-inline-environment-variables": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
-        },
-        "babel-plugin-jscript": {
-          "version": "1.0.4",
-          "from": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
-        },
-        "babel-plugin-member-expression-literals": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
-        },
-        "babel-plugin-property-literals": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
-        },
-        "babel-plugin-proto-to-assign": {
-          "version": "1.0.4",
-          "from": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
-        },
-        "babel-plugin-react-constant-elements": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
-        },
-        "babel-plugin-react-display-name": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
-        },
-        "babel-plugin-remove-console": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
-        },
-        "babel-plugin-remove-debugger": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
-        },
-        "babel-plugin-runtime": {
-          "version": "1.0.7",
-          "from": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
-        },
-        "babel-plugin-undeclared-variables-check": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
-          "dependencies": {
-            "leven": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
-            }
-          }
-        },
-        "babel-plugin-undefined-to-void": {
-          "version": "1.1.6",
-          "from": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
-        },
-        "babylon": {
-          "version": "5.8.34",
-          "from": "https://registry.npmjs.org/babylon/-/babylon-5.8.34.tgz",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.34.tgz"
-        },
-        "bluebird": {
-          "version": "2.10.2",
-          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "convert-source-map": {
-          "version": "1.1.2",
-          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
-        },
-        "core-js": {
-          "version": "1.2.6",
-          "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-        },
-        "debug": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-            }
-          }
-        },
-        "detect-indent": {
-          "version": "3.0.1",
-          "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-          "dependencies": {
-            "get-stdin": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-            }
-          }
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-        },
-        "fs-readdir-recursive": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
-        },
-        "globals": {
-          "version": "6.4.1",
-          "from": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
-        },
-        "home-or-tmp": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-          "dependencies": {
-            "os-tmpdir": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-            },
-            "user-home": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-            }
-          }
-        },
-        "is-integer": {
-          "version": "1.0.6",
-          "from": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
-          "dependencies": {
-            "is-finite": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-              "dependencies": {
-                "number-is-nan": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "js-tokens": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
-        },
-        "json5": {
-          "version": "0.4.0",
-          "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-        },
-        "line-numbers": {
-          "version": "0.2.0",
-          "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-          "dependencies": {
-            "left-pad": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-            }
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "minimatch": {
-          "version": "2.0.10",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                }
-              }
-            }
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.11"
           }
         },
-        "output-file-sync": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
-        },
-        "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-        },
-        "private": {
-          "version": "0.1.6",
-          "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-          "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
-        },
-        "regenerator": {
-          "version": "0.8.40",
-          "from": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
-          "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
-          "dependencies": {
-            "commoner": {
-              "version": "0.10.4",
-              "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
-              "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
-              "dependencies": {
-                "commander": {
-                  "version": "2.9.0",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    }
-                  }
-                },
-                "detective": {
-                  "version": "4.3.1",
-                  "from": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
-                  "dependencies": {
-                    "acorn": {
-                      "version": "1.2.2",
-                      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
-                    },
-                    "defined": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-                    }
-                  }
-                },
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                },
-                "iconv-lite": {
-                  "version": "0.4.13",
-                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                  }
-                },
-                "q": {
-                  "version": "1.4.1",
-                  "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-                  "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-                }
-              }
-            },
-            "defs": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-              "dependencies": {
-                "alter": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-                  "dependencies": {
-                    "stable": {
-                      "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
-                      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
-                    }
-                  }
-                },
-                "ast-traverse": {
-                  "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
-                },
-                "breakable": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
-                },
-                "simple-fmt": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
-                },
-                "simple-is": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
-                },
-                "stringmap": {
-                  "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
-                },
-                "stringset": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
-                },
-                "tryor": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
-                },
-                "yargs": {
-                  "version": "3.27.0",
-                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                    },
-                    "cliui": {
-                      "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                      "dependencies": {
-                        "center-align": {
-                          "version": "0.1.2",
-                          "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.0",
-                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                                }
-                              }
-                            },
-                            "lazy-cache": {
-                              "version": "0.2.7",
-                              "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
-                            }
-                          }
-                        },
-                        "right-align": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.0",
-                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                        }
-                      }
-                    },
-                    "decamelize": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
-                    },
-                    "os-locale": {
-                      "version": "1.4.0",
-                      "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-                      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-                      "dependencies": {
-                        "lcid": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                          "dependencies": {
-                            "invert-kv": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "window-size": {
-                      "version": "0.1.4",
-                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
-                    },
-                    "y18n": {
-                      "version": "3.2.0",
-                      "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "esprima-fb": {
-              "version": "15001.1001.0-dev-harmony-fb",
-              "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
-            },
-            "recast": {
-              "version": "0.10.33",
-              "from": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-              "dependencies": {
-                "ast-types": {
-                  "version": "0.8.12",
-                  "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
-                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
-                }
-              }
-            },
-            "through": {
-              "version": "2.3.8",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            }
-          }
-        },
-        "regexpu": {
-          "version": "1.3.0",
-          "from": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-          "dependencies": {
-            "esprima": {
-              "version": "2.7.1",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
-            },
-            "recast": {
-              "version": "0.10.39",
-              "from": "https://registry.npmjs.org/recast/-/recast-0.10.39.tgz",
-              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.39.tgz",
-              "dependencies": {
-                "esprima-fb": {
-                  "version": "15001.1001.0-dev-harmony-fb",
-                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
-                },
-                "ast-types": {
-                  "version": "0.8.12",
-                  "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
-                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
-                }
-              }
-            },
-            "regenerate": {
-              "version": "1.2.1",
-              "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
-            },
-            "regjsgen": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
-            },
-            "regjsparser": {
-              "version": "0.1.5",
-              "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-              "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-              "dependencies": {
-                "jsesc": {
-                  "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "dependencies": {
-            "is-finite": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-              "dependencies": {
-                "number-is-nan": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "resolve": {
-          "version": "1.1.6",
-          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
-        },
-        "slash": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
-        },
-        "source-map": {
-          "version": "0.5.3",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-        },
-        "source-map-support": {
-          "version": "0.2.10",
-          "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "to-fast-properties": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-        },
-        "trim-right": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-        },
-        "try-resolve": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        }
+      }
+    },
+    "acorn": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "optional": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "alphanum-sort": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
+    },
+    "alter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+      "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
+      "requires": {
+        "stable": "0.1.6"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-cyan": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+    },
+    "anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "requires": {
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+    },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+    },
+    "array-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
+    },
+    "array-slice": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "optional": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "optional": true
+    },
+    "assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "requires": {
+        "util": "0.10.3"
+      }
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "optional": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+    },
+    "ast-traverse": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
+      "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY="
+    },
+    "ast-types": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
+    },
+    "async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "optional": true
+    },
+    "atob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
+      "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw=="
+    },
+    "autoprefixer": {
+      "version": "6.7.7",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+      "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000827",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "autoprefixer-loader": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer-loader/-/autoprefixer-loader-3.2.0.tgz",
+      "integrity": "sha1-Oae2ZGqCaYZQc9lYyX9IYVLCyEo=",
+      "requires": {
+        "autoprefixer": "6.7.7",
+        "loader-utils": "0.2.17",
+        "postcss": "5.2.18",
+        "postcss-safe-parser": "1.0.7"
+      }
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "optional": true
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "optional": true
+    },
+    "babel-core": {
+      "version": "5.8.38",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+      "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
+      "requires": {
+        "babel-plugin-constant-folding": "1.0.1",
+        "babel-plugin-dead-code-elimination": "1.0.2",
+        "babel-plugin-eval": "1.0.1",
+        "babel-plugin-inline-environment-variables": "1.0.1",
+        "babel-plugin-jscript": "1.0.4",
+        "babel-plugin-member-expression-literals": "1.0.1",
+        "babel-plugin-property-literals": "1.0.1",
+        "babel-plugin-proto-to-assign": "1.0.4",
+        "babel-plugin-react-constant-elements": "1.0.3",
+        "babel-plugin-react-display-name": "1.0.3",
+        "babel-plugin-remove-console": "1.0.1",
+        "babel-plugin-remove-debugger": "1.0.1",
+        "babel-plugin-runtime": "1.0.7",
+        "babel-plugin-undeclared-variables-check": "1.0.2",
+        "babel-plugin-undefined-to-void": "1.1.6",
+        "babylon": "5.8.38",
+        "bluebird": "2.11.0",
+        "chalk": "1.1.3",
+        "convert-source-map": "1.5.1",
+        "core-js": "1.2.7",
+        "debug": "2.6.9",
+        "detect-indent": "3.0.1",
+        "esutils": "2.0.2",
+        "fs-readdir-recursive": "0.1.2",
+        "globals": "6.4.1",
+        "home-or-tmp": "1.0.0",
+        "is-integer": "1.0.7",
+        "js-tokens": "1.0.1",
+        "json5": "0.4.0",
+        "lodash": "3.10.1",
+        "minimatch": "2.0.10",
+        "output-file-sync": "1.1.2",
+        "path-exists": "1.0.0",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "regenerator": "0.8.40",
+        "regexpu": "1.3.0",
+        "repeating": "1.1.3",
+        "resolve": "1.7.0",
+        "shebang-regex": "1.0.0",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "source-map-support": "0.2.10",
+        "to-fast-properties": "1.0.3",
+        "trim-right": "1.0.1",
+        "try-resolve": "1.0.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
         }
       }
     },
     "babel-loader": {
-      "version": "5.4.0",
-      "from": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.4.0.tgz",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.4.0.tgz",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.4.2.tgz",
+      "integrity": "sha1-d/4o2OYNDwVrHBvKJbhJTNqrnHY=",
+      "requires": {
+        "babel-core": "5.8.38",
+        "loader-utils": "0.2.17",
+        "object-assign": "3.0.0"
+      },
       "dependencies": {
-        "loader-utils": {
-          "version": "0.2.12",
-          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "json5": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-            }
-          }
-        },
         "object-assign": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         }
       }
     },
-    "bower": {
-      "version": "1.8.0",
-      "from": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+    "babel-plugin-constant-folding": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
+      "integrity": "sha1-g2HTZMmORJw2kr26Ue/whEKQqo4="
+    },
+    "babel-plugin-dead-code-elimination": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
+      "integrity": "sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U="
+    },
+    "babel-plugin-eval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
+      "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo="
+    },
+    "babel-plugin-inline-environment-variables": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
+      "integrity": "sha1-H1jOkSB61qgmqL9kX6/mj/X+P/4="
+    },
+    "babel-plugin-jscript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
+      "integrity": "sha1-jzQsOCduh6R9X6CovT1etsytj8w="
+    },
+    "babel-plugin-member-expression-literals": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
+      "integrity": "sha1-zF7bD6qNyScXDnTW0cAkQAIWJNM="
+    },
+    "babel-plugin-property-literals": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
+      "integrity": "sha1-AlIwGQAZKYCxwRjv6kjOk6q4MzY="
+    },
+    "babel-plugin-proto-to-assign": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
+      "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
+      "requires": {
+        "lodash": "3.10.1"
+      }
+    },
+    "babel-plugin-react-constant-elements": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
+      "integrity": "sha1-lGc26DeEKcvDSdz/YvUcFDs041o="
+    },
+    "babel-plugin-react-display-name": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
+      "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw="
+    },
+    "babel-plugin-remove-console": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
+      "integrity": "sha1-2PJFVsOgUAXUKqqv0neH9T/wE6c="
+    },
+    "babel-plugin-remove-debugger": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
+      "integrity": "sha1-/S6jzWGkKK0fO5yJiC/0KT6MFMc="
+    },
+    "babel-plugin-runtime": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
+      "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8="
+    },
+    "babel-plugin-undeclared-variables-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+      "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
+      "requires": {
+        "leven": "1.0.2"
+      }
+    },
+    "babel-plugin-undefined-to-void": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
+      "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E="
+    },
+    "babylon": {
+      "version": "5.8.38",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+      "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
+      },
       "dependencies": {
-        "abbrev": {
-          "version": "1.0.7",
-          "from": "abbrev@>=1.0.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-        },
-        "archy": {
+        "define-property": {
           "version": "1.0.0",
-          "from": "archy@1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
-        },
-        "bower-config": {
-          "version": "1.3.0",
-          "from": "bower-config@>=1.3.0 <2.0.0",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "graceful-fs@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "from": "optimist@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                },
-                "minimist": {
-                  "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                }
-              }
-            },
-            "osenv": {
-              "version": "0.1.3",
-              "from": "osenv@>=0.1.3 <0.2.0",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                }
-              }
-            },
-            "untildify": {
-              "version": "2.1.0",
-              "from": "untildify@2.1.0",
-              "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                }
-              }
-            }
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "1.0.2"
           }
         },
-        "bower-endpoint-parser": {
-          "version": "0.2.2",
-          "from": "bower-endpoint-parser@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
-        },
-        "bower-json": {
-          "version": "0.4.0",
-          "from": "bower-json@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
-          "dependencies": {
-            "deep-extend": {
-              "version": "0.2.11",
-              "from": "deep-extend@>=0.2.5 <0.3.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
-            },
-            "graceful-fs": {
-              "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-            },
-            "intersect": {
-              "version": "0.0.3",
-              "from": "intersect@>=0.0.3 <0.1.0",
-              "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
-            }
-          }
-        },
-        "bower-logger": {
-          "version": "0.2.2",
-          "from": "bower-logger@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
-        },
-        "bower-registry-client": {
+        "is-accessor-descriptor": {
           "version": "1.0.0",
-          "from": "bower-registry-client@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-1.0.0.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.2.10",
-              "from": "async@>=0.2.8 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-            },
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "graceful-fs@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "request-replay": {
-              "version": "0.2.0",
-              "from": "request-replay@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
-            },
-            "mkdirp": {
-              "version": "0.3.5",
-              "from": "mkdirp@>=0.3.5 <0.4.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
-            }
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "6.0.2"
           }
         },
-        "cardinal": {
-          "version": "0.4.4",
-          "from": "cardinal@0.4.4",
-          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
-          "dependencies": {
-            "redeyed": {
-              "version": "0.4.4",
-              "from": "redeyed@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
-              "dependencies": {
-                "esprima": {
-                  "version": "1.0.4",
-                  "from": "esprima@>=1.0.4 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-                }
-              }
-            },
-            "ansicolors": {
-              "version": "0.2.1",
-              "from": "ansicolors@>=0.2.1 <0.3.0",
-              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
-            }
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "6.0.2"
           }
         },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "chmodr": {
+        "is-descriptor": {
           "version": "1.0.2",
-          "from": "chmodr@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz"
-        },
-        "configstore": {
-          "version": "0.3.2",
-          "from": "configstore@>=0.3.2 <0.4.0",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
-          "dependencies": {
-            "js-yaml": {
-              "version": "3.4.6",
-              "from": "js-yaml@>=3.1.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.3",
-                  "from": "argparse@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
-                  "dependencies": {
-                    "lodash": {
-                      "version": "3.10.1",
-                      "from": "lodash@>=3.2.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                    },
-                    "sprintf-js": {
-                      "version": "1.0.3",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "2.7.1",
-                  "from": "esprima@>=2.6.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
-                },
-                "inherit": {
-                  "version": "2.2.2",
-                  "from": "inherit@>=2.2.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.2.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.1.1",
-              "from": "object-assign@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-            },
-            "osenv": {
-              "version": "0.1.3",
-              "from": "osenv@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                }
-              }
-            },
-            "uuid": {
-              "version": "2.0.1",
-              "from": "uuid@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-            },
-            "xdg-basedir": {
-              "version": "1.0.1",
-              "from": "xdg-basedir@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
-            }
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
-        "decompress-zip": {
-          "version": "0.1.0",
-          "from": "decompress-zip@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
-          "dependencies": {
-            "binary": {
-              "version": "0.3.0",
-              "from": "binary@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-              "dependencies": {
-                "chainsaw": {
-                  "version": "0.1.0",
-                  "from": "chainsaw@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-                  "dependencies": {
-                    "traverse": {
-                      "version": "0.3.9",
-                      "from": "traverse@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
-                    }
-                  }
-                },
-                "buffers": {
-                  "version": "0.1.1",
-                  "from": "buffers@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
-                }
-              }
-            },
-            "mkpath": {
-              "version": "0.1.0",
-              "from": "mkpath@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "from": "readable-stream@>=1.1.8 <2.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "touch": {
-              "version": "0.0.3",
-              "from": "touch@0.0.3",
-              "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
-              "dependencies": {
-                "nopt": {
-                  "version": "1.0.10",
-                  "from": "nopt@>=1.0.10 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
-                }
-              }
-            }
-          }
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
-        "destroy": {
-          "version": "1.0.3",
-          "from": "destroy@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
-        },
-        "fs-write-stream-atomic": {
-          "version": "1.0.7",
-          "from": "fs-write-stream-atomic@>=1.0.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.7.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "graceful-fs@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "iferr": {
-              "version": "0.1.5",
-              "from": "iferr@>=0.1.5 <0.2.0",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz"
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "from": "imurmurhash@>=0.1.4 <0.2.0",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-            },
-            "readable-stream": {
-              "version": "2.0.4",
-              "from": "readable-stream@>=1.0.0 <2.0.0||>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "fstream": {
-          "version": "1.0.8",
-          "from": "fstream@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.3",
-          "from": "fstream-ignore@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "from": "minimatch@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "github": {
-          "version": "0.2.4",
-          "from": "github@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
-          "dependencies": {
-            "mime": {
-              "version": "1.3.4",
-              "from": "mime@>=1.2.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-            }
-          }
-        },
-        "glob": {
-          "version": "4.5.3",
-          "from": "glob@>=4.3.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "3.0.8",
-          "from": "graceful-fs@>=3.0.5 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-        },
-        "handlebars": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "beeper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+    },
+    "big.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+    },
+    "binary-extensions": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+    },
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "bower": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz",
+      "integrity": "sha1-54dqB23rgTf30GUl3F6MZtuC8oo="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
+    },
+    "breakable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
+      "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME="
+    },
+    "browserify-aes": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
+      "integrity": "sha1-BnFJtmjfMcS1hTPgLQHoBthgjiw=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "requires": {
+        "pako": "0.2.9"
+      }
+    },
+    "browserslist": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+      "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+      "requires": {
+        "caniuse-db": "1.0.30000827",
+        "electron-to-chromium": "1.3.42"
+      }
+    },
+    "buffer": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+      "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+      "requires": {
+        "base64-js": "0.0.8",
+        "ieee754": "1.1.11",
+        "isarray": "1.0.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+    },
+    "caniuse-api": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+      "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000827",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
+      }
+    },
+    "caniuse-db": {
+      "version": "1.0.30000827",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000827.tgz",
+      "integrity": "sha1-vSg53Rlgk7RMKMF/k1ExQMnZJYg="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "optional": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
           "version": "2.0.0",
-          "from": "handlebars@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
-          "dependencies": {
-            "optimist": {
-              "version": "0.3.7",
-              "from": "optimist@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                }
-              }
-            },
-            "uglify-js": {
-              "version": "2.3.6",
-              "from": "uglify-js@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                },
-                "source-map": {
-                  "version": "0.1.43",
-                  "from": "source-map@>=0.1.7 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "inquirer": {
-          "version": "0.10.0",
-          "from": "inquirer@0.10.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.10.0.tgz",
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "1.1.0",
-              "from": "ansi-escapes@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.0.tgz"
-            },
-            "ansi-regex": {
-              "version": "2.0.0",
-              "from": "ansi-regex@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "from": "cli-cursor@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "dependencies": {
-                "restore-cursor": {
-                  "version": "1.0.1",
-                  "from": "restore-cursor@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                  "dependencies": {
-                    "exit-hook": {
-                      "version": "1.1.1",
-                      "from": "exit-hook@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
-                    },
-                    "onetime": {
-                      "version": "1.0.0",
-                      "from": "onetime@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "cli-width": {
-              "version": "1.1.0",
-              "from": "cli-width@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
-            },
-            "figures": {
-              "version": "1.4.0",
-              "from": "figures@>=1.3.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "from": "lodash@>=3.3.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-            },
-            "readline2": {
-              "version": "1.0.1",
-              "from": "readline2@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "from": "code-point-at@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                },
-                "mute-stream": {
-                  "version": "0.0.5",
-                  "from": "mute-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-                }
-              }
-            },
-            "run-async": {
-              "version": "0.1.0",
-              "from": "run-async@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-              "dependencies": {
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "rx-lite": {
-              "version": "3.1.2",
-              "from": "rx-lite@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-            },
-            "through": {
-              "version": "2.3.8",
-              "from": "through@>=2.3.6 <3.0.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            }
-          }
-        },
-        "insight": {
-          "version": "0.7.0",
-          "from": "insight@>=0.7.0 <0.8.0",
-          "resolved": "https://registry.npmjs.org/insight/-/insight-0.7.0.tgz",
-          "dependencies": {
-            "async": {
-              "version": "1.5.0",
-              "from": "async@>=1.4.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-            },
-            "configstore": {
-              "version": "1.4.0",
-              "from": "configstore@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "from": "osenv@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    }
-                  }
-                },
-                "uuid": {
-                  "version": "2.0.1",
-                  "from": "uuid@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-                },
-                "write-file-atomic": {
-                  "version": "1.1.4",
-                  "from": "write-file-atomic@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-                  "dependencies": {
-                    "imurmurhash": {
-                      "version": "0.1.4",
-                      "from": "imurmurhash@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-                    },
-                    "slide": {
-                      "version": "1.1.6",
-                      "from": "slide@>=1.1.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-                    }
-                  }
-                },
-                "xdg-basedir": {
-                  "version": "2.0.0",
-                  "from": "xdg-basedir@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash.debounce": {
-              "version": "3.1.1",
-              "from": "lodash.debounce@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-            },
-            "os-name": {
-              "version": "1.0.3",
-              "from": "os-name@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
-              "dependencies": {
-                "osx-release": {
-                  "version": "1.1.0",
-                  "from": "osx-release@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "1.2.0",
-                      "from": "minimist@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                    }
-                  }
-                },
-                "win-release": {
-                  "version": "1.1.1",
-                  "from": "win-release@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
-                  "dependencies": {
-                    "semver": {
-                      "version": "5.1.0",
-                      "from": "semver@>=5.0.1 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "tough-cookie": {
-              "version": "2.2.1",
-              "from": "tough-cookie@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-            }
-          }
-        },
-        "is-root": {
-          "version": "1.0.0",
-          "from": "is-root@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
-        },
-        "junk": {
-          "version": "1.0.2",
-          "from": "junk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.2.tgz"
-        },
-        "lockfile": {
-          "version": "1.0.1",
-          "from": "lockfile@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "from": "lru-cache@>=2.5.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-        },
-        "md5-hex": {
-          "version": "1.1.0",
-          "from": "md5-hex@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.1.0.tgz",
-          "dependencies": {
-            "md5-o-matic": {
-              "version": "0.1.1",
-              "from": "md5-o-matic@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "from": "mkdirp@0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "mout": {
-          "version": "0.11.1",
-          "from": "mout@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz"
-        },
-        "nopt": {
-          "version": "3.0.6",
-          "from": "nopt@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
-        },
-        "opn": {
-          "version": "1.0.2",
-          "from": "opn@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
-        },
-        "p-throttler": {
-          "version": "0.1.1",
-          "from": "p-throttler@0.1.1",
-          "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.1.tgz",
-          "dependencies": {
-            "q": {
-              "version": "0.9.7",
-              "from": "q@>=0.9.2 <0.10.0",
-              "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
-            }
-          }
-        },
-        "promptly": {
-          "version": "0.2.0",
-          "from": "promptly@0.2.0",
-          "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
-          "dependencies": {
-            "read": {
-              "version": "1.0.7",
-              "from": "read@>=1.0.4 <1.1.0",
-              "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-              "dependencies": {
-                "mute-stream": {
-                  "version": "0.0.5",
-                  "from": "mute-stream@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "q": {
-          "version": "1.4.1",
-          "from": "q@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-        },
-        "request": {
-          "version": "2.53.0",
-          "from": "request@2.53.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
-          "dependencies": {
-            "bl": {
-              "version": "0.9.4",
-              "from": "bl@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "caseless": {
-              "version": "0.9.0",
-              "from": "caseless@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.5.2",
-              "from": "forever-agent@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-            },
-            "form-data": {
-              "version": "0.2.0",
-              "from": "form-data@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-                }
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.0.14",
-              "from": "mime-types@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.12.0",
-                  "from": "mime-db@>=1.12.0 <1.13.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-            },
-            "qs": {
-              "version": "2.3.3",
-              "from": "qs@>=2.3.1 <2.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.2",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.1",
-              "from": "tough-cookie@>=0.12.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-            },
-            "http-signature": {
-              "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "asn1": {
-                  "version": "0.1.11",
-                  "from": "asn1@0.1.11",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "from": "ctype@0.5.3",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.6.0",
-              "from": "oauth-sign@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
-            },
-            "hawk": {
-              "version": "2.3.1",
-              "from": "hawk@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "combined-stream": {
-              "version": "0.0.7",
-              "from": "combined-stream@>=0.0.5 <0.1.0",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
-                }
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            }
-          }
-        },
-        "request-progress": {
-          "version": "0.3.1",
-          "from": "request-progress@0.3.1",
-          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
-          "dependencies": {
-            "throttleit": {
-              "version": "0.0.2",
-              "from": "throttleit@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
-            }
-          }
-        },
-        "retry": {
-          "version": "0.6.1",
-          "from": "retry@0.6.1",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
-        },
-        "rimraf": {
-          "version": "2.4.4",
-          "from": "rimraf@>=2.2.8 <3.0.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "5.0.15",
-              "from": "glob@>=5.0.14 <6.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.2",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "semver": {
-          "version": "2.3.2",
-          "from": "semver@>=2.3.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
-        },
-        "semver-utils": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.1.tgz"
-        },
-        "shell-quote": {
-          "version": "1.4.3",
-          "from": "shell-quote@>=1.4.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
-          "dependencies": {
-            "jsonify": {
-              "version": "0.0.0",
-              "from": "jsonify@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-            },
-            "array-filter": {
-              "version": "0.0.1",
-              "from": "array-filter@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
-            },
-            "array-reduce": {
-              "version": "0.0.0",
-              "from": "array-reduce@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
-            },
-            "array-map": {
-              "version": "0.0.0",
-              "from": "array-map@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
-            }
-          }
-        },
-        "stringify-object": {
-          "version": "1.0.1",
-          "from": "stringify-object@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
-        },
-        "tar-fs": {
-          "version": "1.8.1",
-          "from": "tar-fs@>=1.4.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.8.1.tgz",
-          "dependencies": {
-            "pump": {
-              "version": "1.0.1",
-              "from": "pump@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
-              "dependencies": {
-                "end-of-stream": {
-                  "version": "1.1.0",
-                  "from": "end-of-stream@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@>=1.3.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "tar-stream": {
-              "version": "1.3.1",
-              "from": "tar-stream@>=1.1.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.3.1.tgz",
-              "dependencies": {
-                "bl": {
-                  "version": "1.0.0",
-                  "from": "bl@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
-                },
-                "end-of-stream": {
-                  "version": "1.1.0",
-                  "from": "end-of-stream@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.3",
-                      "from": "once@>=1.3.0 <1.4.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.0.4",
-                  "from": "readable-stream@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "tmp": {
-          "version": "0.0.24",
-          "from": "tmp@0.0.24",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
-        },
-        "update-notifier": {
-          "version": "0.6.0",
-          "from": "update-notifier@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.6.0.tgz",
-          "dependencies": {
-            "configstore": {
-              "version": "1.4.0",
-              "from": "configstore@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                },
-                "object-assign": {
-                  "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                },
-                "osenv": {
-                  "version": "0.1.3",
-                  "from": "osenv@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    }
-                  }
-                },
-                "uuid": {
-                  "version": "2.0.1",
-                  "from": "uuid@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
-                },
-                "write-file-atomic": {
-                  "version": "1.1.4",
-                  "from": "write-file-atomic@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
-                  "dependencies": {
-                    "imurmurhash": {
-                      "version": "0.1.4",
-                      "from": "imurmurhash@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-                    },
-                    "slide": {
-                      "version": "1.1.6",
-                      "from": "slide@>=1.1.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-                    }
-                  }
-                },
-                "xdg-basedir": {
-                  "version": "2.0.0",
-                  "from": "xdg-basedir@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-                  "dependencies": {
-                    "os-homedir": {
-                      "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "is-npm": {
-              "version": "1.0.0",
-              "from": "is-npm@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
-            },
-            "latest-version": {
-              "version": "2.0.0",
-              "from": "latest-version@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
-              "dependencies": {
-                "package-json": {
-                  "version": "2.3.0",
-                  "from": "package-json@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.3.0.tgz",
-                  "dependencies": {
-                    "got": {
-                      "version": "5.2.0",
-                      "from": "got@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/got/-/got-5.2.0.tgz",
-                      "dependencies": {
-                        "create-error-class": {
-                          "version": "2.0.1",
-                          "from": "create-error-class@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-2.0.1.tgz",
-                          "dependencies": {
-                            "capture-stack-trace": {
-                              "version": "1.0.0",
-                              "from": "capture-stack-trace@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            }
-                          }
-                        },
-                        "duplexify": {
-                          "version": "3.4.2",
-                          "from": "duplexify@>=3.2.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
-                          "dependencies": {
-                            "end-of-stream": {
-                              "version": "1.0.0",
-                              "from": "end-of-stream@1.0.0",
-                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-                              "dependencies": {
-                                "once": {
-                                  "version": "1.3.3",
-                                  "from": "once@>=1.3.0 <1.4.0",
-                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                                  "dependencies": {
-                                    "wrappy": {
-                                      "version": "1.0.1",
-                                      "from": "wrappy@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "readable-stream": {
-                              "version": "2.0.4",
-                              "from": "readable-stream@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                },
-                                "process-nextick-args": {
-                                  "version": "1.0.6",
-                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                },
-                                "util-deprecate": {
-                                  "version": "1.0.2",
-                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "is-plain-obj": {
-                          "version": "1.1.0",
-                          "from": "is-plain-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
-                        },
-                        "is-redirect": {
-                          "version": "1.0.0",
-                          "from": "is-redirect@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
-                        },
-                        "is-stream": {
-                          "version": "1.0.1",
-                          "from": "is-stream@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
-                        },
-                        "lowercase-keys": {
-                          "version": "1.0.0",
-                          "from": "lowercase-keys@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
-                        },
-                        "node-status-codes": {
-                          "version": "1.0.0",
-                          "from": "node-status-codes@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
-                        },
-                        "object-assign": {
-                          "version": "4.0.1",
-                          "from": "object-assign@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                        },
-                        "parse-json": {
-                          "version": "2.2.0",
-                          "from": "parse-json@>=2.1.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                          "dependencies": {
-                            "error-ex": {
-                              "version": "1.3.0",
-                              "from": "error-ex@>=1.2.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                              "dependencies": {
-                                "is-arrayish": {
-                                  "version": "0.2.1",
-                                  "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.1",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                            }
-                          }
-                        },
-                        "read-all-stream": {
-                          "version": "3.0.1",
-                          "from": "read-all-stream@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
-                          "dependencies": {
-                            "pinkie-promise": {
-                              "version": "1.0.0",
-                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "1.0.0",
-                                  "from": "pinkie@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "readable-stream": {
-                              "version": "2.0.4",
-                              "from": "readable-stream@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                },
-                                "process-nextick-args": {
-                                  "version": "1.0.6",
-                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                },
-                                "util-deprecate": {
-                                  "version": "1.0.2",
-                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "timed-out": {
-                          "version": "2.0.0",
-                          "from": "timed-out@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
-                        },
-                        "unzip-response": {
-                          "version": "1.0.0",
-                          "from": "unzip-response@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz"
-                        },
-                        "url-parse-lax": {
-                          "version": "1.0.0",
-                          "from": "url-parse-lax@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-                          "dependencies": {
-                            "prepend-http": {
-                              "version": "1.0.3",
-                              "from": "prepend-http@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "rc": {
-                      "version": "1.1.5",
-                      "from": "rc@>=1.1.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.5.tgz",
-                      "dependencies": {
-                        "deep-extend": {
-                          "version": "0.4.0",
-                          "from": "deep-extend@>=0.4.0 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
-                        },
-                        "ini": {
-                          "version": "1.3.4",
-                          "from": "ini@>=1.3.0 <1.4.0",
-                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                        },
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@>=1.2.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        },
-                        "strip-json-comments": {
-                          "version": "1.0.4",
-                          "from": "strip-json-comments@>=1.0.4 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-                        }
-                      }
-                    },
-                    "registry-url": {
-                      "version": "3.0.3",
-                      "from": "registry-url@>=3.0.3 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz"
-                    },
-                    "semver": {
-                      "version": "5.1.0",
-                      "from": "semver@>=5.1.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "repeating": {
-              "version": "2.0.0",
-              "from": "repeating@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "semver-diff": {
-              "version": "2.1.0",
-              "from": "semver-diff@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-              "dependencies": {
-                "semver": {
-                  "version": "5.1.0",
-                  "from": "semver@>=5.0.3 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                }
-              }
-            },
-            "string-length": {
-              "version": "1.0.1",
-              "from": "string-length@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "user-home": {
-          "version": "1.1.1",
-          "from": "user-home@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-        },
-        "which": {
-          "version": "1.2.0",
-          "from": "which@>=1.0.8 <2.0.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
-          "dependencies": {
-            "is-absolute": {
-              "version": "0.1.7",
-              "from": "is-absolute@>=0.1.7 <0.2.0",
-              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-              "dependencies": {
-                "is-relative": {
-                  "version": "0.1.3",
-                  "from": "is-relative@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
-                }
-              }
-            }
-          }
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
     "chokidar": {
-      "version": "1.4.1",
-      "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.1.tgz",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.1.tgz",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "requires": {
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.3",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
+    },
+    "clap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+      "requires": {
+        "chalk": "1.1.3"
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
       "dependencies": {
-        "anymatch": {
-          "version": "1.3.0",
-          "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-          "dependencies": {
-            "arrify": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-            },
-            "micromatch": {
-              "version": "2.3.5",
-              "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.5.tgz",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.5.tgz",
-              "dependencies": {
-                "arr-diff": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                  "dependencies": {
-                    "arr-flatten": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
-                    }
-                  }
-                },
-                "array-unique": {
-                  "version": "0.2.1",
-                  "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-                },
-                "braces": {
-                  "version": "1.8.2",
-                  "from": "https://registry.npmjs.org/braces/-/braces-1.8.2.tgz",
-                  "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.2.tgz",
-                  "dependencies": {
-                    "expand-range": {
-                      "version": "1.8.1",
-                      "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
-                      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
-                      "dependencies": {
-                        "fill-range": {
-                          "version": "2.2.3",
-                          "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                          "dependencies": {
-                            "is-number": {
-                              "version": "2.1.0",
-                              "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
-                            },
-                            "isobject": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
-                              "dependencies": {
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                }
-                              }
-                            },
-                            "randomatic": {
-                              "version": "1.1.5",
-                              "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-                              "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.2",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "preserve": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
-                    },
-                    "repeat-element": {
-                      "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-                    }
-                  }
-                },
-                "expand-brackets": {
-                  "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz",
-                  "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
-                },
-                "extglob": {
-                  "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
-                  "dependencies": {
-                    "ansi-green": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
-                      "dependencies": {
-                        "ansi-wrap": {
-                          "version": "0.1.0",
-                          "from": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
-                        }
-                      }
-                    },
-                    "success-symbol": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
-                    }
-                  }
-                },
-                "filename-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
-                },
-                "is-extglob": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                },
-                "kind-of": {
-                  "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
-                  "dependencies": {
-                    "is-buffer": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                    }
-                  }
-                },
-                "lazy-cache": {
-                  "version": "0.2.7",
-                  "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
-                },
-                "normalize-path": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
-                },
-                "object.omit": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
-                  "dependencies": {
-                    "for-own": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
-                      "dependencies": {
-                        "for-in": {
-                          "version": "0.1.4",
-                          "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
-                          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
-                        }
-                      }
-                    },
-                    "is-extendable": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-                    }
-                  }
-                },
-                "parse-glob": {
-                  "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                  "dependencies": {
-                    "glob-base": {
-                      "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
-                    },
-                    "is-dotfile": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
-                    }
-                  }
-                },
-                "regex-cache": {
-                  "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
-                  "dependencies": {
-                    "is-equal-shallow": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
-                    },
-                    "is-primitive": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "0.1.6"
           }
         },
-        "async-each": {
-          "version": "0.1.6",
-          "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
-          "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      }
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+    },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
+    },
+    "clone-stats": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+    },
+    "cloneable-readable": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+      "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+      "requires": {
+        "inherits": "2.0.3",
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "optional": true
+    },
+    "coa": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+      "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+      "requires": {
+        "q": "1.5.1"
+      }
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
+    "color": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+      "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+      "requires": {
+        "clone": "1.0.4",
+        "color-convert": "1.9.1",
+        "color-string": "0.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+    },
+    "colormin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+      "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+      "requires": {
+        "color": "0.11.4",
+        "css-color-names": "0.0.4",
+        "has": "1.0.1"
+      }
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+    },
+    "commoner": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+      "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+      "requires": {
+        "commander": "2.15.1",
+        "detective": "4.7.1",
+        "glob": "5.0.15",
+        "graceful-fs": "4.1.11",
+        "iconv-lite": "0.4.21",
+        "mkdirp": "0.5.1",
+        "private": "0.1.8",
+        "q": "1.5.1",
+        "recast": "0.11.23"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         },
-        "glob-parent": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-        },
-        "is-binary-path": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-          "dependencies": {
-            "binary-extensions": {
-              "version": "1.4.0",
-              "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
-            }
-          }
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "dependencies": {
-            "is-extglob": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-            }
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-        },
-        "readdirp": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.0.5",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            }
+        "recast": {
+          "version": "0.11.23",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+          "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+          "requires": {
+            "ast-types": "0.9.6",
+            "esprima": "3.1.3",
+            "private": "0.1.8",
+            "source-map": "0.5.7"
           }
         }
       }
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-with-sourcemaps": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.5.tgz",
+      "integrity": "sha512-YtnS0VEY+e2Khzsey/6mra9EoM6h/5gxaC0e3mcHpA5yfDxafhygytNmcJWodvUgyXzSiL5MSkPO6bQGgfliHw==",
+      "requires": {
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "requires": {
+        "date-now": "0.1.4"
+      }
+    },
+    "constants-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+      "integrity": "sha1-kld9tSe6bEzwpFaNhLwDH0QeIfI="
+    },
+    "convert-source-map": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "optional": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
+    },
+    "crypto-browserify": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
+      "integrity": "sha1-ubEdvm2WUd2IKgHmzEZ99xjs8Yk=",
+      "requires": {
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      }
+    },
+    "css": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
+      "requires": {
+        "inherits": "2.0.3",
+        "source-map": "0.1.43",
+        "source-map-resolve": "0.3.1",
+        "urix": "0.1.0"
+      },
+      "dependencies": {
+        "atob": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+          "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M="
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        },
+        "source-map-resolve": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+          "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
+          "requires": {
+            "atob": "1.1.3",
+            "resolve-url": "0.2.1",
+            "source-map-url": "0.3.0",
+            "urix": "0.1.0"
+          }
+        },
+        "source-map-url": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+          "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk="
+        }
+      }
+    },
+    "css-color-names": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
     },
     "css-loader": {
       "version": "0.23.1",
-      "from": "https://registry.npmjs.org/css-loader/-/css-loader-0.23.1.tgz",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.23.1.tgz",
+      "integrity": "sha1-n6I/K1wJZSNZEK1ezvO4o2OQ/lA=",
+      "requires": {
+        "css-selector-tokenizer": "0.5.4",
+        "cssnano": "3.10.0",
+        "loader-utils": "0.2.17",
+        "lodash.camelcase": "3.0.1",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-modules-extract-imports": "1.1.0",
+        "postcss-modules-local-by-default": "1.2.0",
+        "postcss-modules-scope": "1.1.0",
+        "postcss-modules-values": "1.3.0",
+        "source-list-map": "0.1.8"
+      }
+    },
+    "css-selector-tokenizer": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
+      "integrity": "sha1-E5uv00o1/QwUKEhwSeBpnm9qLCE=",
+      "requires": {
+        "cssesc": "0.1.0",
+        "fastparse": "1.1.1"
+      }
+    },
+    "cssesc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+      "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
+    },
+    "cssnano": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+      "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+      "requires": {
+        "autoprefixer": "6.7.7",
+        "decamelize": "1.2.0",
+        "defined": "1.0.0",
+        "has": "1.0.1",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-calc": "5.3.1",
+        "postcss-colormin": "2.2.2",
+        "postcss-convert-values": "2.6.1",
+        "postcss-discard-comments": "2.0.4",
+        "postcss-discard-duplicates": "2.1.0",
+        "postcss-discard-empty": "2.1.0",
+        "postcss-discard-overridden": "0.1.1",
+        "postcss-discard-unused": "2.2.3",
+        "postcss-filter-plugins": "2.0.2",
+        "postcss-merge-idents": "2.1.7",
+        "postcss-merge-longhand": "2.0.2",
+        "postcss-merge-rules": "2.1.2",
+        "postcss-minify-font-values": "1.0.5",
+        "postcss-minify-gradients": "1.0.5",
+        "postcss-minify-params": "1.2.2",
+        "postcss-minify-selectors": "2.1.1",
+        "postcss-normalize-charset": "1.1.1",
+        "postcss-normalize-url": "3.0.8",
+        "postcss-ordered-values": "2.2.3",
+        "postcss-reduce-idents": "2.4.0",
+        "postcss-reduce-initial": "1.0.1",
+        "postcss-reduce-transforms": "1.0.4",
+        "postcss-svgo": "2.1.6",
+        "postcss-unique-selectors": "2.0.2",
+        "postcss-value-parser": "3.3.0",
+        "postcss-zindex": "2.2.0"
+      }
+    },
+    "csso": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+      "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+      "requires": {
+        "clap": "1.2.3",
+        "source-map": "0.5.7"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
-        "css-selector-tokenizer": {
-          "version": "0.5.4",
-          "from": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
-          "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
-          "dependencies": {
-            "cssesc": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
-            },
-            "fastparse": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
-            }
-          }
-        },
-        "cssnano": {
-          "version": "3.4.0",
-          "from": "https://registry.npmjs.org/cssnano/-/cssnano-3.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.4.0.tgz",
-          "dependencies": {
-            "autoprefixer": {
-              "version": "6.2.3",
-              "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
-              "dependencies": {
-                "normalize-range": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
-                },
-                "num2fraction": {
-                  "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-                },
-                "browserslist": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
-                },
-                "caniuse-db": {
-                  "version": "1.0.30000386",
-                  "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz",
-                  "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz"
-                }
-              }
-            },
-            "decamelize": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                }
-              }
-            },
-            "defined": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-            },
-            "indexes-of": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
-            },
-            "postcss-calc": {
-              "version": "5.2.0",
-              "from": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.0.tgz",
-              "dependencies": {
-                "postcss-message-helpers": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
-                },
-                "reduce-css-calc": {
-                  "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
-                    },
-                    "reduce-function-call": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-colormin": {
-              "version": "2.1.8",
-              "from": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.1.8.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.1.8.tgz",
-              "dependencies": {
-                "colormin": {
-                  "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/colormin/-/colormin-1.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.0.7.tgz",
-                  "dependencies": {
-                    "color": {
-                      "version": "0.11.1",
-                      "from": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
-                      "resolved": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
-                      "dependencies": {
-                        "color-convert": {
-                          "version": "0.5.3",
-                          "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
-                        },
-                        "color-string": {
-                          "version": "0.3.0",
-                          "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-                          "dependencies": {
-                            "color-name": {
-                              "version": "1.1.1",
-                              "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-                              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "css-color-names": {
-                      "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-convert-values": {
-              "version": "2.3.4",
-              "from": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz"
-            },
-            "postcss-discard-comments": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz"
-            },
-            "postcss-discard-duplicates": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz"
-            },
-            "postcss-discard-empty": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz"
-            },
-            "postcss-discard-unused": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.1.0.tgz",
-              "dependencies": {
-                "flatten": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
-                },
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-filter-plugins": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
-              "dependencies": {
-                "uniqid": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz"
-                }
-              }
-            },
-            "postcss-merge-idents": {
-              "version": "2.1.3",
-              "from": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.3.tgz",
-              "dependencies": {
-                "has-own": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz"
-                }
-              }
-            },
-            "postcss-merge-longhand": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz"
-            },
-            "postcss-merge-rules": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz"
-            },
-            "postcss-minify-font-values": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.2.tgz",
-              "dependencies": {
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-minify-gradients": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz"
-            },
-            "postcss-minify-params": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
-              "dependencies": {
-                "alphanum-sort": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
-                },
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-minify-selectors": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.2.tgz",
-              "dependencies": {
-                "alphanum-sort": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
-                },
-                "postcss-selector-parser": {
-                  "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.0.tgz",
-                  "dependencies": {
-                    "flatten": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
-                    },
-                    "uniq": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-normalize-charset": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz"
-            },
-            "postcss-normalize-url": {
-              "version": "3.0.4",
-              "from": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.4.tgz",
-              "dependencies": {
-                "is-absolute-url": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
-                },
-                "normalize-url": {
-                  "version": "1.4.0",
-                  "from": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
-                  "dependencies": {
-                    "prepend-http": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
-                    },
-                    "query-string": {
-                      "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
-                      "dependencies": {
-                        "strict-uri-encode": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
-                        }
-                      }
-                    },
-                    "sort-keys": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
-                      "dependencies": {
-                        "is-plain-obj": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-ordered-values": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz"
-            },
-            "postcss-reduce-idents": {
-              "version": "2.2.1",
-              "from": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz"
-            },
-            "postcss-reduce-transforms": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz"
-            },
-            "postcss-svgo": {
-              "version": "2.1.1",
-              "from": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.1.tgz",
-              "dependencies": {
-                "is-svg": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz"
-                },
-                "svgo": {
-                  "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/svgo/-/svgo-0.6.1.tgz",
-                  "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.1.tgz",
-                  "dependencies": {
-                    "sax": {
-                      "version": "1.1.4",
-                      "from": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
-                      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz"
-                    },
-                    "coa": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
-                      "dependencies": {
-                        "q": {
-                          "version": "1.4.1",
-                          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-                        }
-                      }
-                    },
-                    "js-yaml": {
-                      "version": "3.4.6",
-                      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
-                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
-                      "dependencies": {
-                        "argparse": {
-                          "version": "1.0.3",
-                          "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
-                          "dependencies": {
-                            "sprintf-js": {
-                              "version": "1.0.3",
-                              "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "esprima": {
-                          "version": "2.7.1",
-                          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
-                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
-                        },
-                        "inherit": {
-                          "version": "2.2.3",
-                          "from": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz",
-                          "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz"
-                        }
-                      }
-                    },
-                    "colors": {
-                      "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
-                    },
-                    "whet.extend": {
-                      "version": "0.9.9",
-                      "from": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-                      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                        }
-                      }
-                    },
-                    "csso": {
-                      "version": "1.4.4",
-                      "from": "https://registry.npmjs.org/csso/-/csso-1.4.4.tgz",
-                      "resolved": "https://registry.npmjs.org/csso/-/csso-1.4.4.tgz",
-                      "dependencies": {
-                        "clap": {
-                          "version": "1.0.10",
-                          "from": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
-                          "resolved": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.1",
-                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.1.0",
-                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.4",
-                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.0",
-                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-unique-selectors": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.1.tgz",
-              "dependencies": {
-                "alphanum-sort": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
-                },
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-value-parser": {
-              "version": "3.2.3",
-              "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
-            },
-            "postcss-zindex": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.1.tgz",
-              "dependencies": {
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "loader-utils": {
-          "version": "0.2.12",
-          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "json5": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.0.1",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-        },
-        "lodash.camelcase": {
-          "version": "3.0.1",
-          "from": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
-          "dependencies": {
-            "lodash._createcompounder": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
-              "dependencies": {
-                "lodash.deburr": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.1.0.tgz"
-                },
-                "lodash.words": {
-                  "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.1.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "postcss": {
-          "version": "5.0.14",
-          "from": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
-          "dependencies": {
-            "supports-color": {
-              "version": "3.1.2",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-            }
-          }
-        },
-        "postcss-modules-extract-imports": {
+        "assert-plus": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.0.tgz"
-        },
-        "postcss-modules-local-by-default": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.0.1.tgz"
-        },
-        "postcss-modules-scope": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.0.tgz"
-        },
-        "postcss-modules-values": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.1.1.tgz",
-          "dependencies": {
-            "icss-replace-symbols": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz"
-            }
-          }
-        },
-        "source-list-map": {
-          "version": "0.1.5",
-          "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
-          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "optional": true
         }
       }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+    },
+    "dateformat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+    },
+    "deap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deap/-/deap-1.0.1.tgz",
+      "integrity": "sha512-k75KYNZMvwAwes2xIPry/QTffXIchjD8QfABvvfTr80P85jv5ZcKqcoDo+vMe71nNnVnXYe8MA28weyqcf/DKw=="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "debug-fabulous": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/debug-fabulous/-/debug-fabulous-0.0.4.tgz",
+      "integrity": "sha1-+gccXYdIRoVCSAdCHKSxawsaB2M=",
+      "requires": {
+        "debug": "2.6.9",
+        "lazy-debug-legacy": "0.0.1",
+        "object-assign": "4.1.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
+        }
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "1.0.4"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "requires": {
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "defs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+      "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
+      "requires": {
+        "alter": "0.2.0",
+        "ast-traverse": "0.1.1",
+        "breakable": "1.0.0",
+        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+        "simple-fmt": "0.1.0",
+        "simple-is": "0.2.0",
+        "stringmap": "0.2.2",
+        "stringset": "0.2.1",
+        "tryor": "0.1.2",
+        "yargs": "3.27.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "deprecated": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+      "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk="
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+    },
+    "detect-indent": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+      "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+      "requires": {
+        "get-stdin": "4.0.1",
+        "minimist": "1.2.0",
+        "repeating": "1.1.3"
+      }
+    },
+    "detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+    },
+    "detective": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+      "requires": {
+        "acorn": "5.5.3",
+        "defined": "1.0.0"
+      }
+    },
+    "domain-browser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+    },
+    "duplexer2": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+      "requires": {
+        "readable-stream": "1.1.14"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "duplexify": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+      "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
+      },
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+          "requires": {
+            "once": "1.4.0"
+          }
+        }
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.42",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz",
+      "integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk="
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+    },
+    "end-of-stream": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+      "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+      "requires": {
+        "once": "1.3.3"
+      },
+      "dependencies": {
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        }
+      }
+    },
+    "enhanced-resolve": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+      "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.2.0",
+        "tapable": "0.1.10"
+      },
+      "dependencies": {
+        "memory-fs": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+          "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA="
+        }
+      }
+    },
+    "errno": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "requires": {
+        "prr": "1.0.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima-fb": {
+      "version": "15001.1001.0-dev-harmony-fb",
+      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+      "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "2.2.3"
+      }
+    },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "requires": {
+        "homedir-polyfill": "1.0.1"
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "requires": {
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fancy-log": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+      "requires": {
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
+      }
+    },
+    "fastparse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+      "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
     },
     "file-loader": {
       "version": "0.8.5",
-      "from": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
-      "dependencies": {
-        "loader-utils": {
-          "version": "0.2.12",
-          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "json5": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-            }
-          }
-        }
+      "integrity": "sha1-knXQMf54DyfUf19K8CvUNxPMFRs=",
+      "requires": {
+        "loader-utils": "0.2.17"
       }
     },
-    "glob": {
-      "version": "5.0.15",
-      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "dependencies": {
-        "inflight": {
-          "version": "1.0.4",
-          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-          "dependencies": {
-            "wrappy": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-            }
-          }
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-        },
-        "minimatch": {
-          "version": "3.0.0",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "once": {
-          "version": "1.3.3",
-          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "dependencies": {
-            "wrappy": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-            }
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-        }
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
-    "gulp": {
-      "version": "3.9.1",
-      "from": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-      "dependencies": {
-        "archy": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "deprecated": {
-          "version": "0.0.1",
-          "from": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
-        },
-        "interpret": {
-          "version": "0.6.6",
-          "from": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
-        },
-        "liftoff": {
-          "version": "2.2.0",
-          "from": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
-          "dependencies": {
-            "extend": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
-            },
-            "findup-sync": {
-              "version": "0.3.0",
-              "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz"
-            },
-            "flagged-respawn": {
-              "version": "0.3.1",
-              "from": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
-            },
-            "rechoir": {
-              "version": "0.6.2",
-              "from": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
-            },
-            "resolve": {
-              "version": "1.1.6",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-        },
-        "orchestrator": {
-          "version": "0.3.7",
-          "from": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
-          "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
-          "dependencies": {
-            "end-of-stream": {
-              "version": "0.1.5",
-              "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-              "dependencies": {
-                "once": {
-                  "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "sequencify": {
-              "version": "0.0.7",
-              "from": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-              "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
-            },
-            "stream-consume": {
-              "version": "0.1.0",
-              "from": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
-            }
-          }
-        },
-        "pretty-hrtime": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz"
-        },
-        "semver": {
-          "version": "4.3.6",
-          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-        },
-        "tildify": {
-          "version": "1.1.2",
-          "from": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-            }
-          }
-        },
-        "v8flags": {
-          "version": "2.0.10",
-          "from": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.10.tgz",
-          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.10.tgz",
-          "dependencies": {
-            "user-home": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-            }
-          }
-        },
-        "vinyl-fs": {
-          "version": "0.3.14",
-          "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-          "dependencies": {
-            "defaults": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-              "dependencies": {
-                "clone": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-                }
-              }
-            },
-            "glob-stream": {
-              "version": "3.1.18",
-              "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-              "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "4.5.3",
-                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "ordered-read-streams": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
-                },
-                "glob2base": {
-                  "version": "0.0.12",
-                  "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-                  "dependencies": {
-                    "find-index": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
-                    }
-                  }
-                },
-                "unique-stream": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "glob-watcher": {
-              "version": "0.0.6",
-              "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-              "dependencies": {
-                "gaze": {
-                  "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-                  "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-                  "dependencies": {
-                    "globule": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                      "dependencies": {
-                        "lodash": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                        },
-                        "glob": {
-                          "version": "3.1.21",
-                          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "1.2.3",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                            },
-                            "inherits": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "minimatch": {
-                          "version": "0.2.14",
-                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                          "dependencies": {
-                            "lru-cache": {
-                              "version": "2.7.3",
-                              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                            },
-                            "sigmund": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "3.0.8",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "strip-bom": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-              "dependencies": {
-                "first-chunk-stream": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
-                },
-                "is-utf8": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
-                }
-              }
-            },
-            "through2": {
-              "version": "0.6.5",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            },
-            "vinyl": {
-              "version": "0.4.6",
-              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-              "dependencies": {
-                "clone": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-                },
-                "clone-stats": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
+    "find-index": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
     },
-    "gulp-autoprefixer": {
-      "version": "3.1.0",
-      "from": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.0.tgz",
-      "dependencies": {
-        "autoprefixer": {
-          "version": "6.2.3",
-          "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
-          "dependencies": {
-            "postcss-value-parser": {
-              "version": "3.2.3",
-              "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
-            },
-            "normalize-range": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
-            },
-            "num2fraction": {
-              "version": "1.2.2",
-              "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-            },
-            "browserslist": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
-            },
-            "caniuse-db": {
-              "version": "1.0.30000386",
-              "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz"
-            }
-          }
-        },
-        "postcss": {
-          "version": "5.0.14",
-          "from": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
-          "dependencies": {
-            "supports-color": {
-              "version": "3.1.2",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.5",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.2.1",
-          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-babel": {
-      "version": "5.3.0",
-      "from": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-5.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-5.3.0.tgz",
-      "dependencies": {
-        "object-assign": {
-          "version": "4.0.1",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-        },
-        "replace-ext": {
-          "version": "0.0.1",
-          "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-        },
-        "through2": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.5",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.2.0",
-          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-buffer": {
-      "version": "0.0.2",
-      "from": "https://registry.npmjs.org/gulp-buffer/-/gulp-buffer-0.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-buffer/-/gulp-buffer-0.0.2.tgz",
-      "dependencies": {
-        "through2": {
-          "version": "0.4.2",
-          "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "2.1.2",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-              "dependencies": {
-                "object-keys": {
-                  "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp-concat": {
-      "version": "2.6.0",
-      "from": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
-      "dependencies": {
-        "concat-with-sourcemaps": {
-          "version": "1.0.4",
-          "from": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-cssnano": {
-      "version": "2.1.0",
-      "from": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.0.tgz",
-      "dependencies": {
-        "cssnano": {
-          "version": "3.4.0",
-          "from": "https://registry.npmjs.org/cssnano/-/cssnano-3.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.4.0.tgz",
-          "dependencies": {
-            "autoprefixer": {
-              "version": "6.2.3",
-              "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
-              "dependencies": {
-                "normalize-range": {
-                  "version": "0.1.2",
-                  "from": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
-                },
-                "num2fraction": {
-                  "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-                },
-                "browserslist": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
-                },
-                "caniuse-db": {
-                  "version": "1.0.30000386",
-                  "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz",
-                  "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz"
-                }
-              }
-            },
-            "decamelize": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                }
-              }
-            },
-            "defined": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-            },
-            "indexes-of": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
-            },
-            "postcss": {
-              "version": "5.0.14",
-              "from": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
-              "dependencies": {
-                "supports-color": {
-                  "version": "3.1.2",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                },
-                "js-base64": {
-                  "version": "2.1.9",
-                  "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-                }
-              }
-            },
-            "postcss-calc": {
-              "version": "5.2.0",
-              "from": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.0.tgz",
-              "dependencies": {
-                "postcss-message-helpers": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
-                },
-                "reduce-css-calc": {
-                  "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
-                    },
-                    "reduce-function-call": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-colormin": {
-              "version": "2.1.8",
-              "from": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.1.8.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.1.8.tgz",
-              "dependencies": {
-                "colormin": {
-                  "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/colormin/-/colormin-1.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.0.7.tgz",
-                  "dependencies": {
-                    "color": {
-                      "version": "0.11.1",
-                      "from": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
-                      "resolved": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
-                      "dependencies": {
-                        "color-convert": {
-                          "version": "0.5.3",
-                          "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
-                        },
-                        "color-string": {
-                          "version": "0.3.0",
-                          "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-                          "dependencies": {
-                            "color-name": {
-                              "version": "1.1.1",
-                              "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-                              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "css-color-names": {
-                      "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-convert-values": {
-              "version": "2.3.4",
-              "from": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz"
-            },
-            "postcss-discard-comments": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz"
-            },
-            "postcss-discard-duplicates": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz"
-            },
-            "postcss-discard-empty": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz"
-            },
-            "postcss-discard-unused": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.1.0.tgz",
-              "dependencies": {
-                "flatten": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
-                },
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-filter-plugins": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
-              "dependencies": {
-                "uniqid": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz"
-                }
-              }
-            },
-            "postcss-merge-idents": {
-              "version": "2.1.3",
-              "from": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.3.tgz",
-              "dependencies": {
-                "has-own": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz"
-                }
-              }
-            },
-            "postcss-merge-longhand": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz"
-            },
-            "postcss-merge-rules": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz"
-            },
-            "postcss-minify-font-values": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.2.tgz",
-              "dependencies": {
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-minify-gradients": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz"
-            },
-            "postcss-minify-params": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
-              "dependencies": {
-                "alphanum-sort": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
-                },
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-minify-selectors": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.2.tgz",
-              "dependencies": {
-                "alphanum-sort": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
-                },
-                "postcss-selector-parser": {
-                  "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.0.tgz",
-                  "dependencies": {
-                    "flatten": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
-                    },
-                    "uniq": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-normalize-charset": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz"
-            },
-            "postcss-normalize-url": {
-              "version": "3.0.4",
-              "from": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.4.tgz",
-              "dependencies": {
-                "is-absolute-url": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
-                },
-                "normalize-url": {
-                  "version": "1.4.0",
-                  "from": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
-                  "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
-                  "dependencies": {
-                    "prepend-http": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
-                    },
-                    "query-string": {
-                      "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
-                      "dependencies": {
-                        "strict-uri-encode": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
-                        }
-                      }
-                    },
-                    "sort-keys": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
-                      "dependencies": {
-                        "is-plain-obj": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-ordered-values": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz"
-            },
-            "postcss-reduce-idents": {
-              "version": "2.2.1",
-              "from": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz"
-            },
-            "postcss-reduce-transforms": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz"
-            },
-            "postcss-svgo": {
-              "version": "2.1.1",
-              "from": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.1.tgz",
-              "dependencies": {
-                "is-svg": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz"
-                },
-                "svgo": {
-                  "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/svgo/-/svgo-0.6.1.tgz",
-                  "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.1.tgz",
-                  "dependencies": {
-                    "sax": {
-                      "version": "1.1.4",
-                      "from": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
-                      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz"
-                    },
-                    "coa": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
-                      "dependencies": {
-                        "q": {
-                          "version": "1.4.1",
-                          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-                        }
-                      }
-                    },
-                    "js-yaml": {
-                      "version": "3.4.6",
-                      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
-                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
-                      "dependencies": {
-                        "argparse": {
-                          "version": "1.0.3",
-                          "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
-                          "dependencies": {
-                            "sprintf-js": {
-                              "version": "1.0.3",
-                              "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "esprima": {
-                          "version": "2.7.1",
-                          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
-                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
-                        },
-                        "inherit": {
-                          "version": "2.2.3",
-                          "from": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz",
-                          "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz"
-                        }
-                      }
-                    },
-                    "colors": {
-                      "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
-                    },
-                    "whet.extend": {
-                      "version": "0.9.9",
-                      "from": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
-                      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                        }
-                      }
-                    },
-                    "csso": {
-                      "version": "1.4.4",
-                      "from": "https://registry.npmjs.org/csso/-/csso-1.4.4.tgz",
-                      "resolved": "https://registry.npmjs.org/csso/-/csso-1.4.4.tgz",
-                      "dependencies": {
-                        "clap": {
-                          "version": "1.0.10",
-                          "from": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
-                          "resolved": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.1",
-                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.1.0",
-                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.4",
-                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.0",
-                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-unique-selectors": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.1.tgz",
-              "dependencies": {
-                "alphanum-sort": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
-                },
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-value-parser": {
-              "version": "3.2.3",
-              "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
-            },
-            "postcss-zindex": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.1.tgz",
-              "dependencies": {
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.0.1",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.2.1",
-          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-if": {
+    "findup-sync": {
       "version": "2.0.0",
-      "from": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+      "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+      "requires": {
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.10",
+        "resolve-dir": "1.0.1"
+      },
       "dependencies": {
-        "gulp-match": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.0.tgz",
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
           "dependencies": {
-            "minimatch": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "0.1.1"
               }
             }
           }
         },
-        "ternary-stream": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "requires": {
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
           "dependencies": {
-            "duplexify": {
-              "version": "3.4.2",
-              "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
               "dependencies": {
-                "end-of-stream": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
             },
-            "fork-stream": {
-              "version": "0.0.4",
-              "from": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz"
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
             },
-            "merge-stream": {
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "requires": {
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "0.1.1"
               }
             }
           }
         },
-        "through2": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
           "dependencies": {
-            "readable-stream": {
-              "version": "2.0.5",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "0.1.1"
               }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-less": {
-      "version": "3.0.5",
-      "from": "https://registry.npmjs.org/gulp-less/-/gulp-less-3.0.5.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-less/-/gulp-less-3.0.5.tgz",
-      "dependencies": {
-        "accord": {
-          "version": "0.20.5",
-          "from": "https://registry.npmjs.org/accord/-/accord-0.20.5.tgz",
-          "resolved": "https://registry.npmjs.org/accord/-/accord-0.20.5.tgz",
-          "dependencies": {
-            "convert-source-map": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
-            },
-            "fobject": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/fobject/-/fobject-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/fobject/-/fobject-0.0.3.tgz",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "3.0.8",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-                }
-              }
-            },
-            "indx": {
-              "version": "0.2.3",
-              "from": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz"
-            },
-            "resolve": {
-              "version": "1.1.6",
-              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
-            },
-            "semver": {
-              "version": "4.3.6",
-              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-            },
-            "uglify-js": {
-              "version": "2.6.1",
-              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                },
-                "source-map": {
-                  "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                },
-                "uglify-to-browserify": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-                },
-                "yargs": {
-                  "version": "3.10.0",
-                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                    },
-                    "cliui": {
-                      "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                      "dependencies": {
-                        "center-align": {
-                          "version": "0.1.2",
-                          "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.0",
-                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                                }
-                              }
-                            },
-                            "lazy-cache": {
-                              "version": "0.2.7",
-                              "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
-                            }
-                          }
-                        },
-                        "right-align": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.0",
-                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                        }
-                      }
-                    },
-                    "decamelize": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
-                    },
-                    "window-size": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "when": {
-              "version": "3.7.5",
-              "from": "https://registry.npmjs.org/when/-/when-3.7.5.tgz",
-              "resolved": "https://registry.npmjs.org/when/-/when-3.7.5.tgz"
             }
           }
         },
-        "object-assign": {
-          "version": "4.0.1",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-        },
-        "through2": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.5",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "6.0.2"
           }
         },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.2.0",
-          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-plumber": {
-      "version": "1.0.1",
-      "from": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.0.1.tgz",
-      "dependencies": {
-        "through2": {
-          "version": "0.6.5",
-          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-size": {
-      "version": "2.0.0",
-      "from": "https://registry.npmjs.org/gulp-size/-/gulp-size-2.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-size/-/gulp-size-2.0.0.tgz",
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.4",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "6.0.2"
           }
         },
-        "gzip-size": {
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "is-number": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
           "dependencies": {
-            "duplexer": {
-              "version": "0.1.1",
-              "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
-            }
-          }
-        },
-        "pretty-bytes": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-2.0.1.tgz",
-          "dependencies": {
-            "get-stdin": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-            },
-            "meow": {
-              "version": "3.7.0",
-              "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-              "dependencies": {
-                "camelcase-keys": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                  "dependencies": {
-                    "escape-string-regexp": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                    }
-                  }
-                },
-                "loud-rejection": {
-                  "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
-                  "dependencies": {
-                    "signal-exit": {
-                      "version": "2.1.2",
-                      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
-                    }
-                  }
-                },
-                "map-obj": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                },
-                "normalize-package-data": {
-                  "version": "2.3.5",
-                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                  "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                  "dependencies": {
-                    "hosted-git-info": {
-                      "version": "2.1.4",
-                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
-                    },
-                    "is-builtin-module": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                      "dependencies": {
-                        "builtin-modules": {
-                          "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-                        }
-                      }
-                    },
-                    "semver": {
-                      "version": "5.1.0",
-                      "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                    },
-                    "validate-npm-package-license": {
-                      "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                      "dependencies": {
-                        "spdx-correct": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                          "dependencies": {
-                            "spdx-license-ids": {
-                              "version": "1.2.0",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
-                            }
-                          }
-                        },
-                        "spdx-expression-parse": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                          "dependencies": {
-                            "spdx-exceptions": {
-                              "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
-                            },
-                            "spdx-license-ids": {
-                              "version": "1.2.0",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                },
-                "read-pkg-up": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "dependencies": {
-                    "find-up": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
-                      "dependencies": {
-                        "path-exists": {
-                          "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.2",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                            },
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.3.0",
-                                  "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                                  "dependencies": {
-                                    "is-arrayish": {
-                                      "version": "0.2.1",
-                                      "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-bom": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                              "dependencies": {
-                                "is-utf8": {
-                                  "version": "0.2.1",
-                                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.2",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "redent": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                  "dependencies": {
-                    "indent-string": {
-                      "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                      "dependencies": {
-                        "repeating": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-indent": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-                    }
-                  }
-                },
-                "trim-newlines": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-                }
-              }
-            },
-            "number-is-nan": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-            }
-          }
-        },
-        "stream-counter": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/stream-counter/-/stream-counter-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-1.0.0.tgz"
-        },
-        "through2": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.5",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-sourcemaps": {
-      "version": "1.6.0",
-      "from": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-      "dependencies": {
-        "convert-source-map": {
-          "version": "1.1.2",
-          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
-        },
-        "graceful-fs": {
-          "version": "4.1.2",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "dependencies": {
-            "is-utf8": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.5",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        },
-        "vinyl": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.0.tgz",
-          "dependencies": {
-            "clone": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-            },
-            "clone-stats": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-uglify": {
-      "version": "1.5.1",
-      "from": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.5.1.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.5.1.tgz",
-      "dependencies": {
-        "deap": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz"
-        },
-        "fancy-log": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.1",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "dateformat": {
-              "version": "1.0.12",
-              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                },
-                "meow": {
-                  "version": "3.6.0",
-                  "from": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
-                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
-                  "dependencies": {
-                    "camelcase-keys": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
-                        },
-                        "map-obj": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "loud-rejection": {
-                      "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
-                      "dependencies": {
-                        "signal-exit": {
-                          "version": "2.1.2",
-                          "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
-                        }
-                      }
-                    },
-                    "minimist": {
-                      "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                    },
-                    "normalize-package-data": {
-                      "version": "2.3.5",
-                      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                      "dependencies": {
-                        "hosted-git-info": {
-                          "version": "2.1.4",
-                          "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
-                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
-                        },
-                        "is-builtin-module": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                          "dependencies": {
-                            "builtin-modules": {
-                              "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
-                            }
-                          }
-                        },
-                        "semver": {
-                          "version": "5.1.0",
-                          "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                        },
-                        "validate-npm-package-license": {
-                          "version": "3.0.1",
-                          "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                          "dependencies": {
-                            "spdx-correct": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                              "dependencies": {
-                                "spdx-license-ids": {
-                                  "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
-                                }
-                              }
-                            },
-                            "spdx-expression-parse": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                              "dependencies": {
-                                "spdx-exceptions": {
-                                  "version": "1.0.4",
-                                  "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
-                                },
-                                "spdx-license-ids": {
-                                  "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "object-assign": {
-                      "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                    },
-                    "read-pkg-up": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                      "dependencies": {
-                        "find-up": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
-                          "dependencies": {
-                            "path-exists": {
-                              "version": "2.1.0",
-                              "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "read-pkg": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                          "dependencies": {
-                            "load-json-file": {
-                              "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                              "dependencies": {
-                                "graceful-fs": {
-                                  "version": "4.1.2",
-                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                                },
-                                "parse-json": {
-                                  "version": "2.2.0",
-                                  "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                                  "dependencies": {
-                                    "error-ex": {
-                                      "version": "1.3.0",
-                                      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                                      "dependencies": {
-                                        "is-arrayish": {
-                                          "version": "0.2.1",
-                                          "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "pify": {
-                                  "version": "2.3.0",
-                                  "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                                },
-                                "pinkie-promise": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                                  "dependencies": {
-                                    "pinkie": {
-                                      "version": "2.0.1",
-                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-bom": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                                  "dependencies": {
-                                    "is-utf8": {
-                                      "version": "0.2.0",
-                                      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "path-type": {
-                              "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                              "dependencies": {
-                                "graceful-fs": {
-                                  "version": "4.1.2",
-                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                                },
-                                "pify": {
-                                  "version": "2.3.0",
-                                  "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                                },
-                                "pinkie-promise": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                                  "dependencies": {
-                                    "pinkie": {
-                                      "version": "2.0.1",
-                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "redent": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                      "dependencies": {
-                        "indent-string": {
-                          "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                          "dependencies": {
-                            "repeating": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-                              "dependencies": {
-                                "is-finite": {
-                                  "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                  "dependencies": {
-                                    "number-is-nan": {
-                                      "version": "1.0.0",
-                                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "strip-indent": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "trim-newlines": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-                    }
-                  }
-                }
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
               }
             }
           }
         },
         "isobject": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          }
+        }
+      }
+    },
+    "fined": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
+      "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
+      }
+    },
+    "first-chunk-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
+    },
+    "flagged-respawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
+      "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c="
+    },
+    "flatten": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+      "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
+    },
+    "flux-standard-action": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/flux-standard-action/-/flux-standard-action-0.6.1.tgz",
+      "integrity": "sha1-bzQhG5SDTqHDzDD056+tPQ+/caI=",
+      "requires": {
+        "lodash.isplainobject": "3.2.0"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "1.0.2"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "optional": true
+    },
+    "fork-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
+      "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA="
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "optional": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "requires": {
+        "map-cache": "0.2.2"
+      }
+    },
+    "fs-readdir-recursive": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
+      "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
             }
           }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "gaze": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+      "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
+      "requires": {
+        "globule": "0.1.0"
+      }
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "optional": true
+        }
+      }
+    },
+    "glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "2.0.10",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "requires": {
+        "is-glob": "2.0.1"
+      }
+    },
+    "glob-stream": {
+      "version": "3.1.18",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+      "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+      "requires": {
+        "glob": "4.5.3",
+        "glob2base": "0.0.12",
+        "minimatch": "2.0.10",
+        "ordered-read-streams": "0.1.0",
+        "through2": "0.6.5",
+        "unique-stream": "1.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "glob-watcher": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+      "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+      "requires": {
+        "gaze": "0.5.2"
+      }
+    },
+    "glob2base": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+      "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+      "requires": {
+        "find-index": "0.1.1"
+      }
+    },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "requires": {
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.0"
+      }
+    },
+    "globals": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+      "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
+    },
+    "globby": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
+      "integrity": "sha1-npGSvNM/Srak+JTl5+qLcTITxII=",
+      "requires": {
+        "array-union": "1.0.2",
+        "async": "1.5.2",
+        "glob": "5.0.15",
+        "object-assign": "3.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        }
+      }
+    },
+    "globule": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+      "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
+      "requires": {
+        "glob": "3.1.21",
+        "lodash": "1.0.2",
+        "minimatch": "0.2.14"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+          "requires": {
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
+          }
+        },
+        "graceful-fs": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
+        },
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
+        },
+        "lodash": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        }
+      }
+    },
+    "glogg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+      "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+      "requires": {
+        "sparkles": "1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "gulp": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+      "requires": {
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.8",
+        "interpret": "1.1.0",
+        "liftoff": "2.5.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.8",
+        "pretty-hrtime": "1.0.3",
+        "semver": "4.3.6",
+        "tildify": "1.2.0",
+        "v8flags": "2.1.1",
+        "vinyl-fs": "0.3.14"
+      }
+    },
+    "gulp-autoprefixer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.1.tgz",
+      "integrity": "sha1-dSMAUc0NFxND14O36bXREg7u+bA=",
+      "requires": {
+        "autoprefixer": "6.7.7",
+        "gulp-util": "3.0.8",
+        "postcss": "5.2.18",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      }
+    },
+    "gulp-babel": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-5.3.0.tgz",
+      "integrity": "sha1-GGlYYkwMeGYK1qUS9CNfyIhtLBs=",
+      "requires": {
+        "babel-core": "5.8.38",
+        "gulp-util": "3.0.8",
+        "object-assign": "4.1.1",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      }
+    },
+    "gulp-buffer": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/gulp-buffer/-/gulp-buffer-0.0.2.tgz",
+      "integrity": "sha1-r4G0NGEBc2tJlC7GyfqGf/5zcDY=",
+      "requires": {
+        "through2": "0.4.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "2.1.2"
+          }
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "requires": {
+            "object-keys": "0.4.0"
+          }
+        }
+      }
+    },
+    "gulp-concat": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
+      "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
+      "requires": {
+        "concat-with-sourcemaps": "1.0.5",
+        "through2": "2.0.3",
+        "vinyl": "2.1.0"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+        },
+        "clone-stats": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+        },
+        "replace-ext": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+        },
+        "vinyl": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+          "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+          "requires": {
+            "clone": "2.1.2",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
+          }
+        }
+      }
+    },
+    "gulp-cssnano": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.3.tgz",
+      "integrity": "sha512-r8qdX5pTXsBb/IRm9loE8Ijz8UiPW/URMC/bKJe4FPNHRaz4aEx8Bev03L0FYHd/7BSGu/ebmfumAkpGuTdenA==",
+      "requires": {
+        "buffer-from": "1.0.0",
+        "cssnano": "3.10.0",
+        "object-assign": "4.1.1",
+        "plugin-error": "1.0.1",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      }
+    },
+    "gulp-if": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+      "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
+      "requires": {
+        "gulp-match": "1.0.3",
+        "ternary-stream": "2.0.1",
+        "through2": "2.0.3"
+      }
+    },
+    "gulp-less": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/gulp-less/-/gulp-less-3.5.0.tgz",
+      "integrity": "sha512-FQLY7unaHdTOXG0jlwxeBQcWoPPrTMQZRA7HfYwSNi9IPVx5l7GJEN72mG4ri2yigp/f/VNGUAJnFMJHBmH3iw==",
+      "requires": {
+        "accord": "0.28.0",
+        "less": "2.7.3",
+        "object-assign": "4.1.1",
+        "plugin-error": "0.1.2",
+        "replace-ext": "1.0.0",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
+          }
+        },
+        "arr-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+          "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
+        },
+        "array-slice": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+          "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
+        },
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
+        },
+        "plugin-error": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+          "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+          "requires": {
+            "ansi-cyan": "0.1.1",
+            "ansi-red": "0.1.1",
+            "arr-diff": "1.1.0",
+            "arr-union": "2.1.0",
+            "extend-shallow": "1.1.4"
+          }
+        },
+        "replace-ext": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+        }
+      }
+    },
+    "gulp-match": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+      "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
+      "requires": {
+        "minimatch": "3.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        }
+      }
+    },
+    "gulp-plumber": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.2.0.tgz",
+      "integrity": "sha512-L/LJftsbKoHbVj6dN5pvMsyJn9jYI0wT0nMg3G6VZhDac4NesezecYTi8/48rHi+yEic3sUpw6jlSc7qNWh32A==",
+      "requires": {
+        "chalk": "1.1.3",
+        "fancy-log": "1.3.2",
+        "plugin-error": "0.1.2",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
+          }
+        },
+        "arr-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+          "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0="
+        },
+        "array-slice": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+          "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
+        },
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
+        },
+        "plugin-error": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+          "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+          "requires": {
+            "ansi-cyan": "0.1.1",
+            "ansi-red": "0.1.1",
+            "arr-diff": "1.1.0",
+            "arr-union": "2.1.0",
+            "extend-shallow": "1.1.4"
+          }
+        }
+      }
+    },
+    "gulp-size": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-size/-/gulp-size-2.1.0.tgz",
+      "integrity": "sha1-HCtk8X+QcdWr2Z0VS3s0gfj7oSg=",
+      "requires": {
+        "chalk": "1.1.3",
+        "gulp-util": "3.0.8",
+        "gzip-size": "3.0.0",
+        "object-assign": "4.1.1",
+        "pretty-bytes": "3.0.1",
+        "stream-counter": "1.0.0",
+        "through2": "2.0.3"
+      }
+    },
+    "gulp-sourcemaps": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.12.1.tgz",
+      "integrity": "sha1-tDfR89mAzyboEYSCNxjOFa5ll7Y=",
+      "requires": {
+        "@gulp-sourcemaps/map-sources": "1.0.0",
+        "acorn": "4.0.13",
+        "convert-source-map": "1.5.1",
+        "css": "2.2.1",
+        "debug-fabulous": "0.0.4",
+        "detect-newline": "2.1.0",
+        "graceful-fs": "4.1.11",
+        "source-map": "0.6.1",
+        "strip-bom": "2.0.0",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "strip-bom": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.5",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "0.2.1"
           }
         },
+        "vinyl": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+          "requires": {
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
+            "replace-ext": "0.0.1"
+          }
+        }
+      }
+    },
+    "gulp-uglify": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.5.4.tgz",
+      "integrity": "sha1-UkeI2HZm0J+dDCH7IXf5ADmmWMk=",
+      "requires": {
+        "deap": "1.0.1",
+        "fancy-log": "1.3.2",
+        "gulp-util": "3.0.8",
+        "isobject": "2.1.0",
+        "through2": "2.0.3",
+        "uglify-js": "2.6.4",
+        "uglify-save-license": "0.4.1",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      },
+      "dependencies": {
         "uglify-js": {
-          "version": "2.6.0",
-          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.0.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-            },
-            "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-            },
-            "yargs": {
-              "version": "3.10.0",
-              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                },
-                "cliui": {
-                  "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "dependencies": {
-                    "center-align": {
-                      "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                }
-                              }
-                            },
-                            "longest": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.2",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                            }
-                          }
-                        },
-                        "lazy-cache": {
-                          "version": "0.2.7",
-                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
-                        }
-                      }
-                    },
-                    "right-align": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                }
-                              }
-                            },
-                            "longest": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.2",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
-                },
-                "window-size": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                }
-              }
-            }
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
+          "integrity": "sha1-ZeovswWck5RpLxX+2HwrNsFrmt8=",
+          "requires": {
+            "async": "0.2.10",
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           }
         },
-        "uglify-save-license": {
-          "version": "0.4.1",
-          "from": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz"
+        "window-size": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
         },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.2.0",
-          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            }
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
           }
         }
       }
     },
     "gulp-util": {
-      "version": "3.0.7",
-      "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
+      },
       "dependencies": {
-        "array-differ": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
-        },
-        "array-uniq": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-        },
-        "beeper": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "dateformat": {
-          "version": "1.0.12",
-          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-          "dependencies": {
-            "get-stdin": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-            },
-            "meow": {
-              "version": "3.6.0",
-              "from": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
-              "dependencies": {
-                "camelcase-keys": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
-                    },
-                    "map-obj": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-                    }
-                  }
-                },
-                "loud-rejection": {
-                  "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
-                  "dependencies": {
-                    "signal-exit": {
-                      "version": "2.1.2",
-                      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
-                    }
-                  }
-                },
-                "normalize-package-data": {
-                  "version": "2.3.5",
-                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                  "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-                  "dependencies": {
-                    "hosted-git-info": {
-                      "version": "2.1.4",
-                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
-                    },
-                    "is-builtin-module": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                      "dependencies": {
-                        "builtin-modules": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
-                        }
-                      }
-                    },
-                    "semver": {
-                      "version": "5.1.0",
-                      "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                    },
-                    "validate-npm-package-license": {
-                      "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                      "dependencies": {
-                        "spdx-correct": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                          "dependencies": {
-                            "spdx-license-ids": {
-                              "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
-                            }
-                          }
-                        },
-                        "spdx-expression-parse": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-                          "dependencies": {
-                            "spdx-exceptions": {
-                              "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
-                            },
-                            "spdx-license-ids": {
-                              "version": "1.1.0",
-                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-                },
-                "read-pkg-up": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "dependencies": {
-                    "find-up": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
-                      "dependencies": {
-                        "path-exists": {
-                          "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.2",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                            },
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.3.0",
-                                  "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
-                                  "dependencies": {
-                                    "is-arrayish": {
-                                      "version": "0.2.1",
-                                      "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-bom": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                              "dependencies": {
-                                "is-utf8": {
-                                  "version": "0.2.0",
-                                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.2",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "redent": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-                  "dependencies": {
-                    "indent-string": {
-                      "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                      "dependencies": {
-                        "repeating": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-indent": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-                    }
-                  }
-                },
-                "trim-newlines": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "fancy-log": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz"
-        },
-        "gulplog": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-          "dependencies": {
-            "glogg": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-              "dependencies": {
-                "sparkles": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "has-gulplog": {
-          "version": "0.1.0",
-          "from": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-          "dependencies": {
-            "sparkles": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
-            }
-          }
-        },
-        "lodash._reescape": {
-          "version": "3.0.0",
-          "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
-        },
-        "lodash._reevaluate": {
-          "version": "3.0.0",
-          "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
-        },
-        "lodash._reinterpolate": {
-          "version": "3.0.0",
-          "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-        },
-        "lodash.template": {
-          "version": "3.6.2",
-          "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-          "dependencies": {
-            "lodash._basecopy": {
-              "version": "3.0.1",
-              "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-            },
-            "lodash._basetostring": {
-              "version": "3.0.1",
-              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-            },
-            "lodash._basevalues": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
-            },
-            "lodash._isiterateecall": {
-              "version": "3.0.9",
-              "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-            },
-            "lodash.escape": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
-            },
-            "lodash.keys": {
-              "version": "3.1.2",
-              "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1",
-                  "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4",
-                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                }
-              }
-            },
-            "lodash.restparam": {
-              "version": "3.6.1",
-              "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-            },
-            "lodash.templatesettings": {
-              "version": "3.1.0",
-              "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-        },
-        "multipipe": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-          "dependencies": {
-            "duplexer2": {
-              "version": "0.0.2",
-              "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
         "object-assign": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-        },
-        "replace-ext": {
-          "version": "0.0.1",
-          "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
-        },
-        "through2": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        }
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "requires": {
+        "glogg": "1.0.1"
+      }
+    },
+    "gzip-size": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+      "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+      "requires": {
+        "duplexer": "0.1.1"
+      }
+    },
+    "har-schema": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+      "optional": true
+    },
+    "har-validator": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "optional": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      }
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+    },
+    "has-gulplog": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+      "requires": {
+        "sparkles": "1.0.0"
+      }
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
           "dependencies": {
-            "readable-stream": {
-              "version": "2.0.5",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
               }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
-        "vinyl": {
-          "version": "0.5.3",
-          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-          "dependencies": {
-            "clone": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-            },
-            "clone-stats": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-            }
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "1.1.6"
           }
         }
       }
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "optional": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "home-or-tmp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+      "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
+      "requires": {
+        "os-tmpdir": "1.0.2",
+        "user-home": "1.1.1"
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "requires": {
+        "parse-passwd": "1.0.0"
+      }
+    },
+    "html-comment-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+      "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4="
+    },
+    "http-browserify": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+      "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
+      "requires": {
+        "Base64": "0.2.1",
+        "inherits": "2.0.3"
+      }
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
+      }
+    },
+    "https-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
+      "integrity": "sha1-s//f5zSyo9Sp79WOhlTJH86G6v0="
+    },
+    "iconv-lite": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0="
+    },
+    "ieee754": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
+    },
+    "image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+      "optional": true
     },
     "imports-loader": {
       "version": "0.6.5",
-      "from": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
       "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
+      "integrity": "sha1-rnRlMDHVnjezwvslRKxhrq41MKY=",
+      "requires": {
+        "loader-utils": "0.2.17",
+        "source-map": "0.1.43"
+      },
       "dependencies": {
-        "loader-utils": {
-          "version": "0.2.12",
-          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "json5": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-            }
-          }
-        },
         "source-map": {
           "version": "0.1.43",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-            }
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "requires": {
+            "amdefine": "1.0.1"
           }
         }
+      }
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "indx": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz",
+      "integrity": "sha1-Fdz1bunPZcAjTFE8J/vVgOcPvFA="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "requires": {
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
+      }
+    },
+    "is-absolute-url": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "requires": {
+        "binary-extensions": "1.11.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "requires": {
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "is-integer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
+      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-odd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
+      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
+      "requires": {
+        "is-number": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+        }
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+    },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "requires": {
+        "is-unc-path": "1.0.0"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-svg": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+      "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+      "requires": {
+        "html-comment-regex": "1.1.1"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "optional": true
+    },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "requires": {
+        "unc-path-regex": "0.1.2"
+      }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "is-valid-glob": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+      "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4="
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "optional": true
+    },
+    "js-base64": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
+      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
+    },
+    "js-tokens": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+      "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4="
+    },
+    "js-yaml": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+      "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "2.7.3"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+        }
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "optional": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "optional": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "optional": true
+        }
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+    },
+    "lazy-debug-legacy": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
+      "integrity": "sha1-U3cWwHduTPeePtG2IfdljCkRsbE="
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "requires": {
+        "readable-stream": "2.3.6"
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "1.0.0"
       }
     },
     "less": {
-      "version": "2.5.3",
-      "from": "https://registry.npmjs.org/less/-/less-2.5.3.tgz",
-      "resolved": "https://registry.npmjs.org/less/-/less-2.5.3.tgz",
-      "dependencies": {
-        "errno": {
-          "version": "0.1.4",
-          "from": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-          "dependencies": {
-            "prr": {
-              "version": "0.0.0",
-              "from": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "3.0.8",
-          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-        },
-        "image-size": {
-          "version": "0.3.5",
-          "from": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
-          "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz"
-        },
-        "mime": {
-          "version": "1.3.4",
-          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "promise": {
-          "version": "6.1.0",
-          "from": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
-          "dependencies": {
-            "asap": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
-            }
-          }
-        },
-        "request": {
-          "version": "2.67.0",
-          "from": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
-          "dependencies": {
-            "bl": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "caseless": {
-              "version": "0.11.0",
-              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-            },
-            "extend": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "form-data": {
-              "version": "1.0.0-rc3",
-              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "1.5.0",
-                  "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-                }
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.8",
-              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.20.0",
-                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-            },
-            "qs": {
-              "version": "5.2.0",
-              "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.2",
-              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.1",
-              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-            },
-            "http-signature": {
-              "version": "1.1.0",
-              "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "jsprim": {
-                  "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
-                    "json-schema": {
-                      "version": "0.2.2",
-                      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.7.1",
-                  "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                    },
-                    "dashdash": {
-                      "version": "1.10.1",
-                      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.1.5",
-                          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                        }
-                      }
-                    },
-                    "jsbn": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                    },
-                    "tweetnacl": {
-                      "version": "0.13.2",
-                      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.0",
-              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-            },
-            "hawk": {
-              "version": "3.1.2",
-              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-            },
-            "har-validator": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
-              "dependencies": {
-                "chalk": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.3",
-                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                    }
-                  }
-                },
-                "commander": {
-                  "version": "2.9.0",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    }
-                  }
-                },
-                "is-my-json-valid": {
-                  "version": "2.12.3",
-                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
-                  "dependencies": {
-                    "generate-function": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "dependencies": {
-                        "is-property": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "jsonpointer": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                    }
-                  }
-                },
-                "pinkie-promise": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                  "dependencies": {
-                    "pinkie": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-            }
-          }
-        }
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/less/-/less-2.7.3.tgz",
+      "integrity": "sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==",
+      "requires": {
+        "errno": "0.1.7",
+        "graceful-fs": "4.1.11",
+        "image-size": "0.5.5",
+        "mime": "1.6.0",
+        "mkdirp": "0.5.1",
+        "promise": "7.3.1",
+        "request": "2.81.0",
+        "source-map": "0.5.7"
       }
     },
     "less-loader": {
-      "version": "2.2.2",
-      "from": "https://registry.npmjs.org/less-loader/-/less-loader-2.2.2.tgz",
-      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-2.2.2.tgz",
-      "dependencies": {
-        "loader-utils": {
-          "version": "0.2.12",
-          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "json5": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-            }
-          }
-        }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-2.2.3.tgz",
+      "integrity": "sha1-ttj4E5yEk98J2ZKpOgBzSwj4RSg=",
+      "requires": {
+        "loader-utils": "0.2.17"
+      }
+    },
+    "leven": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
+      "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM="
+    },
+    "liftoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+      "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+      "requires": {
+        "extend": "3.0.1",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.7.0"
+      }
+    },
+    "loader-utils": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+      "requires": {
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1",
+        "object-assign": "4.1.1"
       }
     },
     "lodash": {
       "version": "3.10.1",
-      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+    },
+    "lodash-es": {
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.8.tgz",
+      "integrity": "sha512-I9mjAxengFAleSThFhhAhvba6fsO0hunb9/0sQ6qQihSZsJRBofv2rYH58WXaOb/O++eUmYpCLywSQ22GfU+sA=="
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+    },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+    },
+    "lodash._createcompounder": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
+      "integrity": "sha1-XdLLVTctbnDg4jkvsjBNZjEJEHU=",
+      "requires": {
+        "lodash.deburr": "3.2.0",
+        "lodash.words": "3.2.0"
+      }
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+    },
+    "lodash._reescape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+    },
+    "lodash.camelcase": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
+      "integrity": "sha1-kyyLh/ikN3iXxnGXUzKC+Xrqwpg=",
+      "requires": {
+        "lodash._createcompounder": "3.0.0"
+      }
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+    },
+    "lodash.deburr": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
+      "integrity": "sha1-baj1QzSjZqfPTEx2742Aqhs2XtU=",
+      "requires": {
+        "lodash._root": "3.0.1"
+      }
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.escape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+      "requires": {
+        "lodash._root": "3.0.1"
+      }
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.isplainobject": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+      "requires": {
+        "lodash._basefor": "3.0.3",
+        "lodash.isarguments": "3.1.0",
+        "lodash.keysin": "3.0.8"
+      }
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.keysin": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+      "requires": {
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
+    "lodash.partialright": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz",
+      "integrity": "sha1-ATDYDoM2MmTUAHTzKbij56ihzEs="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+    },
+    "lodash.template": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+      "requires": {
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
+      }
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "lodash.words": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz",
+      "integrity": "sha1-TiqGSbwIdFsXxpWxo86P7llmI7M=",
+      "requires": {
+        "lodash._root": "3.0.1"
+      }
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+        }
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+    },
+    "macaddress": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
+      "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI="
     },
     "main-bower-files": {
-      "version": "2.11.0",
-      "from": "https://registry.npmjs.org/main-bower-files/-/main-bower-files-2.11.0.tgz",
-      "resolved": "https://registry.npmjs.org/main-bower-files/-/main-bower-files-2.11.0.tgz",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/main-bower-files/-/main-bower-files-2.13.1.tgz",
+      "integrity": "sha1-fhvFxJg1LM7NXfCH8T1fMbwFfT4=",
+      "requires": {
+        "chalk": "1.1.3",
+        "extend": "2.0.1",
+        "globby": "2.1.0",
+        "multimatch": "2.1.0",
+        "path-exists": "1.0.0",
+        "strip-json-comments": "1.0.4",
+        "vinyl-fs": "2.4.4"
+      },
       "dependencies": {
-        "chalk": {
-          "version": "1.1.1",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
         "extend": {
           "version": "2.0.1",
-          "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
+          "integrity": "sha1-HugBBonnOV/5RIJByYZSvHWagmA="
         },
-        "globby": {
-          "version": "2.1.0",
-          "from": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
-          "dependencies": {
-            "array-union": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                }
-              }
-            },
-            "async": {
-              "version": "1.5.0",
-              "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-            },
-            "object-assign": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
-            }
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "requires": {
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
-        "multimatch": {
-          "version": "2.1.0",
-          "from": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+        "glob-stream": {
+          "version": "5.3.5",
+          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+          "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+          "requires": {
+            "extend": "3.0.1",
+            "glob": "5.0.15",
+            "glob-parent": "3.1.0",
+            "micromatch": "2.3.11",
+            "ordered-read-streams": "0.3.0",
+            "through2": "0.6.5",
+            "to-absolute-glob": "0.1.1",
+            "unique-stream": "2.2.1"
+          },
           "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+            "extend": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
             },
-            "array-union": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                }
-              }
-            },
-            "arrify": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
-        },
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-        },
-        "vinyl-fs": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
-          "dependencies": {
-            "duplexify": {
-              "version": "3.4.2",
-              "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
-              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
-              "dependencies": {
-                "end-of-stream": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "glob-stream": {
-              "version": "4.1.1",
-              "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "4.5.3",
-                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "ordered-read-streams": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
-                },
-                "glob2base": {
-                  "version": "0.0.12",
-                  "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-                  "dependencies": {
-                    "find-index": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
-                    }
-                  }
-                },
-                "unique-stream": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.0.tgz",
-                  "dependencies": {
-                    "through2-filter": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-                      "dependencies": {
-                        "through2": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
-                          "dependencies": {
-                            "readable-stream": {
-                              "version": "2.0.5",
-                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                },
-                                "isarray": {
-                                  "version": "0.0.1",
-                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                                },
-                                "process-nextick-args": {
-                                  "version": "1.0.6",
-                                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                },
-                                "util-deprecate": {
-                                  "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "xtend": {
-                          "version": "4.0.1",
-                          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "glob-watcher": {
-              "version": "0.0.8",
-              "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
-              "dependencies": {
-                "gaze": {
-                  "version": "0.5.2",
-                  "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-                  "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-                  "dependencies": {
-                    "globule": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-                      "dependencies": {
-                        "lodash": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                        },
-                        "glob": {
-                          "version": "3.1.21",
-                          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "1.2.3",
-                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                            },
-                            "inherits": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "minimatch": {
-                          "version": "0.2.14",
-                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-                          "dependencies": {
-                            "lru-cache": {
-                              "version": "2.7.3",
-                              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                            },
-                            "sigmund": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "3.0.8",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-            },
-            "merge-stream": {
-              "version": "0.1.8",
-              "from": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz",
-              "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.1.1",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-            },
-            "strip-bom": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-              "dependencies": {
-                "first-chunk-stream": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
-                },
-                "is-utf8": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
-                }
+            "readable-stream": {
+              "version": "1.0.34",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
               }
             },
             "through2": {
               "version": "0.6.5",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            },
-            "vinyl": {
-              "version": "0.4.6",
-              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-              "dependencies": {
-                "clone": {
-                  "version": "0.2.0",
-                  "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-                },
-                "clone-stats": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-                }
+              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+              "requires": {
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
               }
             }
           }
-        }
-      }
-    },
-    "marked": {
-      "version": "0.3.5",
-      "from": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
-    },
-    "node-libs-browser": {
-      "version": "0.5.3",
-      "from": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
-      "dependencies": {
-        "assert": {
-          "version": "1.3.0",
-          "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
         },
-        "browserify-zlib": {
-          "version": "0.1.4",
-          "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-          "dependencies": {
-            "pako": {
-              "version": "0.2.8",
-              "from": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz",
-              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
-            }
+        "gulp-sourcemaps": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+          "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+          "requires": {
+            "convert-source-map": "1.5.1",
+            "graceful-fs": "4.1.11",
+            "strip-bom": "2.0.0",
+            "through2": "2.0.3",
+            "vinyl": "1.2.0"
           }
         },
-        "buffer": {
-          "version": "3.5.5",
-          "from": "https://registry.npmjs.org/buffer/-/buffer-3.5.5.tgz",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.5.5.tgz",
-          "dependencies": {
-            "base64-js": {
-              "version": "0.0.8",
-              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
-            },
-            "ieee754": {
-              "version": "1.1.6",
-              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            }
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "requires": {
+            "is-extglob": "2.1.1"
           }
         },
-        "console-browserify": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-          "dependencies": {
-            "date-now": {
-              "version": "0.1.4",
-              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
-            }
-          }
-        },
-        "constants-browserify": {
+        "isarray": {
           "version": "0.0.1",
-          "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
-        "crypto-browserify": {
-          "version": "3.2.8",
-          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
-          "dependencies": {
-            "pbkdf2-compat": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
-            },
-            "ripemd160": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
-            },
-            "sha.js": {
-              "version": "2.2.6",
-              "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
-              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
-            }
-          }
-        },
-        "domain-browser": {
-          "version": "1.1.7",
-          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
-        },
-        "events": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/events/-/events-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
-        },
-        "http-browserify": {
-          "version": "1.7.0",
-          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
-          "dependencies": {
-            "Base64": {
-              "version": "0.2.1",
-              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
-          }
-        },
-        "https-browserify": {
-          "version": "0.0.0",
-          "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
-        },
-        "os-browserify": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
-        },
-        "path-browserify": {
-          "version": "0.0.0",
-          "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
-        },
-        "process": {
-          "version": "0.11.2",
-          "from": "https://registry.npmjs.org/process/-/process-0.11.2.tgz",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
-        },
-        "punycode": {
-          "version": "1.4.0",
-          "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz"
-        },
-        "querystring-es3": {
-          "version": "0.2.1",
-          "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
-          }
-        },
-        "stream-browserify": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
+        "ordered-read-streams": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+          "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+          "requires": {
+            "is-stream": "1.1.0",
+            "readable-stream": "2.3.6"
           }
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
-        "timers-browserify": {
-          "version": "1.4.2",
-          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
-        },
-        "tty-browserify": {
-          "version": "0.0.0",
-          "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
-        },
-        "url": {
-          "version": "0.10.3",
-          "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-          "dependencies": {
-            "punycode": {
-              "version": "1.3.2",
-              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-            },
-            "querystring": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
-            }
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "0.2.1"
           }
         },
-        "util": {
-          "version": "0.10.3",
-          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
+        "unique-stream": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+          "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+          "requires": {
+            "json-stable-stringify": "1.0.1",
+            "through2-filter": "2.0.0"
           }
         },
-        "vm-browserify": {
-          "version": "0.0.4",
-          "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-          "dependencies": {
-            "indexof": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-            }
+        "vinyl": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+          "requires": {
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
+            "replace-ext": "0.0.1"
+          }
+        },
+        "vinyl-fs": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+          "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+          "requires": {
+            "duplexify": "3.5.4",
+            "glob-stream": "5.3.5",
+            "graceful-fs": "4.1.11",
+            "gulp-sourcemaps": "1.6.0",
+            "is-valid-glob": "0.3.0",
+            "lazystream": "1.0.0",
+            "lodash.isequal": "4.5.0",
+            "merge-stream": "1.0.1",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "readable-stream": "2.3.6",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "1.0.0",
+            "through2": "2.0.3",
+            "through2-filter": "2.0.0",
+            "vali-date": "1.0.0",
+            "vinyl": "1.2.0"
           }
         }
       }
     },
-    "redux": {
-      "version": "3.0.5",
-      "from": "https://registry.npmjs.org/redux/-/redux-3.0.5.tgz",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.0.5.tgz"
-    },
-    "redux-actions": {
-      "version": "0.9.0",
-      "from": "https://registry.npmjs.org/redux-actions/-/redux-actions-0.9.0.tgz",
-      "resolved": "https://registry.npmjs.org/redux-actions/-/redux-actions-0.9.0.tgz",
+    "make-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+      "requires": {
+        "kind-of": "6.0.2"
+      },
       "dependencies": {
-        "flux-standard-action": {
-          "version": "0.6.0",
-          "from": "https://registry.npmjs.org/flux-standard-action/-/flux-standard-action-0.6.0.tgz",
-          "resolved": "https://registry.npmjs.org/flux-standard-action/-/flux-standard-action-0.6.0.tgz",
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+    },
+    "math-expression-evaluator": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+      "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
+    },
+    "memory-fs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+      "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
+      "requires": {
+        "errno": "0.1.7",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "merge-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+      "requires": {
+        "readable-stream": "2.3.6"
+      }
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "optional": true
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "minimatch": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multimatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        }
+      }
+    },
+    "multipipe": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+      "requires": {
+        "duplexer2": "0.0.2"
+      }
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
+      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-odd": "2.0.0",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "natives": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.3.tgz",
+      "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g=="
+    },
+    "node-libs-browser": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
+      "integrity": "sha1-Ve+oiOyQes24z/xOelFxJ4DhO2o=",
+      "requires": {
+        "assert": "1.4.1",
+        "browserify-zlib": "0.1.4",
+        "buffer": "3.6.0",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "3.2.8",
+        "domain-browser": "1.2.0",
+        "events": "1.1.1",
+        "http-browserify": "1.7.0",
+        "https-browserify": "0.0.0",
+        "os-browserify": "0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "1.1.14",
+        "stream-browserify": "1.0.0",
+        "string_decoder": "0.10.31",
+        "timers-browserify": "1.4.2",
+        "tty-browserify": "0.0.0",
+        "url": "0.10.3",
+        "util": "0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+    },
+    "normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "prepend-http": "1.0.4",
+        "query-string": "4.3.4",
+        "sort-keys": "1.1.2"
+      }
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "optional": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
+    },
+    "object-keys": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "object.defaults": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "requires": {
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "object.map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "requires": {
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        }
+      }
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+        }
+      }
+    },
+    "orchestrator": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+      "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
+      "requires": {
+        "end-of-stream": "0.1.5",
+        "sequencify": "0.0.7",
+        "stream-consume": "0.1.1"
+      }
+    },
+    "ordered-read-streams": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+      "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY="
+    },
+    "os-browserify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ="
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "output-file-sync": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
+    },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+    },
+    "parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "requires": {
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+    },
+    "path-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+    },
+    "path-exists": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+      "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "requires": {
+        "path-root-regex": "0.1.2"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
+    },
+    "pbkdf2-compat": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
+      "integrity": "sha1-tuDI+plJTZTgURV1gCpZpcFC8og="
+    },
+    "performance-now": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+      "optional": true
+    },
+    "plugin-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+      "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+      "requires": {
+        "ansi-colors": "1.1.0",
+        "arr-diff": "4.0.0",
+        "arr-union": "3.1.0",
+        "extend-shallow": "3.0.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        }
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    },
+    "postcss": {
+      "version": "5.2.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+      "requires": {
+        "chalk": "1.1.3",
+        "js-base64": "2.4.3",
+        "source-map": "0.5.7",
+        "supports-color": "3.2.3"
+      }
+    },
+    "postcss-calc": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+      "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-css-calc": "1.3.0"
+      }
+    },
+    "postcss-colormin": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+      "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+      "requires": {
+        "colormin": "1.1.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-convert-values": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+      "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-discard-comments": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+      "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-duplicates": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+      "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-empty": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+      "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-overridden": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+      "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-discard-unused": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+      "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+      "requires": {
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
+      }
+    },
+    "postcss-filter-plugins": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+      "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+      "requires": {
+        "postcss": "5.2.18",
+        "uniqid": "4.1.1"
+      }
+    },
+    "postcss-merge-idents": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+      "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-merge-longhand": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+      "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-merge-rules": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+      "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-api": "1.6.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3",
+        "vendors": "1.0.1"
+      }
+    },
+    "postcss-message-helpers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+      "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
+    },
+    "postcss-minify-font-values": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+      "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-minify-gradients": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+      "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-minify-params": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+      "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "uniqs": "2.0.0"
+      }
+    },
+    "postcss-minify-selectors": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+      "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3"
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+      "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
+      "requires": {
+        "postcss": "6.0.21"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "postcss": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+          "requires": {
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+      "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+      "requires": {
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.21"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "css-selector-tokenizer": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+          "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+          "requires": {
+            "cssesc": "0.1.0",
+            "fastparse": "1.1.1",
+            "regexpu-core": "1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "postcss": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+          "requires": {
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+      "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+      "requires": {
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.21"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "css-selector-tokenizer": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+          "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+          "requires": {
+            "cssesc": "0.1.0",
+            "fastparse": "1.1.1",
+            "regexpu-core": "1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "postcss": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+          "requires": {
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-values": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+      "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+      "requires": {
+        "icss-replace-symbols": "1.1.0",
+        "postcss": "6.0.21"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "postcss": {
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+          "requires": {
+            "chalk": "2.3.2",
+            "source-map": "0.6.1",
+            "supports-color": "5.3.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-normalize-charset": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+      "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-normalize-url": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+      "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+      "requires": {
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "1.9.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-ordered-values": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+      "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-reduce-idents": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+      "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+      "requires": {
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-reduce-initial": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+      "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-reduce-transforms": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+      "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-safe-parser": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-1.0.7.tgz",
+      "integrity": "sha1-Q70MjITV99hHTeglxpnk2ryscqg=",
+      "requires": {
+        "postcss": "5.2.18"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+      "requires": {
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
+      }
+    },
+    "postcss-svgo": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+      "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+      "requires": {
+        "is-svg": "2.1.0",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "0.7.2"
+      }
+    },
+    "postcss-unique-selectors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+      "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+    },
+    "postcss-zindex": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+      "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
+      }
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "pretty-bytes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+      "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "pretty-hrtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "optional": true,
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "qs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+      "optional": true
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
+      }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+    },
+    "randomatic": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
           "dependencies": {
-            "lodash.isplainobject": {
-              "version": "3.2.0",
-              "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
-              "dependencies": {
-                "lodash._basefor": {
-                  "version": "3.0.3",
-                  "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.5",
-                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.5.tgz"
-                },
-                "lodash.keysin": {
-                  "version": "3.0.8",
-                  "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
-                  "dependencies": {
-                    "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                    }
-                  }
-                }
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
               }
             }
           }
         },
-        "reduce-reducers": {
-          "version": "0.1.1",
-          "from": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.1.tgz"
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
         }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "readdirp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        }
+      }
+    },
+    "recast": {
+      "version": "0.10.33",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+      "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
+      "requires": {
+        "ast-types": "0.8.12",
+        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+        "private": "0.1.8",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.8.12",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+          "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w="
+        }
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "1.7.0"
+      }
+    },
+    "reduce-css-calc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+      "requires": {
+        "balanced-match": "0.4.2",
+        "math-expression-evaluator": "1.2.17",
+        "reduce-function-call": "1.0.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        }
+      }
+    },
+    "reduce-function-call": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+      "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
+      "requires": {
+        "balanced-match": "0.4.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        }
+      }
+    },
+    "reduce-reducers": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.2.tgz",
+      "integrity": "sha1-+htHGLxSkqcd3R5dg5yb6pdw8Us="
+    },
+    "redux": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "requires": {
+        "lodash": "4.17.5",
+        "lodash-es": "4.17.8",
+        "loose-envify": "1.3.1",
+        "symbol-observable": "1.2.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+        }
+      }
+    },
+    "redux-actions": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/redux-actions/-/redux-actions-0.9.1.tgz",
+      "integrity": "sha1-pydnZUvCFCTD3z9iQHgP+ohyeDw=",
+      "requires": {
+        "flux-standard-action": "0.6.1",
+        "reduce-reducers": "0.1.2"
       }
     },
     "redux-persist": {
       "version": "3.1.1",
-      "from": "redux-persist@*",
       "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-3.1.1.tgz",
+      "integrity": "sha1-RdAEONUYwMI3TCuirdKbNQke2UE=",
+      "requires": {
+        "json-stringify-safe": "5.0.1",
+        "lodash": "4.12.0"
+      },
       "dependencies": {
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <6.0.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
         "lodash": {
           "version": "4.12.0",
-          "from": "lodash@>=4.11.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz",
+          "integrity": "sha1-K9bcRqBA9Z5obJcu0h2T3FkFMlg="
         }
       }
     },
+    "regenerate": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
+    },
+    "regenerator": {
+      "version": "0.8.40",
+      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+      "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
+      "requires": {
+        "commoner": "0.10.8",
+        "defs": "1.1.1",
+        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+        "private": "0.1.8",
+        "recast": "0.10.33",
+        "through": "2.3.8"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "requires": {
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "regexpu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+      "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
+      "requires": {
+        "esprima": "2.7.3",
+        "recast": "0.10.33",
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+        }
+      }
+    },
+    "regexpu-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+      "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+      "requires": {
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "requires": {
+        "jsesc": "0.5.0"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "repeating": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+      "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "replace-ext": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+    },
+    "request": {
+      "version": "2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "optional": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      }
+    },
+    "resolve": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
+      "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
+    "ripemd160": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
+      "integrity": "sha1-K/GYveFnys+lHAqSjoS2i74XH84="
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "requires": {
+        "ret": "0.1.15"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "semver": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+    },
+    "sequencify": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+      "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw="
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "sha.js": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
+      "integrity": "sha1-F93t3F9yL7ZlAWWIlUYZd4ZzFbo="
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+    },
+    "simple-fmt": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
+      "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms="
+    },
+    "simple-is": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+      "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA="
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.1",
+        "use": "3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "optional": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
+    },
+    "source-list-map": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+      "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY="
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-resolve": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
+      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "requires": {
+        "atob": "2.1.0",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+      "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+      "requires": {
+        "source-map": "0.1.32"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+          "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "sparkles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "requires": {
+        "extend-shallow": "3.0.2"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sshpk": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "optional": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "optional": true
+        }
+      }
+    },
+    "stable": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
+      "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA="
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
+    },
+    "stream-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+      "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "1.1.14"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "stream-consume": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
+      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg=="
+    },
+    "stream-counter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-1.0.0.tgz",
+      "integrity": "sha1-kc8lac5NxQYf6816yyY5SloRR1E="
+    },
+    "stream-http": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
+      "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
+      "requires": {
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "stringmap": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
+      "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE="
+    },
+    "stringset": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+      "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "optional": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-bom": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+      "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+      "requires": {
+        "first-chunk-stream": "1.0.0",
+        "is-utf8": "0.2.1"
+      }
+    },
+    "strip-bom-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+      "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+      "requires": {
+        "first-chunk-stream": "1.0.0",
+        "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
+      }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
+    },
     "style-loader": {
-      "version": "0.13.0",
-      "from": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.0.tgz",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.0.tgz",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.2.tgz",
+      "integrity": "sha1-dFMzhM9pjHEEx5URULSXF63C87s=",
+      "requires": {
+        "loader-utils": "1.1.0"
+      },
       "dependencies": {
         "loader-utils": {
-          "version": "0.2.12",
-          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        }
+      }
+    },
+    "supports-color": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "requires": {
+        "has-flag": "1.0.0"
+      }
+    },
+    "svgo": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+      "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+      "requires": {
+        "coa": "1.0.4",
+        "colors": "1.1.2",
+        "csso": "2.3.2",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "sax": "1.2.4",
+        "whet.extend": "0.9.9"
+      }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
+    "tapable": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+      "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q="
+    },
+    "ternary-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+      "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
+      "requires": {
+        "duplexify": "3.5.4",
+        "fork-stream": "0.0.4",
+        "merge-stream": "1.0.1",
+        "through2": "2.0.3"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
+      }
+    },
+    "through2-filter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+      "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+      "requires": {
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "tildify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "time-stamp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+    },
+    "timers-browserify": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+      "requires": {
+        "process": "0.11.10"
+      }
+    },
+    "to-absolute-glob": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+      "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+      "requires": {
+        "extend-shallow": "2.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "requires": {
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        }
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "optional": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "try-resolve": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
+      "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI="
+    },
+    "tryor": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+      "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys="
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "optional": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
+      "dependencies": {
+        "window-size": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
+    },
+    "uglify-save-license": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz",
+      "integrity": "sha1-lXJsF8xv0XHDYX479NjYKqjEzOE="
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+    },
+    "uniqid": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+      "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
+      "requires": {
+        "macaddress": "0.2.8"
+      }
+    },
+    "uniqs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+      "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
+    },
+    "unique-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+      "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
           "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "json5": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "1.0.0"
+              }
             }
           }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },
     "url-loader": {
-      "version": "0.5.7",
-      "from": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.7.tgz",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.7.tgz",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
+      "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
+      "requires": {
+        "loader-utils": "1.1.0",
+        "mime": "1.3.6"
+      },
       "dependencies": {
         "loader-utils": {
-          "version": "0.2.12",
-          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "json5": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-            }
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
           }
         },
         "mime": {
-          "version": "1.2.11",
-          "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
+          "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
+        }
+      }
+    },
+    "use": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+      "requires": {
+        "kind-of": "6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "optional": true
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "requires": {
+        "user-home": "1.1.1"
+      }
+    },
+    "vali-date": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
+    },
+    "vendors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
+      "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "optional": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "optional": true
+        }
+      }
+    },
+    "vinyl": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+      "requires": {
+        "clone": "1.0.4",
+        "clone-stats": "0.0.1",
+        "replace-ext": "0.0.1"
+      }
+    },
+    "vinyl-fs": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+      "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+      "requires": {
+        "defaults": "1.0.3",
+        "glob-stream": "3.1.18",
+        "glob-watcher": "0.0.6",
+        "graceful-fs": "3.0.11",
+        "mkdirp": "0.5.1",
+        "strip-bom": "1.0.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+        },
+        "graceful-fs": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "requires": {
+            "natives": "1.1.3"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "requires": {
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
+          }
         }
       }
     },
     "vinyl-source-stream": {
-      "version": "1.1.0",
-      "from": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
+      "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
+      "requires": {
+        "through2": "2.0.3",
+        "vinyl": "0.4.6"
+      },
       "dependencies": {
+        "clone": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+        },
         "vinyl": {
           "version": "0.4.6",
-          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "dependencies": {
-            "clone": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
-            },
-            "clone-stats": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "requires": {
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
           }
         }
       }
     },
-    "webpack": {
-      "version": "1.12.9",
-      "from": "https://registry.npmjs.org/webpack/-/webpack-1.12.9.tgz",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.9.tgz",
+    "vinyl-sourcemaps-apply": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
+    "watchpack": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+      "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
+      "requires": {
+        "async": "0.9.2",
+        "chokidar": "1.7.0",
+        "graceful-fs": "4.1.11"
+      },
       "dependencies": {
         "async": {
-          "version": "1.5.0",
-          "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        }
+      }
+    },
+    "webpack": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz",
+      "integrity": "sha1-T/MfU9sDM55VFkqdRo7gMklo/pg=",
+      "requires": {
+        "acorn": "3.3.0",
+        "async": "1.5.2",
+        "clone": "1.0.4",
+        "enhanced-resolve": "0.9.1",
+        "interpret": "0.6.6",
+        "loader-utils": "0.2.17",
+        "memory-fs": "0.3.0",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "0.7.0",
+        "optimist": "0.6.1",
+        "supports-color": "3.2.3",
+        "tapable": "0.1.10",
+        "uglify-js": "2.7.5",
+        "watchpack": "0.2.9",
+        "webpack-core": "0.6.9"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
         },
-        "clone": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
-        "enhanced-resolve": {
-          "version": "0.9.1",
-          "from": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
-          "dependencies": {
-            "memory-fs": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
-            },
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            }
+        "base64-js": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+          "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w=="
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "requires": {
+            "base64-js": "1.2.3",
+            "ieee754": "1.1.11",
+            "isarray": "1.0.0"
           }
         },
-        "esprima": {
-          "version": "2.7.1",
-          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+        "constants-browserify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+          "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+        },
+        "crypto-browserify": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
+          "integrity": "sha1-ufx1u0oO1h3PHNXa6W6zDJw+UGw=",
+          "requires": {
+            "browserify-aes": "0.4.0",
+            "pbkdf2-compat": "2.0.1",
+            "ripemd160": "0.2.0",
+            "sha.js": "2.2.6"
+          }
+        },
+        "https-browserify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+          "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
         },
         "interpret": {
           "version": "0.6.6",
-          "from": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
+          "integrity": "sha1-/s16GOfOXKar+5U+H4YhOknxYls="
         },
-        "loader-utils": {
-          "version": "0.2.12",
-          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "json5": {
-              "version": "0.4.0",
-              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-            }
+        "node-libs-browser": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
+          "integrity": "sha1-PicsCBnjCJNeJmdECNevDhSRuDs=",
+          "requires": {
+            "assert": "1.4.1",
+            "browserify-zlib": "0.1.4",
+            "buffer": "4.9.1",
+            "console-browserify": "1.1.0",
+            "constants-browserify": "1.0.0",
+            "crypto-browserify": "3.3.0",
+            "domain-browser": "1.2.0",
+            "events": "1.1.1",
+            "https-browserify": "0.0.1",
+            "os-browserify": "0.2.1",
+            "path-browserify": "0.0.0",
+            "process": "0.11.10",
+            "punycode": "1.4.1",
+            "querystring-es3": "0.2.1",
+            "readable-stream": "2.3.6",
+            "stream-browserify": "2.0.1",
+            "stream-http": "2.8.1",
+            "string_decoder": "0.10.31",
+            "timers-browserify": "2.0.6",
+            "tty-browserify": "0.0.0",
+            "url": "0.11.0",
+            "util": "0.10.3",
+            "vm-browserify": "0.0.4"
           }
         },
-        "memory-fs": {
-          "version": "0.3.0",
-          "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
-          "dependencies": {
-            "errno": {
-              "version": "0.1.4",
-              "from": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-              "dependencies": {
-                "prr": {
-                  "version": "0.0.0",
-                  "from": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.0.5",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            }
+        "os-browserify": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+          "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
+        },
+        "stream-browserify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+          "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6"
           }
         },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
-        "optimist": {
-          "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-            },
-            "minimist": {
-              "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            }
+        "timers-browserify": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
+          "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
+          "requires": {
+            "setimmediate": "1.0.5"
           }
-        },
-        "supports-color": {
-          "version": "3.1.2",
-          "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "dependencies": {
-            "has-flag": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-            }
-          }
-        },
-        "tapable": {
-          "version": "0.1.10",
-          "from": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
         },
         "uglify-js": {
-          "version": "2.6.1",
-          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+          "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
+          "requires": {
+            "async": "0.2.10",
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-            },
-            "source-map": {
-              "version": "0.5.3",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-            },
-            "yargs": {
-              "version": "3.10.0",
-              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                },
-                "cliui": {
-                  "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "dependencies": {
-                    "center-align": {
-                      "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                }
-                              }
-                            },
-                            "longest": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.2",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                            }
-                          }
-                        },
-                        "lazy-cache": {
-                          "version": "0.2.7",
-                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
-                        }
-                      }
-                    },
-                    "right-align": {
-                      "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.0",
-                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                }
-                              }
-                            },
-                            "longest": {
-                              "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.5.2",
-                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
-                },
-                "window-size": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
             }
           }
         },
-        "watchpack": {
-          "version": "0.2.9",
-          "from": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
-          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+        "url": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+          "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          },
           "dependencies": {
-            "async": {
-              "version": "0.9.2",
-              "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-            },
-            "graceful-fs": {
-              "version": "4.1.2",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+            "punycode": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
             }
           }
         },
-        "webpack-core": {
-          "version": "0.6.8",
-          "from": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
-          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                }
-              }
-            },
-            "source-list-map": {
-              "version": "0.1.5",
-              "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
-              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
-            }
+        "window-size": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
           }
         }
+      }
+    },
+    "webpack-core": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
+      "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
+      "requires": {
+        "source-list-map": "0.1.8",
+        "source-map": "0.4.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "when": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
+    },
+    "whet.extend": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+      "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yargs": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+      "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "os-locale": "1.4.0",
+        "window-size": "0.1.4",
+        "y18n": "3.2.1"
       }
     }
   }

--- a/shuup/front/npm-shrinkwrap.json
+++ b/shuup/front/npm-shrinkwrap.json
@@ -1,74 +1,95 @@
 {
   "name": "shuup_front",
   "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "bower": {
       "version": "1.8.0",
-      "from": "bower@>=1.8.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+      "integrity": "sha1-Vdvr7wrZFVOC2enT5JfBNyNFtEo=",
       "dependencies": {
         "abbrev": {
           "version": "1.0.7",
-          "from": "abbrev@>=1.0.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
+          "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM="
         },
         "archy": {
           "version": "1.0.0",
-          "from": "archy@1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
         },
         "bower-config": {
           "version": "1.3.0",
-          "from": "bower-config@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.3.0.tgz",
+          "integrity": "sha1-zBD9cqNYBRoCVxW/C5ops1u7a70=",
+          "requires": {
+            "graceful-fs": "4.1.2",
+            "mout": "0.11.1",
+            "optimist": "0.6.1",
+            "osenv": "0.1.3",
+            "untildify": "2.1.0"
+          },
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.2",
-              "from": "graceful-fs@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+              "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
             },
             "optimist": {
               "version": "0.6.1",
-              "from": "optimist@>=0.6.1 <0.7.0",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+              "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+              },
               "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                },
                 "minimist": {
                   "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
                 }
               }
             },
             "osenv": {
               "version": "0.1.3",
-              "from": "osenv@>=0.1.3 <0.2.0",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+              "requires": {
+                "os-homedir": "1.0.1",
+                "os-tmpdir": "1.0.1"
+              },
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                  "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac="
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24="
                 }
               }
             },
             "untildify": {
               "version": "2.1.0",
-              "from": "untildify@2.1.0",
               "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+              "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+              "requires": {
+                "os-homedir": "1.0.1"
+              },
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                  "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac="
                 }
               }
             }
@@ -76,281 +97,372 @@
         },
         "bower-endpoint-parser": {
           "version": "0.2.2",
-          "from": "bower-endpoint-parser@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz",
+          "integrity": "sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y="
         },
         "bower-json": {
           "version": "0.4.0",
-          "from": "bower-json@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+          "integrity": "sha1-qZw8z0Fu8FkO0N7SUsdg8cbZN2Y=",
+          "requires": {
+            "deep-extend": "0.2.11",
+            "graceful-fs": "2.0.3",
+            "intersect": "0.0.3"
+          },
           "dependencies": {
             "deep-extend": {
               "version": "0.2.11",
-              "from": "deep-extend@>=0.2.5 <0.3.0",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+              "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8="
             },
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
             },
             "intersect": {
               "version": "0.0.3",
-              "from": "intersect@>=0.0.3 <0.1.0",
-              "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz",
+              "integrity": "sha1-waSl5erG7eSvdQTMB+Ctp7yfSSA="
             }
           }
         },
         "bower-logger": {
           "version": "0.2.2",
-          "from": "bower-logger@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz",
+          "integrity": "sha1-Ob4H6Xmy/I4DqUY0IF7ZQiNz04E="
         },
         "bower-registry-client": {
           "version": "1.0.0",
-          "from": "bower-registry-client@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-1.0.0.tgz",
+          "integrity": "sha1-aXw0mQZ1SaEGtJ8m0D5t0QF6kkE=",
+          "requires": {
+            "async": "0.2.10",
+            "graceful-fs": "4.1.2",
+            "lru-cache": "2.7.3",
+            "mkdirp": "0.3.5",
+            "request": "2.53.0",
+            "request-replay": "0.2.0",
+            "rimraf": "2.4.4"
+          },
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.8 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
             },
             "graceful-fs": {
               "version": "4.1.2",
-              "from": "graceful-fs@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-            },
-            "request-replay": {
-              "version": "0.2.0",
-              "from": "request-replay@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+              "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
             },
             "mkdirp": {
               "version": "0.3.5",
-              "from": "mkdirp@>=0.3.5 <0.4.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+              "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+            },
+            "request-replay": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz",
+              "integrity": "sha1-m2k6XRGLOfXFlurV7ZGiZEQFf2A=",
+              "requires": {
+                "retry": "0.6.1"
+              }
             }
           }
         },
         "cardinal": {
           "version": "0.4.4",
-          "from": "cardinal@0.4.4",
           "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+          "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
+          "requires": {
+            "ansicolors": "0.2.1",
+            "redeyed": "0.4.4"
+          },
           "dependencies": {
+            "ansicolors": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+              "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
+            },
             "redeyed": {
               "version": "0.4.4",
-              "from": "redeyed@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+              "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
+              "requires": {
+                "esprima": "1.0.4"
+              },
               "dependencies": {
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "esprima@>=1.0.4 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                  "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
                 }
               }
-            },
-            "ansicolors": {
-              "version": "0.2.1",
-              "from": "ansicolors@>=0.2.1 <0.3.0",
-              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
             }
           }
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+          "requires": {
+            "ansi-styles": "2.1.0",
+            "escape-string-regexp": "1.0.3",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.0",
+            "supports-color": "2.0.0"
+          },
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+              "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
         "chmodr": {
           "version": "1.0.2",
-          "from": "chmodr@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
+          "integrity": "sha1-BGYrky0PAuxm3qorDqQoEZaOPrk="
         },
         "configstore": {
           "version": "0.3.2",
-          "from": "configstore@>=0.3.2 <0.4.0",
           "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+          "integrity": "sha1-JeTBbDdoq/dcWmW8YXYfSVBVtFk=",
+          "requires": {
+            "graceful-fs": "3.0.8",
+            "js-yaml": "3.4.6",
+            "mkdirp": "0.5.0",
+            "object-assign": "2.1.1",
+            "osenv": "0.1.3",
+            "user-home": "1.1.1",
+            "uuid": "2.0.1",
+            "xdg-basedir": "1.0.1"
+          },
           "dependencies": {
             "js-yaml": {
               "version": "3.4.6",
-              "from": "js-yaml@>=3.1.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
+              "integrity": "sha1-a+GyP2JJ9T0pM3D9TRqqY84bTrA=",
+              "requires": {
+                "argparse": "1.0.3",
+                "esprima": "2.7.1",
+                "inherit": "2.2.2"
+              },
               "dependencies": {
                 "argparse": {
                   "version": "1.0.3",
-                  "from": "argparse@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
+                  "integrity": "sha1-FDid7rDCj8TNqUBbn1MqTjeFzoQ=",
+                  "requires": {
+                    "lodash": "3.10.1",
+                    "sprintf-js": "1.0.3"
+                  },
                   "dependencies": {
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.2.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                     },
                     "sprintf-js": {
                       "version": "1.0.3",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
                     }
                   }
                 },
                 "esprima": {
                   "version": "2.7.1",
-                  "from": "esprima@>=2.6.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
+                  "integrity": "sha1-KrfRVJ7dBtFNaabBoXVKygLpZX4="
                 },
                 "inherit": {
                   "version": "2.2.2",
-                  "from": "inherit@>=2.2.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.2.tgz"
+                  "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.2.tgz",
+                  "integrity": "sha1-O1s0F9Q0+BojTWj3lhJhXkFiRKM="
                 }
               }
             },
             "object-assign": {
               "version": "2.1.1",
-              "from": "object-assign@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+              "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
             },
             "osenv": {
               "version": "0.1.3",
-              "from": "osenv@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+              "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+              "requires": {
+                "os-homedir": "1.0.1",
+                "os-tmpdir": "1.0.1"
+              },
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                  "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac="
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24="
                 }
               }
             },
             "uuid": {
               "version": "2.0.1",
-              "from": "uuid@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+              "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
             },
             "xdg-basedir": {
               "version": "1.0.1",
-              "from": "xdg-basedir@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
+              "integrity": "sha1-FP+PY6T9vLBdW27qIrNvMDO58E4=",
+              "requires": {
+                "user-home": "1.1.1"
+              }
             }
           }
         },
         "decompress-zip": {
           "version": "0.1.0",
-          "from": "decompress-zip@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
+          "integrity": "sha1-vOYMEWZPLWYPykvPY0r23l1sFMc=",
+          "requires": {
+            "binary": "0.3.0",
+            "graceful-fs": "3.0.8",
+            "mkpath": "0.1.0",
+            "nopt": "3.0.6",
+            "q": "1.4.1",
+            "readable-stream": "1.1.13",
+            "touch": "0.0.3"
+          },
           "dependencies": {
             "binary": {
               "version": "0.3.0",
-              "from": "binary@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+              "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+              "requires": {
+                "buffers": "0.1.1",
+                "chainsaw": "0.1.0"
+              },
               "dependencies": {
+                "buffers": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+                  "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
+                },
                 "chainsaw": {
                   "version": "0.1.0",
-                  "from": "chainsaw@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                  "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+                  "requires": {
+                    "traverse": "0.3.9"
+                  },
                   "dependencies": {
                     "traverse": {
                       "version": "0.3.9",
-                      "from": "traverse@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+                      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
                     }
                   }
-                },
-                "buffers": {
-                  "version": "0.1.1",
-                  "from": "buffers@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
                 }
               }
             },
             "mkpath": {
               "version": "0.1.0",
-              "from": "mkpath@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+              "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE="
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.8 <2.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 }
               }
             },
             "touch": {
               "version": "0.0.3",
-              "from": "touch@0.0.3",
               "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+              "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
+              "requires": {
+                "nopt": "1.0.10"
+              },
               "dependencies": {
                 "nopt": {
                   "version": "1.0.10",
-                  "from": "nopt@>=1.0.10 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+                  "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+                  "requires": {
+                    "abbrev": "1.0.7"
+                  }
                 }
               }
             }
@@ -358,63 +470,77 @@
         },
         "destroy": {
           "version": "1.0.3",
-          "from": "destroy@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
+          "integrity": "sha1-tDO0ck5x/YVR2YhRdIUcX8N34sk="
         },
         "fs-write-stream-atomic": {
           "version": "1.0.7",
-          "from": "fs-write-stream-atomic@>=1.0.5 <2.0.0",
           "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.7.tgz",
+          "integrity": "sha1-a56kN4AmiDXy7GqPLuWspCxfYTA=",
+          "requires": {
+            "graceful-fs": "4.1.2",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.0.4"
+          },
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.2",
-              "from": "graceful-fs@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+              "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
             },
             "iferr": {
               "version": "0.1.5",
-              "from": "iferr@>=0.1.5 <0.2.0",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz"
+              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
             },
             "imurmurhash": {
               "version": "0.1.4",
-              "from": "imurmurhash@>=0.1.4 <0.2.0",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
             },
             "readable-stream": {
               "version": "2.0.4",
-              "from": "readable-stream@>=1.0.0 <2.0.0||>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+              "integrity": "sha1-JSPvJ/+jOde6nahgPy0FmdBu29g=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "process-nextick-args": "1.0.6",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                  "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                 }
               }
             }
@@ -422,50 +548,68 @@
         },
         "fstream": {
           "version": "1.0.8",
-          "from": "fstream@>=1.0.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz",
+          "integrity": "sha1-fo16c6uzZH7zbkuKFcqAHboD0Dg=",
+          "requires": {
+            "graceful-fs": "4.1.2",
+            "inherits": "2.0.1",
+            "mkdirp": "0.5.0",
+            "rimraf": "2.4.4"
+          },
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.2",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+              "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
             }
           }
         },
         "fstream-ignore": {
           "version": "1.0.3",
-          "from": "fstream-ignore@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
+          "integrity": "sha1-THTZH6iLIrQvT4ahiigg3XnY/N0=",
+          "requires": {
+            "fstream": "1.0.8",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.0"
+          },
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+              "requires": {
+                "brace-expansion": "1.1.2"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.2",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                  "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                  "requires": {
+                    "balanced-match": "0.3.0",
+                    "concat-map": "0.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                      "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                     }
                   }
                 }
@@ -475,57 +619,77 @@
         },
         "github": {
           "version": "0.2.4",
-          "from": "github@>=0.2.3 <0.3.0",
           "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
+          "integrity": "sha1-JPp/DhP6EblGr5ETTFGYKpHOU4s=",
+          "requires": {
+            "mime": "1.3.4"
+          },
           "dependencies": {
             "mime": {
               "version": "1.3.4",
-              "from": "mime@>=1.2.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
             }
           }
         },
         "glob": {
           "version": "4.5.3",
-          "from": "glob@>=4.3.2 <5.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "requires": {
+            "inflight": "1.0.4",
+            "inherits": "2.0.1",
+            "minimatch": "2.0.10",
+            "once": "1.3.3"
+          },
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+              "requires": {
+                "once": "1.3.3",
+                "wrappy": "1.0.1"
+              },
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                 }
               }
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+              "requires": {
+                "brace-expansion": "1.1.2"
+              },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.2",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                  "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                  "requires": {
+                    "balanced-match": "0.3.0",
+                    "concat-map": "0.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                      "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                     }
                   }
                 }
@@ -533,13 +697,16 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+              "requires": {
+                "wrappy": "1.0.1"
+              },
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                 }
               }
             }
@@ -547,45 +714,64 @@
         },
         "graceful-fs": {
           "version": "3.0.8",
-          "from": "graceful-fs@>=3.0.5 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+          "integrity": "sha1-zoE+cl+oL35hR9UcmlymgnBVHCI="
         },
         "handlebars": {
           "version": "2.0.0",
-          "from": "handlebars@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+          "integrity": "sha1-bp1/hRSjRn+l6fgswVjs/B1ax28=",
+          "requires": {
+            "optimist": "0.3.7",
+            "uglify-js": "2.3.6"
+          },
           "dependencies": {
             "optimist": {
               "version": "0.3.7",
-              "from": "optimist@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+              "requires": {
+                "wordwrap": "0.0.3"
+              },
               "dependencies": {
                 "wordwrap": {
                   "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
                 }
               }
             },
             "uglify-js": {
               "version": "2.3.6",
-              "from": "uglify-js@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
+              "optional": true,
+              "requires": {
+                "async": "0.2.10",
+                "optimist": "0.3.7",
+                "source-map": "0.1.43"
+              },
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                  "optional": true
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.7 <0.2.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+                  "optional": true,
+                  "requires": {
+                    "amdefine": "1.0.0"
+                  },
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                      "optional": true
                     }
                   }
                 }
@@ -595,38 +781,59 @@
         },
         "inquirer": {
           "version": "0.10.0",
-          "from": "inquirer@0.10.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.10.0.tgz",
+          "integrity": "sha1-SM0+I/jZiaUtR9xeEOx1MkOH6Qg=",
+          "requires": {
+            "ansi-escapes": "1.1.0",
+            "ansi-regex": "2.0.0",
+            "chalk": "1.1.1",
+            "cli-cursor": "1.0.2",
+            "cli-width": "1.1.0",
+            "figures": "1.4.0",
+            "lodash": "3.10.1",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "strip-ansi": "3.0.0",
+            "through": "2.3.8"
+          },
           "dependencies": {
             "ansi-escapes": {
               "version": "1.1.0",
-              "from": "ansi-escapes@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.0.tgz",
+              "integrity": "sha1-IWCO3TpPxaVow7jYPtSswonV7Hc="
             },
             "ansi-regex": {
               "version": "2.0.0",
-              "from": "ansi-regex@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
             },
             "cli-cursor": {
               "version": "1.0.2",
-              "from": "cli-cursor@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+              "requires": {
+                "restore-cursor": "1.0.1"
+              },
               "dependencies": {
                 "restore-cursor": {
                   "version": "1.0.1",
-                  "from": "restore-cursor@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                  "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                  "requires": {
+                    "exit-hook": "1.1.1",
+                    "onetime": "1.0.0"
+                  },
                   "dependencies": {
                     "exit-hook": {
                       "version": "1.1.1",
-                      "from": "exit-hook@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+                      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
                     },
                     "onetime": {
                       "version": "1.0.0",
-                      "from": "onetime@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+                      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz",
+                      "integrity": "sha1-Ogio4514Ft9S00iGN0+47YtlH2I="
                     }
                   }
                 }
@@ -634,69 +841,86 @@
             },
             "cli-width": {
               "version": "1.1.0",
-              "from": "cli-width@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz",
+              "integrity": "sha1-32LR4amA72DRJW82TU8mlVlNfss="
             },
             "figures": {
               "version": "1.4.0",
-              "from": "figures@>=1.3.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz",
+              "integrity": "sha1-649WOQ2+MIEESlwqnZCJB1pIQy8="
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>=3.3.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
             },
             "readline2": {
               "version": "1.0.1",
-              "from": "readline2@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+              "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+              "requires": {
+                "code-point-at": "1.0.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "mute-stream": "0.0.5"
+              },
               "dependencies": {
                 "code-point-at": {
                   "version": "1.0.0",
-                  "from": "code-point-at@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                  "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                     }
                   }
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                     }
                   }
                 },
                 "mute-stream": {
                   "version": "0.0.5",
-                  "from": "mute-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                  "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
                 }
               }
             },
             "run-async": {
               "version": "0.1.0",
-              "from": "run-async@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+              "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+              "requires": {
+                "once": "1.3.3"
+              },
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "requires": {
+                    "wrappy": "1.0.1"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                     }
                   }
                 }
@@ -704,89 +928,125 @@
             },
             "rx-lite": {
               "version": "3.1.2",
-              "from": "rx-lite@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+              "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              }
             },
             "through": {
               "version": "2.3.8",
-              "from": "through@>=2.3.6 <3.0.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
             }
           }
         },
         "insight": {
           "version": "0.7.0",
-          "from": "insight@>=0.7.0 <0.8.0",
           "resolved": "https://registry.npmjs.org/insight/-/insight-0.7.0.tgz",
+          "integrity": "sha1-Bh+RiYNb04qXpgwrduoMazAJn/Y=",
+          "requires": {
+            "async": "1.5.0",
+            "chalk": "1.1.1",
+            "configstore": "1.4.0",
+            "inquirer": "0.10.0",
+            "lodash.debounce": "3.1.1",
+            "object-assign": "4.0.1",
+            "os-name": "1.0.3",
+            "request": "2.53.0",
+            "tough-cookie": "2.2.1"
+          },
           "dependencies": {
             "async": {
               "version": "1.5.0",
-              "from": "async@>=1.4.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+              "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM="
             },
             "configstore": {
               "version": "1.4.0",
-              "from": "configstore@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
+              "integrity": "sha1-w1eB0FAdJowlxUuLF/YkDopPsCE=",
+              "requires": {
+                "graceful-fs": "4.1.2",
+                "mkdirp": "0.5.0",
+                "object-assign": "4.0.1",
+                "os-tmpdir": "1.0.1",
+                "osenv": "0.1.3",
+                "uuid": "2.0.1",
+                "write-file-atomic": "1.1.4",
+                "xdg-basedir": "2.0.0"
+              },
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                  "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24="
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "osenv@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+                  "requires": {
+                    "os-homedir": "1.0.1",
+                    "os-tmpdir": "1.0.1"
+                  },
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                      "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac="
                     }
                   }
                 },
                 "uuid": {
                   "version": "2.0.1",
-                  "from": "uuid@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+                  "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
                 },
                 "write-file-atomic": {
                   "version": "1.1.4",
-                  "from": "write-file-atomic@>=1.1.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
+                  "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
+                  "requires": {
+                    "graceful-fs": "4.1.2",
+                    "imurmurhash": "0.1.4",
+                    "slide": "1.1.6"
+                  },
                   "dependencies": {
                     "imurmurhash": {
                       "version": "0.1.4",
-                      "from": "imurmurhash@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
                     },
                     "slide": {
                       "version": "1.1.6",
-                      "from": "slide@>=1.1.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+                      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
                     }
                   }
                 },
                 "xdg-basedir": {
                   "version": "2.0.0",
-                  "from": "xdg-basedir@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+                  "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+                  "requires": {
+                    "os-homedir": "1.0.1"
+                  },
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                      "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac="
                     }
                   }
                 }
@@ -794,47 +1054,60 @@
             },
             "lodash.debounce": {
               "version": "3.1.1",
-              "from": "lodash.debounce@>=3.0.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
+              "integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
+              "requires": {
+                "lodash._getnative": "3.9.1"
+              },
               "dependencies": {
                 "lodash._getnative": {
                   "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                  "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
                 }
               }
             },
             "object-assign": {
               "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+              "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
             },
             "os-name": {
               "version": "1.0.3",
-              "from": "os-name@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+              "integrity": "sha1-GzefZINa98Wn9JizV8uVIVwVnt8=",
+              "requires": {
+                "osx-release": "1.1.0",
+                "win-release": "1.1.1"
+              },
               "dependencies": {
                 "osx-release": {
                   "version": "1.1.0",
-                  "from": "osx-release@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
+                  "integrity": "sha1-8heRGigTaUmvG/kwiyQeJzfTzWw=",
+                  "requires": {
+                    "minimist": "1.2.0"
+                  },
                   "dependencies": {
                     "minimist": {
                       "version": "1.2.0",
-                      "from": "minimist@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                     }
                   }
                 },
                 "win-release": {
                   "version": "1.1.1",
-                  "from": "win-release@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+                  "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+                  "requires": {
+                    "semver": "5.1.0"
+                  },
                   "dependencies": {
                     "semver": {
                       "version": "5.1.0",
-                      "from": "semver@>=5.0.1 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+                      "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU="
                     }
                   }
                 }
@@ -842,96 +1115,114 @@
             },
             "tough-cookie": {
               "version": "2.2.1",
-              "from": "tough-cookie@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
+              "integrity": "sha1-OwUWt5nnDoFkQ2oURuflh3/aEY4="
             }
           }
         },
         "is-root": {
           "version": "1.0.0",
-          "from": "is-root@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
+          "integrity": "sha1-B7bCM7w5TNnQK6FclmvWZg1jQtU="
         },
         "junk": {
           "version": "1.0.2",
-          "from": "junk@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.2.tgz",
+          "integrity": "sha1-zHHbPAXVOzI40PHeyXqIJnwQcA4="
         },
         "lockfile": {
           "version": "1.0.1",
-          "from": "lockfile@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
+          "integrity": "sha1-nTU+z+P1TRULtX+J1RdGk1o5xPU="
         },
         "lru-cache": {
           "version": "2.7.3",
-          "from": "lru-cache@>=2.5.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
         },
         "md5-hex": {
           "version": "1.1.0",
-          "from": "md5-hex@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.1.0.tgz",
+          "integrity": "sha1-0QcHTE7oHLyn8rYRUGadzjgFgIA=",
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          },
           "dependencies": {
             "md5-o-matic": {
               "version": "0.1.1",
-              "from": "md5-o-matic@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+              "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
             }
           }
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "requires": {
+            "minimist": "0.0.8"
+          },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             }
           }
         },
         "mout": {
           "version": "0.11.1",
-          "from": "mout@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz"
+          "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
+          "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
         },
         "nopt": {
           "version": "3.0.6",
-          "from": "nopt@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "requires": {
+            "abbrev": "1.0.7"
+          }
         },
         "opn": {
           "version": "1.0.2",
-          "from": "opn@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
+          "integrity": "sha1-uQlkM0bQChq8l3qLlvPOPFPVz18="
         },
         "p-throttler": {
           "version": "0.1.1",
-          "from": "p-throttler@0.1.1",
           "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.1.tgz",
+          "integrity": "sha1-FSRkCdIl0+78qFxQ3nEKg6eMymo=",
+          "requires": {
+            "q": "0.9.7"
+          },
           "dependencies": {
             "q": {
               "version": "0.9.7",
-              "from": "q@>=0.9.2 <0.10.0",
-              "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+              "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+              "integrity": "sha1-TeLmyzspCIyeTLwDv51C+5bOL3U="
             }
           }
         },
         "promptly": {
           "version": "0.2.0",
-          "from": "promptly@0.2.0",
           "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
+          "integrity": "sha1-c+8gD6gynV06jfQXmJULhkbKRtk=",
+          "requires": {
+            "read": "1.0.7"
+          },
           "dependencies": {
             "read": {
               "version": "1.0.7",
-              "from": "read@>=1.0.4 <1.1.0",
               "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+              "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+              "requires": {
+                "mute-stream": "0.0.5"
+              },
               "dependencies": {
                 "mute-stream": {
                   "version": "0.0.5",
-                  "from": "mute-stream@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                  "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
                 }
               }
             }
@@ -939,43 +1230,76 @@
         },
         "q": {
           "version": "1.4.1",
-          "from": "q@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
         },
         "request": {
           "version": "2.53.0",
-          "from": "request@2.53.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+          "integrity": "sha1-GAo66St7Y5gC5PlUXdj83rcddgw=",
+          "requires": {
+            "aws-sign2": "0.5.0",
+            "bl": "0.9.4",
+            "caseless": "0.9.0",
+            "combined-stream": "0.0.7",
+            "forever-agent": "0.5.2",
+            "form-data": "0.2.0",
+            "hawk": "2.3.1",
+            "http-signature": "0.10.1",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.0.14",
+            "node-uuid": "1.4.7",
+            "oauth-sign": "0.6.0",
+            "qs": "2.3.3",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.2.1",
+            "tunnel-agent": "0.4.2"
+          },
           "dependencies": {
+            "aws-sign2": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM="
+            },
             "bl": {
               "version": "0.9.4",
-              "from": "bl@>=0.9.0 <0.10.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "integrity": "sha1-RwLd9y++Ds2CeHwAwROuoZNa0Oc=",
+              "requires": {
+                "readable-stream": "1.0.33"
+              },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                     }
                   }
                 }
@@ -983,209 +1307,259 @@
             },
             "caseless": {
               "version": "0.9.0",
-              "from": "caseless@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.5.2",
-              "from": "forever-agent@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-            },
-            "form-data": {
-              "version": "0.2.0",
-              "from": "form-data@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-                }
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.0.14",
-              "from": "mime-types@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.12.0",
-                  "from": "mime-db@>=1.12.0 <1.13.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "from": "node-uuid@>=1.4.0 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-            },
-            "qs": {
-              "version": "2.3.3",
-              "from": "qs@>=2.3.1 <2.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.2",
-              "from": "tunnel-agent@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.1",
-              "from": "tough-cookie@>=0.12.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-            },
-            "http-signature": {
-              "version": "0.10.1",
-              "from": "http-signature@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "asn1": {
-                  "version": "0.1.11",
-                  "from": "asn1@0.1.11",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                },
-                "ctype": {
-                  "version": "0.5.3",
-                  "from": "ctype@0.5.3",
-                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.6.0",
-              "from": "oauth-sign@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
-            },
-            "hawk": {
-              "version": "2.3.1",
-              "from": "hawk@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.5.0",
-              "from": "aws-sign2@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+              "integrity": "sha1-t7Zc5r8UE4hlOc/VM/CzDv+pz4g="
             },
             "combined-stream": {
               "version": "0.0.7",
-              "from": "combined-stream@>=0.0.5 <0.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+              "requires": {
+                "delayed-stream": "0.0.5"
+              },
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                  "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
+                }
+              }
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+              "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
+            },
+            "form-data": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
+              "requires": {
+                "async": "0.9.2",
+                "combined-stream": "0.0.7",
+                "mime-types": "2.0.14"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "0.9.2",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                  "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+                }
+              }
+            },
+            "hawk": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+              "requires": {
+                "asn1": "0.1.11",
+                "assert-plus": "0.1.5",
+                "ctype": "0.5.3"
+              },
+              "dependencies": {
+                "asn1": {
+                  "version": "0.1.11",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
+                },
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
                 }
               }
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+            },
+            "mime-types": {
+              "version": "2.0.14",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+              "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+              "requires": {
+                "mime-db": "1.12.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.12.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                  "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.7",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
+            },
+            "oauth-sign": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+              "integrity": "sha1-fb6uRPbKRU4fFoRR1jB0ZzWBPOM="
+            },
+            "qs": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+              "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+            },
+            "tough-cookie": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
+              "integrity": "sha1-OwUWt5nnDoFkQ2oURuflh3/aEY4="
+            },
+            "tunnel-agent": {
+              "version": "0.4.2",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+              "integrity": "sha1-EQTj82rIcSXChycAZ9WC0YEzv+4="
             }
           }
         },
         "request-progress": {
           "version": "0.3.1",
-          "from": "request-progress@0.3.1",
           "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+          "integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
+          "requires": {
+            "throttleit": "0.0.2"
+          },
           "dependencies": {
             "throttleit": {
               "version": "0.0.2",
-              "from": "throttleit@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+              "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8="
             }
           }
         },
         "retry": {
           "version": "0.6.1",
-          "from": "retry@0.6.1",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz",
+          "integrity": "sha1-/ckO7ZQ/3hG4k1VLjMY9DombqRg="
         },
         "rimraf": {
           "version": "2.4.4",
-          "from": "rimraf@>=2.2.8 <3.0.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
+          "integrity": "sha1-tSjOLr4ObYn7A7Jl3hHWHaDbz4I=",
+          "requires": {
+            "glob": "5.0.15"
+          },
           "dependencies": {
             "glob": {
               "version": "5.0.15",
-              "from": "glob@>=5.0.14 <6.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "requires": {
+                "inflight": "1.0.4",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.0",
+                "once": "1.3.3",
+                "path-is-absolute": "1.0.0"
+              },
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+                  "requires": {
+                    "once": "1.3.3",
+                    "wrappy": "1.0.1"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "minimatch": {
                   "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+                  "requires": {
+                    "brace-expansion": "1.1.2"
+                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.2",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                      "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                      "requires": {
+                        "balanced-match": "0.3.0",
+                        "concat-map": "0.0.1"
+                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                          "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                         }
                       }
                     }
@@ -1193,20 +1567,23 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "requires": {
+                    "wrappy": "1.0.1"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
                 }
               }
             }
@@ -1214,70 +1591,91 @@
         },
         "semver": {
           "version": "2.3.2",
-          "from": "semver@>=2.3.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+          "integrity": "sha1-uYSPJdbPNjMwc+ye+IVtQvEjPlI="
         },
         "semver-utils": {
           "version": "1.1.1",
-          "from": "semver-utils@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.1.tgz",
+          "integrity": "sha1-J9kv7DTSfPpCcH07QNAlrphV8t8="
         },
         "shell-quote": {
           "version": "1.4.3",
-          "from": "shell-quote@>=1.4.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+          "integrity": "sha1-lSxE4LHtkBPvU5WBecxkPod3Rms=",
+          "requires": {
+            "array-filter": "0.0.1",
+            "array-map": "0.0.0",
+            "array-reduce": "0.0.0",
+            "jsonify": "0.0.0"
+          },
           "dependencies": {
-            "jsonify": {
-              "version": "0.0.0",
-              "from": "jsonify@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-            },
             "array-filter": {
               "version": "0.0.1",
-              "from": "array-filter@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
-            },
-            "array-reduce": {
-              "version": "0.0.0",
-              "from": "array-reduce@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+              "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
             },
             "array-map": {
               "version": "0.0.0",
-              "from": "array-map@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+              "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
+            },
+            "array-reduce": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+              "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
             }
           }
         },
         "stringify-object": {
           "version": "1.0.1",
-          "from": "stringify-object@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz",
+          "integrity": "sha1-htNefb+86apFY31+zdeEfhWduKI="
         },
         "tar-fs": {
           "version": "1.8.1",
-          "from": "tar-fs@>=1.4.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.8.1.tgz",
+          "integrity": "sha1-PubPo1FjN3Xqp1469uwwfp6qQDw=",
+          "requires": {
+            "mkdirp": "0.5.0",
+            "pump": "1.0.1",
+            "tar-stream": "1.3.1"
+          },
           "dependencies": {
             "pump": {
               "version": "1.0.1",
-              "from": "pump@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
+              "integrity": "sha1-8fFAn7m9EIW721drQ7hOxLXq3Bo=",
+              "requires": {
+                "end-of-stream": "1.1.0",
+                "once": "1.3.3"
+              },
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.1.0",
-                  "from": "end-of-stream@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "integrity": "sha1-6TUyWLqpEIll78QcsO+K3i88+wc=",
+                  "requires": {
+                    "once": "1.3.3"
+                  }
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "requires": {
+                    "wrappy": "1.0.1"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                     }
                   }
                 }
@@ -1285,28 +1683,43 @@
             },
             "tar-stream": {
               "version": "1.3.1",
-              "from": "tar-stream@>=1.1.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.3.1.tgz",
+              "integrity": "sha1-SQ7CrR7Fgj/OY/GLuQTHRpzXCJc=",
+              "requires": {
+                "bl": "1.0.0",
+                "end-of-stream": "1.1.0",
+                "readable-stream": "2.0.4",
+                "xtend": "4.0.1"
+              },
               "dependencies": {
                 "bl": {
                   "version": "1.0.0",
-                  "from": "bl@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                  "integrity": "sha1-ramoqJptesYIYvfex9sgeHPgw/U=",
+                  "requires": {
+                    "readable-stream": "2.0.4"
+                  }
                 },
                 "end-of-stream": {
                   "version": "1.1.0",
-                  "from": "end-of-stream@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "integrity": "sha1-6TUyWLqpEIll78QcsO+K3i88+wc=",
+                  "requires": {
+                    "once": "1.3.3"
+                  },
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                      "requires": {
+                        "wrappy": "1.0.1"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                         }
                       }
                     }
@@ -1314,45 +1727,53 @@
                 },
                 "readable-stream": {
                   "version": "2.0.4",
-                  "from": "readable-stream@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                  "integrity": "sha1-JSPvJ/+jOde6nahgPy0FmdBu29g=",
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "process-nextick-args": "1.0.6",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                      "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                 }
               }
             }
@@ -1360,77 +1781,108 @@
         },
         "tmp": {
           "version": "0.0.24",
-          "from": "tmp@0.0.24",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
+          "integrity": "sha1-1qXhmNFKmDXMby18PZ4wJCjIzxI="
         },
         "update-notifier": {
           "version": "0.6.0",
-          "from": "update-notifier@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.6.0.tgz",
+          "integrity": "sha1-VKTHNX2YoykDM1Xi0OuvnJxkaVg=",
+          "requires": {
+            "chalk": "1.1.1",
+            "configstore": "1.4.0",
+            "is-npm": "1.0.0",
+            "latest-version": "2.0.0",
+            "repeating": "2.0.0",
+            "semver-diff": "2.1.0",
+            "string-length": "1.0.1"
+          },
           "dependencies": {
             "configstore": {
               "version": "1.4.0",
-              "from": "configstore@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
+              "integrity": "sha1-w1eB0FAdJowlxUuLF/YkDopPsCE=",
+              "requires": {
+                "graceful-fs": "4.1.2",
+                "mkdirp": "0.5.0",
+                "object-assign": "4.0.1",
+                "os-tmpdir": "1.0.1",
+                "osenv": "0.1.3",
+                "uuid": "2.0.1",
+                "write-file-atomic": "1.1.4",
+                "xdg-basedir": "2.0.0"
+              },
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                  "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
                 },
                 "object-assign": {
                   "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+                  "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
                 },
                 "os-tmpdir": {
                   "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                  "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24="
                 },
                 "osenv": {
                   "version": "0.1.3",
-                  "from": "osenv@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
+                  "requires": {
+                    "os-homedir": "1.0.1",
+                    "os-tmpdir": "1.0.1"
+                  },
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                      "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac="
                     }
                   }
                 },
                 "uuid": {
                   "version": "2.0.1",
-                  "from": "uuid@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+                  "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
                 },
                 "write-file-atomic": {
                   "version": "1.1.4",
-                  "from": "write-file-atomic@>=1.1.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.1.4.tgz",
+                  "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
+                  "requires": {
+                    "graceful-fs": "4.1.2",
+                    "imurmurhash": "0.1.4",
+                    "slide": "1.1.6"
+                  },
                   "dependencies": {
                     "imurmurhash": {
                       "version": "0.1.4",
-                      "from": "imurmurhash@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+                      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
                     },
                     "slide": {
                       "version": "1.1.6",
-                      "from": "slide@>=1.1.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
+                      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+                      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
                     }
                   }
                 },
                 "xdg-basedir": {
                   "version": "2.0.0",
-                  "from": "xdg-basedir@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+                  "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+                  "requires": {
+                    "os-homedir": "1.0.1"
+                  },
                   "dependencies": {
                     "os-homedir": {
                       "version": "1.0.1",
-                      "from": "os-homedir@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+                      "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac="
                     }
                   }
                 }
@@ -1438,60 +1890,99 @@
             },
             "is-npm": {
               "version": "1.0.0",
-              "from": "is-npm@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+              "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
             },
             "latest-version": {
               "version": "2.0.0",
-              "from": "latest-version@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+              "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
+              "requires": {
+                "package-json": "2.3.0"
+              },
               "dependencies": {
                 "package-json": {
                   "version": "2.3.0",
-                  "from": "package-json@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.3.0.tgz",
+                  "integrity": "sha1-aTjax6J0Q4W/LXlTau4kjBrHKCY=",
+                  "requires": {
+                    "got": "5.2.0",
+                    "rc": "1.1.5",
+                    "registry-url": "3.0.3",
+                    "semver": "5.1.0"
+                  },
                   "dependencies": {
                     "got": {
                       "version": "5.2.0",
-                      "from": "got@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/got/-/got-5.2.0.tgz",
+                      "integrity": "sha1-NdFaPaSAZHC2dGZII+nDu3kkNH4=",
+                      "requires": {
+                        "create-error-class": "2.0.1",
+                        "duplexify": "3.4.2",
+                        "is-plain-obj": "1.1.0",
+                        "is-redirect": "1.0.0",
+                        "is-stream": "1.0.1",
+                        "lowercase-keys": "1.0.0",
+                        "node-status-codes": "1.0.0",
+                        "object-assign": "4.0.1",
+                        "parse-json": "2.2.0",
+                        "pinkie-promise": "2.0.0",
+                        "read-all-stream": "3.0.1",
+                        "timed-out": "2.0.0",
+                        "unzip-response": "1.0.0",
+                        "url-parse-lax": "1.0.0"
+                      },
                       "dependencies": {
                         "create-error-class": {
                           "version": "2.0.1",
-                          "from": "create-error-class@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-2.0.1.tgz",
+                          "integrity": "sha1-qHWe1cjSFKRh6B0Y5wqssz3WPJw=",
+                          "requires": {
+                            "capture-stack-trace": "1.0.0",
+                            "inherits": "2.0.1"
+                          },
                           "dependencies": {
                             "capture-stack-trace": {
                               "version": "1.0.0",
-                              "from": "capture-stack-trace@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+                              "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                             }
                           }
                         },
                         "duplexify": {
                           "version": "3.4.2",
-                          "from": "duplexify@>=3.2.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
+                          "integrity": "sha1-caV4rwPg0GPrjxMmr/1eVgAUXhs=",
+                          "requires": {
+                            "end-of-stream": "1.0.0",
+                            "readable-stream": "2.0.4"
+                          },
                           "dependencies": {
                             "end-of-stream": {
                               "version": "1.0.0",
-                              "from": "end-of-stream@1.0.0",
                               "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                              "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
+                              "requires": {
+                                "once": "1.3.3"
+                              },
                               "dependencies": {
                                 "once": {
                                   "version": "1.3.3",
-                                  "from": "once@>=1.3.0 <1.4.0",
                                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                                  "requires": {
+                                    "wrappy": "1.0.1"
+                                  },
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.1",
-                                      "from": "wrappy@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                                     }
                                   }
                                 }
@@ -1499,38 +1990,46 @@
                             },
                             "readable-stream": {
                               "version": "2.0.4",
-                              "from": "readable-stream@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                              "integrity": "sha1-JSPvJ/+jOde6nahgPy0FmdBu29g=",
+                              "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.1",
+                                "isarray": "0.0.1",
+                                "process-nextick-args": "1.0.6",
+                                "string_decoder": "0.10.31",
+                                "util-deprecate": "1.0.2"
+                              },
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                                 },
                                 "process-nextick-args": {
                                   "version": "1.0.6",
-                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                                  "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                                 },
                                 "util-deprecate": {
                                   "version": "1.0.2",
-                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                                 }
                               }
                             }
@@ -1538,48 +2037,54 @@
                         },
                         "is-plain-obj": {
                           "version": "1.1.0",
-                          "from": "is-plain-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+                          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
                         },
                         "is-redirect": {
                           "version": "1.0.0",
-                          "from": "is-redirect@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+                          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
                         },
                         "is-stream": {
                           "version": "1.0.1",
-                          "from": "is-stream@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz",
+                          "integrity": "sha1-tEzkWx8MPfWD9rXev4Tc+XQ6yLU="
                         },
                         "lowercase-keys": {
                           "version": "1.0.0",
-                          "from": "lowercase-keys@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
                         },
                         "node-status-codes": {
                           "version": "1.0.0",
-                          "from": "node-status-codes@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+                          "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
                         },
                         "object-assign": {
                           "version": "4.0.1",
-                          "from": "object-assign@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+                          "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
                         },
                         "parse-json": {
                           "version": "2.2.0",
-                          "from": "parse-json@>=2.1.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                          "requires": {
+                            "error-ex": "1.3.0"
+                          },
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
-                              "from": "error-ex@>=1.2.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                              "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                              "requires": {
+                                "is-arrayish": "0.2.1"
+                              },
                               "dependencies": {
                                 "is-arrayish": {
                                   "version": "0.2.1",
-                                  "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                  "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
                                 }
                               }
                             }
@@ -1587,67 +2092,85 @@
                         },
                         "pinkie-promise": {
                           "version": "2.0.0",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                          "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                          "requires": {
+                            "pinkie": "2.0.1"
+                          },
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.1",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                              "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw="
                             }
                           }
                         },
                         "read-all-stream": {
                           "version": "3.0.1",
-                          "from": "read-all-stream@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.0.1.tgz",
+                          "integrity": "sha1-w3Aa7NfJEVFmd1kO7epJaExi+kc=",
+                          "requires": {
+                            "pinkie-promise": "1.0.0",
+                            "readable-stream": "2.0.4"
+                          },
                           "dependencies": {
                             "pinkie-promise": {
                               "version": "1.0.0",
-                              "from": "pinkie-promise@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+                              "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+                              "requires": {
+                                "pinkie": "1.0.0"
+                              },
                               "dependencies": {
                                 "pinkie": {
                                   "version": "1.0.0",
-                                  "from": "pinkie@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+                                  "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q="
                                 }
                               }
                             },
                             "readable-stream": {
                               "version": "2.0.4",
-                              "from": "readable-stream@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                              "integrity": "sha1-JSPvJ/+jOde6nahgPy0FmdBu29g=",
+                              "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.1",
+                                "isarray": "0.0.1",
+                                "process-nextick-args": "1.0.6",
+                                "string_decoder": "0.10.31",
+                                "util-deprecate": "1.0.2"
+                              },
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                                 },
                                 "process-nextick-args": {
                                   "version": "1.0.6",
-                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                                  "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                                 },
                                 "util-deprecate": {
                                   "version": "1.0.2",
-                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                                 }
                               }
                             }
@@ -1655,23 +2178,26 @@
                         },
                         "timed-out": {
                           "version": "2.0.0",
-                          "from": "timed-out@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
+                          "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo="
                         },
                         "unzip-response": {
                           "version": "1.0.0",
-                          "from": "unzip-response@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.0.tgz",
+                          "integrity": "sha1-v9pU7uxljwDC301ElLncoMoA8+Q="
                         },
                         "url-parse-lax": {
                           "version": "1.0.0",
-                          "from": "url-parse-lax@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+                          "requires": {
+                            "prepend-http": "1.0.3"
+                          },
                           "dependencies": {
                             "prepend-http": {
                               "version": "1.0.3",
-                              "from": "prepend-http@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
+                              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
+                              "integrity": "sha1-TQ0rb5788RkMI5MTJbTzqduoSGk="
                             }
                           }
                         }
@@ -1679,40 +2205,49 @@
                     },
                     "rc": {
                       "version": "1.1.5",
-                      "from": "rc@>=1.1.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.5.tgz",
+                      "integrity": "sha1-O64o177YfRzLWGP43OjCfyzu6Jw=",
+                      "requires": {
+                        "deep-extend": "0.4.0",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "1.0.4"
+                      },
                       "dependencies": {
                         "deep-extend": {
                           "version": "0.4.0",
-                          "from": "deep-extend@>=0.4.0 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz",
+                          "integrity": "sha1-9YtG21jrXWQ5zdDy5sr7Rzn8EoM="
                         },
                         "ini": {
                           "version": "1.3.4",
-                          "from": "ini@>=1.3.0 <1.4.0",
-                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
                         },
                         "minimist": {
                           "version": "1.2.0",
-                          "from": "minimist@>=1.2.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                         },
                         "strip-json-comments": {
                           "version": "1.0.4",
-                          "from": "strip-json-comments@>=1.0.4 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+                          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E="
                         }
                       }
                     },
                     "registry-url": {
                       "version": "3.0.3",
-                      "from": "registry-url@>=3.0.3 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
+                      "integrity": "sha1-yfUQLg/ZyfJQUip/GfaGcshMzJY=",
+                      "requires": {
+                        "rc": "1.1.5"
+                      }
                     },
                     "semver": {
                       "version": "5.1.0",
-                      "from": "semver@>=5.1.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+                      "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU="
                     }
                   }
                 }
@@ -1720,18 +2255,24 @@
             },
             "repeating": {
               "version": "2.0.0",
-              "from": "repeating@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+              "integrity": "sha1-/SfW0mTRj76/qlZVPde4JTWlA04=",
+              "requires": {
+                "is-finite": "1.0.1"
+              },
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                     }
                   }
                 }
@@ -1739,30 +2280,39 @@
             },
             "semver-diff": {
               "version": "2.1.0",
-              "from": "semver-diff@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+              "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+              "requires": {
+                "semver": "5.1.0"
+              },
               "dependencies": {
                 "semver": {
                   "version": "5.1.0",
-                  "from": "semver@>=5.0.3 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+                  "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU="
                 }
               }
             },
             "string-length": {
               "version": "1.0.1",
-              "from": "string-length@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
+              "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+              "requires": {
+                "strip-ansi": "3.0.0"
+              },
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                     }
                   }
                 }
@@ -1772,23 +2322,29 @@
         },
         "user-home": {
           "version": "1.1.1",
-          "from": "user-home@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+          "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
         },
         "which": {
           "version": "1.2.0",
-          "from": "which@>=1.0.8 <2.0.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
+          "integrity": "sha1-pcjfWrx5L2zpZSyNnKjzqRt35Z0=",
+          "requires": {
+            "is-absolute": "0.1.7"
+          },
           "dependencies": {
             "is-absolute": {
               "version": "0.1.7",
-              "from": "is-absolute@>=0.1.7 <0.2.0",
               "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+              "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
+              "requires": {
+                "is-relative": "0.1.3"
+              },
               "dependencies": {
                 "is-relative": {
                   "version": "0.1.3",
-                  "from": "is-relative@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                  "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI="
                 }
               }
             }
@@ -1798,126 +2354,182 @@
     },
     "gulp": {
       "version": "3.9.1",
-      "from": "gulp@>=3.9.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+      "requires": {
+        "archy": "1.0.0",
+        "chalk": "1.1.1",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.7",
+        "interpret": "0.6.6",
+        "liftoff": "2.2.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.7",
+        "pretty-hrtime": "1.0.1",
+        "semver": "4.3.6",
+        "tildify": "1.1.2",
+        "v8flags": "2.0.10",
+        "vinyl-fs": "0.3.14"
+      },
       "dependencies": {
         "archy": {
           "version": "1.0.0",
-          "from": "archy@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+          "requires": {
+            "ansi-styles": "2.1.0",
+            "escape-string-regexp": "1.0.3",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.0",
+            "supports-color": "2.0.0"
+          },
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+              "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
         "deprecated": {
           "version": "0.0.1",
-          "from": "deprecated@>=0.0.1 <0.0.2",
-          "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+          "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk="
         },
         "interpret": {
           "version": "0.6.6",
-          "from": "interpret@>=0.6.2 <0.7.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
+          "integrity": "sha1-/s16GOfOXKar+5U+H4YhOknxYls="
         },
         "liftoff": {
           "version": "2.2.0",
-          "from": "liftoff@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
+          "integrity": "sha1-9fz6RYMRMVnRKTWooGFvUBKLV1M=",
+          "requires": {
+            "extend": "2.0.1",
+            "findup-sync": "0.3.0",
+            "flagged-respawn": "0.3.1",
+            "rechoir": "0.6.2",
+            "resolve": "1.1.6"
+          },
           "dependencies": {
             "extend": {
               "version": "2.0.1",
-              "from": "extend@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
+              "integrity": "sha1-HugBBonnOV/5RIJByYZSvHWagmA="
             },
             "findup-sync": {
               "version": "0.3.0",
-              "from": "findup-sync@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+              "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+              "requires": {
+                "glob": "5.0.15"
+              },
               "dependencies": {
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                  "requires": {
+                    "inflight": "1.0.4",
+                    "inherits": "2.0.1",
+                    "minimatch": "3.0.0",
+                    "once": "1.3.3",
+                    "path-is-absolute": "1.0.0"
+                  },
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+                      "requires": {
+                        "once": "1.3.3",
+                        "wrappy": "1.0.1"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                     },
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+                      "requires": {
+                        "brace-expansion": "1.1.2"
+                      },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.2",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                          "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                          "requires": {
+                            "balanced-match": "0.3.0",
+                            "concat-map": "0.0.1"
+                          },
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                             }
                           }
                         }
@@ -1925,20 +2537,23 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                      "requires": {
+                        "wrappy": "1.0.1"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
                     }
                   }
                 }
@@ -1946,45 +2561,59 @@
             },
             "flagged-respawn": {
               "version": "0.3.1",
-              "from": "flagged-respawn@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
+              "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz",
+              "integrity": "sha1-OXcAkl324SRSICpx6J2JVF+7vp0="
             },
             "rechoir": {
               "version": "0.6.2",
-              "from": "rechoir@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+              "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+              "requires": {
+                "resolve": "1.1.6"
+              }
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@>=1.1.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
+              "integrity": "sha1-00kq0FTKgA9b76YS5hvqwe7Jj48="
             }
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "orchestrator": {
           "version": "0.3.7",
-          "from": "orchestrator@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
+          "integrity": "sha1-xFBk4ixaKnuZc09AmpX/7cfTw98=",
+          "requires": {
+            "end-of-stream": "0.1.5",
+            "sequencify": "0.0.7",
+            "stream-consume": "0.1.0"
+          },
           "dependencies": {
             "end-of-stream": {
               "version": "0.1.5",
-              "from": "end-of-stream@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+              "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+              "requires": {
+                "once": "1.3.3"
+              },
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "requires": {
+                    "wrappy": "1.0.1"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                     }
                   }
                 }
@@ -1992,127 +2621,189 @@
             },
             "sequencify": {
               "version": "0.0.7",
-              "from": "sequencify@>=0.0.7 <0.1.0",
-              "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
+              "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+              "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw="
             },
             "stream-consume": {
               "version": "0.1.0",
-              "from": "stream-consume@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
+              "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8="
             }
           }
         },
         "pretty-hrtime": {
           "version": "1.0.1",
-          "from": "pretty-hrtime@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz",
+          "integrity": "sha1-Hk+VKm3XHnkZmzpz8l15l7aUuoM="
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
         },
         "tildify": {
           "version": "1.1.2",
-          "from": "tildify@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
+          "integrity": "sha1-n2Edii6TpeUHVtsEDxzSt/2AhZ0=",
+          "requires": {
+            "os-homedir": "1.0.1"
+          },
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
-              "from": "os-homedir@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+              "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac="
             }
           }
         },
         "v8flags": {
           "version": "2.0.10",
-          "from": "v8flags@>=2.0.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.10.tgz",
+          "integrity": "sha1-ZKFhN06XSRAJx43vL5ZJAOltnO8=",
+          "requires": {
+            "user-home": "1.1.1"
+          },
           "dependencies": {
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+              "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
             }
           }
         },
         "vinyl-fs": {
           "version": "0.3.14",
-          "from": "vinyl-fs@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+          "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+          "requires": {
+            "defaults": "1.0.3",
+            "glob-stream": "3.1.18",
+            "glob-watcher": "0.0.6",
+            "graceful-fs": "3.0.8",
+            "mkdirp": "0.5.1",
+            "strip-bom": "1.0.0",
+            "through2": "0.6.5",
+            "vinyl": "0.4.6"
+          },
           "dependencies": {
             "defaults": {
               "version": "1.0.3",
-              "from": "defaults@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+              "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+              "requires": {
+                "clone": "1.0.2"
+              },
               "dependencies": {
                 "clone": {
                   "version": "1.0.2",
-                  "from": "clone@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                  "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
                 }
               }
             },
             "glob-stream": {
               "version": "3.1.18",
-              "from": "glob-stream@>=3.1.5 <4.0.0",
               "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+              "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+              "requires": {
+                "glob": "4.5.3",
+                "glob2base": "0.0.12",
+                "minimatch": "2.0.10",
+                "ordered-read-streams": "0.1.0",
+                "through2": "0.6.5",
+                "unique-stream": "1.0.0"
+              },
               "dependencies": {
                 "glob": {
                   "version": "4.5.3",
-                  "from": "glob@>=4.3.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+                  "requires": {
+                    "inflight": "1.0.4",
+                    "inherits": "2.0.1",
+                    "minimatch": "2.0.10",
+                    "once": "1.3.3"
+                  },
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+                      "requires": {
+                        "once": "1.3.3",
+                        "wrappy": "1.0.1"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                      "requires": {
+                        "wrappy": "1.0.1"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                         }
                       }
                     }
                   }
                 },
+                "glob2base": {
+                  "version": "0.0.12",
+                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+                  "requires": {
+                    "find-index": "0.1.1"
+                  },
+                  "dependencies": {
+                    "find-index": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+                      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
+                    }
+                  }
+                },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                  "requires": {
+                    "brace-expansion": "1.1.2"
+                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.2",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                      "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                      "requires": {
+                        "balanced-match": "0.3.0",
+                        "concat-map": "0.0.1"
+                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                          "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                         }
                       }
                     }
@@ -2120,79 +2811,87 @@
                 },
                 "ordered-read-streams": {
                   "version": "0.1.0",
-                  "from": "ordered-read-streams@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
-                },
-                "glob2base": {
-                  "version": "0.0.12",
-                  "from": "glob2base@>=0.0.12 <0.0.13",
-                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-                  "dependencies": {
-                    "find-index": {
-                      "version": "0.1.1",
-                      "from": "find-index@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+                  "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY="
                 },
                 "unique-stream": {
                   "version": "1.0.0",
-                  "from": "unique-stream@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+                  "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
                 }
               }
             },
             "glob-watcher": {
               "version": "0.0.6",
-              "from": "glob-watcher@>=0.0.6 <0.0.7",
               "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+              "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+              "requires": {
+                "gaze": "0.5.2"
+              },
               "dependencies": {
                 "gaze": {
                   "version": "0.5.2",
-                  "from": "gaze@>=0.5.1 <0.6.0",
                   "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+                  "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
+                  "requires": {
+                    "globule": "0.1.0"
+                  },
                   "dependencies": {
                     "globule": {
                       "version": "0.1.0",
-                      "from": "globule@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                      "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
+                      "requires": {
+                        "glob": "3.1.21",
+                        "lodash": "1.0.2",
+                        "minimatch": "0.2.14"
+                      },
                       "dependencies": {
-                        "lodash": {
-                          "version": "1.0.2",
-                          "from": "lodash@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                        },
                         "glob": {
                           "version": "3.1.21",
-                          "from": "glob@>=3.1.21 <3.2.0",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+                          "requires": {
+                            "graceful-fs": "1.2.3",
+                            "inherits": "1.0.2",
+                            "minimatch": "0.2.14"
+                          },
                           "dependencies": {
                             "graceful-fs": {
                               "version": "1.2.3",
-                              "from": "graceful-fs@>=1.2.0 <1.3.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                              "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
                             },
                             "inherits": {
                               "version": "1.0.2",
-                              "from": "inherits@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+                              "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
                             }
                           }
                         },
+                        "lodash": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
+                        },
                         "minimatch": {
                           "version": "0.2.14",
-                          "from": "minimatch@>=0.2.11 <0.3.0",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+                          "requires": {
+                            "lru-cache": "2.7.3",
+                            "sigmund": "1.0.1"
+                          },
                           "dependencies": {
                             "lru-cache": {
                               "version": "2.7.3",
-                              "from": "lru-cache@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
                             },
                             "sigmund": {
                               "version": "1.0.1",
-                              "from": "sigmund@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
                             }
                           }
                         }
@@ -2204,91 +2903,112 @@
             },
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+              "integrity": "sha1-zoE+cl+oL35hR9UcmlymgnBVHCI="
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 }
               }
             },
             "strip-bom": {
               "version": "1.0.0",
-              "from": "strip-bom@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+              "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+              "requires": {
+                "first-chunk-stream": "1.0.0",
+                "is-utf8": "0.2.0"
+              },
               "dependencies": {
                 "first-chunk-stream": {
                   "version": "1.0.0",
-                  "from": "first-chunk-stream@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+                  "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
                 },
                 "is-utf8": {
                   "version": "0.2.0",
-                  "from": "is-utf8@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+                  "integrity": "sha1-uKpUElrmJr/k4765ZfFqicWKETc="
                 }
               }
             },
             "through2": {
               "version": "0.6.5",
-              "from": "through2@>=0.6.1 <0.7.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+              "requires": {
+                "readable-stream": "1.0.33",
+                "xtend": "4.0.1"
+              },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <4.1.0-0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                 }
               }
             },
             "vinyl": {
               "version": "0.4.6",
-              "from": "vinyl@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+              "requires": {
+                "clone": "0.2.0",
+                "clone-stats": "0.0.1"
+              },
               "dependencies": {
                 "clone": {
                   "version": "0.2.0",
-                  "from": "clone@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                  "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
                 },
                 "clone-stats": {
                   "version": "0.0.1",
-                  "from": "clone-stats@>=0.0.1 <0.0.2",
-                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
                 }
               }
             }
@@ -2298,123 +3018,163 @@
     },
     "gulp-autoprefixer": {
       "version": "3.1.0",
-      "from": "gulp-autoprefixer@>=3.0.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.0.tgz",
+      "integrity": "sha1-KzraQ5/bEg7U6zpXSxIiNKi6KDo=",
+      "requires": {
+        "autoprefixer": "6.1.2",
+        "gulp-util": "3.0.7",
+        "postcss": "5.0.13",
+        "through2": "2.0.0",
+        "vinyl-sourcemaps-apply": "0.2.0"
+      },
       "dependencies": {
         "autoprefixer": {
           "version": "6.1.2",
-          "from": "autoprefixer@>=6.0.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.1.2.tgz",
+          "integrity": "sha1-EaNrUMwOStqrVXCu0oz4GHbhqz0=",
+          "requires": {
+            "browserslist": "1.0.1",
+            "caniuse-db": "1.0.30000377",
+            "num2fraction": "1.2.2",
+            "postcss": "5.0.13",
+            "postcss-value-parser": "3.2.3"
+          },
           "dependencies": {
-            "postcss-value-parser": {
-              "version": "3.2.3",
-              "from": "postcss-value-parser@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
-            },
-            "num2fraction": {
-              "version": "1.2.2",
-              "from": "num2fraction@>=1.2.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-            },
             "browserslist": {
               "version": "1.0.1",
-              "from": "browserslist@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
+              "integrity": "sha1-7w3XCDGM33QyX67qWe/shNlGRxc=",
+              "requires": {
+                "caniuse-db": "1.0.30000377"
+              }
             },
             "caniuse-db": {
               "version": "1.0.30000377",
-              "from": "caniuse-db@>=1.0.30000372 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000377.tgz"
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000377.tgz",
+              "integrity": "sha1-EFRNqPHD/lCTrDaThgQs2i9QXqk="
+            },
+            "num2fraction": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+              "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+            },
+            "postcss-value-parser": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
+              "integrity": "sha1-IW5yR7vSa3Zoq57r0I3muW6ytFM="
             }
           }
         },
         "postcss": {
           "version": "5.0.13",
-          "from": "postcss@>=5.0.4 <6.0.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.13.tgz",
+          "integrity": "sha1-kHMep8vD54bnFP5rtrea3z4YmoY=",
+          "requires": {
+            "js-base64": "2.1.9",
+            "source-map": "0.5.3",
+            "supports-color": "3.1.2"
+          },
           "dependencies": {
-            "supports-color": {
-              "version": "3.1.2",
-              "from": "supports-color@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                }
-              }
+            "js-base64": {
+              "version": "2.1.9",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+              "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            "supports-color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+              "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+              "requires": {
+                "has-flag": "1.0.0"
+              },
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                  "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+                }
+              }
             }
           }
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+          "integrity": "sha1-9BocMd9eEp5DFERvZuygXNajBIA=",
+          "requires": {
+            "readable-stream": "2.0.5",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "process-nextick-args": "1.0.6",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                  "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             }
           }
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.2.0",
-          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
+          "integrity": "sha1-FGyxqfF+mumlR0D0du5XXdKlIpQ=",
+          "requires": {
+            "source-map": "0.5.3"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             }
           }
         }
@@ -2422,57 +3182,75 @@
     },
     "gulp-concat": {
       "version": "2.6.0",
-      "from": "gulp-concat@>=2.6.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
+      "integrity": "sha1-WFz7EVQR80h3MTEUBWa2qBxpy5E=",
+      "requires": {
+        "concat-with-sourcemaps": "1.0.4",
+        "gulp-util": "3.0.7",
+        "through2": "0.6.5"
+      },
       "dependencies": {
         "concat-with-sourcemaps": {
           "version": "1.0.4",
-          "from": "concat-with-sourcemaps@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
+          "integrity": "sha1-9Vs74q60dgGxCi1SWcz7cP0vHdY=",
+          "requires": {
+            "source-map": "0.5.3"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             }
           }
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "1.0.33",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             }
           }
         }
@@ -2480,109 +3258,177 @@
     },
     "gulp-cssnano": {
       "version": "2.0.0",
-      "from": "gulp-cssnano@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.0.0.tgz",
+      "integrity": "sha1-HojyqwQQfe1iXudfMxqd5n9m+gM=",
+      "requires": {
+        "cssnano": "3.4.0",
+        "gulp-util": "3.0.7",
+        "object-assign": "3.0.0",
+        "vinyl-sourcemaps-apply": "0.1.4"
+      },
       "dependencies": {
         "cssnano": {
           "version": "3.4.0",
-          "from": "cssnano@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.4.0.tgz",
+          "integrity": "sha1-FNORAy3kdg0i5dufH+wfCGjku7c=",
+          "requires": {
+            "autoprefixer": "6.1.2",
+            "decamelize": "1.1.1",
+            "defined": "1.0.0",
+            "indexes-of": "1.0.1",
+            "object-assign": "4.0.1",
+            "postcss": "5.0.13",
+            "postcss-calc": "5.0.0",
+            "postcss-colormin": "2.1.7",
+            "postcss-convert-values": "2.3.4",
+            "postcss-discard-comments": "2.0.2",
+            "postcss-discard-duplicates": "2.0.0",
+            "postcss-discard-empty": "2.0.0",
+            "postcss-discard-unused": "2.1.0",
+            "postcss-filter-plugins": "2.0.0",
+            "postcss-merge-idents": "2.1.3",
+            "postcss-merge-longhand": "2.0.1",
+            "postcss-merge-rules": "2.0.3",
+            "postcss-minify-font-values": "1.0.2",
+            "postcss-minify-gradients": "1.0.1",
+            "postcss-minify-params": "1.0.4",
+            "postcss-minify-selectors": "2.0.1",
+            "postcss-normalize-charset": "1.1.0",
+            "postcss-normalize-url": "3.0.4",
+            "postcss-ordered-values": "2.0.2",
+            "postcss-reduce-idents": "2.2.1",
+            "postcss-reduce-transforms": "1.0.3",
+            "postcss-svgo": "2.1.1",
+            "postcss-unique-selectors": "2.0.1",
+            "postcss-value-parser": "3.2.3",
+            "postcss-zindex": "2.0.0"
+          },
           "dependencies": {
             "autoprefixer": {
               "version": "6.1.2",
-              "from": "autoprefixer@>=6.0.3 <7.0.0",
               "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.1.2.tgz",
+              "integrity": "sha1-EaNrUMwOStqrVXCu0oz4GHbhqz0=",
+              "requires": {
+                "browserslist": "1.0.1",
+                "caniuse-db": "1.0.30000377",
+                "num2fraction": "1.2.2",
+                "postcss": "5.0.13",
+                "postcss-value-parser": "3.2.3"
+              },
               "dependencies": {
-                "num2fraction": {
-                  "version": "1.2.2",
-                  "from": "num2fraction@>=1.2.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-                },
                 "browserslist": {
                   "version": "1.0.1",
-                  "from": "browserslist@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
+                  "integrity": "sha1-7w3XCDGM33QyX67qWe/shNlGRxc=",
+                  "requires": {
+                    "caniuse-db": "1.0.30000377"
+                  }
                 },
                 "caniuse-db": {
                   "version": "1.0.30000377",
-                  "from": "caniuse-db@>=1.0.30000372 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000377.tgz"
+                  "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000377.tgz",
+                  "integrity": "sha1-EFRNqPHD/lCTrDaThgQs2i9QXqk="
+                },
+                "num2fraction": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+                  "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
                 }
               }
             },
             "decamelize": {
               "version": "1.1.1",
-              "from": "decamelize@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
+              "integrity": "sha1-iHFHmmwEh/VlPUipkvHQOBym8DE="
             },
             "defined": {
               "version": "1.0.0",
-              "from": "defined@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
             },
             "indexes-of": {
               "version": "1.0.1",
-              "from": "indexes-of@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+              "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
             },
             "object-assign": {
               "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+              "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
             },
             "postcss": {
               "version": "5.0.13",
-              "from": "postcss@>=5.0.10 <6.0.0",
               "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.13.tgz",
+              "integrity": "sha1-kHMep8vD54bnFP5rtrea3z4YmoY=",
+              "requires": {
+                "js-base64": "2.1.9",
+                "source-map": "0.5.3",
+                "supports-color": "3.1.2"
+              },
               "dependencies": {
-                "supports-color": {
-                  "version": "3.1.2",
-                  "from": "supports-color@>=3.1.2 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "1.0.0",
-                      "from": "has-flag@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                    }
-                  }
+                "js-base64": {
+                  "version": "2.1.9",
+                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+                  "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
                 },
                 "source-map": {
                   "version": "0.5.3",
-                  "from": "source-map@>=0.5.1 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+                  "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
                 },
-                "js-base64": {
-                  "version": "2.1.9",
-                  "from": "js-base64@>=2.1.9 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+                "supports-color": {
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+                  "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+                  "requires": {
+                    "has-flag": "1.0.0"
+                  },
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+                    }
+                  }
                 }
               }
             },
             "postcss-calc": {
               "version": "5.0.0",
-              "from": "postcss-calc@>=5.0.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.0.0.tgz",
+              "integrity": "sha1-I08GAOPe1THwFq0EXtRria71UsE=",
+              "requires": {
+                "postcss": "5.0.13",
+                "postcss-message-helpers": "2.0.0",
+                "reduce-css-calc": "1.2.0"
+              },
               "dependencies": {
                 "postcss-message-helpers": {
                   "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+                  "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
                 },
                 "reduce-css-calc": {
                   "version": "1.2.0",
-                  "from": "reduce-css-calc@>=1.2.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
+                  "integrity": "sha1-4ZHjYuk9pMDw+ZLeoSkyouENsZE=",
+                  "requires": {
+                    "balanced-match": "0.1.0",
+                    "reduce-function-call": "1.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
+                      "integrity": "sha1-tQS9BYabOSWd0MXvw12EMXbczEo="
                     },
                     "reduce-function-call": {
                       "version": "1.0.1",
-                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
+                      "integrity": "sha1-+gLhJuaVgkJjyrkdOlsP3B3Sepo=",
+                      "requires": {
+                        "balanced-match": "0.1.0"
+                      }
                     }
                   }
                 }
@@ -2590,150 +3436,215 @@
             },
             "postcss-colormin": {
               "version": "2.1.7",
-              "from": "postcss-colormin@>=2.1.7 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.1.7.tgz",
+              "integrity": "sha1-ueMLBNaCa+aFjBJMGav0E1UY0eQ=",
+              "requires": {
+                "colr-convert": "1.0.5",
+                "css-color-names": "0.0.2",
+                "postcss": "5.0.13",
+                "postcss-value-parser": "3.2.3"
+              },
               "dependencies": {
                 "colr-convert": {
                   "version": "1.0.5",
-                  "from": "colr-convert@>=1.0.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/colr-convert/-/colr-convert-1.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/colr-convert/-/colr-convert-1.0.5.tgz",
+                  "integrity": "sha1-tKIskyLfojjSqAqpBzbBEnGEG3E="
                 },
                 "css-color-names": {
                   "version": "0.0.2",
-                  "from": "css-color-names@0.0.2",
-                  "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.2.tgz",
+                  "integrity": "sha1-+6GOjP+GV5Vy10nBRsR+6D8OqVU="
                 }
               }
             },
             "postcss-convert-values": {
               "version": "2.3.4",
-              "from": "postcss-convert-values@>=2.3.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz",
+              "integrity": "sha1-IyG6A5fzIleRMNi58OiaQtguYjk=",
+              "requires": {
+                "postcss": "5.0.13",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-discard-comments": {
               "version": "2.0.2",
-              "from": "postcss-discard-comments@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.2.tgz",
+              "integrity": "sha1-mJl0Sq0TIfnxP/uMZydgav7KUPg=",
+              "requires": {
+                "postcss": "5.0.13"
+              }
             },
             "postcss-discard-duplicates": {
               "version": "2.0.0",
-              "from": "postcss-discard-duplicates@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz",
+              "integrity": "sha1-FqGQHl15GUexmOSmsp1+EjgU3RI=",
+              "requires": {
+                "postcss": "5.0.13"
+              }
             },
             "postcss-discard-empty": {
               "version": "2.0.0",
-              "from": "postcss-discard-empty@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz",
+              "integrity": "sha1-QEdovgWpEzBJARVIbh1SGRjI52E=",
+              "requires": {
+                "postcss": "5.0.13"
+              }
             },
             "postcss-discard-unused": {
               "version": "2.1.0",
-              "from": "postcss-discard-unused@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.1.0.tgz",
+              "integrity": "sha1-Vfdq6tVxwAvHQZ4wViacDRIT8Ug=",
+              "requires": {
+                "flatten": "0.0.1",
+                "postcss": "5.0.13",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "flatten": {
                   "version": "0.0.1",
-                  "from": "flatten@0.0.1",
-                  "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
+                  "integrity": "sha1-VURAdm2goNYDmZ9DNFP2wvxqdcE="
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-filter-plugins": {
               "version": "2.0.0",
-              "from": "postcss-filter-plugins@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
+              "integrity": "sha1-rM5dGMQOUb5ZiRG27Ki1TZ5b3t8=",
+              "requires": {
+                "postcss": "5.0.13",
+                "uniqid": "1.0.0"
+              },
               "dependencies": {
                 "uniqid": {
                   "version": "1.0.0",
-                  "from": "uniqid@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz",
+                  "integrity": "sha1-JYJSTgdASESkLelPviv1SeG3RVU="
                 }
               }
             },
             "postcss-merge-idents": {
               "version": "2.1.3",
-              "from": "postcss-merge-idents@>=2.1.3 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.3.tgz",
+              "integrity": "sha1-Ri1cz7en3+/b1int1n3TABCUqQ0=",
+              "requires": {
+                "has-own": "1.0.0",
+                "postcss": "5.0.13",
+                "postcss-value-parser": "3.2.3"
+              },
               "dependencies": {
                 "has-own": {
                   "version": "1.0.0",
-                  "from": "has-own@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz",
+                  "integrity": "sha1-MGIkbjHP2Iepph7m04ylcok3jNE="
                 }
               }
             },
             "postcss-merge-longhand": {
               "version": "2.0.1",
-              "from": "postcss-merge-longhand@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
+              "integrity": "sha1-/1m13sbVhs4s6hgxOPVcWHb6nNw=",
+              "requires": {
+                "postcss": "5.0.13"
+              }
             },
             "postcss-merge-rules": {
               "version": "2.0.3",
-              "from": "postcss-merge-rules@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz",
+              "integrity": "sha1-ku/377WhMCmFPrtKozCb5SXzGeY=",
+              "requires": {
+                "postcss": "5.0.13"
+              }
             },
             "postcss-minify-font-values": {
               "version": "1.0.2",
-              "from": "postcss-minify-font-values@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.2.tgz",
+              "integrity": "sha1-n2oEX/QWChbaYGF90/wyq9vufYs=",
+              "requires": {
+                "object-assign": "4.0.1",
+                "postcss": "5.0.13",
+                "postcss-value-parser": "3.2.3",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-minify-gradients": {
               "version": "1.0.1",
-              "from": "postcss-minify-gradients@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz",
+              "integrity": "sha1-PbMiSjlXEXMrwK6XtMdll0gaQPg=",
+              "requires": {
+                "postcss": "5.0.13",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-minify-params": {
               "version": "1.0.4",
-              "from": "postcss-minify-params@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
+              "integrity": "sha1-Kne5bbgEh/Ff75QVlbEbWVNo1UM=",
+              "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.0.13",
+                "postcss-value-parser": "3.2.3",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+                  "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-minify-selectors": {
               "version": "2.0.1",
-              "from": "postcss-minify-selectors@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.1.tgz",
+              "integrity": "sha1-Fea5n8CmGXZUkSF06oNEN6GLE4I=",
+              "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.0.13",
+                "postcss-selector-parser": "1.3.0"
+              },
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+                  "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
                 },
                 "postcss-selector-parser": {
                   "version": "1.3.0",
-                  "from": "postcss-selector-parser@>=1.1.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.0.tgz",
+                  "integrity": "sha1-PfYKh/0xOGkRDw7ksJcS0HA/qIU=",
+                  "requires": {
+                    "flatten": "0.0.1",
+                    "indexes-of": "1.0.1",
+                    "uniq": "1.0.1"
+                  },
                   "dependencies": {
                     "flatten": {
                       "version": "0.0.1",
-                      "from": "flatten@0.0.1",
-                      "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
+                      "integrity": "sha1-VURAdm2goNYDmZ9DNFP2wvxqdcE="
                     },
                     "uniq": {
                       "version": "1.0.1",
-                      "from": "uniq@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+                      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
                     }
                   }
                 }
@@ -2741,50 +3652,72 @@
             },
             "postcss-normalize-charset": {
               "version": "1.1.0",
-              "from": "postcss-normalize-charset@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz",
+              "integrity": "sha1-L70w4SJIxEKYHTHqJITUb9BiiXA=",
+              "requires": {
+                "postcss": "5.0.13"
+              }
             },
             "postcss-normalize-url": {
               "version": "3.0.4",
-              "from": "postcss-normalize-url@>=3.0.4 <4.0.0",
               "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.4.tgz",
+              "integrity": "sha1-0EUeiYFmqUeTaHSOxPEL91PftyA=",
+              "requires": {
+                "is-absolute-url": "2.0.0",
+                "normalize-url": "1.4.0",
+                "object-assign": "4.0.1",
+                "postcss": "5.0.13",
+                "postcss-value-parser": "3.2.3"
+              },
               "dependencies": {
                 "is-absolute-url": {
                   "version": "2.0.0",
-                  "from": "is-absolute-url@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
+                  "integrity": "sha1-nEsgsOXAy++aR5o2ft5vmRZ581k="
                 },
                 "normalize-url": {
                   "version": "1.4.0",
-                  "from": "normalize-url@>=1.3.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
+                  "integrity": "sha1-iuk+l932bxdUTB8SotwMDktXYv8=",
+                  "requires": {
+                    "object-assign": "4.0.1",
+                    "prepend-http": "1.0.3",
+                    "query-string": "3.0.0",
+                    "sort-keys": "1.1.1"
+                  },
                   "dependencies": {
                     "prepend-http": {
                       "version": "1.0.3",
-                      "from": "prepend-http@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
+                      "integrity": "sha1-TQ0rb5788RkMI5MTJbTzqduoSGk="
                     },
                     "query-string": {
                       "version": "3.0.0",
-                      "from": "query-string@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
+                      "integrity": "sha1-Av0wbwQyBAuRsRBj+UBP4bvUuns=",
+                      "requires": {
+                        "strict-uri-encode": "1.0.2"
+                      },
                       "dependencies": {
                         "strict-uri-encode": {
                           "version": "1.0.2",
-                          "from": "strict-uri-encode@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.0.2.tgz",
+                          "integrity": "sha1-/RnmOdiadmJWoz5hHThBXfjWBY0="
                         }
                       }
                     },
                     "sort-keys": {
                       "version": "1.1.1",
-                      "from": "sort-keys@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
+                      "integrity": "sha1-p5HCYHHfZsNWv13K2c+1ensvgm4=",
+                      "requires": {
+                        "is-plain-obj": "1.1.0"
+                      },
                       "dependencies": {
                         "is-plain-obj": {
                           "version": "1.1.0",
-                          "from": "is-plain-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+                          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
                         }
                       }
                     }
@@ -2794,166 +3727,227 @@
             },
             "postcss-ordered-values": {
               "version": "2.0.2",
-              "from": "postcss-ordered-values@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz",
+              "integrity": "sha1-//PE55yrXr84RQZX4282F6UCNUo=",
+              "requires": {
+                "postcss": "5.0.13",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-reduce-idents": {
               "version": "2.2.1",
-              "from": "postcss-reduce-idents@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz",
+              "integrity": "sha1-7NgvcZ+0DtoisLbUHD/C2sataps=",
+              "requires": {
+                "postcss": "5.0.13",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-reduce-transforms": {
               "version": "1.0.3",
-              "from": "postcss-reduce-transforms@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz",
+              "integrity": "sha1-/Bk+Q1qXPBD5gBx0cAqDD3lkM0M=",
+              "requires": {
+                "postcss": "5.0.13",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-svgo": {
               "version": "2.1.1",
-              "from": "postcss-svgo@>=2.0.4 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.1.tgz",
+              "integrity": "sha1-2sWzddCSeJ1ku/yr6dx0hriqjs0=",
+              "requires": {
+                "is-svg": "1.1.1",
+                "postcss": "5.0.13",
+                "postcss-value-parser": "3.2.3",
+                "svgo": "0.6.1"
+              },
               "dependencies": {
                 "is-svg": {
                   "version": "1.1.1",
-                  "from": "is-svg@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz",
+                  "integrity": "sha1-rA76r7ZTrFhHNwix+HNjbKEQ4xs="
                 },
                 "svgo": {
                   "version": "0.6.1",
-                  "from": "svgo@>=0.6.1 <0.7.0",
                   "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.1.tgz",
+                  "integrity": "sha1-ud2NRQZgyl+IsiJx+9yLKpZmN6k=",
+                  "requires": {
+                    "coa": "1.0.1",
+                    "colors": "1.1.2",
+                    "csso": "1.4.4",
+                    "js-yaml": "3.4.6",
+                    "mkdirp": "0.5.1",
+                    "sax": "1.1.4",
+                    "whet.extend": "0.9.9"
+                  },
                   "dependencies": {
-                    "sax": {
-                      "version": "1.1.4",
-                      "from": "sax@>=1.1.4 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz"
-                    },
                     "coa": {
                       "version": "1.0.1",
-                      "from": "coa@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
+                      "integrity": "sha1-f5WTRs/IcZ4/cjPNaFKFSnxn2KM=",
+                      "requires": {
+                        "q": "1.4.1"
+                      },
                       "dependencies": {
                         "q": {
                           "version": "1.4.1",
-                          "from": "q@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-                        }
-                      }
-                    },
-                    "js-yaml": {
-                      "version": "3.4.6",
-                      "from": "js-yaml@>=3.4.3 <3.5.0",
-                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
-                      "dependencies": {
-                        "argparse": {
-                          "version": "1.0.3",
-                          "from": "argparse@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
-                          "dependencies": {
-                            "lodash": {
-                              "version": "3.10.1",
-                              "from": "lodash@>=3.2.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                            },
-                            "sprintf-js": {
-                              "version": "1.0.3",
-                              "from": "sprintf-js@>=1.0.2 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "esprima": {
-                          "version": "2.7.1",
-                          "from": "esprima@>=2.6.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
-                        },
-                        "inherit": {
-                          "version": "2.2.2",
-                          "from": "inherit@>=2.2.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.2.tgz"
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
                         }
                       }
                     },
                     "colors": {
                       "version": "1.1.2",
-                      "from": "colors@>=1.1.2 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
-                    },
-                    "whet.extend": {
-                      "version": "0.9.9",
-                      "from": "whet.extend@>=0.9.9 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.1 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+                      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
                     },
                     "csso": {
                       "version": "1.4.4",
-                      "from": "csso@>=1.4.2 <1.5.0",
                       "resolved": "https://registry.npmjs.org/csso/-/csso-1.4.4.tgz",
+                      "integrity": "sha1-Cuv6UJPvMMysbbP/V1nfymIba2o=",
+                      "requires": {
+                        "clap": "1.0.10"
+                      },
                       "dependencies": {
                         "clap": {
                           "version": "1.0.10",
-                          "from": "clap@>=1.0.9 <2.0.0",
                           "resolved": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
+                          "integrity": "sha1-T3qT4URUWvhd/SnZL9l04yVIYyo=",
+                          "requires": {
+                            "chalk": "1.1.1"
+                          },
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@1.1.1",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                              "requires": {
+                                "ansi-styles": "2.1.0",
+                                "escape-string-regexp": "1.0.3",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.0",
+                                "supports-color": "2.0.0"
+                              },
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                  "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.3",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                  "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                 }
                               }
                             }
                           }
                         }
                       }
+                    },
+                    "js-yaml": {
+                      "version": "3.4.6",
+                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
+                      "integrity": "sha1-a+GyP2JJ9T0pM3D9TRqqY84bTrA=",
+                      "requires": {
+                        "argparse": "1.0.3",
+                        "esprima": "2.7.1",
+                        "inherit": "2.2.2"
+                      },
+                      "dependencies": {
+                        "argparse": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
+                          "integrity": "sha1-FDid7rDCj8TNqUBbn1MqTjeFzoQ=",
+                          "requires": {
+                            "lodash": "3.10.1",
+                            "sprintf-js": "1.0.3"
+                          },
+                          "dependencies": {
+                            "lodash": {
+                              "version": "3.10.1",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                            },
+                            "sprintf-js": {
+                              "version": "1.0.3",
+                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                              "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+                            }
+                          }
+                        },
+                        "esprima": {
+                          "version": "2.7.1",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
+                          "integrity": "sha1-KrfRVJ7dBtFNaabBoXVKygLpZX4="
+                        },
+                        "inherit": {
+                          "version": "2.2.2",
+                          "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.2.tgz",
+                          "integrity": "sha1-O1s0F9Q0+BojTWj3lhJhXkFiRKM="
+                        }
+                      }
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                      "requires": {
+                        "minimist": "0.0.8"
+                      },
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                        }
+                      }
+                    },
+                    "sax": {
+                      "version": "1.1.4",
+                      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+                      "integrity": "sha1-dLbTPJrh4AFRDxeakRaFiPGu2qk="
+                    },
+                    "whet.extend": {
+                      "version": "0.9.9",
+                      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+                      "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
                     }
                   }
                 }
@@ -2961,52 +3955,66 @@
             },
             "postcss-unique-selectors": {
               "version": "2.0.1",
-              "from": "postcss-unique-selectors@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.1.tgz",
+              "integrity": "sha1-bN71L+F2CIVFquZw3+fRRgS+CTE=",
+              "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.0.13",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+                  "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-value-parser": {
               "version": "3.2.3",
-              "from": "postcss-value-parser@>=3.1.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
+              "integrity": "sha1-IW5yR7vSa3Zoq57r0I3muW6ytFM="
             },
             "postcss-zindex": {
               "version": "2.0.0",
-              "from": "postcss-zindex@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.0.tgz",
+              "integrity": "sha1-Y23eKwfvSittetiwNOI39TXv0rk=",
+              "requires": {
+                "postcss": "5.0.13"
+              }
             }
           }
         },
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
+          "integrity": "sha1-xfy9Q+LyOEI8LcmL3db3m3K8NFs=",
+          "requires": {
+            "source-map": "0.1.43"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.1.43",
-              "from": "source-map@>=0.1.39 <0.2.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+              "requires": {
+                "amdefine": "1.0.0"
+              },
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM="
                 }
               }
             }
@@ -3016,72 +4024,114 @@
     },
     "gulp-less": {
       "version": "3.0.5",
-      "from": "gulp-less@>=3.0.3 <4.0.0",
       "resolved": "https://registry.npmjs.org/gulp-less/-/gulp-less-3.0.5.tgz",
+      "integrity": "sha1-gpSiB+Xo0m8L+pdsunZir1yZvQE=",
+      "requires": {
+        "accord": "0.20.5",
+        "gulp-util": "3.0.7",
+        "less": "2.5.3",
+        "object-assign": "4.0.1",
+        "through2": "2.0.0",
+        "vinyl-sourcemaps-apply": "0.2.0"
+      },
       "dependencies": {
         "accord": {
           "version": "0.20.5",
-          "from": "accord@>=0.20.1 <0.21.0",
           "resolved": "https://registry.npmjs.org/accord/-/accord-0.20.5.tgz",
+          "integrity": "sha1-pP2ObnJB4G73pjyoOUHNjkndrIw=",
+          "requires": {
+            "convert-source-map": "1.1.2",
+            "fobject": "0.0.3",
+            "glob": "5.0.15",
+            "indx": "0.2.3",
+            "lodash": "3.10.1",
+            "resolve": "1.1.6",
+            "semver": "4.3.6",
+            "uglify-js": "2.6.1",
+            "when": "3.7.5"
+          },
           "dependencies": {
             "convert-source-map": {
               "version": "1.1.2",
-              "from": "convert-source-map@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz",
+              "integrity": "sha1-gmY3iDEHOQf6OE8LKuyrC6BYZpM="
             },
             "fobject": {
               "version": "0.0.3",
-              "from": "fobject@0.0.3",
               "resolved": "https://registry.npmjs.org/fobject/-/fobject-0.0.3.tgz",
+              "integrity": "sha1-nRPrA9hr8JvdPRQxccrKiLPzgww=",
+              "requires": {
+                "graceful-fs": "3.0.8",
+                "semver": "4.3.6",
+                "when": "3.7.5"
+              },
               "dependencies": {
                 "graceful-fs": {
                   "version": "3.0.8",
-                  "from": "graceful-fs@>=3.0.2 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+                  "integrity": "sha1-zoE+cl+oL35hR9UcmlymgnBVHCI="
                 }
               }
             },
             "glob": {
               "version": "5.0.15",
-              "from": "glob@>=5.0.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "requires": {
+                "inflight": "1.0.4",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.0",
+                "once": "1.3.3",
+                "path-is-absolute": "1.0.0"
+              },
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+                  "requires": {
+                    "once": "1.3.3",
+                    "wrappy": "1.0.1"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "minimatch": {
                   "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+                  "requires": {
+                    "brace-expansion": "1.1.2"
+                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.2",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                      "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                      "requires": {
+                        "balanced-match": "0.3.0",
+                        "concat-map": "0.0.1"
+                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                          "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                         }
                       }
                     }
@@ -3089,150 +4139,193 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "requires": {
+                    "wrappy": "1.0.1"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
                 }
               }
             },
             "indx": {
               "version": "0.2.3",
-              "from": "indx@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz"
+              "resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz",
+              "integrity": "sha1-Fdz1bunPZcAjTFE8J/vVgOcPvFA="
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
+              "integrity": "sha1-00kq0FTKgA9b76YS5hvqwe7Jj48="
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=4.3.4 <5.0.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
             },
             "uglify-js": {
               "version": "2.6.1",
-              "from": "uglify-js@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+              "integrity": "sha1-7bvhiIujUl3tOnv4NrMLNAXTFhs=",
+              "requires": {
+                "async": "0.2.10",
+                "source-map": "0.5.3",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
                 },
                 "source-map": {
                   "version": "0.5.3",
-                  "from": "source-map@>=0.5.1 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+                  "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
                 },
                 "yargs": {
                   "version": "3.10.0",
-                  "from": "yargs@>=3.10.0 <3.11.0",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.1.1",
+                    "window-size": "0.1.0"
+                  },
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                      "requires": {
+                        "center-align": "0.1.2",
+                        "right-align": "0.1.3",
+                        "wordwrap": "0.0.2"
+                      },
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.2",
-                          "from": "center-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
+                          "integrity": "sha1-dPqFQPwZsmqubtx+AxzWmT1JW6A=",
+                          "requires": {
+                            "align-text": "0.1.3",
+                            "lazy-cache": "0.2.7"
+                          },
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "integrity": "sha1-cts5g4cu7CMTkZyUJqmTpBr+k/c=",
+                              "requires": {
+                                "kind-of": "2.0.1",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.5.2"
+                              },
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.1",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                  "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                                  "requires": {
+                                    "is-buffer": "1.1.0"
+                                  },
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.0",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                                      "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                                 }
                               }
                             },
                             "lazy-cache": {
                               "version": "0.2.7",
-                              "from": "lazy-cache@>=0.2.4 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+                              "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
                             }
                           }
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "right-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                          "requires": {
+                            "align-text": "0.1.3"
+                          },
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "integrity": "sha1-cts5g4cu7CMTkZyUJqmTpBr+k/c=",
+                              "requires": {
+                                "kind-of": "2.0.1",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.5.2"
+                              },
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.1",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                  "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                                  "requires": {
+                                    "is-buffer": "1.1.0"
+                                  },
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.0",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                                      "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                                 }
                               }
                             }
@@ -3240,20 +4333,20 @@
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.1.1",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
+                      "integrity": "sha1-iHFHmmwEh/VlPUipkvHQOBym8DE="
                     },
                     "window-size": {
                       "version": "0.1.0",
-                      "from": "window-size@0.1.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
                     }
                   }
                 }
@@ -3261,111 +4354,187 @@
             },
             "when": {
               "version": "3.7.5",
-              "from": "when@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/when/-/when-3.7.5.tgz"
+              "resolved": "https://registry.npmjs.org/when/-/when-3.7.5.tgz",
+              "integrity": "sha1-GZ/xFCmJYklXv/YawaLnFa8/YQo="
             }
           }
         },
         "less": {
           "version": "2.5.3",
-          "from": "less@>=2.5.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/less/-/less-2.5.3.tgz",
+          "integrity": "sha1-n/WG6KcDUV/Bjcmce8SY0vOtSEk=",
+          "requires": {
+            "errno": "0.1.4",
+            "graceful-fs": "3.0.8",
+            "image-size": "0.3.5",
+            "mime": "1.3.4",
+            "mkdirp": "0.5.1",
+            "promise": "6.1.0",
+            "request": "2.67.0",
+            "source-map": "0.4.4"
+          },
           "dependencies": {
             "errno": {
               "version": "0.1.4",
-              "from": "errno@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+              "optional": true,
+              "requires": {
+                "prr": "0.0.0"
+              },
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
-                  "from": "prr@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+                  "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+                  "optional": true
                 }
               }
             },
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.5 <4.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+              "integrity": "sha1-zoE+cl+oL35hR9UcmlymgnBVHCI=",
+              "optional": true
             },
             "image-size": {
               "version": "0.3.5",
-              "from": "image-size@>=0.3.5 <0.4.0",
-              "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz"
+              "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
+              "integrity": "sha1-gyQOqy+1sAsEqrjHSwRx6cunrYw=",
+              "optional": true
             },
             "mime": {
               "version": "1.3.4",
-              "from": "mime@>=1.2.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+              "optional": true
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "optional": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                  "optional": true
                 }
               }
             },
             "promise": {
               "version": "6.1.0",
-              "from": "promise@>=6.0.1 <7.0.0",
               "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+              "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY=",
+              "optional": true,
+              "requires": {
+                "asap": "1.0.0"
+              },
               "dependencies": {
                 "asap": {
                   "version": "1.0.0",
-                  "from": "asap@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
+                  "integrity": "sha1-sqRdpf36ILBJb8N2jMJ8EvqRan0=",
+                  "optional": true
                 }
               }
             },
             "request": {
               "version": "2.67.0",
-              "from": "request@>=2.51.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
+              "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
+              "optional": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "bl": "1.0.0",
+                "caseless": "0.11.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.0",
+                "forever-agent": "0.6.1",
+                "form-data": "1.0.0-rc3",
+                "har-validator": "2.0.3",
+                "hawk": "3.1.2",
+                "http-signature": "1.1.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.8",
+                "node-uuid": "1.4.7",
+                "oauth-sign": "0.8.0",
+                "qs": "5.2.0",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.2.1",
+                "tunnel-agent": "0.4.2"
+              },
               "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+                  "optional": true
+                },
                 "bl": {
                   "version": "1.0.0",
-                  "from": "bl@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                  "integrity": "sha1-ramoqJptesYIYvfex9sgeHPgw/U=",
+                  "optional": true,
+                  "requires": {
+                    "readable-stream": "2.0.5"
+                  },
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+                      "optional": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.1",
+                        "isarray": "0.0.1",
+                        "process-nextick-args": "1.0.6",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                      },
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "optional": true
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                          "optional": true
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                          "optional": true
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                          "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU=",
+                          "optional": true
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "optional": true
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                          "optional": true
                         }
                       }
                     }
@@ -3373,337 +4542,478 @@
                 },
                 "caseless": {
                   "version": "0.11.0",
-                  "from": "caseless@>=0.11.0 <0.12.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-                },
-                "extend": {
-                  "version": "3.0.0",
-                  "from": "extend@>=3.0.0 <3.1.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "from": "forever-agent@>=0.6.1 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-                },
-                "form-data": {
-                  "version": "1.0.0-rc3",
-                  "from": "form-data@>=1.0.0-rc3 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-                  "dependencies": {
-                    "async": {
-                      "version": "1.5.0",
-                      "from": "async@>=1.4.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-                    }
-                  }
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                },
-                "mime-types": {
-                  "version": "2.1.8",
-                  "from": "mime-types@>=2.1.7 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.20.0",
-                      "from": "mime-db@>=1.20.0 <1.21.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
-                    }
-                  }
-                },
-                "node-uuid": {
-                  "version": "1.4.7",
-                  "from": "node-uuid@>=1.4.7 <1.5.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-                },
-                "qs": {
-                  "version": "5.2.0",
-                  "from": "qs@>=5.2.0 <5.3.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.2",
-                  "from": "tunnel-agent@>=0.4.1 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-                },
-                "tough-cookie": {
-                  "version": "2.2.1",
-                  "from": "tough-cookie@>=2.2.0 <2.3.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-                },
-                "http-signature": {
-                  "version": "1.1.0",
-                  "from": "http-signature@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "assert-plus@>=0.1.5 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                    },
-                    "jsprim": {
-                      "version": "1.2.2",
-                      "from": "jsprim@>=1.2.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                      "dependencies": {
-                        "extsprintf": {
-                          "version": "1.0.2",
-                          "from": "extsprintf@1.0.2",
-                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                        },
-                        "json-schema": {
-                          "version": "0.2.2",
-                          "from": "json-schema@0.2.2",
-                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
-                        },
-                        "verror": {
-                          "version": "1.3.6",
-                          "from": "verror@1.3.6",
-                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.7.1",
-                      "from": "sshpk@>=1.7.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
-                      "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3",
-                          "from": "asn1@>=0.2.3 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                        },
-                        "assert-plus": {
-                          "version": "0.2.0",
-                          "from": "assert-plus@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                        },
-                        "dashdash": {
-                          "version": "1.10.1",
-                          "from": "dashdash@>=1.10.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
-                          "dependencies": {
-                            "assert-plus": {
-                              "version": "0.1.5",
-                              "from": "assert-plus@>=0.1.0 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                            }
-                          }
-                        },
-                        "jsbn": {
-                          "version": "0.1.0",
-                          "from": "jsbn@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                        },
-                        "tweetnacl": {
-                          "version": "0.13.2",
-                          "from": "tweetnacl@>=0.13.0 <1.0.0",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
-                        },
-                        "jodid25519": {
-                          "version": "1.0.2",
-                          "from": "jodid25519@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "oauth-sign": {
-                  "version": "0.8.0",
-                  "from": "oauth-sign@>=0.8.0 <0.9.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-                },
-                "hawk": {
-                  "version": "3.1.2",
-                  "from": "hawk@>=3.1.0 <3.2.0",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3",
-                      "from": "hoek@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                    },
-                    "boom": {
-                      "version": "2.10.1",
-                      "from": "boom@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "cryptiles@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "from": "sntp@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "from": "aws-sign2@>=0.6.0 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-                },
-                "stringstream": {
-                  "version": "0.0.5",
-                  "from": "stringstream@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                  "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+                  "optional": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
-                  "from": "combined-stream@>=1.0.5 <1.1.0",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "from": "delayed-stream@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
                     }
                   }
                 },
-                "isstream": {
-                  "version": "0.1.2",
-                  "from": "isstream@>=0.1.2 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                "extend": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                  "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+                  "optional": true
                 },
-                "is-typedarray": {
-                  "version": "1.0.0",
-                  "from": "is-typedarray@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                  "optional": true
+                },
+                "form-data": {
+                  "version": "1.0.0-rc3",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                  "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
+                  "optional": true,
+                  "requires": {
+                    "async": "1.5.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.8"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "1.5.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+                      "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM=",
+                      "optional": true
+                    }
+                  }
                 },
                 "har-validator": {
                   "version": "2.0.3",
-                  "from": "har-validator@>=2.0.2 <2.1.0",
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
+                  "integrity": "sha1-Wp4SVkpXHPC4Hvk8IVe9FhcWiIM=",
+                  "optional": true,
+                  "requires": {
+                    "chalk": "1.1.1",
+                    "commander": "2.9.0",
+                    "is-my-json-valid": "2.12.3",
+                    "pinkie-promise": "2.0.0"
+                  },
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.1",
-                      "from": "chalk@>=1.1.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                      "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                      "optional": true,
+                      "requires": {
+                        "ansi-styles": "2.1.0",
+                        "escape-string-regexp": "1.0.3",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.0",
+                        "supports-color": "2.0.0"
+                      },
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.1.0",
-                          "from": "ansi-styles@>=2.1.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                          "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI=",
+                          "optional": true
                         },
                         "escape-string-regexp": {
                           "version": "1.0.3",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                          "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U=",
+                          "optional": true
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                          "optional": true,
+                          "requires": {
+                            "ansi-regex": "2.0.0"
+                          },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                              "optional": true
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.0",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                          "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                          "optional": true,
+                          "requires": {
+                            "ansi-regex": "2.0.0"
+                          },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.0.0",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                              "optional": true
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                          "optional": true
                         }
                       }
                     },
                     "commander": {
                       "version": "2.9.0",
-                      "from": "commander@>=2.9.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                      "optional": true,
+                      "requires": {
+                        "graceful-readlink": "1.0.1"
+                      },
                       "dependencies": {
                         "graceful-readlink": {
                           "version": "1.0.1",
-                          "from": "graceful-readlink@>=1.0.0",
-                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                          "optional": true
                         }
                       }
                     },
                     "is-my-json-valid": {
                       "version": "2.12.3",
-                      "from": "is-my-json-valid@>=2.12.3 <3.0.0",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
+                      "integrity": "sha1-WjnR12stu4MUC70Vex1e5L3IWtY=",
+                      "optional": true,
+                      "requires": {
+                        "generate-function": "2.0.0",
+                        "generate-object-property": "1.2.0",
+                        "jsonpointer": "2.0.0",
+                        "xtend": "4.0.1"
+                      },
                       "dependencies": {
                         "generate-function": {
                           "version": "2.0.0",
-                          "from": "generate-function@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                          "optional": true
                         },
                         "generate-object-property": {
                           "version": "1.2.0",
-                          "from": "generate-object-property@>=1.1.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                          "optional": true,
+                          "requires": {
+                            "is-property": "1.0.2"
+                          },
                           "dependencies": {
                             "is-property": {
                               "version": "1.0.2",
-                              "from": "is-property@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                              "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                              "optional": true
                             }
                           }
                         },
                         "jsonpointer": {
                           "version": "2.0.0",
-                          "from": "jsonpointer@2.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                          "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
+                          "optional": true
                         },
                         "xtend": {
                           "version": "4.0.1",
-                          "from": "xtend@>=4.0.0 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                          "optional": true
                         }
                       }
                     },
                     "pinkie-promise": {
                       "version": "2.0.0",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                      "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                      "optional": true,
+                      "requires": {
+                        "pinkie": "2.0.1"
+                      },
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.1",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                          "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw=",
+                          "optional": true
                         }
                       }
                     }
                   }
+                },
+                "hawk": {
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
+                  "integrity": "sha1-kMkBGIhuIZddGtSumz4oTtGaLeg=",
+                  "optional": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                      "optional": true,
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                      "optional": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
+                  "integrity": "sha1-XS1+m270mYCtWxKNjk7wmjHJDZU=",
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "0.1.5",
+                    "jsprim": "1.2.2",
+                    "sshpk": "1.7.1"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+                      "optional": true
+                    },
+                    "jsprim": {
+                      "version": "1.2.2",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+                      "integrity": "sha1-8gyQaskqvVjjt5rIvHCkiDJRLaE=",
+                      "optional": true,
+                      "requires": {
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.2",
+                        "verror": "1.3.6"
+                      },
+                      "dependencies": {
+                        "extsprintf": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+                        },
+                        "json-schema": {
+                          "version": "0.2.2",
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                          "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+                          "optional": true
+                        },
+                        "verror": {
+                          "version": "1.3.6",
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                          "optional": true,
+                          "requires": {
+                            "extsprintf": "1.0.2"
+                          }
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.7.1",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
+                      "integrity": "sha1-Vl44bEKnfmBi+9FMBHL/Ic1TOYw=",
+                      "optional": true,
+                      "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "0.2.0",
+                        "dashdash": "1.10.1",
+                        "ecc-jsbn": "0.1.1",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.0",
+                        "tweetnacl": "0.13.2"
+                      },
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                          "optional": true
+                        },
+                        "assert-plus": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                          "optional": true
+                        },
+                        "dashdash": {
+                          "version": "1.10.1",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
+                          "integrity": "sha1-Cr8a+JqPUSmoHxjCs1sh3yJiL2A=",
+                          "optional": true,
+                          "requires": {
+                            "assert-plus": "0.1.5"
+                          },
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "0.1.5",
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                              "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+                              "optional": true
+                            }
+                          }
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.0"
+                          }
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.0"
+                          }
+                        },
+                        "jsbn": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                          "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                          "optional": true
+                        },
+                        "tweetnacl": {
+                          "version": "0.13.2",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz",
+                          "integrity": "sha1-RTFhdwRp1FzSZsNkBOK8maj6mUQ=",
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+                  "optional": true
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                  "optional": true
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                  "optional": true
+                },
+                "mime-types": {
+                  "version": "2.1.8",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
+                  "integrity": "sha1-+vV4I94EvHy/9O6CxrY5RugSrnI=",
+                  "requires": {
+                    "mime-db": "1.20.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.20.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz",
+                      "integrity": "sha1-SW+Q/QH+DgMciCPsOqlFD/2hjtg="
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.7",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                  "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+                  "optional": true
+                },
+                "oauth-sign": {
+                  "version": "0.8.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+                  "integrity": "sha1-k4/ch1dlulJxN9iuydF44k3rxVM=",
+                  "optional": true
+                },
+                "qs": {
+                  "version": "5.2.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+                  "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=",
+                  "optional": true
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+                  "optional": true
+                },
+                "tough-cookie": {
+                  "version": "2.2.1",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
+                  "integrity": "sha1-OwUWt5nnDoFkQ2oURuflh3/aEY4=",
+                  "optional": true
+                },
+                "tunnel-agent": {
+                  "version": "0.4.2",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+                  "integrity": "sha1-EQTj82rIcSXChycAZ9WC0YEzv+4=",
+                  "optional": true
                 }
               }
             },
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.2 <0.5.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "optional": true,
+              "requires": {
+                "amdefine": "1.0.0"
+              },
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                  "optional": true
                 }
               }
             }
@@ -3711,67 +5021,82 @@
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+          "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+          "integrity": "sha1-9BocMd9eEp5DFERvZuygXNajBIA=",
+          "requires": {
+            "readable-stream": "2.0.5",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "process-nextick-args": "1.0.6",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                  "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             }
           }
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.2.0",
-          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
+          "integrity": "sha1-FGyxqfF+mumlR0D0du5XXdKlIpQ=",
+          "requires": {
+            "source-map": "0.5.3"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             }
           }
         }
@@ -3779,45 +5104,59 @@
     },
     "gulp-plumber": {
       "version": "1.0.1",
-      "from": "gulp-plumber@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.0.1.tgz",
+      "integrity": "sha1-VtjnSgoFqLddLswRgA0Bkd9UKvI=",
+      "requires": {
+        "gulp-util": "3.0.7",
+        "through2": "0.6.5"
+      },
       "dependencies": {
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "1.0.33",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             }
           }
         }
@@ -3825,172 +5164,240 @@
     },
     "gulp-uglify": {
       "version": "1.5.1",
-      "from": "gulp-uglify@>=1.4.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.5.1.tgz",
+      "integrity": "sha1-nhMpQkc1TJHhWs4RaxYweJNmIGo=",
+      "requires": {
+        "deap": "1.0.0",
+        "fancy-log": "1.1.0",
+        "gulp-util": "3.0.7",
+        "isobject": "2.0.0",
+        "through2": "2.0.0",
+        "uglify-js": "2.6.0",
+        "uglify-save-license": "0.4.1",
+        "vinyl-sourcemaps-apply": "0.2.0"
+      },
       "dependencies": {
         "deap": {
           "version": "1.0.0",
-          "from": "deap@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz",
+          "integrity": "sha1-sUi/gkMKJ2mbdIOgPra2dYW/yIg="
         },
         "fancy-log": {
           "version": "1.1.0",
-          "from": "fancy-log@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
+          "integrity": "sha1-CMTzYH/jFCCHzPQl7sbj+TV6Rts=",
+          "requires": {
+            "chalk": "1.1.1",
+            "dateformat": "1.0.12"
+          },
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+              "requires": {
+                "ansi-styles": "2.1.0",
+                "escape-string-regexp": "1.0.3",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.0",
+                "supports-color": "2.0.0"
+              },
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                  "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                 }
               }
             },
             "dateformat": {
               "version": "1.0.12",
-              "from": "dateformat@>=1.0.11 <2.0.0",
               "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+              "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+              "requires": {
+                "get-stdin": "4.0.1",
+                "meow": "3.6.0"
+              },
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
                 },
                 "meow": {
                   "version": "3.6.0",
-                  "from": "meow@>=3.3.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
+                  "integrity": "sha1-56U1KVy4nbDgeCQo5V+oYVv54VA=",
+                  "requires": {
+                    "camelcase-keys": "2.0.0",
+                    "loud-rejection": "1.2.0",
+                    "minimist": "1.2.0",
+                    "normalize-package-data": "2.3.5",
+                    "object-assign": "4.0.1",
+                    "read-pkg-up": "1.0.1",
+                    "redent": "1.0.0",
+                    "trim-newlines": "1.0.0"
+                  },
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "2.0.0",
-                      "from": "camelcase-keys@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                      "integrity": "sha1-q4fnQNcqH/yxKkPMBMFLOdVJ6rk=",
+                      "requires": {
+                        "camelcase": "2.0.1",
+                        "map-obj": "1.0.1"
+                      },
                       "dependencies": {
                         "camelcase": {
                           "version": "2.0.1",
-                          "from": "camelcase@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz",
+                          "integrity": "sha1-V1aNaHuNpWxMHRe0x0o87ibXOus="
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
                         }
                       }
                     },
                     "loud-rejection": {
                       "version": "1.2.0",
-                      "from": "loud-rejection@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
+                      "integrity": "sha1-9Ph9tqvsO3/keDRTHs9qARFD5Y0=",
+                      "requires": {
+                        "signal-exit": "2.1.2"
+                      },
                       "dependencies": {
                         "signal-exit": {
                           "version": "2.1.2",
-                          "from": "signal-exit@>=2.1.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
+                          "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ="
                         }
                       }
                     },
                     "minimist": {
                       "version": "1.2.0",
-                      "from": "minimist@>=1.1.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                     },
                     "normalize-package-data": {
                       "version": "2.3.5",
-                      "from": "normalize-package-data@>=2.3.4 <3.0.0",
                       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                      "requires": {
+                        "hosted-git-info": "2.1.4",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.1.0",
+                        "validate-npm-package-license": "3.0.1"
+                      },
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.4",
-                          "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+                          "integrity": "sha1-2elTsmmIvogJbEbpJklNlgTDAPg="
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "from": "is-builtin-module@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                          "requires": {
+                            "builtin-modules": "1.1.0"
+                          },
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.0",
-                              "from": "builtin-modules@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
+                              "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw="
                             }
                           }
                         },
                         "semver": {
                           "version": "5.1.0",
-                          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+                          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU="
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
                           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                          "requires": {
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.2"
+                          },
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
-                              "from": "spdx-correct@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                              "requires": {
+                                "spdx-license-ids": "1.1.0"
+                              },
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+                                  "integrity": "sha1-KGlKzfOf4n3kUUP/+B8h9sZtRKw="
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.2",
-                              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                              "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
+                              "requires": {
+                                "spdx-exceptions": "1.0.4",
+                                "spdx-license-ids": "1.1.0"
+                              },
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
-                                  "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                                  "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0="
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+                                  "integrity": "sha1-KGlKzfOf4n3kUUP/+B8h9sZtRKw="
                                 }
                               }
                             }
@@ -4000,33 +5407,47 @@
                     },
                     "object-assign": {
                       "version": "4.0.1",
-                      "from": "object-assign@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+                      "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
                     },
                     "read-pkg-up": {
                       "version": "1.0.1",
-                      "from": "read-pkg-up@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                      "requires": {
+                        "find-up": "1.1.0",
+                        "read-pkg": "1.1.0"
+                      },
                       "dependencies": {
                         "find-up": {
                           "version": "1.1.0",
-                          "from": "find-up@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                          "integrity": "sha1-pjsO7EYlopAlNImKX57siq7QRuk=",
+                          "requires": {
+                            "path-exists": "2.1.0",
+                            "pinkie-promise": "2.0.0"
+                          },
                           "dependencies": {
                             "path-exists": {
                               "version": "2.1.0",
-                              "from": "path-exists@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                              "requires": {
+                                "pinkie-promise": "2.0.0"
+                              }
                             },
                             "pinkie-promise": {
                               "version": "2.0.0",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                              "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                              "requires": {
+                                "pinkie": "2.0.1"
+                              },
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.1",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                                  "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw="
                                 }
                               }
                             }
@@ -4034,33 +5455,51 @@
                         },
                         "read-pkg": {
                           "version": "1.1.0",
-                          "from": "read-pkg@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                          "requires": {
+                            "load-json-file": "1.1.0",
+                            "normalize-package-data": "2.3.5",
+                            "path-type": "1.1.0"
+                          },
                           "dependencies": {
                             "load-json-file": {
                               "version": "1.1.0",
-                              "from": "load-json-file@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                              "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                              "requires": {
+                                "graceful-fs": "4.1.2",
+                                "parse-json": "2.2.0",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.0",
+                                "strip-bom": "2.0.0"
+                              },
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "4.1.2",
-                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                                  "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
                                 },
                                 "parse-json": {
                                   "version": "2.2.0",
-                                  "from": "parse-json@>=2.2.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                                  "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                                  "requires": {
+                                    "error-ex": "1.3.0"
+                                  },
                                   "dependencies": {
                                     "error-ex": {
                                       "version": "1.3.0",
-                                      "from": "error-ex@>=1.2.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                      "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                                      "requires": {
+                                        "is-arrayish": "0.2.1"
+                                      },
                                       "dependencies": {
                                         "is-arrayish": {
                                           "version": "0.2.1",
-                                          "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
                                         }
                                       }
                                     }
@@ -4068,30 +5507,36 @@
                                 },
                                 "pify": {
                                   "version": "2.3.0",
-                                  "from": "pify@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                                 },
                                 "pinkie-promise": {
                                   "version": "2.0.0",
-                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                                  "requires": {
+                                    "pinkie": "2.0.1"
+                                  },
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.1",
-                                      "from": "pinkie@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                                      "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw="
                                     }
                                   }
                                 },
                                 "strip-bom": {
                                   "version": "2.0.0",
-                                  "from": "strip-bom@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                                  "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                                  "requires": {
+                                    "is-utf8": "0.2.0"
+                                  },
                                   "dependencies": {
                                     "is-utf8": {
                                       "version": "0.2.0",
-                                      "from": "is-utf8@>=0.2.0 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+                                      "integrity": "sha1-uKpUElrmJr/k4765ZfFqicWKETc="
                                     }
                                   }
                                 }
@@ -4099,28 +5544,36 @@
                             },
                             "path-type": {
                               "version": "1.1.0",
-                              "from": "path-type@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                              "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                              "requires": {
+                                "graceful-fs": "4.1.2",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.0"
+                              },
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "4.1.2",
-                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                                  "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
                                 },
                                 "pify": {
                                   "version": "2.3.0",
-                                  "from": "pify@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                                  "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                                 },
                                 "pinkie-promise": {
                                   "version": "2.0.0",
-                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                                  "requires": {
+                                    "pinkie": "2.0.1"
+                                  },
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.1",
-                                      "from": "pinkie@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                                      "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw="
                                     }
                                   }
                                 }
@@ -4132,28 +5585,41 @@
                     },
                     "redent": {
                       "version": "1.0.0",
-                      "from": "redent@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+                      "requires": {
+                        "indent-string": "2.1.0",
+                        "strip-indent": "1.0.1"
+                      },
                       "dependencies": {
                         "indent-string": {
                           "version": "2.1.0",
-                          "from": "indent-string@>=2.1.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+                          "requires": {
+                            "repeating": "2.0.0"
+                          },
                           "dependencies": {
                             "repeating": {
                               "version": "2.0.0",
-                              "from": "repeating@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                              "integrity": "sha1-/SfW0mTRj76/qlZVPde4JTWlA04=",
+                              "requires": {
+                                "is-finite": "1.0.1"
+                              },
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                  "requires": {
+                                    "number-is-nan": "1.0.0"
+                                  },
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                     }
                                   }
                                 }
@@ -4163,15 +5629,18 @@
                         },
                         "strip-indent": {
                           "version": "1.0.1",
-                          "from": "strip-indent@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+                          "requires": {
+                            "get-stdin": "4.0.1"
+                          }
                         }
                       }
                     },
                     "trim-newlines": {
                       "version": "1.0.0",
-                      "from": "trim-newlines@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
                     }
                   }
                 }
@@ -4181,172 +5650,227 @@
         },
         "isobject": {
           "version": "2.0.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+          "integrity": "sha1-II3ocr1zeMKpKvlCij9W65GhIsQ=",
+          "requires": {
+            "isarray": "0.0.1"
+          },
           "dependencies": {
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
             }
           }
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+          "integrity": "sha1-9BocMd9eEp5DFERvZuygXNajBIA=",
+          "requires": {
+            "readable-stream": "2.0.5",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "process-nextick-args": "1.0.6",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                  "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             }
           }
         },
         "uglify-js": {
           "version": "2.6.0",
-          "from": "uglify-js@2.6.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.0.tgz",
+          "integrity": "sha1-JeqhzDVQ45QQzu+v0c+7a20V8AE=",
+          "requires": {
+            "async": "0.2.10",
+            "source-map": "0.5.3",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
             },
             "yargs": {
               "version": "3.10.0",
-              "from": "yargs@>=3.10.0 <3.11.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.1.1",
+                "window-size": "0.1.0"
+              },
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                  "requires": {
+                    "center-align": "0.1.2",
+                    "right-align": "0.1.3",
+                    "wordwrap": "0.0.2"
+                  },
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.2",
-                      "from": "center-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
+                      "integrity": "sha1-dPqFQPwZsmqubtx+AxzWmT1JW6A=",
+                      "requires": {
+                        "align-text": "0.1.3",
+                        "lazy-cache": "0.2.7"
+                      },
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "integrity": "sha1-cts5g4cu7CMTkZyUJqmTpBr+k/c=",
+                          "requires": {
+                            "kind-of": "2.0.1",
+                            "longest": "1.0.1",
+                            "repeat-string": "1.5.2"
+                          },
                           "dependencies": {
                             "kind-of": {
                               "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                              "requires": {
+                                "is-buffer": "1.1.0"
+                              },
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.0",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                                  "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                             }
                           }
                         },
                         "lazy-cache": {
                           "version": "0.2.7",
-                          "from": "lazy-cache@>=0.2.4 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+                          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
                         }
                       }
                     },
                     "right-align": {
                       "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                      "requires": {
+                        "align-text": "0.1.3"
+                      },
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "integrity": "sha1-cts5g4cu7CMTkZyUJqmTpBr+k/c=",
+                          "requires": {
+                            "kind-of": "2.0.1",
+                            "longest": "1.0.1",
+                            "repeat-string": "1.5.2"
+                          },
                           "dependencies": {
                             "kind-of": {
                               "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                              "requires": {
+                                "is-buffer": "1.1.0"
+                              },
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.0",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                                  "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                             }
                           }
                         }
@@ -4354,20 +5878,20 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.1.1",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
+                  "integrity": "sha1-iHFHmmwEh/VlPUipkvHQOBym8DE="
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "window-size@0.1.0",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
                 }
               }
             }
@@ -4375,18 +5899,21 @@
         },
         "uglify-save-license": {
           "version": "0.4.1",
-          "from": "uglify-save-license@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz",
+          "integrity": "sha1-lXJsF8xv0XHDYX479NjYKqjEzOE="
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.2.0",
-          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
+          "integrity": "sha1-FGyxqfF+mumlR0D0du5XXdKlIpQ=",
+          "requires": {
+            "source-map": "0.5.3"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             }
           }
         }
@@ -4394,172 +5921,246 @@
     },
     "gulp-util": {
       "version": "3.0.7",
-      "from": "gulp-util@>=3.0.6 <4.0.0",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
+      "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.2",
+        "beeper": "1.1.0",
+        "chalk": "1.1.1",
+        "dateformat": "1.0.12",
+        "fancy-log": "1.1.0",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.0",
+        "vinyl": "0.5.3"
+      },
       "dependencies": {
         "array-differ": {
           "version": "1.0.0",
-          "from": "array-differ@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+          "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
         },
         "array-uniq": {
           "version": "1.0.2",
-          "from": "array-uniq@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+          "integrity": "sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0="
         },
         "beeper": {
           "version": "1.1.0",
-          "from": "beeper@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
+          "integrity": "sha1-nub8HOf1T+qs585zWIsFYDeGaiw="
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+          "requires": {
+            "ansi-styles": "2.1.0",
+            "escape-string-regexp": "1.0.3",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.0",
+            "supports-color": "2.0.0"
+          },
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+              "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
         "dateformat": {
           "version": "1.0.12",
-          "from": "dateformat@>=1.0.11 <2.0.0",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+          "requires": {
+            "get-stdin": "4.0.1",
+            "meow": "3.6.0"
+          },
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
             },
             "meow": {
               "version": "3.6.0",
-              "from": "meow@>=3.3.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
+              "integrity": "sha1-56U1KVy4nbDgeCQo5V+oYVv54VA=",
+              "requires": {
+                "camelcase-keys": "2.0.0",
+                "loud-rejection": "1.2.0",
+                "minimist": "1.2.0",
+                "normalize-package-data": "2.3.5",
+                "object-assign": "4.0.1",
+                "read-pkg-up": "1.0.1",
+                "redent": "1.0.0",
+                "trim-newlines": "1.0.0"
+              },
               "dependencies": {
                 "camelcase-keys": {
                   "version": "2.0.0",
-                  "from": "camelcase-keys@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                  "integrity": "sha1-q4fnQNcqH/yxKkPMBMFLOdVJ6rk=",
+                  "requires": {
+                    "camelcase": "2.0.1",
+                    "map-obj": "1.0.1"
+                  },
                   "dependencies": {
                     "camelcase": {
                       "version": "2.0.1",
-                      "from": "camelcase@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz",
+                      "integrity": "sha1-V1aNaHuNpWxMHRe0x0o87ibXOus="
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
                     }
                   }
                 },
                 "loud-rejection": {
                   "version": "1.2.0",
-                  "from": "loud-rejection@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
+                  "integrity": "sha1-9Ph9tqvsO3/keDRTHs9qARFD5Y0=",
+                  "requires": {
+                    "signal-exit": "2.1.2"
+                  },
                   "dependencies": {
                     "signal-exit": {
                       "version": "2.1.2",
-                      "from": "signal-exit@>=2.1.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
+                      "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ="
                     }
                   }
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                  "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                  "requires": {
+                    "hosted-git-info": "2.1.4",
+                    "is-builtin-module": "1.0.0",
+                    "semver": "5.1.0",
+                    "validate-npm-package-license": "3.0.1"
+                  },
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.4",
-                      "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+                      "integrity": "sha1-2elTsmmIvogJbEbpJklNlgTDAPg="
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                      "requires": {
+                        "builtin-modules": "1.1.0"
+                      },
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.0",
-                          "from": "builtin-modules@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
+                          "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw="
                         }
                       }
                     },
                     "semver": {
                       "version": "5.1.0",
-                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+                      "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU="
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                      "requires": {
+                        "spdx-correct": "1.0.2",
+                        "spdx-expression-parse": "1.0.2"
+                      },
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                          "requires": {
+                            "spdx-license-ids": "1.1.0"
+                          },
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+                              "integrity": "sha1-KGlKzfOf4n3kUUP/+B8h9sZtRKw="
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.2",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                          "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
+                          "requires": {
+                            "spdx-exceptions": "1.0.4",
+                            "spdx-license-ids": "1.1.0"
+                          },
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.4",
-                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                              "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0="
                             },
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+                              "integrity": "sha1-KGlKzfOf4n3kUUP/+B8h9sZtRKw="
                             }
                           }
                         }
@@ -4569,33 +6170,47 @@
                 },
                 "object-assign": {
                   "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+                  "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
                 },
                 "read-pkg-up": {
                   "version": "1.0.1",
-                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                  "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                  "requires": {
+                    "find-up": "1.1.0",
+                    "read-pkg": "1.1.0"
+                  },
                   "dependencies": {
                     "find-up": {
                       "version": "1.1.0",
-                      "from": "find-up@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                      "integrity": "sha1-pjsO7EYlopAlNImKX57siq7QRuk=",
+                      "requires": {
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.0"
+                      },
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
-                          "from": "path-exists@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                          "requires": {
+                            "pinkie-promise": "2.0.0"
+                          }
                         },
                         "pinkie-promise": {
                           "version": "2.0.0",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                          "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                          "requires": {
+                            "pinkie": "2.0.1"
+                          },
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.1",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                              "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw="
                             }
                           }
                         }
@@ -4603,33 +6218,51 @@
                     },
                     "read-pkg": {
                       "version": "1.1.0",
-                      "from": "read-pkg@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                      "requires": {
+                        "load-json-file": "1.1.0",
+                        "normalize-package-data": "2.3.5",
+                        "path-type": "1.1.0"
+                      },
                       "dependencies": {
                         "load-json-file": {
                           "version": "1.1.0",
-                          "from": "load-json-file@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                          "requires": {
+                            "graceful-fs": "4.1.2",
+                            "parse-json": "2.2.0",
+                            "pify": "2.3.0",
+                            "pinkie-promise": "2.0.0",
+                            "strip-bom": "2.0.0"
+                          },
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                              "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
                             },
                             "parse-json": {
                               "version": "2.2.0",
-                              "from": "parse-json@>=2.2.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                              "requires": {
+                                "error-ex": "1.3.0"
+                              },
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.3.0",
-                                  "from": "error-ex@>=1.2.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                  "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                                  "requires": {
+                                    "is-arrayish": "0.2.1"
+                                  },
                                   "dependencies": {
                                     "is-arrayish": {
                                       "version": "0.2.1",
-                                      "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
                                     }
                                   }
                                 }
@@ -4637,30 +6270,36 @@
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                             },
                             "pinkie-promise": {
                               "version": "2.0.0",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                              "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                              "requires": {
+                                "pinkie": "2.0.1"
+                              },
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.1",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                                  "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw="
                                 }
                               }
                             },
                             "strip-bom": {
                               "version": "2.0.0",
-                              "from": "strip-bom@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                              "requires": {
+                                "is-utf8": "0.2.0"
+                              },
                               "dependencies": {
                                 "is-utf8": {
                                   "version": "0.2.0",
-                                  "from": "is-utf8@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+                                  "integrity": "sha1-uKpUElrmJr/k4765ZfFqicWKETc="
                                 }
                               }
                             }
@@ -4668,28 +6307,36 @@
                         },
                         "path-type": {
                           "version": "1.1.0",
-                          "from": "path-type@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                          "requires": {
+                            "graceful-fs": "4.1.2",
+                            "pify": "2.3.0",
+                            "pinkie-promise": "2.0.0"
+                          },
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                              "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                             },
                             "pinkie-promise": {
                               "version": "2.0.0",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                              "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                              "requires": {
+                                "pinkie": "2.0.1"
+                              },
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.1",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                                  "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw="
                                 }
                               }
                             }
@@ -4701,28 +6348,41 @@
                 },
                 "redent": {
                   "version": "1.0.0",
-                  "from": "redent@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                  "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+                  "requires": {
+                    "indent-string": "2.1.0",
+                    "strip-indent": "1.0.1"
+                  },
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
-                      "from": "indent-string@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+                      "requires": {
+                        "repeating": "2.0.0"
+                      },
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.0",
-                          "from": "repeating@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                          "integrity": "sha1-/SfW0mTRj76/qlZVPde4JTWlA04=",
+                          "requires": {
+                            "is-finite": "1.0.1"
+                          },
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                              "requires": {
+                                "number-is-nan": "1.0.0"
+                              },
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                 }
                               }
                             }
@@ -4732,15 +6392,18 @@
                     },
                     "strip-indent": {
                       "version": "1.0.1",
-                      "from": "strip-indent@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+                      "requires": {
+                        "get-stdin": "4.0.1"
+                      }
                     }
                   }
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
-                  "from": "trim-newlines@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                  "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
                 }
               }
             }
@@ -4748,23 +6411,33 @@
         },
         "fancy-log": {
           "version": "1.1.0",
-          "from": "fancy-log@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
+          "integrity": "sha1-CMTzYH/jFCCHzPQl7sbj+TV6Rts=",
+          "requires": {
+            "chalk": "1.1.1",
+            "dateformat": "1.0.12"
+          }
         },
         "gulplog": {
           "version": "1.0.0",
-          "from": "gulplog@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+          "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+          "requires": {
+            "glogg": "1.0.0"
+          },
           "dependencies": {
             "glogg": {
               "version": "1.0.0",
-              "from": "glogg@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+              "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+              "requires": {
+                "sparkles": "1.0.0"
+              },
               "dependencies": {
                 "sparkles": {
                   "version": "1.0.0",
-                  "from": "sparkles@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                  "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
                 }
               }
             }
@@ -4772,134 +6445,172 @@
         },
         "has-gulplog": {
           "version": "0.1.0",
-          "from": "has-gulplog@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+          "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+          "requires": {
+            "sparkles": "1.0.0"
+          },
           "dependencies": {
             "sparkles": {
               "version": "1.0.0",
-              "from": "sparkles@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+              "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
             }
           }
         },
         "lodash._reescape": {
           "version": "3.0.0",
-          "from": "lodash._reescape@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+          "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
         },
         "lodash._reevaluate": {
           "version": "3.0.0",
-          "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+          "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
         },
         "lodash._reinterpolate": {
           "version": "3.0.0",
-          "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+          "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
         },
         "lodash.template": {
           "version": "3.6.2",
-          "from": "lodash.template@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+          "requires": {
+            "lodash._basecopy": "3.0.1",
+            "lodash._basetostring": "3.0.1",
+            "lodash._basevalues": "3.0.0",
+            "lodash._isiterateecall": "3.0.9",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.escape": "3.0.0",
+            "lodash.keys": "3.1.2",
+            "lodash.restparam": "3.6.1",
+            "lodash.templatesettings": "3.1.0"
+          },
           "dependencies": {
             "lodash._basecopy": {
               "version": "3.0.1",
-              "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+              "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
             },
             "lodash._basetostring": {
               "version": "3.0.1",
-              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+              "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
             },
             "lodash._basevalues": {
               "version": "3.0.0",
-              "from": "lodash._basevalues@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+              "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
             },
             "lodash._isiterateecall": {
               "version": "3.0.9",
-              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+              "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
             },
             "lodash.escape": {
               "version": "3.0.0",
-              "from": "lodash.escape@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
+              "integrity": "sha1-+ylMmae/tYYDn2bWucJ+2HTLe1E=",
+              "requires": {
+                "lodash._basetostring": "3.0.1"
+              }
             },
             "lodash.keys": {
               "version": "3.1.2",
-              "from": "lodash.keys@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+              "requires": {
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.0.4",
+                "lodash.isarray": "3.0.4"
+              },
               "dependencies": {
                 "lodash._getnative": {
                   "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                  "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
                 },
                 "lodash.isarguments": {
                   "version": "3.0.4",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                  "integrity": "sha1-67uITEjSc2akTqb+5X7XtaMqgeA="
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
                 }
               }
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "from": "lodash.restparam@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
             },
             "lodash.templatesettings": {
               "version": "3.1.0",
-              "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
+              "integrity": "sha1-U4Uv2DK5IGBaLrYZGby7+484W7Y=",
+              "requires": {
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.0.0"
+              }
             }
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "multipipe": {
           "version": "0.1.2",
-          "from": "multipipe@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+          "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+          "requires": {
+            "duplexer2": "0.0.2"
+          },
           "dependencies": {
             "duplexer2": {
               "version": "0.0.2",
-              "from": "duplexer2@0.0.2",
               "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+              "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+              "requires": {
+                "readable-stream": "1.1.13"
+              },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                     }
                   }
                 }
@@ -4909,77 +6620,94 @@
         },
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         },
         "replace-ext": {
           "version": "0.0.1",
-          "from": "replace-ext@0.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+          "integrity": "sha1-9BocMd9eEp5DFERvZuygXNajBIA=",
+          "requires": {
+            "readable-stream": "2.0.5",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "process-nextick-args": "1.0.6",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                  "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             }
           }
         },
         "vinyl": {
           "version": "0.5.3",
-          "from": "vinyl@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+          "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+          "requires": {
+            "clone": "1.0.2",
+            "clone-stats": "0.0.1",
+            "replace-ext": "0.0.1"
+          },
           "dependencies": {
             "clone": {
               "version": "1.0.2",
-              "from": "clone@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+              "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
             },
             "clone-stats": {
               "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2",
-              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+              "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
             }
           }
         }

--- a/shuup/notify/npm-shrinkwrap.json
+++ b/shuup/notify/npm-shrinkwrap.json
@@ -1,58 +1,83 @@
 {
   "name": "shuup.notify",
   "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "autoprefixer-loader": {
       "version": "2.1.0",
-      "from": "autoprefixer-loader@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/autoprefixer-loader/-/autoprefixer-loader-2.1.0.tgz",
+      "integrity": "sha1-lXcoXJvo0iFi4ln3VD7N5BORHGg=",
+      "requires": {
+        "autoprefixer-core": "5.2.1",
+        "loader-utils": "0.2.12",
+        "postcss": "5.0.13",
+        "postcss-safe-parser": "1.0.2"
+      },
       "dependencies": {
         "autoprefixer-core": {
           "version": "5.2.1",
-          "from": "autoprefixer-core@>=5.2.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
+          "integrity": "sha1-5kDEFK5Bmq4hwa1DyOoPPbgqVm0=",
+          "requires": {
+            "browserslist": "0.4.0",
+            "caniuse-db": "1.0.30000377",
+            "num2fraction": "1.2.2",
+            "postcss": "4.1.16"
+          },
           "dependencies": {
             "browserslist": {
               "version": "0.4.0",
-              "from": "browserslist@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
-            },
-            "num2fraction": {
-              "version": "1.2.2",
-              "from": "num2fraction@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
+              "integrity": "sha1-O9SrkZncG5FQ1NbbpNnTqrvIbdQ=",
+              "requires": {
+                "caniuse-db": "1.0.30000377"
+              }
             },
             "caniuse-db": {
               "version": "1.0.30000377",
-              "from": "caniuse-db@>=1.0.30000214 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000377.tgz"
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000377.tgz",
+              "integrity": "sha1-EFRNqPHD/lCTrDaThgQs2i9QXqk="
+            },
+            "num2fraction": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+              "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
             },
             "postcss": {
               "version": "4.1.16",
-              "from": "postcss@>=4.1.12 <4.2.0",
               "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
+              "integrity": "sha1-TESbTIr53zyvbTf44eV10DYXWNw=",
+              "requires": {
+                "es6-promise": "2.3.0",
+                "js-base64": "2.1.9",
+                "source-map": "0.4.4"
+              },
               "dependencies": {
                 "es6-promise": {
                   "version": "2.3.0",
-                  "from": "es6-promise@>=2.3.0 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
-                },
-                "source-map": {
-                  "version": "0.4.4",
-                  "from": "source-map@>=0.4.2 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+                  "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
                 },
                 "js-base64": {
                   "version": "2.1.9",
-                  "from": "js-base64@>=2.1.8 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+                  "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                  "requires": {
+                    "amdefine": "1.0.0"
+                  },
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM="
+                    }
+                  }
                 }
               }
             }
@@ -60,145 +85,220 @@
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "integrity": "sha1-+qKlAVY6PCyd2leqjDnYvmKN56I=",
+          "requires": {
+            "big.js": "3.1.3",
+            "json5": "0.4.0"
+          },
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
             }
           }
         },
         "postcss": {
           "version": "5.0.13",
-          "from": "postcss@>=5.0.3 <6.0.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.13.tgz",
+          "integrity": "sha1-kHMep8vD54bnFP5rtrea3z4YmoY=",
+          "requires": {
+            "js-base64": "2.1.9",
+            "source-map": "0.5.3",
+            "supports-color": "3.1.2"
+          },
           "dependencies": {
-            "supports-color": {
-              "version": "3.1.2",
-              "from": "supports-color@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                }
-              }
+            "js-base64": {
+              "version": "2.1.9",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+              "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            "supports-color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+              "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+              "requires": {
+                "has-flag": "1.0.0"
+              },
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                  "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+                }
+              }
             }
           }
         },
         "postcss-safe-parser": {
           "version": "1.0.2",
-          "from": "postcss-safe-parser@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-1.0.2.tgz",
+          "integrity": "sha1-286UMjeqayqHhVHrvIy18fP572o=",
+          "requires": {
+            "babel-plugin-add-module-exports": "0.1.1",
+            "babel-preset-es2015-loose": "6.1.3",
+            "babel-preset-stage-0": "6.3.13",
+            "postcss": "5.0.13"
+          },
           "dependencies": {
             "babel-plugin-add-module-exports": {
               "version": "0.1.1",
-              "from": "babel-plugin-add-module-exports@0.1.1",
               "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.1.1.tgz",
+              "integrity": "sha1-2uvb6OvaqBc4X0TwBoYCpr9/dcY=",
+              "requires": {
+                "babel-template": "6.3.13",
+                "lodash": "3.10.1"
+              },
               "dependencies": {
                 "babel-template": {
                   "version": "6.3.13",
-                  "from": "babel-template@>=6.0.16 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                  "integrity": "sha1-hXXxaGepKKna6E87vNyn54Bvwiw=",
+                  "requires": {
+                    "babel-runtime": "5.8.34",
+                    "babel-traverse": "6.3.19",
+                    "babel-types": "6.3.20",
+                    "babylon": "6.3.20",
+                    "lodash": "3.10.1"
+                  },
                   "dependencies": {
-                    "babylon": {
-                      "version": "6.3.20",
-                      "from": "babylon@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
                     },
                     "babel-traverse": {
                       "version": "6.3.19",
-                      "from": "babel-traverse@>=6.3.13 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                      "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                      "requires": {
+                        "babel-code-frame": "6.3.13",
+                        "babel-messages": "6.3.18",
+                        "babel-runtime": "5.8.34",
+                        "babel-types": "6.3.20",
+                        "babylon": "6.3.20",
+                        "debug": "2.2.0",
+                        "globals": "8.15.0",
+                        "invariant": "2.2.0",
+                        "lodash": "3.10.1",
+                        "repeating": "1.1.3"
+                      },
                       "dependencies": {
                         "babel-code-frame": {
                           "version": "6.3.13",
-                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
                           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "chalk": "1.1.1",
+                            "esutils": "2.0.2",
+                            "js-tokens": "1.0.2",
+                            "line-numbers": "0.2.0",
+                            "repeating": "1.1.3"
+                          },
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@>=1.1.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                              "requires": {
+                                "ansi-styles": "2.1.0",
+                                "escape-string-regexp": "1.0.3",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.0",
+                                "supports-color": "2.0.0"
+                              },
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                  "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.3",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                  "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                 }
                               }
                             },
                             "esutils": {
                               "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                             },
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                              "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                             },
                             "line-numbers": {
                               "version": "0.2.0",
-                              "from": "line-numbers@>=0.2.0 <0.3.0",
                               "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                              "requires": {
+                                "left-pad": "0.0.3"
+                              },
                               "dependencies": {
                                 "left-pad": {
                                   "version": "0.0.3",
-                                  "from": "left-pad@0.0.3",
-                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                  "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
                                 }
                               }
                             }
@@ -206,40 +306,52 @@
                         },
                         "babel-messages": {
                           "version": "6.3.18",
-                          "from": "babel-messages@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                          "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
                         },
                         "debug": {
                           "version": "2.2.0",
-                          "from": "debug@>=2.2.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                          "requires": {
+                            "ms": "0.7.1"
+                          },
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "ms@0.7.1",
-                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
                             }
                           }
                         },
                         "globals": {
                           "version": "8.15.0",
-                          "from": "globals@>=8.3.0 <9.0.0",
-                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                          "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
                         },
                         "invariant": {
                           "version": "2.2.0",
-                          "from": "invariant@>=2.2.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                          "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                          "requires": {
+                            "loose-envify": "1.1.0"
+                          },
                           "dependencies": {
                             "loose-envify": {
                               "version": "1.1.0",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                              "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                              "requires": {
+                                "js-tokens": "1.0.2"
+                              },
                               "dependencies": {
                                 "js-tokens": {
                                   "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                 }
                               }
                             }
@@ -247,18 +359,24 @@
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.3 <2.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                          "requires": {
+                            "is-finite": "1.0.1"
+                          },
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                              "requires": {
+                                "number-is-nan": "1.0.0"
+                              },
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                 }
                               }
                             }
@@ -268,463 +386,92 @@
                     },
                     "babel-types": {
                       "version": "6.3.20",
-                      "from": "babel-types@>=6.3.13 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                      "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "esutils": "2.0.2",
+                        "lodash": "3.10.1",
+                        "to-fast-properties": "1.0.1"
+                      },
                       "dependencies": {
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                         },
                         "to-fast-properties": {
                           "version": "1.0.1",
-                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                          "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
                         }
                       }
                     },
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
+                    "babylon": {
+                      "version": "6.3.20",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                      "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                      "requires": {
+                        "babel-runtime": "5.8.34"
                       }
                     }
                   }
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                  "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                 }
               }
             },
             "babel-preset-es2015-loose": {
               "version": "6.1.3",
-              "from": "babel-preset-es2015-loose@6.1.3",
               "resolved": "https://registry.npmjs.org/babel-preset-es2015-loose/-/babel-preset-es2015-loose-6.1.3.tgz",
+              "integrity": "sha1-haspI8+kLByrB2XBqITNQm0kOHw=",
+              "requires": {
+                "babel-plugin-transform-es2015-arrow-functions": "6.3.13",
+                "babel-plugin-transform-es2015-block-scoped-functions": "6.3.13",
+                "babel-plugin-transform-es2015-block-scoping": "6.3.13",
+                "babel-plugin-transform-es2015-classes": "6.3.15",
+                "babel-plugin-transform-es2015-computed-properties": "6.3.13",
+                "babel-plugin-transform-es2015-constants": "6.1.4",
+                "babel-plugin-transform-es2015-destructuring": "6.3.15",
+                "babel-plugin-transform-es2015-for-of": "6.3.13",
+                "babel-plugin-transform-es2015-function-name": "6.3.19",
+                "babel-plugin-transform-es2015-literals": "6.3.13",
+                "babel-plugin-transform-es2015-modules-commonjs": "6.3.16",
+                "babel-plugin-transform-es2015-object-super": "6.3.13",
+                "babel-plugin-transform-es2015-parameters": "6.3.18",
+                "babel-plugin-transform-es2015-shorthand-properties": "6.3.13",
+                "babel-plugin-transform-es2015-spread": "6.3.14",
+                "babel-plugin-transform-es2015-sticky-regex": "6.3.13",
+                "babel-plugin-transform-es2015-template-literals": "6.3.13",
+                "babel-plugin-transform-es2015-typeof-symbol": "6.3.13",
+                "babel-plugin-transform-es2015-unicode-regex": "6.3.13",
+                "babel-plugin-transform-regenerator": "6.3.18"
+              },
               "dependencies": {
-                "babel-plugin-transform-es2015-template-literals": {
-                  "version": "6.3.13",
-                  "from": "babel-plugin-transform-es2015-template-literals@>=6.0.14 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.3.13.tgz",
-                  "dependencies": {
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-es2015-literals": {
-                  "version": "6.3.13",
-                  "from": "babel-plugin-transform-es2015-literals@>=6.0.15 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.3.13.tgz",
-                  "dependencies": {
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-es2015-function-name": {
-                  "version": "6.3.19",
-                  "from": "babel-plugin-transform-es2015-function-name@>=6.0.14 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.3.19.tgz",
-                  "dependencies": {
-                    "babel-helper-function-name": {
-                      "version": "6.3.15",
-                      "from": "babel-helper-function-name@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
-                      "dependencies": {
-                        "babel-traverse": {
-                          "version": "6.3.19",
-                          "from": "babel-traverse@>=6.3.15 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                          "dependencies": {
-                            "babel-code-frame": {
-                              "version": "6.3.13",
-                              "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                              "dependencies": {
-                                "chalk": {
-                                  "version": "1.1.1",
-                                  "from": "chalk@>=1.1.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.1.0",
-                                      "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.3",
-                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                    },
-                                    "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "3.0.0",
-                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "supports-color@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "esutils": {
-                                  "version": "2.0.2",
-                                  "from": "esutils@>=2.0.2 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                },
-                                "js-tokens": {
-                                  "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                },
-                                "line-numbers": {
-                                  "version": "0.2.0",
-                                  "from": "line-numbers@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                                  "dependencies": {
-                                    "left-pad": {
-                                      "version": "0.0.3",
-                                      "from": "left-pad@0.0.3",
-                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "babel-messages": {
-                              "version": "6.3.18",
-                              "from": "babel-messages@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                            },
-                            "babylon": {
-                              "version": "6.3.20",
-                              "from": "babylon@>=6.3.15 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                            },
-                            "debug": {
-                              "version": "2.2.0",
-                              "from": "debug@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                              "dependencies": {
-                                "ms": {
-                                  "version": "0.7.1",
-                                  "from": "ms@0.7.1",
-                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                                }
-                              }
-                            },
-                            "globals": {
-                              "version": "8.15.0",
-                              "from": "globals@>=8.3.0 <9.0.0",
-                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                            },
-                            "invariant": {
-                              "version": "2.2.0",
-                              "from": "invariant@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                              "dependencies": {
-                                "loose-envify": {
-                                  "version": "1.1.0",
-                                  "from": "loose-envify@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                                  "dependencies": {
-                                    "js-tokens": {
-                                      "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "lodash": {
-                              "version": "3.10.1",
-                              "from": "lodash@>=3.10.1 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                            },
-                            "repeating": {
-                              "version": "1.1.3",
-                              "from": "repeating@>=1.1.3 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                              "dependencies": {
-                                "is-finite": {
-                                  "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                  "dependencies": {
-                                    "number-is-nan": {
-                                      "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "babel-helper-get-function-arity": {
-                          "version": "6.3.13",
-                          "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
-                        },
-                        "babel-template": {
-                          "version": "6.3.13",
-                          "from": "babel-template@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
-                          "dependencies": {
-                            "babylon": {
-                              "version": "6.3.20",
-                              "from": "babylon@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                            },
-                            "lodash": {
-                              "version": "3.10.1",
-                              "from": "lodash@>=3.10.1 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-types": {
-                      "version": "6.3.20",
-                      "from": "babel-types@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
-                      "dependencies": {
-                        "babel-traverse": {
-                          "version": "6.3.19",
-                          "from": "babel-traverse@>=6.3.17 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                          "dependencies": {
-                            "babel-code-frame": {
-                              "version": "6.3.13",
-                              "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                              "dependencies": {
-                                "chalk": {
-                                  "version": "1.1.1",
-                                  "from": "chalk@>=1.1.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.1.0",
-                                      "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.3",
-                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                    },
-                                    "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "3.0.0",
-                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "supports-color@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "js-tokens": {
-                                  "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                },
-                                "line-numbers": {
-                                  "version": "0.2.0",
-                                  "from": "line-numbers@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                                  "dependencies": {
-                                    "left-pad": {
-                                      "version": "0.0.3",
-                                      "from": "left-pad@0.0.3",
-                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "babel-messages": {
-                              "version": "6.3.18",
-                              "from": "babel-messages@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                            },
-                            "babylon": {
-                              "version": "6.3.20",
-                              "from": "babylon@>=6.3.15 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                            },
-                            "debug": {
-                              "version": "2.2.0",
-                              "from": "debug@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                              "dependencies": {
-                                "ms": {
-                                  "version": "0.7.1",
-                                  "from": "ms@0.7.1",
-                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                                }
-                              }
-                            },
-                            "globals": {
-                              "version": "8.15.0",
-                              "from": "globals@>=8.3.0 <9.0.0",
-                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                            },
-                            "invariant": {
-                              "version": "2.2.0",
-                              "from": "invariant@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                              "dependencies": {
-                                "loose-envify": {
-                                  "version": "1.1.0",
-                                  "from": "loose-envify@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                                  "dependencies": {
-                                    "js-tokens": {
-                                      "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "repeating": {
-                              "version": "1.1.3",
-                              "from": "repeating@>=1.1.3 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                              "dependencies": {
-                                "is-finite": {
-                                  "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                  "dependencies": {
-                                    "number-is-nan": {
-                                      "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        },
-                        "to-fast-properties": {
-                          "version": "1.0.1",
-                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
                 "babel-plugin-transform-es2015-arrow-functions": {
                   "version": "6.3.13",
-                  "from": "babel-plugin-transform-es2015-arrow-functions@>=6.0.14 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.3.13.tgz",
+                  "integrity": "sha1-peHibg2BuHf+oMBvsqkf0kftfTU=",
+                  "requires": {
+                    "babel-runtime": "5.8.34"
+                  },
                   "dependencies": {
                     "babel-runtime": {
                       "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
                       "dependencies": {
                         "core-js": {
                           "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
                         }
                       }
                     }
@@ -732,1941 +479,24 @@
                 },
                 "babel-plugin-transform-es2015-block-scoped-functions": {
                   "version": "6.3.13",
-                  "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.0.14 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.3.13.tgz",
+                  "integrity": "sha1-pfz/ifh3WI9B/rG3gmg5G0RcMVs=",
+                  "requires": {
+                    "babel-runtime": "5.8.34"
+                  },
                   "dependencies": {
                     "babel-runtime": {
                       "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
                       "dependencies": {
                         "core-js": {
                           "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-es2015-classes": {
-                  "version": "6.3.15",
-                  "from": "babel-plugin-transform-es2015-classes@>=6.1.2 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.3.15.tgz",
-                  "dependencies": {
-                    "babel-helper-optimise-call-expression": {
-                      "version": "6.3.13",
-                      "from": "babel-helper-optimise-call-expression@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.3.13.tgz"
-                    },
-                    "babel-helper-function-name": {
-                      "version": "6.3.15",
-                      "from": "babel-helper-function-name@>=6.3.15 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
-                      "dependencies": {
-                        "babel-helper-get-function-arity": {
-                          "version": "6.3.13",
-                          "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
-                        }
-                      }
-                    },
-                    "babel-helper-replace-supers": {
-                      "version": "6.3.13",
-                      "from": "babel-helper-replace-supers@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.3.13.tgz"
-                    },
-                    "babel-template": {
-                      "version": "6.3.13",
-                      "from": "babel-template@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
-                      "dependencies": {
-                        "babylon": {
-                          "version": "6.3.20",
-                          "from": "babylon@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                        },
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        }
-                      }
-                    },
-                    "babel-traverse": {
-                      "version": "6.3.19",
-                      "from": "babel-traverse@>=6.3.15 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                      "dependencies": {
-                        "babel-code-frame": {
-                          "version": "6.3.13",
-                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.1",
-                              "from": "chalk@>=1.1.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.3",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "js-tokens": {
-                              "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                            },
-                            "line-numbers": {
-                              "version": "0.2.0",
-                              "from": "line-numbers@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                              "dependencies": {
-                                "left-pad": {
-                                  "version": "0.0.3",
-                                  "from": "left-pad@0.0.3",
-                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "babylon": {
-                          "version": "6.3.20",
-                          "from": "babylon@>=6.3.15 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                        },
-                        "debug": {
-                          "version": "2.2.0",
-                          "from": "debug@>=2.2.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                          "dependencies": {
-                            "ms": {
-                              "version": "0.7.1",
-                              "from": "ms@0.7.1",
-                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                            }
-                          }
-                        },
-                        "globals": {
-                          "version": "8.15.0",
-                          "from": "globals@>=8.3.0 <9.0.0",
-                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                        },
-                        "invariant": {
-                          "version": "2.2.0",
-                          "from": "invariant@>=2.2.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                          "dependencies": {
-                            "loose-envify": {
-                              "version": "1.1.0",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                              "dependencies": {
-                                "js-tokens": {
-                                  "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        },
-                        "repeating": {
-                          "version": "1.1.3",
-                          "from": "repeating@>=1.1.3 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-helper-define-map": {
-                      "version": "6.3.13",
-                      "from": "babel-helper-define-map@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.3.13.tgz",
-                      "dependencies": {
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.3.18",
-                      "from": "babel-messages@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                    },
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    },
-                    "babel-types": {
-                      "version": "6.3.20",
-                      "from": "babel-types@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
-                      "dependencies": {
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        },
-                        "to-fast-properties": {
-                          "version": "1.0.1",
-                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-es2015-object-super": {
-                  "version": "6.3.13",
-                  "from": "babel-plugin-transform-es2015-object-super@>=6.0.14 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.3.13.tgz",
-                  "dependencies": {
-                    "babel-helper-replace-supers": {
-                      "version": "6.3.13",
-                      "from": "babel-helper-replace-supers@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.3.13.tgz",
-                      "dependencies": {
-                        "babel-helper-optimise-call-expression": {
-                          "version": "6.3.13",
-                          "from": "babel-helper-optimise-call-expression@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.3.13.tgz"
-                        },
-                        "babel-traverse": {
-                          "version": "6.3.19",
-                          "from": "babel-traverse@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                          "dependencies": {
-                            "babel-code-frame": {
-                              "version": "6.3.13",
-                              "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                              "dependencies": {
-                                "chalk": {
-                                  "version": "1.1.1",
-                                  "from": "chalk@>=1.1.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.1.0",
-                                      "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.3",
-                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                    },
-                                    "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "3.0.0",
-                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "supports-color@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "esutils": {
-                                  "version": "2.0.2",
-                                  "from": "esutils@>=2.0.2 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                },
-                                "js-tokens": {
-                                  "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                },
-                                "line-numbers": {
-                                  "version": "0.2.0",
-                                  "from": "line-numbers@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                                  "dependencies": {
-                                    "left-pad": {
-                                      "version": "0.0.3",
-                                      "from": "left-pad@0.0.3",
-                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "babylon": {
-                              "version": "6.3.20",
-                              "from": "babylon@>=6.3.15 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                            },
-                            "debug": {
-                              "version": "2.2.0",
-                              "from": "debug@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                              "dependencies": {
-                                "ms": {
-                                  "version": "0.7.1",
-                                  "from": "ms@0.7.1",
-                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                                }
-                              }
-                            },
-                            "globals": {
-                              "version": "8.15.0",
-                              "from": "globals@>=8.3.0 <9.0.0",
-                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                            },
-                            "invariant": {
-                              "version": "2.2.0",
-                              "from": "invariant@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                              "dependencies": {
-                                "loose-envify": {
-                                  "version": "1.1.0",
-                                  "from": "loose-envify@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                                  "dependencies": {
-                                    "js-tokens": {
-                                      "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "lodash": {
-                              "version": "3.10.1",
-                              "from": "lodash@>=3.10.1 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                            },
-                            "repeating": {
-                              "version": "1.1.3",
-                              "from": "repeating@>=1.1.3 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                              "dependencies": {
-                                "is-finite": {
-                                  "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                  "dependencies": {
-                                    "number-is-nan": {
-                                      "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "babel-messages": {
-                          "version": "6.3.18",
-                          "from": "babel-messages@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                        },
-                        "babel-template": {
-                          "version": "6.3.13",
-                          "from": "babel-template@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
-                          "dependencies": {
-                            "babylon": {
-                              "version": "6.3.20",
-                              "from": "babylon@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                            },
-                            "lodash": {
-                              "version": "3.10.1",
-                              "from": "lodash@>=3.10.1 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                            }
-                          }
-                        },
-                        "babel-types": {
-                          "version": "6.3.20",
-                          "from": "babel-types@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
-                          "dependencies": {
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "lodash": {
-                              "version": "3.10.1",
-                              "from": "lodash@>=3.10.1 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                            },
-                            "to-fast-properties": {
-                              "version": "1.0.1",
-                              "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-es2015-shorthand-properties": {
-                  "version": "6.3.13",
-                  "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.0.14 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.3.13.tgz",
-                  "dependencies": {
-                    "babel-types": {
-                      "version": "6.3.20",
-                      "from": "babel-types@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
-                      "dependencies": {
-                        "babel-traverse": {
-                          "version": "6.3.19",
-                          "from": "babel-traverse@>=6.3.17 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                          "dependencies": {
-                            "babel-code-frame": {
-                              "version": "6.3.13",
-                              "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                              "dependencies": {
-                                "chalk": {
-                                  "version": "1.1.1",
-                                  "from": "chalk@>=1.1.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.1.0",
-                                      "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.3",
-                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                    },
-                                    "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "3.0.0",
-                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "supports-color@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "js-tokens": {
-                                  "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                },
-                                "line-numbers": {
-                                  "version": "0.2.0",
-                                  "from": "line-numbers@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                                  "dependencies": {
-                                    "left-pad": {
-                                      "version": "0.0.3",
-                                      "from": "left-pad@0.0.3",
-                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "babel-messages": {
-                              "version": "6.3.18",
-                              "from": "babel-messages@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                            },
-                            "babylon": {
-                              "version": "6.3.20",
-                              "from": "babylon@>=6.3.15 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                            },
-                            "debug": {
-                              "version": "2.2.0",
-                              "from": "debug@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                              "dependencies": {
-                                "ms": {
-                                  "version": "0.7.1",
-                                  "from": "ms@0.7.1",
-                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                                }
-                              }
-                            },
-                            "globals": {
-                              "version": "8.15.0",
-                              "from": "globals@>=8.3.0 <9.0.0",
-                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                            },
-                            "invariant": {
-                              "version": "2.2.0",
-                              "from": "invariant@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                              "dependencies": {
-                                "loose-envify": {
-                                  "version": "1.1.0",
-                                  "from": "loose-envify@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                                  "dependencies": {
-                                    "js-tokens": {
-                                      "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "repeating": {
-                              "version": "1.1.3",
-                              "from": "repeating@>=1.1.3 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                              "dependencies": {
-                                "is-finite": {
-                                  "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                  "dependencies": {
-                                    "number-is-nan": {
-                                      "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        },
-                        "to-fast-properties": {
-                          "version": "1.0.1",
-                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-es2015-computed-properties": {
-                  "version": "6.3.13",
-                  "from": "babel-plugin-transform-es2015-computed-properties@>=6.0.14 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.3.13.tgz",
-                  "dependencies": {
-                    "babel-helper-define-map": {
-                      "version": "6.3.13",
-                      "from": "babel-helper-define-map@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.3.13.tgz",
-                      "dependencies": {
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        },
-                        "babel-types": {
-                          "version": "6.3.20",
-                          "from": "babel-types@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
-                          "dependencies": {
-                            "babel-traverse": {
-                              "version": "6.3.19",
-                              "from": "babel-traverse@>=6.3.17 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                              "dependencies": {
-                                "babel-code-frame": {
-                                  "version": "6.3.13",
-                                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                                  "dependencies": {
-                                    "chalk": {
-                                      "version": "1.1.1",
-                                      "from": "chalk@>=1.1.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                                      "dependencies": {
-                                        "ansi-styles": {
-                                          "version": "2.1.0",
-                                          "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                        },
-                                        "escape-string-regexp": {
-                                          "version": "1.0.3",
-                                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                        },
-                                        "has-ansi": {
-                                          "version": "2.0.0",
-                                          "from": "has-ansi@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "strip-ansi": {
-                                          "version": "3.0.0",
-                                          "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "supports-color": {
-                                          "version": "2.0.0",
-                                          "from": "supports-color@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "js-tokens": {
-                                      "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                    },
-                                    "line-numbers": {
-                                      "version": "0.2.0",
-                                      "from": "line-numbers@>=0.2.0 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                                      "dependencies": {
-                                        "left-pad": {
-                                          "version": "0.0.3",
-                                          "from": "left-pad@0.0.3",
-                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "babel-messages": {
-                                  "version": "6.3.18",
-                                  "from": "babel-messages@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                                },
-                                "babylon": {
-                                  "version": "6.3.20",
-                                  "from": "babylon@>=6.3.15 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                                },
-                                "debug": {
-                                  "version": "2.2.0",
-                                  "from": "debug@>=2.2.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                                  "dependencies": {
-                                    "ms": {
-                                      "version": "0.7.1",
-                                      "from": "ms@0.7.1",
-                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                                    }
-                                  }
-                                },
-                                "globals": {
-                                  "version": "8.15.0",
-                                  "from": "globals@>=8.3.0 <9.0.0",
-                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                                },
-                                "invariant": {
-                                  "version": "2.2.0",
-                                  "from": "invariant@>=2.2.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                                  "dependencies": {
-                                    "loose-envify": {
-                                      "version": "1.1.0",
-                                      "from": "loose-envify@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                                      "dependencies": {
-                                        "js-tokens": {
-                                          "version": "1.0.2",
-                                          "from": "js-tokens@>=1.0.1 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "repeating": {
-                                  "version": "1.1.3",
-                                  "from": "repeating@>=1.1.3 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                                  "dependencies": {
-                                    "is-finite": {
-                                      "version": "1.0.1",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                      "dependencies": {
-                                        "number-is-nan": {
-                                          "version": "1.0.0",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "to-fast-properties": {
-                              "version": "1.0.1",
-                              "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "babel-helper-function-name": {
-                          "version": "6.3.15",
-                          "from": "babel-helper-function-name@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
-                          "dependencies": {
-                            "babel-traverse": {
-                              "version": "6.3.19",
-                              "from": "babel-traverse@>=6.3.15 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                              "dependencies": {
-                                "babel-code-frame": {
-                                  "version": "6.3.13",
-                                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                                  "dependencies": {
-                                    "chalk": {
-                                      "version": "1.1.1",
-                                      "from": "chalk@>=1.1.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                                      "dependencies": {
-                                        "ansi-styles": {
-                                          "version": "2.1.0",
-                                          "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                        },
-                                        "escape-string-regexp": {
-                                          "version": "1.0.3",
-                                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                        },
-                                        "has-ansi": {
-                                          "version": "2.0.0",
-                                          "from": "has-ansi@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "strip-ansi": {
-                                          "version": "3.0.0",
-                                          "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "supports-color": {
-                                          "version": "2.0.0",
-                                          "from": "supports-color@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "esutils": {
-                                      "version": "2.0.2",
-                                      "from": "esutils@>=2.0.2 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                    },
-                                    "js-tokens": {
-                                      "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                    },
-                                    "line-numbers": {
-                                      "version": "0.2.0",
-                                      "from": "line-numbers@>=0.2.0 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                                      "dependencies": {
-                                        "left-pad": {
-                                          "version": "0.0.3",
-                                          "from": "left-pad@0.0.3",
-                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "babel-messages": {
-                                  "version": "6.3.18",
-                                  "from": "babel-messages@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                                },
-                                "babylon": {
-                                  "version": "6.3.20",
-                                  "from": "babylon@>=6.3.15 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                                },
-                                "debug": {
-                                  "version": "2.2.0",
-                                  "from": "debug@>=2.2.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                                  "dependencies": {
-                                    "ms": {
-                                      "version": "0.7.1",
-                                      "from": "ms@0.7.1",
-                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                                    }
-                                  }
-                                },
-                                "globals": {
-                                  "version": "8.15.0",
-                                  "from": "globals@>=8.3.0 <9.0.0",
-                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                                },
-                                "invariant": {
-                                  "version": "2.2.0",
-                                  "from": "invariant@>=2.2.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                                  "dependencies": {
-                                    "loose-envify": {
-                                      "version": "1.1.0",
-                                      "from": "loose-envify@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                                      "dependencies": {
-                                        "js-tokens": {
-                                          "version": "1.0.2",
-                                          "from": "js-tokens@>=1.0.1 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "repeating": {
-                                  "version": "1.1.3",
-                                  "from": "repeating@>=1.1.3 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                                  "dependencies": {
-                                    "is-finite": {
-                                      "version": "1.0.1",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                      "dependencies": {
-                                        "number-is-nan": {
-                                          "version": "1.0.0",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "babel-helper-get-function-arity": {
-                              "version": "6.3.13",
-                              "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-template": {
-                      "version": "6.3.13",
-                      "from": "babel-template@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
-                      "dependencies": {
-                        "babylon": {
-                          "version": "6.3.20",
-                          "from": "babylon@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                        },
-                        "babel-traverse": {
-                          "version": "6.3.19",
-                          "from": "babel-traverse@>=6.3.15 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                          "dependencies": {
-                            "babel-code-frame": {
-                              "version": "6.3.13",
-                              "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                              "dependencies": {
-                                "chalk": {
-                                  "version": "1.1.1",
-                                  "from": "chalk@>=1.1.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.1.0",
-                                      "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.3",
-                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                    },
-                                    "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "3.0.0",
-                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "supports-color@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "esutils": {
-                                  "version": "2.0.2",
-                                  "from": "esutils@>=2.0.2 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                },
-                                "js-tokens": {
-                                  "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                },
-                                "line-numbers": {
-                                  "version": "0.2.0",
-                                  "from": "line-numbers@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                                  "dependencies": {
-                                    "left-pad": {
-                                      "version": "0.0.3",
-                                      "from": "left-pad@0.0.3",
-                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "babel-messages": {
-                              "version": "6.3.18",
-                              "from": "babel-messages@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                            },
-                            "debug": {
-                              "version": "2.2.0",
-                              "from": "debug@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                              "dependencies": {
-                                "ms": {
-                                  "version": "0.7.1",
-                                  "from": "ms@0.7.1",
-                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                                }
-                              }
-                            },
-                            "globals": {
-                              "version": "8.15.0",
-                              "from": "globals@>=8.3.0 <9.0.0",
-                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                            },
-                            "invariant": {
-                              "version": "2.2.0",
-                              "from": "invariant@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                              "dependencies": {
-                                "loose-envify": {
-                                  "version": "1.1.0",
-                                  "from": "loose-envify@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                                  "dependencies": {
-                                    "js-tokens": {
-                                      "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "repeating": {
-                              "version": "1.1.3",
-                              "from": "repeating@>=1.1.3 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                              "dependencies": {
-                                "is-finite": {
-                                  "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                  "dependencies": {
-                                    "number-is-nan": {
-                                      "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "babel-types": {
-                          "version": "6.3.20",
-                          "from": "babel-types@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
-                          "dependencies": {
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "to-fast-properties": {
-                              "version": "1.0.1",
-                              "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        }
-                      }
-                    },
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-es2015-for-of": {
-                  "version": "6.3.13",
-                  "from": "babel-plugin-transform-es2015-for-of@>=6.0.14 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.3.13.tgz",
-                  "dependencies": {
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-es2015-sticky-regex": {
-                  "version": "6.3.13",
-                  "from": "babel-plugin-transform-es2015-sticky-regex@>=6.0.14 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.3.13.tgz",
-                  "dependencies": {
-                    "babel-helper-regex": {
-                      "version": "6.3.13",
-                      "from": "babel-helper-regex@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.3.13.tgz",
-                      "dependencies": {
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        }
-                      }
-                    },
-                    "babel-types": {
-                      "version": "6.3.20",
-                      "from": "babel-types@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
-                      "dependencies": {
-                        "babel-traverse": {
-                          "version": "6.3.19",
-                          "from": "babel-traverse@>=6.3.17 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                          "dependencies": {
-                            "babel-code-frame": {
-                              "version": "6.3.13",
-                              "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                              "dependencies": {
-                                "chalk": {
-                                  "version": "1.1.1",
-                                  "from": "chalk@>=1.1.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.1.0",
-                                      "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.3",
-                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                    },
-                                    "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "3.0.0",
-                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "supports-color@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "js-tokens": {
-                                  "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                },
-                                "line-numbers": {
-                                  "version": "0.2.0",
-                                  "from": "line-numbers@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                                  "dependencies": {
-                                    "left-pad": {
-                                      "version": "0.0.3",
-                                      "from": "left-pad@0.0.3",
-                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "babel-messages": {
-                              "version": "6.3.18",
-                              "from": "babel-messages@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                            },
-                            "babylon": {
-                              "version": "6.3.20",
-                              "from": "babylon@>=6.3.15 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                            },
-                            "debug": {
-                              "version": "2.2.0",
-                              "from": "debug@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                              "dependencies": {
-                                "ms": {
-                                  "version": "0.7.1",
-                                  "from": "ms@0.7.1",
-                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                                }
-                              }
-                            },
-                            "globals": {
-                              "version": "8.15.0",
-                              "from": "globals@>=8.3.0 <9.0.0",
-                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                            },
-                            "invariant": {
-                              "version": "2.2.0",
-                              "from": "invariant@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                              "dependencies": {
-                                "loose-envify": {
-                                  "version": "1.1.0",
-                                  "from": "loose-envify@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                                  "dependencies": {
-                                    "js-tokens": {
-                                      "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "repeating": {
-                              "version": "1.1.3",
-                              "from": "repeating@>=1.1.3 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                              "dependencies": {
-                                "is-finite": {
-                                  "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                  "dependencies": {
-                                    "number-is-nan": {
-                                      "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        },
-                        "to-fast-properties": {
-                          "version": "1.0.1",
-                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-es2015-unicode-regex": {
-                  "version": "6.3.13",
-                  "from": "babel-plugin-transform-es2015-unicode-regex@>=6.0.14 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.3.13.tgz",
-                  "dependencies": {
-                    "babel-helper-regex": {
-                      "version": "6.3.13",
-                      "from": "babel-helper-regex@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.3.13.tgz",
-                      "dependencies": {
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        },
-                        "babel-types": {
-                          "version": "6.3.20",
-                          "from": "babel-types@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
-                          "dependencies": {
-                            "babel-traverse": {
-                              "version": "6.3.19",
-                              "from": "babel-traverse@>=6.3.17 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                              "dependencies": {
-                                "babel-code-frame": {
-                                  "version": "6.3.13",
-                                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                                  "dependencies": {
-                                    "chalk": {
-                                      "version": "1.1.1",
-                                      "from": "chalk@>=1.1.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                                      "dependencies": {
-                                        "ansi-styles": {
-                                          "version": "2.1.0",
-                                          "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                        },
-                                        "escape-string-regexp": {
-                                          "version": "1.0.3",
-                                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                        },
-                                        "has-ansi": {
-                                          "version": "2.0.0",
-                                          "from": "has-ansi@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "strip-ansi": {
-                                          "version": "3.0.0",
-                                          "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "supports-color": {
-                                          "version": "2.0.0",
-                                          "from": "supports-color@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "js-tokens": {
-                                      "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                    },
-                                    "line-numbers": {
-                                      "version": "0.2.0",
-                                      "from": "line-numbers@>=0.2.0 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                                      "dependencies": {
-                                        "left-pad": {
-                                          "version": "0.0.3",
-                                          "from": "left-pad@0.0.3",
-                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "babel-messages": {
-                                  "version": "6.3.18",
-                                  "from": "babel-messages@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                                },
-                                "babylon": {
-                                  "version": "6.3.20",
-                                  "from": "babylon@>=6.3.15 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                                },
-                                "debug": {
-                                  "version": "2.2.0",
-                                  "from": "debug@>=2.2.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                                  "dependencies": {
-                                    "ms": {
-                                      "version": "0.7.1",
-                                      "from": "ms@0.7.1",
-                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                                    }
-                                  }
-                                },
-                                "globals": {
-                                  "version": "8.15.0",
-                                  "from": "globals@>=8.3.0 <9.0.0",
-                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                                },
-                                "invariant": {
-                                  "version": "2.2.0",
-                                  "from": "invariant@>=2.2.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                                  "dependencies": {
-                                    "loose-envify": {
-                                      "version": "1.1.0",
-                                      "from": "loose-envify@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                                      "dependencies": {
-                                        "js-tokens": {
-                                          "version": "1.0.2",
-                                          "from": "js-tokens@>=1.0.1 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "repeating": {
-                                  "version": "1.1.3",
-                                  "from": "repeating@>=1.1.3 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                                  "dependencies": {
-                                    "is-finite": {
-                                      "version": "1.0.1",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                      "dependencies": {
-                                        "number-is-nan": {
-                                          "version": "1.0.0",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "to-fast-properties": {
-                              "version": "1.0.1",
-                              "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "regexpu": {
-                      "version": "1.3.0",
-                      "from": "regexpu@>=1.1.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-                      "dependencies": {
-                        "esprima": {
-                          "version": "2.7.1",
-                          "from": "esprima@>=2.6.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
-                        },
-                        "recast": {
-                          "version": "0.10.39",
-                          "from": "recast@>=0.10.10 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.39.tgz",
-                          "dependencies": {
-                            "esprima-fb": {
-                              "version": "15001.1001.0-dev-harmony-fb",
-                              "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-                              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
-                            },
-                            "source-map": {
-                              "version": "0.5.3",
-                              "from": "source-map@>=0.5.0 <0.6.0",
-                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-                            },
-                            "private": {
-                              "version": "0.1.6",
-                              "from": "private@>=0.1.5 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
-                            },
-                            "ast-types": {
-                              "version": "0.8.12",
-                              "from": "ast-types@0.8.12",
-                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
-                            }
-                          }
-                        },
-                        "regenerate": {
-                          "version": "1.2.1",
-                          "from": "regenerate@>=1.2.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
-                        },
-                        "regjsgen": {
-                          "version": "0.2.0",
-                          "from": "regjsgen@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
-                        },
-                        "regjsparser": {
-                          "version": "0.1.5",
-                          "from": "regjsparser@>=0.1.4 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                          "dependencies": {
-                            "jsesc": {
-                              "version": "0.5.0",
-                              "from": "jsesc@>=0.5.0 <0.6.0",
-                              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-es2015-constants": {
-                  "version": "6.1.4",
-                  "from": "babel-plugin-transform-es2015-constants@>=6.0.15 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-constants/-/babel-plugin-transform-es2015-constants-6.1.4.tgz",
-                  "dependencies": {
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-es2015-spread": {
-                  "version": "6.3.14",
-                  "from": "babel-plugin-transform-es2015-spread@>=6.0.14 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.3.14.tgz",
-                  "dependencies": {
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-es2015-parameters": {
-                  "version": "6.3.18",
-                  "from": "babel-plugin-transform-es2015-parameters@>=6.0.14 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.3.18.tgz",
-                  "dependencies": {
-                    "babel-traverse": {
-                      "version": "6.3.19",
-                      "from": "babel-traverse@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                      "dependencies": {
-                        "babel-code-frame": {
-                          "version": "6.3.13",
-                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.1",
-                              "from": "chalk@>=1.1.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.3",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "js-tokens": {
-                              "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                            },
-                            "line-numbers": {
-                              "version": "0.2.0",
-                              "from": "line-numbers@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                              "dependencies": {
-                                "left-pad": {
-                                  "version": "0.0.3",
-                                  "from": "left-pad@0.0.3",
-                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "babel-messages": {
-                          "version": "6.3.18",
-                          "from": "babel-messages@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                        },
-                        "babylon": {
-                          "version": "6.3.20",
-                          "from": "babylon@>=6.3.15 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                        },
-                        "debug": {
-                          "version": "2.2.0",
-                          "from": "debug@>=2.2.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                          "dependencies": {
-                            "ms": {
-                              "version": "0.7.1",
-                              "from": "ms@0.7.1",
-                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                            }
-                          }
-                        },
-                        "globals": {
-                          "version": "8.15.0",
-                          "from": "globals@>=8.3.0 <9.0.0",
-                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                        },
-                        "invariant": {
-                          "version": "2.2.0",
-                          "from": "invariant@>=2.2.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                          "dependencies": {
-                            "loose-envify": {
-                              "version": "1.1.0",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                              "dependencies": {
-                                "js-tokens": {
-                                  "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        },
-                        "repeating": {
-                          "version": "1.1.3",
-                          "from": "repeating@>=1.1.3 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                              "dependencies": {
-                                "number-is-nan": {
-                                  "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-helper-call-delegate": {
-                      "version": "6.3.13",
-                      "from": "babel-helper-call-delegate@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.3.13.tgz",
-                      "dependencies": {
-                        "babel-helper-hoist-variables": {
-                          "version": "6.3.13",
-                          "from": "babel-helper-hoist-variables@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.3.13.tgz"
-                        }
-                      }
-                    },
-                    "babel-helper-get-function-arity": {
-                      "version": "6.3.13",
-                      "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
-                    },
-                    "babel-template": {
-                      "version": "6.3.13",
-                      "from": "babel-template@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
-                      "dependencies": {
-                        "babylon": {
-                          "version": "6.3.20",
-                          "from": "babylon@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                        },
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        }
-                      }
-                    },
-                    "babel-types": {
-                      "version": "6.3.20",
-                      "from": "babel-types@>=6.3.18 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
-                      "dependencies": {
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                        },
-                        "to-fast-properties": {
-                          "version": "1.0.1",
-                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-es2015-destructuring": {
-                  "version": "6.3.15",
-                  "from": "babel-plugin-transform-es2015-destructuring@>=6.0.14 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.3.15.tgz",
-                  "dependencies": {
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
                         }
                       }
                     }
@@ -2674,84 +504,164 @@
                 },
                 "babel-plugin-transform-es2015-block-scoping": {
                   "version": "6.3.13",
-                  "from": "babel-plugin-transform-es2015-block-scoping@>=6.0.14 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.3.13.tgz",
+                  "integrity": "sha1-PoglKzHk+KIGAabzlfdHZULsCfg=",
+                  "requires": {
+                    "babel-runtime": "5.8.34",
+                    "babel-template": "6.3.13",
+                    "babel-traverse": "6.3.19",
+                    "babel-types": "6.3.20",
+                    "lodash": "3.10.1"
+                  },
                   "dependencies": {
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    },
+                    "babel-template": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                      "integrity": "sha1-hXXxaGepKKna6E87vNyn54Bvwiw=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "babel-types": "6.3.20",
+                        "babylon": "6.3.20",
+                        "lodash": "3.10.1"
+                      },
+                      "dependencies": {
+                        "babylon": {
+                          "version": "6.3.20",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                          "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
+                        }
+                      }
+                    },
                     "babel-traverse": {
                       "version": "6.3.19",
-                      "from": "babel-traverse@>=6.3.13 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                      "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                      "requires": {
+                        "babel-code-frame": "6.3.13",
+                        "babel-messages": "6.3.18",
+                        "babel-runtime": "5.8.34",
+                        "babel-types": "6.3.20",
+                        "babylon": "6.3.20",
+                        "debug": "2.2.0",
+                        "globals": "8.15.0",
+                        "invariant": "2.2.0",
+                        "lodash": "3.10.1",
+                        "repeating": "1.1.3"
+                      },
                       "dependencies": {
                         "babel-code-frame": {
                           "version": "6.3.13",
-                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
                           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "chalk": "1.1.1",
+                            "esutils": "2.0.2",
+                            "js-tokens": "1.0.2",
+                            "line-numbers": "0.2.0",
+                            "repeating": "1.1.3"
+                          },
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@>=1.1.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                              "requires": {
+                                "ansi-styles": "2.1.0",
+                                "escape-string-regexp": "1.0.3",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.0",
+                                "supports-color": "2.0.0"
+                              },
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                  "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.3",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                  "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                 }
                               }
                             },
                             "esutils": {
                               "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                             },
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                              "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                             },
                             "line-numbers": {
                               "version": "0.2.0",
-                              "from": "line-numbers@>=0.2.0 <0.3.0",
                               "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                              "requires": {
+                                "left-pad": "0.0.3"
+                              },
                               "dependencies": {
                                 "left-pad": {
                                   "version": "0.0.3",
-                                  "from": "left-pad@0.0.3",
-                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                  "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
                                 }
                               }
                             }
@@ -2759,45 +669,60 @@
                         },
                         "babel-messages": {
                           "version": "6.3.18",
-                          "from": "babel-messages@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                          "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
                         },
                         "babylon": {
                           "version": "6.3.20",
-                          "from": "babylon@>=6.3.15 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                          "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
                         },
                         "debug": {
                           "version": "2.2.0",
-                          "from": "debug@>=2.2.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                          "requires": {
+                            "ms": "0.7.1"
+                          },
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "ms@0.7.1",
-                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
                             }
                           }
                         },
                         "globals": {
                           "version": "8.15.0",
-                          "from": "globals@>=8.3.0 <9.0.0",
-                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                          "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
                         },
                         "invariant": {
                           "version": "2.2.0",
-                          "from": "invariant@>=2.2.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                          "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                          "requires": {
+                            "loose-envify": "1.1.0"
+                          },
                           "dependencies": {
                             "loose-envify": {
                               "version": "1.1.0",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                              "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                              "requires": {
+                                "js-tokens": "1.0.2"
+                              },
                               "dependencies": {
                                 "js-tokens": {
                                   "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                 }
                               }
                             }
@@ -2805,18 +730,24 @@
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.3 <2.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                          "requires": {
+                            "is-finite": "1.0.1"
+                          },
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                              "requires": {
+                                "number-is-nan": "1.0.0"
+                              },
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                 }
                               }
                             }
@@ -2826,66 +757,1747 @@
                     },
                     "babel-types": {
                       "version": "6.3.20",
-                      "from": "babel-types@>=6.3.18 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                      "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "esutils": "2.0.2",
+                        "lodash": "3.10.1",
+                        "to-fast-properties": "1.0.1"
+                      },
                       "dependencies": {
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                         },
                         "to-fast-properties": {
                           "version": "1.0.1",
-                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "babel-template": {
-                      "version": "6.3.13",
-                      "from": "babel-template@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
-                      "dependencies": {
-                        "babylon": {
-                          "version": "6.3.20",
-                          "from": "babylon@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
+                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                          "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
                         }
                       }
                     },
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.10.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                    }
+                  }
+                },
+                "babel-plugin-transform-es2015-classes": {
+                  "version": "6.3.15",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.3.15.tgz",
+                  "integrity": "sha1-8WmUPUA6HsYM5L5gso0QX2OH6ME=",
+                  "requires": {
+                    "babel-helper-define-map": "6.3.13",
+                    "babel-helper-function-name": "6.3.15",
+                    "babel-helper-optimise-call-expression": "6.3.13",
+                    "babel-helper-replace-supers": "6.3.13",
+                    "babel-messages": "6.3.18",
+                    "babel-runtime": "5.8.34",
+                    "babel-template": "6.3.13",
+                    "babel-traverse": "6.3.19",
+                    "babel-types": "6.3.20"
+                  },
+                  "dependencies": {
+                    "babel-helper-define-map": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.3.13.tgz",
+                      "integrity": "sha1-4nqzLcATAF9YmkrpPbM7F0s7LQc=",
+                      "requires": {
+                        "babel-helper-function-name": "6.3.15",
+                        "babel-runtime": "5.8.34",
+                        "babel-types": "6.3.20",
+                        "lodash": "3.10.1"
+                      },
+                      "dependencies": {
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        }
+                      }
+                    },
+                    "babel-helper-function-name": {
+                      "version": "6.3.15",
+                      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
+                      "integrity": "sha1-WDNPTimTd7uk+EJAyq97+axxDto=",
+                      "requires": {
+                        "babel-helper-get-function-arity": "6.3.13",
+                        "babel-runtime": "5.8.34",
+                        "babel-template": "6.3.13",
+                        "babel-traverse": "6.3.19",
+                        "babel-types": "6.3.20"
+                      },
+                      "dependencies": {
+                        "babel-helper-get-function-arity": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz",
+                          "integrity": "sha1-skc2lFI+Q1ueGBdtGkYD5sCUwGI=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20"
+                          }
+                        }
+                      }
+                    },
+                    "babel-helper-optimise-call-expression": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.3.13.tgz",
+                      "integrity": "sha1-3n4W5Zs6vT9WrwMi1ec/jrn8s5w=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-types": "6.3.20"
+                      }
+                    },
+                    "babel-helper-replace-supers": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.3.13.tgz",
+                      "integrity": "sha1-ROyT1+nXwG8znUq6dZJPiN7pEg8=",
+                      "requires": {
+                        "babel-helper-optimise-call-expression": "6.3.13",
+                        "babel-messages": "6.3.18",
+                        "babel-runtime": "5.8.34",
+                        "babel-template": "6.3.13",
+                        "babel-traverse": "6.3.19",
+                        "babel-types": "6.3.20"
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.3.18",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                      "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                      "requires": {
+                        "babel-runtime": "5.8.34"
+                      }
                     },
                     "babel-runtime": {
                       "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
                       "dependencies": {
                         "core-js": {
                           "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    },
+                    "babel-template": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                      "integrity": "sha1-hXXxaGepKKna6E87vNyn54Bvwiw=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "babel-types": "6.3.20",
+                        "babylon": "6.3.20",
+                        "lodash": "3.10.1"
+                      },
+                      "dependencies": {
+                        "babylon": {
+                          "version": "6.3.20",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                          "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        }
+                      }
+                    },
+                    "babel-traverse": {
+                      "version": "6.3.19",
+                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                      "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                      "requires": {
+                        "babel-code-frame": "6.3.13",
+                        "babel-messages": "6.3.18",
+                        "babel-runtime": "5.8.34",
+                        "babel-types": "6.3.20",
+                        "babylon": "6.3.20",
+                        "debug": "2.2.0",
+                        "globals": "8.15.0",
+                        "invariant": "2.2.0",
+                        "lodash": "3.10.1",
+                        "repeating": "1.1.3"
+                      },
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "chalk": "1.1.1",
+                            "esutils": "2.0.2",
+                            "js-tokens": "1.0.2",
+                            "line-numbers": "0.2.0",
+                            "repeating": "1.1.3"
+                          },
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.1",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                              "requires": {
+                                "ansi-styles": "2.1.0",
+                                "escape-string-regexp": "1.0.3",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.0",
+                                "supports-color": "2.0.0"
+                              },
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.1.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                  "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                  "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                }
+                              }
+                            },
+                            "esutils": {
+                              "version": "2.0.2",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                            },
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                              "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                            },
+                            "line-numbers": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                              "requires": {
+                                "left-pad": "0.0.3"
+                              },
+                              "dependencies": {
+                                "left-pad": {
+                                  "version": "0.0.3",
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                  "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babylon": {
+                          "version": "6.3.20",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                          "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
+                        },
+                        "debug": {
+                          "version": "2.2.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                          "requires": {
+                            "ms": "0.7.1"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "8.15.0",
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                          "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                        },
+                        "invariant": {
+                          "version": "2.2.0",
+                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                          "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                          "requires": {
+                            "loose-envify": "1.1.0"
+                          },
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.1.0",
+                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                              "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                              "requires": {
+                                "js-tokens": "1.0.2"
+                              },
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                          "requires": {
+                            "is-finite": "1.0.1"
+                          },
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                              "requires": {
+                                "number-is-nan": "1.0.0"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-types": {
+                      "version": "6.3.20",
+                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                      "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "esutils": "2.0.2",
+                        "lodash": "3.10.1",
+                        "to-fast-properties": "1.0.1"
+                      },
+                      "dependencies": {
+                        "esutils": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        },
+                        "to-fast-properties": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                          "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
                         }
                       }
                     }
                   }
                 },
-                "babel-plugin-transform-es2015-typeof-symbol": {
+                "babel-plugin-transform-es2015-computed-properties": {
                   "version": "6.3.13",
-                  "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.1.2 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.3.13.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.3.13.tgz",
+                  "integrity": "sha1-qpakZzvNATtDtF5Q+eNZ5R+51bs=",
+                  "requires": {
+                    "babel-helper-define-map": "6.3.13",
+                    "babel-runtime": "5.8.34",
+                    "babel-template": "6.3.13"
+                  },
                   "dependencies": {
+                    "babel-helper-define-map": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.3.13.tgz",
+                      "integrity": "sha1-4nqzLcATAF9YmkrpPbM7F0s7LQc=",
+                      "requires": {
+                        "babel-helper-function-name": "6.3.15",
+                        "babel-runtime": "5.8.34",
+                        "babel-types": "6.3.20",
+                        "lodash": "3.10.1"
+                      },
+                      "dependencies": {
+                        "babel-helper-function-name": {
+                          "version": "6.3.15",
+                          "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
+                          "integrity": "sha1-WDNPTimTd7uk+EJAyq97+axxDto=",
+                          "requires": {
+                            "babel-helper-get-function-arity": "6.3.13",
+                            "babel-runtime": "5.8.34",
+                            "babel-template": "6.3.13",
+                            "babel-traverse": "6.3.19",
+                            "babel-types": "6.3.20"
+                          },
+                          "dependencies": {
+                            "babel-helper-get-function-arity": {
+                              "version": "6.3.13",
+                              "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz",
+                              "integrity": "sha1-skc2lFI+Q1ueGBdtGkYD5sCUwGI=",
+                              "requires": {
+                                "babel-runtime": "5.8.34",
+                                "babel-types": "6.3.20"
+                              }
+                            },
+                            "babel-traverse": {
+                              "version": "6.3.19",
+                              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                              "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                              "requires": {
+                                "babel-code-frame": "6.3.13",
+                                "babel-messages": "6.3.18",
+                                "babel-runtime": "5.8.34",
+                                "babel-types": "6.3.20",
+                                "babylon": "6.3.20",
+                                "debug": "2.2.0",
+                                "globals": "8.15.0",
+                                "invariant": "2.2.0",
+                                "lodash": "3.10.1",
+                                "repeating": "1.1.3"
+                              },
+                              "dependencies": {
+                                "babel-code-frame": {
+                                  "version": "6.3.13",
+                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                  "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34",
+                                    "chalk": "1.1.1",
+                                    "esutils": "2.0.2",
+                                    "js-tokens": "1.0.2",
+                                    "line-numbers": "0.2.0",
+                                    "repeating": "1.1.3"
+                                  },
+                                  "dependencies": {
+                                    "chalk": {
+                                      "version": "1.1.1",
+                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                      "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                      "requires": {
+                                        "ansi-styles": "2.1.0",
+                                        "escape-string-regexp": "1.0.3",
+                                        "has-ansi": "2.0.0",
+                                        "strip-ansi": "3.0.0",
+                                        "supports-color": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-styles": {
+                                          "version": "2.1.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                          "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                        },
+                                        "escape-string-regexp": {
+                                          "version": "1.0.3",
+                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                          "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                        },
+                                        "has-ansi": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                            }
+                                          }
+                                        },
+                                        "strip-ansi": {
+                                          "version": "3.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                          "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                            }
+                                          }
+                                        },
+                                        "supports-color": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                        }
+                                      }
+                                    },
+                                    "esutils": {
+                                      "version": "2.0.2",
+                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                                    },
+                                    "js-tokens": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                    },
+                                    "line-numbers": {
+                                      "version": "0.2.0",
+                                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                      "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                      "requires": {
+                                        "left-pad": "0.0.3"
+                                      },
+                                      "dependencies": {
+                                        "left-pad": {
+                                          "version": "0.0.3",
+                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                          "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "babel-messages": {
+                                  "version": "6.3.18",
+                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                                  "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
+                                },
+                                "babylon": {
+                                  "version": "6.3.20",
+                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                                  "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
+                                },
+                                "debug": {
+                                  "version": "2.2.0",
+                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                                  "requires": {
+                                    "ms": "0.7.1"
+                                  },
+                                  "dependencies": {
+                                    "ms": {
+                                      "version": "0.7.1",
+                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                                    }
+                                  }
+                                },
+                                "globals": {
+                                  "version": "8.15.0",
+                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                                  "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                                },
+                                "invariant": {
+                                  "version": "2.2.0",
+                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                  "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                                  "requires": {
+                                    "loose-envify": "1.1.0"
+                                  },
+                                  "dependencies": {
+                                    "loose-envify": {
+                                      "version": "1.1.0",
+                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                      "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                      "requires": {
+                                        "js-tokens": "1.0.2"
+                                      },
+                                      "dependencies": {
+                                        "js-tokens": {
+                                          "version": "1.0.2",
+                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                          "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "repeating": {
+                                  "version": "1.1.3",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                  "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                                  "requires": {
+                                    "is-finite": "1.0.1"
+                                  },
+                                  "dependencies": {
+                                    "is-finite": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                      "requires": {
+                                        "number-is-nan": "1.0.0"
+                                      },
+                                      "dependencies": {
+                                        "number-is-nan": {
+                                          "version": "1.0.0",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-types": {
+                          "version": "6.3.20",
+                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                          "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-traverse": "6.3.19",
+                            "esutils": "2.0.2",
+                            "lodash": "3.10.1",
+                            "to-fast-properties": "1.0.1"
+                          },
+                          "dependencies": {
+                            "babel-traverse": {
+                              "version": "6.3.19",
+                              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                              "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                              "requires": {
+                                "babel-code-frame": "6.3.13",
+                                "babel-messages": "6.3.18",
+                                "babel-runtime": "5.8.34",
+                                "babel-types": "6.3.20",
+                                "babylon": "6.3.20",
+                                "debug": "2.2.0",
+                                "globals": "8.15.0",
+                                "invariant": "2.2.0",
+                                "lodash": "3.10.1",
+                                "repeating": "1.1.3"
+                              },
+                              "dependencies": {
+                                "babel-code-frame": {
+                                  "version": "6.3.13",
+                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                  "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34",
+                                    "chalk": "1.1.1",
+                                    "esutils": "2.0.2",
+                                    "js-tokens": "1.0.2",
+                                    "line-numbers": "0.2.0",
+                                    "repeating": "1.1.3"
+                                  },
+                                  "dependencies": {
+                                    "chalk": {
+                                      "version": "1.1.1",
+                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                      "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                      "requires": {
+                                        "ansi-styles": "2.1.0",
+                                        "escape-string-regexp": "1.0.3",
+                                        "has-ansi": "2.0.0",
+                                        "strip-ansi": "3.0.0",
+                                        "supports-color": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-styles": {
+                                          "version": "2.1.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                          "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                        },
+                                        "escape-string-regexp": {
+                                          "version": "1.0.3",
+                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                          "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                        },
+                                        "has-ansi": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                            }
+                                          }
+                                        },
+                                        "strip-ansi": {
+                                          "version": "3.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                          "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                            }
+                                          }
+                                        },
+                                        "supports-color": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                        }
+                                      }
+                                    },
+                                    "js-tokens": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                    },
+                                    "line-numbers": {
+                                      "version": "0.2.0",
+                                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                      "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                      "requires": {
+                                        "left-pad": "0.0.3"
+                                      },
+                                      "dependencies": {
+                                        "left-pad": {
+                                          "version": "0.0.3",
+                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                          "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "babel-messages": {
+                                  "version": "6.3.18",
+                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                                  "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
+                                },
+                                "babylon": {
+                                  "version": "6.3.20",
+                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                                  "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
+                                },
+                                "debug": {
+                                  "version": "2.2.0",
+                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                                  "requires": {
+                                    "ms": "0.7.1"
+                                  },
+                                  "dependencies": {
+                                    "ms": {
+                                      "version": "0.7.1",
+                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                                    }
+                                  }
+                                },
+                                "globals": {
+                                  "version": "8.15.0",
+                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                                  "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                                },
+                                "invariant": {
+                                  "version": "2.2.0",
+                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                  "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                                  "requires": {
+                                    "loose-envify": "1.1.0"
+                                  },
+                                  "dependencies": {
+                                    "loose-envify": {
+                                      "version": "1.1.0",
+                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                      "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                      "requires": {
+                                        "js-tokens": "1.0.2"
+                                      },
+                                      "dependencies": {
+                                        "js-tokens": {
+                                          "version": "1.0.2",
+                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                          "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "repeating": {
+                                  "version": "1.1.3",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                  "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                                  "requires": {
+                                    "is-finite": "1.0.1"
+                                  },
+                                  "dependencies": {
+                                    "is-finite": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                      "requires": {
+                                        "number-is-nan": "1.0.0"
+                                      },
+                                      "dependencies": {
+                                        "number-is-nan": {
+                                          "version": "1.0.0",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "esutils": {
+                              "version": "2.0.2",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                            },
+                            "to-fast-properties": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                              "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
+                            }
+                          }
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        }
+                      }
+                    },
                     "babel-runtime": {
                       "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
                       "dependencies": {
                         "core-js": {
                           "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    },
+                    "babel-template": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                      "integrity": "sha1-hXXxaGepKKna6E87vNyn54Bvwiw=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "babel-types": "6.3.20",
+                        "babylon": "6.3.20",
+                        "lodash": "3.10.1"
+                      },
+                      "dependencies": {
+                        "babel-traverse": {
+                          "version": "6.3.19",
+                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                          "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                          "requires": {
+                            "babel-code-frame": "6.3.13",
+                            "babel-messages": "6.3.18",
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20",
+                            "babylon": "6.3.20",
+                            "debug": "2.2.0",
+                            "globals": "8.15.0",
+                            "invariant": "2.2.0",
+                            "lodash": "3.10.1",
+                            "repeating": "1.1.3"
+                          },
+                          "dependencies": {
+                            "babel-code-frame": {
+                              "version": "6.3.13",
+                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                              "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                              "requires": {
+                                "babel-runtime": "5.8.34",
+                                "chalk": "1.1.1",
+                                "esutils": "2.0.2",
+                                "js-tokens": "1.0.2",
+                                "line-numbers": "0.2.0",
+                                "repeating": "1.1.3"
+                              },
+                              "dependencies": {
+                                "chalk": {
+                                  "version": "1.1.1",
+                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                  "requires": {
+                                    "ansi-styles": "2.1.0",
+                                    "escape-string-regexp": "1.0.3",
+                                    "has-ansi": "2.0.0",
+                                    "strip-ansi": "3.0.0",
+                                    "supports-color": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-styles": {
+                                      "version": "2.1.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                    },
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                    },
+                                    "has-ansi": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                        }
+                                      }
+                                    },
+                                    "strip-ansi": {
+                                      "version": "3.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                      "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                        }
+                                      }
+                                    },
+                                    "supports-color": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                    }
+                                  }
+                                },
+                                "esutils": {
+                                  "version": "2.0.2",
+                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                                },
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                },
+                                "line-numbers": {
+                                  "version": "0.2.0",
+                                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                  "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                  "requires": {
+                                    "left-pad": "0.0.3"
+                                  },
+                                  "dependencies": {
+                                    "left-pad": {
+                                      "version": "0.0.3",
+                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                      "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "babel-messages": {
+                              "version": "6.3.18",
+                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                              "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "debug": {
+                              "version": "2.2.0",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                              "requires": {
+                                "ms": "0.7.1"
+                              },
+                              "dependencies": {
+                                "ms": {
+                                  "version": "0.7.1",
+                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                                }
+                              }
+                            },
+                            "globals": {
+                              "version": "8.15.0",
+                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                              "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                            },
+                            "invariant": {
+                              "version": "2.2.0",
+                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                              "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                              "requires": {
+                                "loose-envify": "1.1.0"
+                              },
+                              "dependencies": {
+                                "loose-envify": {
+                                  "version": "1.1.0",
+                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                  "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                  "requires": {
+                                    "js-tokens": "1.0.2"
+                                  },
+                                  "dependencies": {
+                                    "js-tokens": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                              "requires": {
+                                "is-finite": "1.0.1"
+                              },
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                  "requires": {
+                                    "number-is-nan": "1.0.0"
+                                  },
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-types": {
+                          "version": "6.3.20",
+                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                          "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-traverse": "6.3.19",
+                            "esutils": "2.0.2",
+                            "lodash": "3.10.1",
+                            "to-fast-properties": "1.0.1"
+                          },
+                          "dependencies": {
+                            "esutils": {
+                              "version": "2.0.2",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                            },
+                            "to-fast-properties": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                              "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
+                            }
+                          }
+                        },
+                        "babylon": {
+                          "version": "6.3.20",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                          "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-es2015-constants": {
+                  "version": "6.1.4",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-constants/-/babel-plugin-transform-es2015-constants-6.1.4.tgz",
+                  "integrity": "sha1-5LjHj7SKuYsBB/Mp+rYEDnnDWjM=",
+                  "requires": {
+                    "babel-runtime": "5.8.34"
+                  },
+                  "dependencies": {
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-es2015-destructuring": {
+                  "version": "6.3.15",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.3.15.tgz",
+                  "integrity": "sha1-pA8rCTbN3T2uC74CXcNiR6XP9/Y=",
+                  "requires": {
+                    "babel-runtime": "5.8.34"
+                  },
+                  "dependencies": {
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-es2015-for-of": {
+                  "version": "6.3.13",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.3.13.tgz",
+                  "integrity": "sha1-MhIaNskaCRtsGVUjQZrN+1wtiRQ=",
+                  "requires": {
+                    "babel-runtime": "5.8.34"
+                  },
+                  "dependencies": {
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-es2015-function-name": {
+                  "version": "6.3.19",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.3.19.tgz",
+                  "integrity": "sha1-DdtXeRKwG0y4Wx9a80BMKSVl8xw=",
+                  "requires": {
+                    "babel-helper-function-name": "6.3.15",
+                    "babel-runtime": "5.8.34",
+                    "babel-types": "6.3.20"
+                  },
+                  "dependencies": {
+                    "babel-helper-function-name": {
+                      "version": "6.3.15",
+                      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
+                      "integrity": "sha1-WDNPTimTd7uk+EJAyq97+axxDto=",
+                      "requires": {
+                        "babel-helper-get-function-arity": "6.3.13",
+                        "babel-runtime": "5.8.34",
+                        "babel-template": "6.3.13",
+                        "babel-traverse": "6.3.19",
+                        "babel-types": "6.3.20"
+                      },
+                      "dependencies": {
+                        "babel-helper-get-function-arity": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz",
+                          "integrity": "sha1-skc2lFI+Q1ueGBdtGkYD5sCUwGI=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20"
+                          }
+                        },
+                        "babel-template": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                          "integrity": "sha1-hXXxaGepKKna6E87vNyn54Bvwiw=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-traverse": "6.3.19",
+                            "babel-types": "6.3.20",
+                            "babylon": "6.3.20",
+                            "lodash": "3.10.1"
+                          },
+                          "dependencies": {
+                            "babylon": {
+                              "version": "6.3.20",
+                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                              "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "lodash": {
+                              "version": "3.10.1",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                            }
+                          }
+                        },
+                        "babel-traverse": {
+                          "version": "6.3.19",
+                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                          "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                          "requires": {
+                            "babel-code-frame": "6.3.13",
+                            "babel-messages": "6.3.18",
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20",
+                            "babylon": "6.3.20",
+                            "debug": "2.2.0",
+                            "globals": "8.15.0",
+                            "invariant": "2.2.0",
+                            "lodash": "3.10.1",
+                            "repeating": "1.1.3"
+                          },
+                          "dependencies": {
+                            "babel-code-frame": {
+                              "version": "6.3.13",
+                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                              "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                              "requires": {
+                                "babel-runtime": "5.8.34",
+                                "chalk": "1.1.1",
+                                "esutils": "2.0.2",
+                                "js-tokens": "1.0.2",
+                                "line-numbers": "0.2.0",
+                                "repeating": "1.1.3"
+                              },
+                              "dependencies": {
+                                "chalk": {
+                                  "version": "1.1.1",
+                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                  "requires": {
+                                    "ansi-styles": "2.1.0",
+                                    "escape-string-regexp": "1.0.3",
+                                    "has-ansi": "2.0.0",
+                                    "strip-ansi": "3.0.0",
+                                    "supports-color": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-styles": {
+                                      "version": "2.1.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                    },
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                    },
+                                    "has-ansi": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                        }
+                                      }
+                                    },
+                                    "strip-ansi": {
+                                      "version": "3.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                      "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                        }
+                                      }
+                                    },
+                                    "supports-color": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                    }
+                                  }
+                                },
+                                "esutils": {
+                                  "version": "2.0.2",
+                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                                },
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                },
+                                "line-numbers": {
+                                  "version": "0.2.0",
+                                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                  "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                  "requires": {
+                                    "left-pad": "0.0.3"
+                                  },
+                                  "dependencies": {
+                                    "left-pad": {
+                                      "version": "0.0.3",
+                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                      "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "babel-messages": {
+                              "version": "6.3.18",
+                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                              "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "babylon": {
+                              "version": "6.3.20",
+                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                              "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "debug": {
+                              "version": "2.2.0",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                              "requires": {
+                                "ms": "0.7.1"
+                              },
+                              "dependencies": {
+                                "ms": {
+                                  "version": "0.7.1",
+                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                                }
+                              }
+                            },
+                            "globals": {
+                              "version": "8.15.0",
+                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                              "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                            },
+                            "invariant": {
+                              "version": "2.2.0",
+                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                              "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                              "requires": {
+                                "loose-envify": "1.1.0"
+                              },
+                              "dependencies": {
+                                "loose-envify": {
+                                  "version": "1.1.0",
+                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                  "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                  "requires": {
+                                    "js-tokens": "1.0.2"
+                                  },
+                                  "dependencies": {
+                                    "js-tokens": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "lodash": {
+                              "version": "3.10.1",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                              "requires": {
+                                "is-finite": "1.0.1"
+                              },
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                  "requires": {
+                                    "number-is-nan": "1.0.0"
+                                  },
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    },
+                    "babel-types": {
+                      "version": "6.3.20",
+                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                      "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "esutils": "2.0.2",
+                        "lodash": "3.10.1",
+                        "to-fast-properties": "1.0.1"
+                      },
+                      "dependencies": {
+                        "babel-traverse": {
+                          "version": "6.3.19",
+                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                          "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                          "requires": {
+                            "babel-code-frame": "6.3.13",
+                            "babel-messages": "6.3.18",
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20",
+                            "babylon": "6.3.20",
+                            "debug": "2.2.0",
+                            "globals": "8.15.0",
+                            "invariant": "2.2.0",
+                            "lodash": "3.10.1",
+                            "repeating": "1.1.3"
+                          },
+                          "dependencies": {
+                            "babel-code-frame": {
+                              "version": "6.3.13",
+                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                              "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                              "requires": {
+                                "babel-runtime": "5.8.34",
+                                "chalk": "1.1.1",
+                                "esutils": "2.0.2",
+                                "js-tokens": "1.0.2",
+                                "line-numbers": "0.2.0",
+                                "repeating": "1.1.3"
+                              },
+                              "dependencies": {
+                                "chalk": {
+                                  "version": "1.1.1",
+                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                  "requires": {
+                                    "ansi-styles": "2.1.0",
+                                    "escape-string-regexp": "1.0.3",
+                                    "has-ansi": "2.0.0",
+                                    "strip-ansi": "3.0.0",
+                                    "supports-color": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-styles": {
+                                      "version": "2.1.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                    },
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                    },
+                                    "has-ansi": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                        }
+                                      }
+                                    },
+                                    "strip-ansi": {
+                                      "version": "3.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                      "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                        }
+                                      }
+                                    },
+                                    "supports-color": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                    }
+                                  }
+                                },
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                },
+                                "line-numbers": {
+                                  "version": "0.2.0",
+                                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                  "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                  "requires": {
+                                    "left-pad": "0.0.3"
+                                  },
+                                  "dependencies": {
+                                    "left-pad": {
+                                      "version": "0.0.3",
+                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                      "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "babel-messages": {
+                              "version": "6.3.18",
+                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                              "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "babylon": {
+                              "version": "6.3.20",
+                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                              "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "debug": {
+                              "version": "2.2.0",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                              "requires": {
+                                "ms": "0.7.1"
+                              },
+                              "dependencies": {
+                                "ms": {
+                                  "version": "0.7.1",
+                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                                }
+                              }
+                            },
+                            "globals": {
+                              "version": "8.15.0",
+                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                              "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                            },
+                            "invariant": {
+                              "version": "2.2.0",
+                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                              "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                              "requires": {
+                                "loose-envify": "1.1.0"
+                              },
+                              "dependencies": {
+                                "loose-envify": {
+                                  "version": "1.1.0",
+                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                  "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                  "requires": {
+                                    "js-tokens": "1.0.2"
+                                  },
+                                  "dependencies": {
+                                    "js-tokens": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                              "requires": {
+                                "is-finite": "1.0.1"
+                              },
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                  "requires": {
+                                    "number-is-nan": "1.0.0"
+                                  },
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        },
+                        "to-fast-properties": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                          "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-es2015-literals": {
+                  "version": "6.3.13",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.3.13.tgz",
+                  "integrity": "sha1-0Wyr35ZCuYFqz3wZp78G1SNIiyk=",
+                  "requires": {
+                    "babel-runtime": "5.8.34"
+                  },
+                  "dependencies": {
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
                         }
                       }
                     }
@@ -2893,84 +2505,162 @@
                 },
                 "babel-plugin-transform-es2015-modules-commonjs": {
                   "version": "6.3.16",
-                  "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.0.15 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.3.16.tgz",
+                  "integrity": "sha1-9qkT5HOS6mHW/Fc3E5Fr77Z4R4g=",
+                  "requires": {
+                    "babel-plugin-transform-strict-mode": "6.3.13",
+                    "babel-runtime": "5.8.34",
+                    "babel-template": "6.3.13",
+                    "babel-types": "6.3.20"
+                  },
                   "dependencies": {
-                    "babel-types": {
-                      "version": "6.3.20",
-                      "from": "babel-types@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                    "babel-plugin-transform-strict-mode": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.3.13.tgz",
+                      "integrity": "sha1-jWpZDT2Rr2zdoKh2GLPO6XDlV0Y=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-types": "6.3.20"
+                      }
+                    },
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    },
+                    "babel-template": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                      "integrity": "sha1-hXXxaGepKKna6E87vNyn54Bvwiw=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "babel-types": "6.3.20",
+                        "babylon": "6.3.20",
+                        "lodash": "3.10.1"
+                      },
                       "dependencies": {
                         "babel-traverse": {
                           "version": "6.3.19",
-                          "from": "babel-traverse@>=6.3.17 <7.0.0",
                           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                          "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                          "requires": {
+                            "babel-code-frame": "6.3.13",
+                            "babel-messages": "6.3.18",
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20",
+                            "babylon": "6.3.20",
+                            "debug": "2.2.0",
+                            "globals": "8.15.0",
+                            "invariant": "2.2.0",
+                            "lodash": "3.10.1",
+                            "repeating": "1.1.3"
+                          },
                           "dependencies": {
                             "babel-code-frame": {
                               "version": "6.3.13",
-                              "from": "babel-code-frame@>=6.3.13 <7.0.0",
                               "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                              "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                              "requires": {
+                                "babel-runtime": "5.8.34",
+                                "chalk": "1.1.1",
+                                "esutils": "2.0.2",
+                                "js-tokens": "1.0.2",
+                                "line-numbers": "0.2.0",
+                                "repeating": "1.1.3"
+                              },
                               "dependencies": {
                                 "chalk": {
                                   "version": "1.1.1",
-                                  "from": "chalk@>=1.1.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                  "requires": {
+                                    "ansi-styles": "2.1.0",
+                                    "escape-string-regexp": "1.0.3",
+                                    "has-ansi": "2.0.0",
+                                    "strip-ansi": "3.0.0",
+                                    "supports-color": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-styles": {
                                       "version": "2.1.0",
-                                      "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                     },
                                     "escape-string-regexp": {
                                       "version": "1.0.3",
-                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
                                     },
                                     "has-ansi": {
                                       "version": "2.0.0",
-                                      "from": "has-ansi@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
                                       "dependencies": {
                                         "ansi-regex": {
                                           "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                         }
                                       }
                                     },
                                     "strip-ansi": {
                                       "version": "3.0.0",
-                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
                                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                      "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
                                       "dependencies": {
                                         "ansi-regex": {
                                           "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                         }
                                       }
                                     },
                                     "supports-color": {
                                       "version": "2.0.0",
-                                      "from": "supports-color@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                     }
                                   }
                                 },
+                                "esutils": {
+                                  "version": "2.0.2",
+                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                                },
                                 "js-tokens": {
                                   "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                 },
                                 "line-numbers": {
                                   "version": "0.2.0",
-                                  "from": "line-numbers@>=0.2.0 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                  "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                  "requires": {
+                                    "left-pad": "0.0.3"
+                                  },
                                   "dependencies": {
                                     "left-pad": {
                                       "version": "0.0.3",
-                                      "from": "left-pad@0.0.3",
-                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                      "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
                                     }
                                   }
                                 }
@@ -2978,45 +2668,52 @@
                             },
                             "babel-messages": {
                               "version": "6.3.18",
-                              "from": "babel-messages@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                            },
-                            "babylon": {
-                              "version": "6.3.20",
-                              "from": "babylon@>=6.3.15 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
+                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                              "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
                             },
                             "debug": {
                               "version": "2.2.0",
-                              "from": "debug@>=2.2.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                              "requires": {
+                                "ms": "0.7.1"
+                              },
                               "dependencies": {
                                 "ms": {
                                   "version": "0.7.1",
-                                  "from": "ms@0.7.1",
-                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
                                 }
                               }
                             },
                             "globals": {
                               "version": "8.15.0",
-                              "from": "globals@>=8.3.0 <9.0.0",
-                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                              "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
                             },
                             "invariant": {
                               "version": "2.2.0",
-                              "from": "invariant@>=2.2.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                              "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                              "requires": {
+                                "loose-envify": "1.1.0"
+                              },
                               "dependencies": {
                                 "loose-envify": {
                                   "version": "1.1.0",
-                                  "from": "loose-envify@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                  "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                  "requires": {
+                                    "js-tokens": "1.0.2"
+                                  },
                                   "dependencies": {
                                     "js-tokens": {
                                       "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                     }
                                   }
                                 }
@@ -3024,18 +2721,250 @@
                             },
                             "repeating": {
                               "version": "1.1.3",
-                              "from": "repeating@>=1.1.3 <2.0.0",
                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                              "requires": {
+                                "is-finite": "1.0.1"
+                              },
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                  "requires": {
+                                    "number-is-nan": "1.0.0"
+                                  },
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babylon": {
+                          "version": "6.3.20",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                          "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        }
+                      }
+                    },
+                    "babel-types": {
+                      "version": "6.3.20",
+                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                      "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "esutils": "2.0.2",
+                        "lodash": "3.10.1",
+                        "to-fast-properties": "1.0.1"
+                      },
+                      "dependencies": {
+                        "babel-traverse": {
+                          "version": "6.3.19",
+                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                          "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                          "requires": {
+                            "babel-code-frame": "6.3.13",
+                            "babel-messages": "6.3.18",
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20",
+                            "babylon": "6.3.20",
+                            "debug": "2.2.0",
+                            "globals": "8.15.0",
+                            "invariant": "2.2.0",
+                            "lodash": "3.10.1",
+                            "repeating": "1.1.3"
+                          },
+                          "dependencies": {
+                            "babel-code-frame": {
+                              "version": "6.3.13",
+                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                              "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                              "requires": {
+                                "babel-runtime": "5.8.34",
+                                "chalk": "1.1.1",
+                                "esutils": "2.0.2",
+                                "js-tokens": "1.0.2",
+                                "line-numbers": "0.2.0",
+                                "repeating": "1.1.3"
+                              },
+                              "dependencies": {
+                                "chalk": {
+                                  "version": "1.1.1",
+                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                  "requires": {
+                                    "ansi-styles": "2.1.0",
+                                    "escape-string-regexp": "1.0.3",
+                                    "has-ansi": "2.0.0",
+                                    "strip-ansi": "3.0.0",
+                                    "supports-color": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-styles": {
+                                      "version": "2.1.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                    },
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                    },
+                                    "has-ansi": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                        }
+                                      }
+                                    },
+                                    "strip-ansi": {
+                                      "version": "3.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                      "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                        }
+                                      }
+                                    },
+                                    "supports-color": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                    }
+                                  }
+                                },
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                },
+                                "line-numbers": {
+                                  "version": "0.2.0",
+                                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                  "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                  "requires": {
+                                    "left-pad": "0.0.3"
+                                  },
+                                  "dependencies": {
+                                    "left-pad": {
+                                      "version": "0.0.3",
+                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                      "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "babel-messages": {
+                              "version": "6.3.18",
+                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                              "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "babylon": {
+                              "version": "6.3.20",
+                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                              "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "debug": {
+                              "version": "2.2.0",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                              "requires": {
+                                "ms": "0.7.1"
+                              },
+                              "dependencies": {
+                                "ms": {
+                                  "version": "0.7.1",
+                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                                }
+                              }
+                            },
+                            "globals": {
+                              "version": "8.15.0",
+                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                              "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                            },
+                            "invariant": {
+                              "version": "2.2.0",
+                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                              "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                              "requires": {
+                                "loose-envify": "1.1.0"
+                              },
+                              "dependencies": {
+                                "loose-envify": {
+                                  "version": "1.1.0",
+                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                  "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                  "requires": {
+                                    "js-tokens": "1.0.2"
+                                  },
+                                  "dependencies": {
+                                    "js-tokens": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                              "requires": {
+                                "is-finite": "1.0.1"
+                              },
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                  "requires": {
+                                    "number-is-nan": "1.0.0"
+                                  },
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                     }
                                   }
                                 }
@@ -3045,178 +2974,283 @@
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                         },
                         "lodash": {
                           "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                         },
                         "to-fast-properties": {
                           "version": "1.0.1",
-                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                          "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
                         }
                       }
-                    },
-                    "babel-runtime": {
-                      "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-                        }
-                      }
-                    },
-                    "babel-template": {
+                    }
+                  }
+                },
+                "babel-plugin-transform-es2015-object-super": {
+                  "version": "6.3.13",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.3.13.tgz",
+                  "integrity": "sha1-dhw1Dlx9GeGu/34A+2/A/7RbIsY=",
+                  "requires": {
+                    "babel-helper-replace-supers": "6.3.13",
+                    "babel-runtime": "5.8.34"
+                  },
+                  "dependencies": {
+                    "babel-helper-replace-supers": {
                       "version": "6.3.13",
-                      "from": "babel-template@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.3.13.tgz",
+                      "integrity": "sha1-ROyT1+nXwG8znUq6dZJPiN7pEg8=",
+                      "requires": {
+                        "babel-helper-optimise-call-expression": "6.3.13",
+                        "babel-messages": "6.3.18",
+                        "babel-runtime": "5.8.34",
+                        "babel-template": "6.3.13",
+                        "babel-traverse": "6.3.19",
+                        "babel-types": "6.3.20"
+                      },
                       "dependencies": {
-                        "babylon": {
-                          "version": "6.3.20",
-                          "from": "babylon@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
+                        "babel-helper-optimise-call-expression": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.3.13.tgz",
+                          "integrity": "sha1-3n4W5Zs6vT9WrwMi1ec/jrn8s5w=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20"
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.3.18",
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                          "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
+                        },
+                        "babel-template": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                          "integrity": "sha1-hXXxaGepKKna6E87vNyn54Bvwiw=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-traverse": "6.3.19",
+                            "babel-types": "6.3.20",
+                            "babylon": "6.3.20",
+                            "lodash": "3.10.1"
+                          },
+                          "dependencies": {
+                            "babylon": {
+                              "version": "6.3.20",
+                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                              "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "lodash": {
+                              "version": "3.10.1",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                            }
+                          }
                         },
                         "babel-traverse": {
                           "version": "6.3.19",
-                          "from": "babel-traverse@>=6.3.13 <7.0.0",
                           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                          "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                          "requires": {
+                            "babel-code-frame": "6.3.13",
+                            "babel-messages": "6.3.18",
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20",
+                            "babylon": "6.3.20",
+                            "debug": "2.2.0",
+                            "globals": "8.15.0",
+                            "invariant": "2.2.0",
+                            "lodash": "3.10.1",
+                            "repeating": "1.1.3"
+                          },
                           "dependencies": {
                             "babel-code-frame": {
                               "version": "6.3.13",
-                              "from": "babel-code-frame@>=6.3.13 <7.0.0",
                               "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                              "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                              "requires": {
+                                "babel-runtime": "5.8.34",
+                                "chalk": "1.1.1",
+                                "esutils": "2.0.2",
+                                "js-tokens": "1.0.2",
+                                "line-numbers": "0.2.0",
+                                "repeating": "1.1.3"
+                              },
                               "dependencies": {
                                 "chalk": {
                                   "version": "1.1.1",
-                                  "from": "chalk@>=1.1.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                  "requires": {
+                                    "ansi-styles": "2.1.0",
+                                    "escape-string-regexp": "1.0.3",
+                                    "has-ansi": "2.0.0",
+                                    "strip-ansi": "3.0.0",
+                                    "supports-color": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-styles": {
                                       "version": "2.1.0",
-                                      "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                     },
                                     "escape-string-regexp": {
                                       "version": "1.0.3",
-                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
                                     },
                                     "has-ansi": {
                                       "version": "2.0.0",
-                                      "from": "has-ansi@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
                                       "dependencies": {
                                         "ansi-regex": {
                                           "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                         }
                                       }
                                     },
                                     "strip-ansi": {
                                       "version": "3.0.0",
-                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
                                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                      "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
                                       "dependencies": {
                                         "ansi-regex": {
                                           "version": "2.0.0",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                         }
                                       }
                                     },
                                     "supports-color": {
                                       "version": "2.0.0",
-                                      "from": "supports-color@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                     }
                                   }
                                 },
                                 "esutils": {
                                   "version": "2.0.2",
-                                  "from": "esutils@>=2.0.2 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                                 },
                                 "js-tokens": {
                                   "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                 },
                                 "line-numbers": {
                                   "version": "0.2.0",
-                                  "from": "line-numbers@>=0.2.0 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                  "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                  "requires": {
+                                    "left-pad": "0.0.3"
+                                  },
                                   "dependencies": {
                                     "left-pad": {
                                       "version": "0.0.3",
-                                      "from": "left-pad@0.0.3",
-                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                      "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
                                     }
                                   }
                                 }
                               }
                             },
-                            "babel-messages": {
-                              "version": "6.3.18",
-                              "from": "babel-messages@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                            "babylon": {
+                              "version": "6.3.20",
+                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                              "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
                             },
                             "debug": {
                               "version": "2.2.0",
-                              "from": "debug@>=2.2.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                              "requires": {
+                                "ms": "0.7.1"
+                              },
                               "dependencies": {
                                 "ms": {
                                   "version": "0.7.1",
-                                  "from": "ms@0.7.1",
-                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
                                 }
                               }
                             },
                             "globals": {
                               "version": "8.15.0",
-                              "from": "globals@>=8.3.0 <9.0.0",
-                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                              "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
                             },
                             "invariant": {
                               "version": "2.2.0",
-                              "from": "invariant@>=2.2.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                              "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                              "requires": {
+                                "loose-envify": "1.1.0"
+                              },
                               "dependencies": {
                                 "loose-envify": {
                                   "version": "1.1.0",
-                                  "from": "loose-envify@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                  "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                  "requires": {
+                                    "js-tokens": "1.0.2"
+                                  },
                                   "dependencies": {
                                     "js-tokens": {
                                       "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                     }
                                   }
                                 }
                               }
                             },
+                            "lodash": {
+                              "version": "3.10.1",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                            },
                             "repeating": {
                               "version": "1.1.3",
-                              "from": "repeating@>=1.1.3 <2.0.0",
                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                              "requires": {
+                                "is-finite": "1.0.1"
+                              },
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                  "requires": {
+                                    "number-is-nan": "1.0.0"
+                                  },
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                     }
                                   }
                                 }
@@ -3224,122 +3258,1486 @@
                             }
                           }
                         },
-                        "lodash": {
-                          "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                        "babel-types": {
+                          "version": "6.3.20",
+                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                          "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-traverse": "6.3.19",
+                            "esutils": "2.0.2",
+                            "lodash": "3.10.1",
+                            "to-fast-properties": "1.0.1"
+                          },
+                          "dependencies": {
+                            "esutils": {
+                              "version": "2.0.2",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                            },
+                            "lodash": {
+                              "version": "3.10.1",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                            },
+                            "to-fast-properties": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                              "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
+                            }
+                          }
                         }
                       }
                     },
-                    "babel-plugin-transform-strict-mode": {
-                      "version": "6.3.13",
-                      "from": "babel-plugin-transform-strict-mode@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.3.13.tgz"
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
                     }
                   }
                 },
-                "babel-plugin-transform-regenerator": {
+                "babel-plugin-transform-es2015-parameters": {
                   "version": "6.3.18",
-                  "from": "babel-plugin-transform-regenerator@>=6.0.14 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.3.18.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.3.18.tgz",
+                  "integrity": "sha1-GUEHqJC6sfT3JDS6NlW0PNsl5iE=",
+                  "requires": {
+                    "babel-helper-call-delegate": "6.3.13",
+                    "babel-helper-get-function-arity": "6.3.13",
+                    "babel-runtime": "5.8.34",
+                    "babel-template": "6.3.13",
+                    "babel-traverse": "6.3.19",
+                    "babel-types": "6.3.20"
+                  },
                   "dependencies": {
-                    "babel-plugin-syntax-async-functions": {
+                    "babel-helper-call-delegate": {
                       "version": "6.3.13",
-                      "from": "babel-plugin-syntax-async-functions@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.3.13.tgz"
+                      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.3.13.tgz",
+                      "integrity": "sha1-HeDTTutSakaUbyMOsV/AJ8uxHm4=",
+                      "requires": {
+                        "babel-helper-hoist-variables": "6.3.13",
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "babel-types": "6.3.20"
+                      },
+                      "dependencies": {
+                        "babel-helper-hoist-variables": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.3.13.tgz",
+                          "integrity": "sha1-C2tTfb/W8Qd9Yxr/l+2ydLdgLFk=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20"
+                          }
+                        }
+                      }
                     },
-                    "babel-core": {
-                      "version": "6.3.17",
-                      "from": "babel-core@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.3.17.tgz",
+                    "babel-helper-get-function-arity": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz",
+                      "integrity": "sha1-skc2lFI+Q1ueGBdtGkYD5sCUwGI=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-types": "6.3.20"
+                      }
+                    },
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    },
+                    "babel-template": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                      "integrity": "sha1-hXXxaGepKKna6E87vNyn54Bvwiw=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "babel-types": "6.3.20",
+                        "babylon": "6.3.20",
+                        "lodash": "3.10.1"
+                      },
+                      "dependencies": {
+                        "babylon": {
+                          "version": "6.3.20",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                          "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        }
+                      }
+                    },
+                    "babel-traverse": {
+                      "version": "6.3.19",
+                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                      "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                      "requires": {
+                        "babel-code-frame": "6.3.13",
+                        "babel-messages": "6.3.18",
+                        "babel-runtime": "5.8.34",
+                        "babel-types": "6.3.20",
+                        "babylon": "6.3.20",
+                        "debug": "2.2.0",
+                        "globals": "8.15.0",
+                        "invariant": "2.2.0",
+                        "lodash": "3.10.1",
+                        "repeating": "1.1.3"
+                      },
                       "dependencies": {
                         "babel-code-frame": {
                           "version": "6.3.13",
-                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
                           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "chalk": "1.1.1",
+                            "esutils": "2.0.2",
+                            "js-tokens": "1.0.2",
+                            "line-numbers": "0.2.0",
+                            "repeating": "1.1.3"
+                          },
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@>=1.1.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                              "requires": {
+                                "ansi-styles": "2.1.0",
+                                "escape-string-regexp": "1.0.3",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.0",
+                                "supports-color": "2.0.0"
+                              },
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                  "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.3",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                  "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                 }
                               }
                             },
                             "esutils": {
                               "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                             },
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                              "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                             },
                             "line-numbers": {
                               "version": "0.2.0",
-                              "from": "line-numbers@>=0.2.0 <0.3.0",
                               "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                              "requires": {
+                                "left-pad": "0.0.3"
+                              },
                               "dependencies": {
                                 "left-pad": {
                                   "version": "0.0.3",
-                                  "from": "left-pad@0.0.3",
-                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                  "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.3.18",
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                          "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
+                        },
+                        "babylon": {
+                          "version": "6.3.20",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                          "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
+                        },
+                        "debug": {
+                          "version": "2.2.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                          "requires": {
+                            "ms": "0.7.1"
+                          },
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "8.15.0",
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                          "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                        },
+                        "invariant": {
+                          "version": "2.2.0",
+                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                          "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                          "requires": {
+                            "loose-envify": "1.1.0"
+                          },
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.1.0",
+                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                              "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                              "requires": {
+                                "js-tokens": "1.0.2"
+                              },
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                          "requires": {
+                            "is-finite": "1.0.1"
+                          },
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                              "requires": {
+                                "number-is-nan": "1.0.0"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-types": {
+                      "version": "6.3.20",
+                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                      "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "esutils": "2.0.2",
+                        "lodash": "3.10.1",
+                        "to-fast-properties": "1.0.1"
+                      },
+                      "dependencies": {
+                        "esutils": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        },
+                        "to-fast-properties": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                          "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-es2015-shorthand-properties": {
+                  "version": "6.3.13",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.3.13.tgz",
+                  "integrity": "sha1-akiEQqwcr+3vKDavE6c1cpmCtTY=",
+                  "requires": {
+                    "babel-runtime": "5.8.34",
+                    "babel-types": "6.3.20"
+                  },
+                  "dependencies": {
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    },
+                    "babel-types": {
+                      "version": "6.3.20",
+                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                      "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "esutils": "2.0.2",
+                        "lodash": "3.10.1",
+                        "to-fast-properties": "1.0.1"
+                      },
+                      "dependencies": {
+                        "babel-traverse": {
+                          "version": "6.3.19",
+                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                          "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                          "requires": {
+                            "babel-code-frame": "6.3.13",
+                            "babel-messages": "6.3.18",
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20",
+                            "babylon": "6.3.20",
+                            "debug": "2.2.0",
+                            "globals": "8.15.0",
+                            "invariant": "2.2.0",
+                            "lodash": "3.10.1",
+                            "repeating": "1.1.3"
+                          },
+                          "dependencies": {
+                            "babel-code-frame": {
+                              "version": "6.3.13",
+                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                              "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                              "requires": {
+                                "babel-runtime": "5.8.34",
+                                "chalk": "1.1.1",
+                                "esutils": "2.0.2",
+                                "js-tokens": "1.0.2",
+                                "line-numbers": "0.2.0",
+                                "repeating": "1.1.3"
+                              },
+                              "dependencies": {
+                                "chalk": {
+                                  "version": "1.1.1",
+                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                  "requires": {
+                                    "ansi-styles": "2.1.0",
+                                    "escape-string-regexp": "1.0.3",
+                                    "has-ansi": "2.0.0",
+                                    "strip-ansi": "3.0.0",
+                                    "supports-color": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-styles": {
+                                      "version": "2.1.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                    },
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                    },
+                                    "has-ansi": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                        }
+                                      }
+                                    },
+                                    "strip-ansi": {
+                                      "version": "3.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                      "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                        }
+                                      }
+                                    },
+                                    "supports-color": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                    }
+                                  }
+                                },
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                },
+                                "line-numbers": {
+                                  "version": "0.2.0",
+                                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                  "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                  "requires": {
+                                    "left-pad": "0.0.3"
+                                  },
+                                  "dependencies": {
+                                    "left-pad": {
+                                      "version": "0.0.3",
+                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                      "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "babel-messages": {
+                              "version": "6.3.18",
+                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                              "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "babylon": {
+                              "version": "6.3.20",
+                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                              "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "debug": {
+                              "version": "2.2.0",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                              "requires": {
+                                "ms": "0.7.1"
+                              },
+                              "dependencies": {
+                                "ms": {
+                                  "version": "0.7.1",
+                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                                }
+                              }
+                            },
+                            "globals": {
+                              "version": "8.15.0",
+                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                              "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                            },
+                            "invariant": {
+                              "version": "2.2.0",
+                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                              "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                              "requires": {
+                                "loose-envify": "1.1.0"
+                              },
+                              "dependencies": {
+                                "loose-envify": {
+                                  "version": "1.1.0",
+                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                  "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                  "requires": {
+                                    "js-tokens": "1.0.2"
+                                  },
+                                  "dependencies": {
+                                    "js-tokens": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                    }
+                                  }
                                 }
                               }
                             },
                             "repeating": {
                               "version": "1.1.3",
-                              "from": "repeating@>=1.1.3 <2.0.0",
                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                              "requires": {
+                                "is-finite": "1.0.1"
+                              },
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                  "requires": {
+                                    "number-is-nan": "1.0.0"
+                                  },
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        },
+                        "to-fast-properties": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                          "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-es2015-spread": {
+                  "version": "6.3.14",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.3.14.tgz",
+                  "integrity": "sha1-YB9fB8998+OPYjAQDiQIEsNNiB4=",
+                  "requires": {
+                    "babel-runtime": "5.8.34"
+                  },
+                  "dependencies": {
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-es2015-sticky-regex": {
+                  "version": "6.3.13",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.3.13.tgz",
+                  "integrity": "sha1-2G7VnWM0VK/43OFHuBlI0VYrt2E=",
+                  "requires": {
+                    "babel-helper-regex": "6.3.13",
+                    "babel-runtime": "5.8.34",
+                    "babel-types": "6.3.20"
+                  },
+                  "dependencies": {
+                    "babel-helper-regex": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.3.13.tgz",
+                      "integrity": "sha1-PsxDF0ckTCwauGwm7k59y3zrFeM=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-types": "6.3.20",
+                        "lodash": "3.10.1"
+                      },
+                      "dependencies": {
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        }
+                      }
+                    },
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    },
+                    "babel-types": {
+                      "version": "6.3.20",
+                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                      "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "esutils": "2.0.2",
+                        "lodash": "3.10.1",
+                        "to-fast-properties": "1.0.1"
+                      },
+                      "dependencies": {
+                        "babel-traverse": {
+                          "version": "6.3.19",
+                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                          "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                          "requires": {
+                            "babel-code-frame": "6.3.13",
+                            "babel-messages": "6.3.18",
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20",
+                            "babylon": "6.3.20",
+                            "debug": "2.2.0",
+                            "globals": "8.15.0",
+                            "invariant": "2.2.0",
+                            "lodash": "3.10.1",
+                            "repeating": "1.1.3"
+                          },
+                          "dependencies": {
+                            "babel-code-frame": {
+                              "version": "6.3.13",
+                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                              "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                              "requires": {
+                                "babel-runtime": "5.8.34",
+                                "chalk": "1.1.1",
+                                "esutils": "2.0.2",
+                                "js-tokens": "1.0.2",
+                                "line-numbers": "0.2.0",
+                                "repeating": "1.1.3"
+                              },
+                              "dependencies": {
+                                "chalk": {
+                                  "version": "1.1.1",
+                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                  "requires": {
+                                    "ansi-styles": "2.1.0",
+                                    "escape-string-regexp": "1.0.3",
+                                    "has-ansi": "2.0.0",
+                                    "strip-ansi": "3.0.0",
+                                    "supports-color": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-styles": {
+                                      "version": "2.1.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                    },
+                                    "escape-string-regexp": {
+                                      "version": "1.0.3",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                    },
+                                    "has-ansi": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                        }
+                                      }
+                                    },
+                                    "strip-ansi": {
+                                      "version": "3.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                      "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                      "requires": {
+                                        "ansi-regex": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                        }
+                                      }
+                                    },
+                                    "supports-color": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                    }
+                                  }
+                                },
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                },
+                                "line-numbers": {
+                                  "version": "0.2.0",
+                                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                  "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                  "requires": {
+                                    "left-pad": "0.0.3"
+                                  },
+                                  "dependencies": {
+                                    "left-pad": {
+                                      "version": "0.0.3",
+                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                      "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "babel-messages": {
+                              "version": "6.3.18",
+                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                              "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "babylon": {
+                              "version": "6.3.20",
+                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                              "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "debug": {
+                              "version": "2.2.0",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                              "requires": {
+                                "ms": "0.7.1"
+                              },
+                              "dependencies": {
+                                "ms": {
+                                  "version": "0.7.1",
+                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                                }
+                              }
+                            },
+                            "globals": {
+                              "version": "8.15.0",
+                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                              "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                            },
+                            "invariant": {
+                              "version": "2.2.0",
+                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                              "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                              "requires": {
+                                "loose-envify": "1.1.0"
+                              },
+                              "dependencies": {
+                                "loose-envify": {
+                                  "version": "1.1.0",
+                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                  "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                  "requires": {
+                                    "js-tokens": "1.0.2"
+                                  },
+                                  "dependencies": {
+                                    "js-tokens": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                              "requires": {
+                                "is-finite": "1.0.1"
+                              },
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                  "requires": {
+                                    "number-is-nan": "1.0.0"
+                                  },
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        },
+                        "to-fast-properties": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                          "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-es2015-template-literals": {
+                  "version": "6.3.13",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.3.13.tgz",
+                  "integrity": "sha1-XpsKXzr/UclHNuTfmNU7bg4Th0c=",
+                  "requires": {
+                    "babel-runtime": "5.8.34"
+                  },
+                  "dependencies": {
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-es2015-typeof-symbol": {
+                  "version": "6.3.13",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.3.13.tgz",
+                  "integrity": "sha1-3J6JnyPmIg8vREe0h7hzSEV+9pQ=",
+                  "requires": {
+                    "babel-runtime": "5.8.34"
+                  },
+                  "dependencies": {
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-es2015-unicode-regex": {
+                  "version": "6.3.13",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.3.13.tgz",
+                  "integrity": "sha1-f5yReDF+SRiQJTC0iLVn9agKMIY=",
+                  "requires": {
+                    "babel-helper-regex": "6.3.13",
+                    "babel-runtime": "5.8.34",
+                    "regexpu": "1.3.0"
+                  },
+                  "dependencies": {
+                    "babel-helper-regex": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.3.13.tgz",
+                      "integrity": "sha1-PsxDF0ckTCwauGwm7k59y3zrFeM=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-types": "6.3.20",
+                        "lodash": "3.10.1"
+                      },
+                      "dependencies": {
+                        "babel-types": {
+                          "version": "6.3.20",
+                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                          "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-traverse": "6.3.19",
+                            "esutils": "2.0.2",
+                            "lodash": "3.10.1",
+                            "to-fast-properties": "1.0.1"
+                          },
+                          "dependencies": {
+                            "babel-traverse": {
+                              "version": "6.3.19",
+                              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                              "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                              "requires": {
+                                "babel-code-frame": "6.3.13",
+                                "babel-messages": "6.3.18",
+                                "babel-runtime": "5.8.34",
+                                "babel-types": "6.3.20",
+                                "babylon": "6.3.20",
+                                "debug": "2.2.0",
+                                "globals": "8.15.0",
+                                "invariant": "2.2.0",
+                                "lodash": "3.10.1",
+                                "repeating": "1.1.3"
+                              },
+                              "dependencies": {
+                                "babel-code-frame": {
+                                  "version": "6.3.13",
+                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                  "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34",
+                                    "chalk": "1.1.1",
+                                    "esutils": "2.0.2",
+                                    "js-tokens": "1.0.2",
+                                    "line-numbers": "0.2.0",
+                                    "repeating": "1.1.3"
+                                  },
+                                  "dependencies": {
+                                    "chalk": {
+                                      "version": "1.1.1",
+                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                      "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                      "requires": {
+                                        "ansi-styles": "2.1.0",
+                                        "escape-string-regexp": "1.0.3",
+                                        "has-ansi": "2.0.0",
+                                        "strip-ansi": "3.0.0",
+                                        "supports-color": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-styles": {
+                                          "version": "2.1.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                          "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                        },
+                                        "escape-string-regexp": {
+                                          "version": "1.0.3",
+                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                          "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                        },
+                                        "has-ansi": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                            }
+                                          }
+                                        },
+                                        "strip-ansi": {
+                                          "version": "3.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                          "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                            }
+                                          }
+                                        },
+                                        "supports-color": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                        }
+                                      }
+                                    },
+                                    "js-tokens": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                    },
+                                    "line-numbers": {
+                                      "version": "0.2.0",
+                                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                      "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                      "requires": {
+                                        "left-pad": "0.0.3"
+                                      },
+                                      "dependencies": {
+                                        "left-pad": {
+                                          "version": "0.0.3",
+                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                          "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "babel-messages": {
+                                  "version": "6.3.18",
+                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                                  "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
+                                },
+                                "babylon": {
+                                  "version": "6.3.20",
+                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                                  "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
+                                },
+                                "debug": {
+                                  "version": "2.2.0",
+                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                                  "requires": {
+                                    "ms": "0.7.1"
+                                  },
+                                  "dependencies": {
+                                    "ms": {
+                                      "version": "0.7.1",
+                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                                    }
+                                  }
+                                },
+                                "globals": {
+                                  "version": "8.15.0",
+                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                                  "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                                },
+                                "invariant": {
+                                  "version": "2.2.0",
+                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                  "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                                  "requires": {
+                                    "loose-envify": "1.1.0"
+                                  },
+                                  "dependencies": {
+                                    "loose-envify": {
+                                      "version": "1.1.0",
+                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                      "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                      "requires": {
+                                        "js-tokens": "1.0.2"
+                                      },
+                                      "dependencies": {
+                                        "js-tokens": {
+                                          "version": "1.0.2",
+                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                          "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "repeating": {
+                                  "version": "1.1.3",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                  "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                                  "requires": {
+                                    "is-finite": "1.0.1"
+                                  },
+                                  "dependencies": {
+                                    "is-finite": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                      "requires": {
+                                        "number-is-nan": "1.0.0"
+                                      },
+                                      "dependencies": {
+                                        "number-is-nan": {
+                                          "version": "1.0.0",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "esutils": {
+                              "version": "2.0.2",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                            },
+                            "to-fast-properties": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                              "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
+                            }
+                          }
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                        }
+                      }
+                    },
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                        }
+                      }
+                    },
+                    "regexpu": {
+                      "version": "1.3.0",
+                      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                      "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
+                      "requires": {
+                        "esprima": "2.7.1",
+                        "recast": "0.10.39",
+                        "regenerate": "1.2.1",
+                        "regjsgen": "0.2.0",
+                        "regjsparser": "0.1.5"
+                      },
+                      "dependencies": {
+                        "esprima": {
+                          "version": "2.7.1",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
+                          "integrity": "sha1-KrfRVJ7dBtFNaabBoXVKygLpZX4="
+                        },
+                        "recast": {
+                          "version": "0.10.39",
+                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.39.tgz",
+                          "integrity": "sha1-9jcjTaHtPQ+gB7HEZnjhWIh7jaQ=",
+                          "requires": {
+                            "ast-types": "0.8.12",
+                            "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                            "private": "0.1.6",
+                            "source-map": "0.5.3"
+                          },
+                          "dependencies": {
+                            "ast-types": {
+                              "version": "0.8.12",
+                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+                              "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w="
+                            },
+                            "esprima-fb": {
+                              "version": "15001.1001.0-dev-harmony-fb",
+                              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                              "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+                            },
+                            "private": {
+                              "version": "0.1.6",
+                              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+                              "integrity": "sha1-VcapdtD5uvuZJIUTUP5HubX7t8E="
+                            },
+                            "source-map": {
+                              "version": "0.5.3",
+                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+                              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
+                            }
+                          }
+                        },
+                        "regenerate": {
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
+                          "integrity": "sha1-njC6aKa9lqw9y6YqsJ1V1LL8vgQ="
+                        },
+                        "regjsgen": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                          "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+                        },
+                        "regjsparser": {
+                          "version": "0.1.5",
+                          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                          "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+                          "requires": {
+                            "jsesc": "0.5.0"
+                          },
+                          "dependencies": {
+                            "jsesc": {
+                              "version": "0.5.0",
+                              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                              "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-regenerator": {
+                  "version": "6.3.18",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.3.18.tgz",
+                  "integrity": "sha1-89H9Joc1faCzd/oU5drGLmHsyks=",
+                  "requires": {
+                    "babel-core": "6.3.17",
+                    "babel-plugin-syntax-async-functions": "6.3.13",
+                    "babel-plugin-transform-es2015-block-scoping": "6.3.13",
+                    "babel-plugin-transform-es2015-for-of": "6.3.13",
+                    "babel-runtime": "5.8.34",
+                    "babel-traverse": "6.3.19",
+                    "babel-types": "6.3.20",
+                    "babylon": "6.3.20",
+                    "private": "0.1.6"
+                  },
+                  "dependencies": {
+                    "babel-core": {
+                      "version": "6.3.17",
+                      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.3.17.tgz",
+                      "integrity": "sha1-ckwcHmSfEJnd3DB5fk5iJM9NOTU=",
+                      "requires": {
+                        "babel-code-frame": "6.3.13",
+                        "babel-generator": "6.3.20",
+                        "babel-helpers": "6.3.13",
+                        "babel-messages": "6.3.18",
+                        "babel-register": "6.3.13",
+                        "babel-runtime": "5.8.34",
+                        "babel-template": "6.3.13",
+                        "babel-traverse": "6.3.19",
+                        "babel-types": "6.3.20",
+                        "babylon": "6.3.20",
+                        "convert-source-map": "1.1.2",
+                        "debug": "2.2.0",
+                        "json5": "0.4.0",
+                        "lodash": "3.10.1",
+                        "minimatch": "2.0.10",
+                        "path-exists": "1.0.0",
+                        "path-is-absolute": "1.0.0",
+                        "private": "0.1.6",
+                        "shebang-regex": "1.0.0",
+                        "slash": "1.0.0",
+                        "source-map": "0.5.3"
+                      },
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "chalk": "1.1.1",
+                            "esutils": "2.0.2",
+                            "js-tokens": "1.0.2",
+                            "line-numbers": "0.2.0",
+                            "repeating": "1.1.3"
+                          },
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.1",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                              "requires": {
+                                "ansi-styles": "2.1.0",
+                                "escape-string-regexp": "1.0.3",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.0",
+                                "supports-color": "2.0.0"
+                              },
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.1.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                  "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.3",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                  "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                }
+                              }
+                            },
+                            "esutils": {
+                              "version": "2.0.2",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                            },
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                              "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                            },
+                            "line-numbers": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                              "requires": {
+                                "left-pad": "0.0.3"
+                              },
+                              "dependencies": {
+                                "left-pad": {
+                                  "version": "0.0.3",
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                  "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                }
+                              }
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                              "requires": {
+                                "is-finite": "1.0.1"
+                              },
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                  "requires": {
+                                    "number-is-nan": "1.0.0"
+                                  },
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                     }
                                   }
                                 }
@@ -3349,40 +4747,62 @@
                         },
                         "babel-generator": {
                           "version": "6.3.20",
-                          "from": "babel-generator@>=6.3.17 <7.0.0",
                           "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.3.20.tgz",
+                          "integrity": "sha1-yJ+b0y68nv3/X57HmeAHrtrAzvw=",
+                          "requires": {
+                            "babel-messages": "6.3.18",
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20",
+                            "detect-indent": "3.0.1",
+                            "is-integer": "1.0.6",
+                            "lodash": "3.10.1",
+                            "repeating": "1.1.3",
+                            "source-map": "0.5.3",
+                            "trim-right": "1.0.1"
+                          },
                           "dependencies": {
                             "detect-indent": {
                               "version": "3.0.1",
-                              "from": "detect-indent@>=3.0.1 <4.0.0",
                               "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                              "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+                              "requires": {
+                                "get-stdin": "4.0.1",
+                                "minimist": "1.2.0",
+                                "repeating": "1.1.3"
+                              },
                               "dependencies": {
                                 "get-stdin": {
                                   "version": "4.0.1",
-                                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                                  "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
                                 },
                                 "minimist": {
                                   "version": "1.2.0",
-                                  "from": "minimist@>=1.1.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                                 }
                               }
                             },
                             "is-integer": {
                               "version": "1.0.6",
-                              "from": "is-integer@>=1.0.4 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                              "integrity": "sha1-UnOBn62ogNEj4awAqTjnFy3Y2V4=",
+                              "requires": {
+                                "is-finite": "1.0.1"
+                              },
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                  "requires": {
+                                    "number-is-nan": "1.0.0"
+                                  },
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                     }
                                   }
                                 }
@@ -3390,18 +4810,24 @@
                             },
                             "repeating": {
                               "version": "1.1.3",
-                              "from": "repeating@>=1.1.3 <2.0.0",
                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                              "requires": {
+                                "is-finite": "1.0.1"
+                              },
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                  "requires": {
+                                    "number-is-nan": "1.0.0"
+                                  },
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                     }
                                   }
                                 }
@@ -3409,67 +4835,88 @@
                             },
                             "trim-right": {
                               "version": "1.0.1",
-                              "from": "trim-right@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+                              "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
                             }
                           }
                         },
                         "babel-helpers": {
                           "version": "6.3.13",
-                          "from": "babel-helpers@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.3.13.tgz"
+                          "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.3.13.tgz",
+                          "integrity": "sha1-Kw14jjt3RS9o8c4LY/1KkeEGvQo=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-template": "6.3.13"
+                          }
                         },
                         "babel-messages": {
                           "version": "6.3.18",
-                          "from": "babel-messages@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                        },
-                        "babel-template": {
-                          "version": "6.3.13",
-                          "from": "babel-template@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz"
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                          "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
                         },
                         "babel-register": {
                           "version": "6.3.13",
-                          "from": "babel-register@>=6.3.13 <7.0.0",
                           "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.3.13.tgz",
+                          "integrity": "sha1-hYt3zXdlqlqCozwmu7G8eyZHE78=",
+                          "requires": {
+                            "babel-core": "6.3.17",
+                            "babel-runtime": "5.8.34",
+                            "core-js": "1.2.6",
+                            "home-or-tmp": "1.0.0",
+                            "lodash": "3.10.1",
+                            "path-exists": "1.0.0",
+                            "source-map-support": "0.2.10"
+                          },
                           "dependencies": {
                             "core-js": {
                               "version": "1.2.6",
-                              "from": "core-js@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                              "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
                             },
                             "home-or-tmp": {
                               "version": "1.0.0",
-                              "from": "home-or-tmp@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                              "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
+                              "requires": {
+                                "os-tmpdir": "1.0.1",
+                                "user-home": "1.1.1"
+                              },
                               "dependencies": {
                                 "os-tmpdir": {
                                   "version": "1.0.1",
-                                  "from": "os-tmpdir@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+                                  "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24="
                                 },
                                 "user-home": {
                                   "version": "1.1.1",
-                                  "from": "user-home@>=1.1.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+                                  "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
                                 }
                               }
                             },
                             "source-map-support": {
                               "version": "0.2.10",
-                              "from": "source-map-support@>=0.2.10 <0.3.0",
                               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                              "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+                              "requires": {
+                                "source-map": "0.1.32"
+                              },
                               "dependencies": {
                                 "source-map": {
                                   "version": "0.1.32",
-                                  "from": "source-map@0.1.32",
                                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                                  "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+                                  "requires": {
+                                    "amdefine": "1.0.0"
+                                  },
                                   "dependencies": {
                                     "amdefine": {
                                       "version": "1.0.0",
-                                      "from": "amdefine@>=0.0.4",
-                                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM="
                                     }
                                   }
                                 }
@@ -3477,52 +4924,74 @@
                             }
                           }
                         },
+                        "babel-template": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                          "integrity": "sha1-hXXxaGepKKna6E87vNyn54Bvwiw=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-traverse": "6.3.19",
+                            "babel-types": "6.3.20",
+                            "babylon": "6.3.20",
+                            "lodash": "3.10.1"
+                          }
+                        },
                         "convert-source-map": {
                           "version": "1.1.2",
-                          "from": "convert-source-map@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
+                          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz",
+                          "integrity": "sha1-gmY3iDEHOQf6OE8LKuyrC6BYZpM="
                         },
                         "debug": {
                           "version": "2.2.0",
-                          "from": "debug@>=2.1.1 <3.0.0",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                          "requires": {
+                            "ms": "0.7.1"
+                          },
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "ms@0.7.1",
-                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
                             }
                           }
                         },
                         "json5": {
                           "version": "0.4.0",
-                          "from": "json5@>=0.4.0 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+                          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+                          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
                         },
                         "lodash": {
                           "version": "3.10.1",
-                          "from": "lodash@>=3.10.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                         },
                         "minimatch": {
                           "version": "2.0.10",
-                          "from": "minimatch@>=2.0.3 <3.0.0",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                          "requires": {
+                            "brace-expansion": "1.1.2"
+                          },
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.2",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                              "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                              "requires": {
+                                "balanced-match": "0.3.0",
+                                "concat-map": "0.0.1"
+                              },
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.3.0",
-                                  "from": "balanced-match@>=0.3.0 <0.4.0",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                  "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                                 }
                               }
                             }
@@ -3530,118 +4999,165 @@
                         },
                         "path-exists": {
                           "version": "1.0.0",
-                          "from": "path-exists@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+                          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE="
                         },
                         "path-is-absolute": {
                           "version": "1.0.0",
-                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
                         },
                         "shebang-regex": {
                           "version": "1.0.0",
-                          "from": "shebang-regex@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
                         },
                         "slash": {
                           "version": "1.0.0",
-                          "from": "slash@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+                          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
                         },
                         "source-map": {
                           "version": "0.5.3",
-                          "from": "source-map@>=0.5.0 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+                          "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
                         }
+                      }
+                    },
+                    "babel-plugin-syntax-async-functions": {
+                      "version": "6.3.13",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.3.13.tgz",
+                      "integrity": "sha1-Tzf8UeM4c3aafO5Gh2HqMSRMcI4=",
+                      "requires": {
+                        "babel-runtime": "5.8.34"
                       }
                     },
                     "babel-runtime": {
                       "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
                       "dependencies": {
                         "core-js": {
                           "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
                         }
                       }
                     },
                     "babel-traverse": {
                       "version": "6.3.19",
-                      "from": "babel-traverse@>=6.3.13 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                      "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                      "requires": {
+                        "babel-code-frame": "6.3.13",
+                        "babel-messages": "6.3.18",
+                        "babel-runtime": "5.8.34",
+                        "babel-types": "6.3.20",
+                        "babylon": "6.3.20",
+                        "debug": "2.2.0",
+                        "globals": "8.15.0",
+                        "invariant": "2.2.0",
+                        "lodash": "3.10.1",
+                        "repeating": "1.1.3"
+                      },
                       "dependencies": {
                         "babel-code-frame": {
                           "version": "6.3.13",
-                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
                           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "chalk": "1.1.1",
+                            "esutils": "2.0.2",
+                            "js-tokens": "1.0.2",
+                            "line-numbers": "0.2.0",
+                            "repeating": "1.1.3"
+                          },
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@>=1.1.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                              "requires": {
+                                "ansi-styles": "2.1.0",
+                                "escape-string-regexp": "1.0.3",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.0",
+                                "supports-color": "2.0.0"
+                              },
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                  "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.3",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                  "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                 }
                               }
                             },
                             "esutils": {
                               "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                             },
                             "js-tokens": {
                               "version": "1.0.2",
-                              "from": "js-tokens@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                              "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                             },
                             "line-numbers": {
                               "version": "0.2.0",
-                              "from": "line-numbers@>=0.2.0 <0.3.0",
                               "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                              "requires": {
+                                "left-pad": "0.0.3"
+                              },
                               "dependencies": {
                                 "left-pad": {
                                   "version": "0.0.3",
-                                  "from": "left-pad@0.0.3",
-                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                  "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
                                 }
                               }
                             }
@@ -3649,40 +5165,52 @@
                         },
                         "babel-messages": {
                           "version": "6.3.18",
-                          "from": "babel-messages@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                          "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
                         },
                         "debug": {
                           "version": "2.2.0",
-                          "from": "debug@>=2.2.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                          "requires": {
+                            "ms": "0.7.1"
+                          },
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "ms@0.7.1",
-                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
                             }
                           }
                         },
                         "globals": {
                           "version": "8.15.0",
-                          "from": "globals@>=8.3.0 <9.0.0",
-                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                          "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
                         },
                         "invariant": {
                           "version": "2.2.0",
-                          "from": "invariant@>=2.2.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                          "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                          "requires": {
+                            "loose-envify": "1.1.0"
+                          },
                           "dependencies": {
                             "loose-envify": {
                               "version": "1.1.0",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                              "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                              "requires": {
+                                "js-tokens": "1.0.2"
+                              },
                               "dependencies": {
                                 "js-tokens": {
                                   "version": "1.0.2",
-                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                 }
                               }
                             }
@@ -3690,23 +5218,29 @@
                         },
                         "lodash": {
                           "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.3 <2.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                          "requires": {
+                            "is-finite": "1.0.1"
+                          },
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                              "requires": {
+                                "number-is-nan": "1.0.0"
+                              },
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                 }
                               }
                             }
@@ -3716,35 +5250,45 @@
                     },
                     "babel-types": {
                       "version": "6.3.20",
-                      "from": "babel-types@>=6.3.18 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                      "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                      "requires": {
+                        "babel-runtime": "5.8.34",
+                        "babel-traverse": "6.3.19",
+                        "esutils": "2.0.2",
+                        "lodash": "3.10.1",
+                        "to-fast-properties": "1.0.1"
+                      },
                       "dependencies": {
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                         },
                         "lodash": {
                           "version": "3.10.1",
-                          "from": "lodash@>=3.10.1 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                         },
                         "to-fast-properties": {
                           "version": "1.0.1",
-                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                          "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
                         }
                       }
                     },
                     "babylon": {
                       "version": "6.3.20",
-                      "from": "babylon@>=6.3.18 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                      "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                      "requires": {
+                        "babel-runtime": "5.8.34"
+                      }
                     },
                     "private": {
                       "version": "0.1.6",
-                      "from": "private@>=0.1.5 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+                      "integrity": "sha1-VcapdtD5uvuZJIUTUP5HubX7t8E="
                     }
                   }
                 }
@@ -3752,28 +5296,43 @@
             },
             "babel-preset-stage-0": {
               "version": "6.3.13",
-              "from": "babel-preset-stage-0@6.3.13",
               "resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.3.13.tgz",
+              "integrity": "sha1-eKN8VvCzmI8qeZMtywzrj/N3sNE=",
+              "requires": {
+                "babel-plugin-transform-do-expressions": "6.3.13",
+                "babel-plugin-transform-function-bind": "6.3.13",
+                "babel-preset-stage-1": "6.3.13"
+              },
               "dependencies": {
                 "babel-plugin-transform-do-expressions": {
                   "version": "6.3.13",
-                  "from": "babel-plugin-transform-do-expressions@>=6.3.13 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.3.13.tgz",
+                  "integrity": "sha1-3TqCm565As1l3QmRqVdlJ7Jssjg=",
+                  "requires": {
+                    "babel-plugin-syntax-do-expressions": "6.3.13",
+                    "babel-runtime": "5.8.34"
+                  },
                   "dependencies": {
                     "babel-plugin-syntax-do-expressions": {
                       "version": "6.3.13",
-                      "from": "babel-plugin-syntax-do-expressions@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.3.13.tgz"
+                      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.3.13.tgz",
+                      "integrity": "sha1-noFTa+WOVuvC3xcIDoe9a7PdnO8=",
+                      "requires": {
+                        "babel-runtime": "5.8.34"
+                      }
                     },
                     "babel-runtime": {
                       "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
                       "dependencies": {
                         "core-js": {
                           "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
                         }
                       }
                     }
@@ -3781,23 +5340,33 @@
                 },
                 "babel-plugin-transform-function-bind": {
                   "version": "6.3.13",
-                  "from": "babel-plugin-transform-function-bind@>=6.3.13 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.3.13.tgz",
+                  "integrity": "sha1-lAT7Xm2M3qZGYysja4mpo6Exs94=",
+                  "requires": {
+                    "babel-plugin-syntax-function-bind": "6.3.13",
+                    "babel-runtime": "5.8.34"
+                  },
                   "dependencies": {
                     "babel-plugin-syntax-function-bind": {
                       "version": "6.3.13",
-                      "from": "babel-plugin-syntax-function-bind@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.3.13.tgz"
+                      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.3.13.tgz",
+                      "integrity": "sha1-2J4Y/c+QCjrbB+ctfMR7f9wqd+w=",
+                      "requires": {
+                        "babel-runtime": "5.8.34"
+                      }
                     },
                     "babel-runtime": {
                       "version": "5.8.34",
-                      "from": "babel-runtime@>=5.0.0 <6.0.0",
                       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                      "requires": {
+                        "core-js": "1.2.6"
+                      },
                       "dependencies": {
                         "core-js": {
                           "version": "1.2.6",
-                          "from": "core-js@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
                         }
                       }
                     }
@@ -3805,99 +5374,172 @@
                 },
                 "babel-preset-stage-1": {
                   "version": "6.3.13",
-                  "from": "babel-preset-stage-1@>=6.3.13 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.3.13.tgz",
+                  "integrity": "sha1-5B31GNIMjcwst9rlpsB4yMfc+9k=",
+                  "requires": {
+                    "babel-plugin-transform-class-constructor-call": "6.3.13",
+                    "babel-plugin-transform-class-properties": "6.3.13",
+                    "babel-plugin-transform-decorators": "6.3.13",
+                    "babel-plugin-transform-export-extensions": "6.3.13",
+                    "babel-preset-stage-2": "6.3.13"
+                  },
                   "dependencies": {
                     "babel-plugin-transform-class-constructor-call": {
                       "version": "6.3.13",
-                      "from": "babel-plugin-transform-class-constructor-call@>=6.3.13 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.3.13.tgz",
+                      "integrity": "sha1-BYE/IfBHR1V23hoHNMnvRHqZ1nQ=",
+                      "requires": {
+                        "babel-plugin-syntax-class-constructor-call": "6.3.13",
+                        "babel-runtime": "5.8.34",
+                        "babel-template": "6.3.13"
+                      },
                       "dependencies": {
+                        "babel-plugin-syntax-class-constructor-call": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.3.13.tgz",
+                          "integrity": "sha1-uzRot+Bq4bxivy1B8Suu5fDTtLg=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
+                        },
+                        "babel-runtime": {
+                          "version": "5.8.34",
+                          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                          "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                          "requires": {
+                            "core-js": "1.2.6"
+                          },
+                          "dependencies": {
+                            "core-js": {
+                              "version": "1.2.6",
+                              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                              "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                            }
+                          }
+                        },
                         "babel-template": {
                           "version": "6.3.13",
-                          "from": "babel-template@>=6.3.13 <7.0.0",
                           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                          "integrity": "sha1-hXXxaGepKKna6E87vNyn54Bvwiw=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-traverse": "6.3.19",
+                            "babel-types": "6.3.20",
+                            "babylon": "6.3.20",
+                            "lodash": "3.10.1"
+                          },
                           "dependencies": {
-                            "babylon": {
-                              "version": "6.3.20",
-                              "from": "babylon@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                            },
                             "babel-traverse": {
                               "version": "6.3.19",
-                              "from": "babel-traverse@>=6.3.13 <7.0.0",
                               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                              "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                              "requires": {
+                                "babel-code-frame": "6.3.13",
+                                "babel-messages": "6.3.18",
+                                "babel-runtime": "5.8.34",
+                                "babel-types": "6.3.20",
+                                "babylon": "6.3.20",
+                                "debug": "2.2.0",
+                                "globals": "8.15.0",
+                                "invariant": "2.2.0",
+                                "lodash": "3.10.1",
+                                "repeating": "1.1.3"
+                              },
                               "dependencies": {
                                 "babel-code-frame": {
                                   "version": "6.3.13",
-                                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
                                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                  "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34",
+                                    "chalk": "1.1.1",
+                                    "esutils": "2.0.2",
+                                    "js-tokens": "1.0.2",
+                                    "line-numbers": "0.2.0",
+                                    "repeating": "1.1.3"
+                                  },
                                   "dependencies": {
                                     "chalk": {
                                       "version": "1.1.1",
-                                      "from": "chalk@>=1.1.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                      "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                      "requires": {
+                                        "ansi-styles": "2.1.0",
+                                        "escape-string-regexp": "1.0.3",
+                                        "has-ansi": "2.0.0",
+                                        "strip-ansi": "3.0.0",
+                                        "supports-color": "2.0.0"
+                                      },
                                       "dependencies": {
                                         "ansi-styles": {
                                           "version": "2.1.0",
-                                          "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                          "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                         },
                                         "escape-string-regexp": {
                                           "version": "1.0.3",
-                                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                          "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
                                         },
                                         "has-ansi": {
                                           "version": "2.0.0",
-                                          "from": "has-ansi@>=2.0.0 <3.0.0",
                                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
                                           "dependencies": {
                                             "ansi-regex": {
                                               "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                             }
                                           }
                                         },
                                         "strip-ansi": {
                                           "version": "3.0.0",
-                                          "from": "strip-ansi@>=3.0.0 <4.0.0",
                                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                          "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
                                           "dependencies": {
                                             "ansi-regex": {
                                               "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                             }
                                           }
                                         },
                                         "supports-color": {
                                           "version": "2.0.0",
-                                          "from": "supports-color@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                         }
                                       }
                                     },
                                     "esutils": {
                                       "version": "2.0.2",
-                                      "from": "esutils@>=2.0.2 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                                     },
                                     "js-tokens": {
                                       "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                     },
                                     "line-numbers": {
                                       "version": "0.2.0",
-                                      "from": "line-numbers@>=0.2.0 <0.3.0",
                                       "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                      "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                      "requires": {
+                                        "left-pad": "0.0.3"
+                                      },
                                       "dependencies": {
                                         "left-pad": {
                                           "version": "0.0.3",
-                                          "from": "left-pad@0.0.3",
-                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                          "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
                                         }
                                       }
                                     }
@@ -3905,40 +5547,52 @@
                                 },
                                 "babel-messages": {
                                   "version": "6.3.18",
-                                  "from": "babel-messages@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                                  "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
                                 },
                                 "debug": {
                                   "version": "2.2.0",
-                                  "from": "debug@>=2.2.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                                  "requires": {
+                                    "ms": "0.7.1"
+                                  },
                                   "dependencies": {
                                     "ms": {
                                       "version": "0.7.1",
-                                      "from": "ms@0.7.1",
-                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
                                     }
                                   }
                                 },
                                 "globals": {
                                   "version": "8.15.0",
-                                  "from": "globals@>=8.3.0 <9.0.0",
-                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                                  "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
                                 },
                                 "invariant": {
                                   "version": "2.2.0",
-                                  "from": "invariant@>=2.2.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                  "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                                  "requires": {
+                                    "loose-envify": "1.1.0"
+                                  },
                                   "dependencies": {
                                     "loose-envify": {
                                       "version": "1.1.0",
-                                      "from": "loose-envify@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                      "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                      "requires": {
+                                        "js-tokens": "1.0.2"
+                                      },
                                       "dependencies": {
                                         "js-tokens": {
                                           "version": "1.0.2",
-                                          "from": "js-tokens@>=1.0.1 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                          "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                         }
                                       }
                                     }
@@ -3946,18 +5600,24 @@
                                 },
                                 "repeating": {
                                   "version": "1.1.3",
-                                  "from": "repeating@>=1.1.3 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                  "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                                  "requires": {
+                                    "is-finite": "1.0.1"
+                                  },
                                   "dependencies": {
                                     "is-finite": {
                                       "version": "1.0.1",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                      "requires": {
+                                        "number-is-nan": "1.0.0"
+                                      },
                                       "dependencies": {
                                         "number-is-nan": {
                                           "version": "1.0.0",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                         }
                                       }
                                     }
@@ -3967,42 +5627,40 @@
                             },
                             "babel-types": {
                               "version": "6.3.20",
-                              "from": "babel-types@>=6.3.13 <7.0.0",
                               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                              "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                              "requires": {
+                                "babel-runtime": "5.8.34",
+                                "babel-traverse": "6.3.19",
+                                "esutils": "2.0.2",
+                                "lodash": "3.10.1",
+                                "to-fast-properties": "1.0.1"
+                              },
                               "dependencies": {
                                 "esutils": {
                                   "version": "2.0.2",
-                                  "from": "esutils@>=2.0.2 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                                 },
                                 "to-fast-properties": {
                                   "version": "1.0.1",
-                                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                                  "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
                                 }
+                              }
+                            },
+                            "babylon": {
+                              "version": "6.3.20",
+                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                              "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
                               }
                             },
                             "lodash": {
                               "version": "3.10.1",
-                              "from": "lodash@>=3.10.1 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                            }
-                          }
-                        },
-                        "babel-plugin-syntax-class-constructor-call": {
-                          "version": "6.3.13",
-                          "from": "babel-plugin-syntax-class-constructor-call@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.3.13.tgz"
-                        },
-                        "babel-runtime": {
-                          "version": "5.8.34",
-                          "from": "babel-runtime@>=5.0.0 <6.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                          "dependencies": {
-                            "core-js": {
-                              "version": "1.2.6",
-                              "from": "core-js@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                             }
                           }
                         }
@@ -4010,23 +5668,33 @@
                     },
                     "babel-plugin-transform-class-properties": {
                       "version": "6.3.13",
-                      "from": "babel-plugin-transform-class-properties@>=6.3.13 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.3.13.tgz",
+                      "integrity": "sha1-/s0oHRovKGbMAgtbjvQ1d5IrbdU=",
+                      "requires": {
+                        "babel-plugin-syntax-class-properties": "6.3.13",
+                        "babel-runtime": "5.8.34"
+                      },
                       "dependencies": {
                         "babel-plugin-syntax-class-properties": {
                           "version": "6.3.13",
-                          "from": "babel-plugin-syntax-class-properties@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.3.13.tgz"
+                          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.3.13.tgz",
+                          "integrity": "sha1-fs8Ytf2I7BL5eq/542vBmyytab8=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
                         },
                         "babel-runtime": {
                           "version": "5.8.34",
-                          "from": "babel-runtime@>=5.0.0 <6.0.0",
                           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                          "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                          "requires": {
+                            "core-js": "1.2.6"
+                          },
                           "dependencies": {
                             "core-js": {
                               "version": "1.2.6",
-                              "from": "core-js@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                              "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
                             }
                           }
                         }
@@ -4034,84 +5702,394 @@
                     },
                     "babel-plugin-transform-decorators": {
                       "version": "6.3.13",
-                      "from": "babel-plugin-transform-decorators@>=6.3.13 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.3.13.tgz",
+                      "integrity": "sha1-4fFo8QJx6wy1wT2mYfBtTMSK7GA=",
+                      "requires": {
+                        "babel-helper-define-map": "6.3.13",
+                        "babel-helper-explode-class": "6.3.13",
+                        "babel-plugin-syntax-decorators": "6.3.13",
+                        "babel-runtime": "5.8.34",
+                        "babel-template": "6.3.13",
+                        "babel-types": "6.3.20"
+                      },
                       "dependencies": {
-                        "babel-types": {
-                          "version": "6.3.20",
-                          "from": "babel-types@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                        "babel-helper-define-map": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.3.13.tgz",
+                          "integrity": "sha1-4nqzLcATAF9YmkrpPbM7F0s7LQc=",
+                          "requires": {
+                            "babel-helper-function-name": "6.3.15",
+                            "babel-runtime": "5.8.34",
+                            "babel-types": "6.3.20",
+                            "lodash": "3.10.1"
+                          },
                           "dependencies": {
+                            "babel-helper-function-name": {
+                              "version": "6.3.15",
+                              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
+                              "integrity": "sha1-WDNPTimTd7uk+EJAyq97+axxDto=",
+                              "requires": {
+                                "babel-helper-get-function-arity": "6.3.13",
+                                "babel-runtime": "5.8.34",
+                                "babel-template": "6.3.13",
+                                "babel-traverse": "6.3.19",
+                                "babel-types": "6.3.20"
+                              },
+                              "dependencies": {
+                                "babel-helper-get-function-arity": {
+                                  "version": "6.3.13",
+                                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz",
+                                  "integrity": "sha1-skc2lFI+Q1ueGBdtGkYD5sCUwGI=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34",
+                                    "babel-types": "6.3.20"
+                                  }
+                                },
+                                "babel-traverse": {
+                                  "version": "6.3.19",
+                                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                                  "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                                  "requires": {
+                                    "babel-code-frame": "6.3.13",
+                                    "babel-messages": "6.3.18",
+                                    "babel-runtime": "5.8.34",
+                                    "babel-types": "6.3.20",
+                                    "babylon": "6.3.20",
+                                    "debug": "2.2.0",
+                                    "globals": "8.15.0",
+                                    "invariant": "2.2.0",
+                                    "lodash": "3.10.1",
+                                    "repeating": "1.1.3"
+                                  },
+                                  "dependencies": {
+                                    "babel-code-frame": {
+                                      "version": "6.3.13",
+                                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                      "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                                      "requires": {
+                                        "babel-runtime": "5.8.34",
+                                        "chalk": "1.1.1",
+                                        "esutils": "2.0.2",
+                                        "js-tokens": "1.0.2",
+                                        "line-numbers": "0.2.0",
+                                        "repeating": "1.1.3"
+                                      },
+                                      "dependencies": {
+                                        "chalk": {
+                                          "version": "1.1.1",
+                                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                          "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                          "requires": {
+                                            "ansi-styles": "2.1.0",
+                                            "escape-string-regexp": "1.0.3",
+                                            "has-ansi": "2.0.0",
+                                            "strip-ansi": "3.0.0",
+                                            "supports-color": "2.0.0"
+                                          },
+                                          "dependencies": {
+                                            "ansi-styles": {
+                                              "version": "2.1.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                              "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                            },
+                                            "escape-string-regexp": {
+                                              "version": "1.0.3",
+                                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                              "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                            },
+                                            "has-ansi": {
+                                              "version": "2.0.0",
+                                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                              "requires": {
+                                                "ansi-regex": "2.0.0"
+                                              },
+                                              "dependencies": {
+                                                "ansi-regex": {
+                                                  "version": "2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                                }
+                                              }
+                                            },
+                                            "strip-ansi": {
+                                              "version": "3.0.0",
+                                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                              "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                              "requires": {
+                                                "ansi-regex": "2.0.0"
+                                              },
+                                              "dependencies": {
+                                                "ansi-regex": {
+                                                  "version": "2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                                }
+                                              }
+                                            },
+                                            "supports-color": {
+                                              "version": "2.0.0",
+                                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                            }
+                                          }
+                                        },
+                                        "esutils": {
+                                          "version": "2.0.2",
+                                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                                        },
+                                        "js-tokens": {
+                                          "version": "1.0.2",
+                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                          "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                        },
+                                        "line-numbers": {
+                                          "version": "0.2.0",
+                                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                          "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                          "requires": {
+                                            "left-pad": "0.0.3"
+                                          },
+                                          "dependencies": {
+                                            "left-pad": {
+                                              "version": "0.0.3",
+                                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                              "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "babel-messages": {
+                                      "version": "6.3.18",
+                                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                                      "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                                      "requires": {
+                                        "babel-runtime": "5.8.34"
+                                      }
+                                    },
+                                    "babylon": {
+                                      "version": "6.3.20",
+                                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                                      "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                                      "requires": {
+                                        "babel-runtime": "5.8.34"
+                                      }
+                                    },
+                                    "debug": {
+                                      "version": "2.2.0",
+                                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                                      "requires": {
+                                        "ms": "0.7.1"
+                                      },
+                                      "dependencies": {
+                                        "ms": {
+                                          "version": "0.7.1",
+                                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                                        }
+                                      }
+                                    },
+                                    "globals": {
+                                      "version": "8.15.0",
+                                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                                      "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                                    },
+                                    "invariant": {
+                                      "version": "2.2.0",
+                                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                      "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                                      "requires": {
+                                        "loose-envify": "1.1.0"
+                                      },
+                                      "dependencies": {
+                                        "loose-envify": {
+                                          "version": "1.1.0",
+                                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                          "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                          "requires": {
+                                            "js-tokens": "1.0.2"
+                                          },
+                                          "dependencies": {
+                                            "js-tokens": {
+                                              "version": "1.0.2",
+                                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                              "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "repeating": {
+                                      "version": "1.1.3",
+                                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                      "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                                      "requires": {
+                                        "is-finite": "1.0.1"
+                                      },
+                                      "dependencies": {
+                                        "is-finite": {
+                                          "version": "1.0.1",
+                                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                          "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                          "requires": {
+                                            "number-is-nan": "1.0.0"
+                                          },
+                                          "dependencies": {
+                                            "number-is-nan": {
+                                              "version": "1.0.0",
+                                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                              "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "lodash": {
+                              "version": "3.10.1",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                            }
+                          }
+                        },
+                        "babel-helper-explode-class": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.3.13.tgz",
+                          "integrity": "sha1-9e8x6KxTwxJ+nabHfyk5H2of2+k=",
+                          "requires": {
+                            "babel-helper-bindify-decorators": "6.3.13",
+                            "babel-runtime": "5.8.34",
+                            "babel-traverse": "6.3.19",
+                            "babel-types": "6.3.20"
+                          },
+                          "dependencies": {
+                            "babel-helper-bindify-decorators": {
+                              "version": "6.3.13",
+                              "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.3.13.tgz",
+                              "integrity": "sha1-L74QlOr3nxj8uinU9NJrkdjS4AM=",
+                              "requires": {
+                                "babel-runtime": "5.8.34",
+                                "babel-traverse": "6.3.19",
+                                "babel-types": "6.3.20"
+                              }
+                            },
                             "babel-traverse": {
                               "version": "6.3.19",
-                              "from": "babel-traverse@>=6.3.17 <7.0.0",
                               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                              "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                              "requires": {
+                                "babel-code-frame": "6.3.13",
+                                "babel-messages": "6.3.18",
+                                "babel-runtime": "5.8.34",
+                                "babel-types": "6.3.20",
+                                "babylon": "6.3.20",
+                                "debug": "2.2.0",
+                                "globals": "8.15.0",
+                                "invariant": "2.2.0",
+                                "lodash": "3.10.1",
+                                "repeating": "1.1.3"
+                              },
                               "dependencies": {
                                 "babel-code-frame": {
                                   "version": "6.3.13",
-                                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
                                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                  "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34",
+                                    "chalk": "1.1.1",
+                                    "esutils": "2.0.2",
+                                    "js-tokens": "1.0.2",
+                                    "line-numbers": "0.2.0",
+                                    "repeating": "1.1.3"
+                                  },
                                   "dependencies": {
                                     "chalk": {
                                       "version": "1.1.1",
-                                      "from": "chalk@>=1.1.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                      "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                      "requires": {
+                                        "ansi-styles": "2.1.0",
+                                        "escape-string-regexp": "1.0.3",
+                                        "has-ansi": "2.0.0",
+                                        "strip-ansi": "3.0.0",
+                                        "supports-color": "2.0.0"
+                                      },
                                       "dependencies": {
                                         "ansi-styles": {
                                           "version": "2.1.0",
-                                          "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                          "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                         },
                                         "escape-string-regexp": {
                                           "version": "1.0.3",
-                                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                          "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
                                         },
                                         "has-ansi": {
                                           "version": "2.0.0",
-                                          "from": "has-ansi@>=2.0.0 <3.0.0",
                                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
                                           "dependencies": {
                                             "ansi-regex": {
                                               "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                             }
                                           }
                                         },
                                         "strip-ansi": {
                                           "version": "3.0.0",
-                                          "from": "strip-ansi@>=3.0.0 <4.0.0",
                                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                          "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
                                           "dependencies": {
                                             "ansi-regex": {
                                               "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                             }
                                           }
                                         },
                                         "supports-color": {
                                           "version": "2.0.0",
-                                          "from": "supports-color@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                         }
                                       }
                                     },
+                                    "esutils": {
+                                      "version": "2.0.2",
+                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                                    },
                                     "js-tokens": {
                                       "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                     },
                                     "line-numbers": {
                                       "version": "0.2.0",
-                                      "from": "line-numbers@>=0.2.0 <0.3.0",
                                       "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                      "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                      "requires": {
+                                        "left-pad": "0.0.3"
+                                      },
                                       "dependencies": {
                                         "left-pad": {
                                           "version": "0.0.3",
-                                          "from": "left-pad@0.0.3",
-                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                          "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
                                         }
                                       }
                                     }
@@ -4119,45 +6097,298 @@
                                 },
                                 "babel-messages": {
                                   "version": "6.3.18",
-                                  "from": "babel-messages@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                                  "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
                                 },
                                 "babylon": {
                                   "version": "6.3.20",
-                                  "from": "babylon@>=6.3.15 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
+                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                                  "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
                                 },
                                 "debug": {
                                   "version": "2.2.0",
-                                  "from": "debug@>=2.2.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                                  "requires": {
+                                    "ms": "0.7.1"
+                                  },
                                   "dependencies": {
                                     "ms": {
                                       "version": "0.7.1",
-                                      "from": "ms@0.7.1",
-                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
                                     }
                                   }
                                 },
                                 "globals": {
                                   "version": "8.15.0",
-                                  "from": "globals@>=8.3.0 <9.0.0",
-                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                                  "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
                                 },
                                 "invariant": {
                                   "version": "2.2.0",
-                                  "from": "invariant@>=2.2.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                  "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                                  "requires": {
+                                    "loose-envify": "1.1.0"
+                                  },
                                   "dependencies": {
                                     "loose-envify": {
                                       "version": "1.1.0",
-                                      "from": "loose-envify@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                      "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                      "requires": {
+                                        "js-tokens": "1.0.2"
+                                      },
                                       "dependencies": {
                                         "js-tokens": {
                                           "version": "1.0.2",
-                                          "from": "js-tokens@>=1.0.1 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                          "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "lodash": {
+                                  "version": "3.10.1",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                                  "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                                },
+                                "repeating": {
+                                  "version": "1.1.3",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                  "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                                  "requires": {
+                                    "is-finite": "1.0.1"
+                                  },
+                                  "dependencies": {
+                                    "is-finite": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                      "requires": {
+                                        "number-is-nan": "1.0.0"
+                                      },
+                                      "dependencies": {
+                                        "number-is-nan": {
+                                          "version": "1.0.0",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-plugin-syntax-decorators": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.3.13.tgz",
+                          "integrity": "sha1-DxEAkRlIj7mETzYnb4hg1flO7DA=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
+                        },
+                        "babel-runtime": {
+                          "version": "5.8.34",
+                          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                          "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                          "requires": {
+                            "core-js": "1.2.6"
+                          },
+                          "dependencies": {
+                            "core-js": {
+                              "version": "1.2.6",
+                              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                              "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
+                            }
+                          }
+                        },
+                        "babel-template": {
+                          "version": "6.3.13",
+                          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                          "integrity": "sha1-hXXxaGepKKna6E87vNyn54Bvwiw=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-traverse": "6.3.19",
+                            "babel-types": "6.3.20",
+                            "babylon": "6.3.20",
+                            "lodash": "3.10.1"
+                          },
+                          "dependencies": {
+                            "babel-traverse": {
+                              "version": "6.3.19",
+                              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                              "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                              "requires": {
+                                "babel-code-frame": "6.3.13",
+                                "babel-messages": "6.3.18",
+                                "babel-runtime": "5.8.34",
+                                "babel-types": "6.3.20",
+                                "babylon": "6.3.20",
+                                "debug": "2.2.0",
+                                "globals": "8.15.0",
+                                "invariant": "2.2.0",
+                                "lodash": "3.10.1",
+                                "repeating": "1.1.3"
+                              },
+                              "dependencies": {
+                                "babel-code-frame": {
+                                  "version": "6.3.13",
+                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                  "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34",
+                                    "chalk": "1.1.1",
+                                    "esutils": "2.0.2",
+                                    "js-tokens": "1.0.2",
+                                    "line-numbers": "0.2.0",
+                                    "repeating": "1.1.3"
+                                  },
+                                  "dependencies": {
+                                    "chalk": {
+                                      "version": "1.1.1",
+                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                      "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                      "requires": {
+                                        "ansi-styles": "2.1.0",
+                                        "escape-string-regexp": "1.0.3",
+                                        "has-ansi": "2.0.0",
+                                        "strip-ansi": "3.0.0",
+                                        "supports-color": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-styles": {
+                                          "version": "2.1.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                          "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                        },
+                                        "escape-string-regexp": {
+                                          "version": "1.0.3",
+                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                          "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                        },
+                                        "has-ansi": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                            }
+                                          }
+                                        },
+                                        "strip-ansi": {
+                                          "version": "3.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                          "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                            }
+                                          }
+                                        },
+                                        "supports-color": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                        }
+                                      }
+                                    },
+                                    "esutils": {
+                                      "version": "2.0.2",
+                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                                    },
+                                    "js-tokens": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                    },
+                                    "line-numbers": {
+                                      "version": "0.2.0",
+                                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                      "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                      "requires": {
+                                        "left-pad": "0.0.3"
+                                      },
+                                      "dependencies": {
+                                        "left-pad": {
+                                          "version": "0.0.3",
+                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                          "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "babel-messages": {
+                                  "version": "6.3.18",
+                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                                  "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
+                                },
+                                "debug": {
+                                  "version": "2.2.0",
+                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                                  "requires": {
+                                    "ms": "0.7.1"
+                                  },
+                                  "dependencies": {
+                                    "ms": {
+                                      "version": "0.7.1",
+                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                                    }
+                                  }
+                                },
+                                "globals": {
+                                  "version": "8.15.0",
+                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                                  "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                                },
+                                "invariant": {
+                                  "version": "2.2.0",
+                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                  "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                                  "requires": {
+                                    "loose-envify": "1.1.0"
+                                  },
+                                  "dependencies": {
+                                    "loose-envify": {
+                                      "version": "1.1.0",
+                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                      "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                      "requires": {
+                                        "js-tokens": "1.0.2"
+                                      },
+                                      "dependencies": {
+                                        "js-tokens": {
+                                          "version": "1.0.2",
+                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                          "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                         }
                                       }
                                     }
@@ -4165,18 +6396,250 @@
                                 },
                                 "repeating": {
                                   "version": "1.1.3",
-                                  "from": "repeating@>=1.1.3 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                  "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                                  "requires": {
+                                    "is-finite": "1.0.1"
+                                  },
                                   "dependencies": {
                                     "is-finite": {
                                       "version": "1.0.1",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                      "requires": {
+                                        "number-is-nan": "1.0.0"
+                                      },
                                       "dependencies": {
                                         "number-is-nan": {
                                           "version": "1.0.0",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "babylon": {
+                              "version": "6.3.20",
+                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                              "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
+                            },
+                            "lodash": {
+                              "version": "3.10.1",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                            }
+                          }
+                        },
+                        "babel-types": {
+                          "version": "6.3.20",
+                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                          "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                          "requires": {
+                            "babel-runtime": "5.8.34",
+                            "babel-traverse": "6.3.19",
+                            "esutils": "2.0.2",
+                            "lodash": "3.10.1",
+                            "to-fast-properties": "1.0.1"
+                          },
+                          "dependencies": {
+                            "babel-traverse": {
+                              "version": "6.3.19",
+                              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                              "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                              "requires": {
+                                "babel-code-frame": "6.3.13",
+                                "babel-messages": "6.3.18",
+                                "babel-runtime": "5.8.34",
+                                "babel-types": "6.3.20",
+                                "babylon": "6.3.20",
+                                "debug": "2.2.0",
+                                "globals": "8.15.0",
+                                "invariant": "2.2.0",
+                                "lodash": "3.10.1",
+                                "repeating": "1.1.3"
+                              },
+                              "dependencies": {
+                                "babel-code-frame": {
+                                  "version": "6.3.13",
+                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                  "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34",
+                                    "chalk": "1.1.1",
+                                    "esutils": "2.0.2",
+                                    "js-tokens": "1.0.2",
+                                    "line-numbers": "0.2.0",
+                                    "repeating": "1.1.3"
+                                  },
+                                  "dependencies": {
+                                    "chalk": {
+                                      "version": "1.1.1",
+                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                      "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                      "requires": {
+                                        "ansi-styles": "2.1.0",
+                                        "escape-string-regexp": "1.0.3",
+                                        "has-ansi": "2.0.0",
+                                        "strip-ansi": "3.0.0",
+                                        "supports-color": "2.0.0"
+                                      },
+                                      "dependencies": {
+                                        "ansi-styles": {
+                                          "version": "2.1.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                          "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
+                                        },
+                                        "escape-string-regexp": {
+                                          "version": "1.0.3",
+                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                          "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
+                                        },
+                                        "has-ansi": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                            }
+                                          }
+                                        },
+                                        "strip-ansi": {
+                                          "version": "3.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                          "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                          "requires": {
+                                            "ansi-regex": "2.0.0"
+                                          },
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                            }
+                                          }
+                                        },
+                                        "supports-color": {
+                                          "version": "2.0.0",
+                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                        }
+                                      }
+                                    },
+                                    "js-tokens": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                    },
+                                    "line-numbers": {
+                                      "version": "0.2.0",
+                                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                      "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                      "requires": {
+                                        "left-pad": "0.0.3"
+                                      },
+                                      "dependencies": {
+                                        "left-pad": {
+                                          "version": "0.0.3",
+                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                          "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "babel-messages": {
+                                  "version": "6.3.18",
+                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                                  "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
+                                },
+                                "babylon": {
+                                  "version": "6.3.20",
+                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                                  "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
+                                },
+                                "debug": {
+                                  "version": "2.2.0",
+                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                                  "requires": {
+                                    "ms": "0.7.1"
+                                  },
+                                  "dependencies": {
+                                    "ms": {
+                                      "version": "0.7.1",
+                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                                    }
+                                  }
+                                },
+                                "globals": {
+                                  "version": "8.15.0",
+                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                                  "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
+                                },
+                                "invariant": {
+                                  "version": "2.2.0",
+                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                  "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                                  "requires": {
+                                    "loose-envify": "1.1.0"
+                                  },
+                                  "dependencies": {
+                                    "loose-envify": {
+                                      "version": "1.1.0",
+                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                      "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                      "requires": {
+                                        "js-tokens": "1.0.2"
+                                      },
+                                      "dependencies": {
+                                        "js-tokens": {
+                                          "version": "1.0.2",
+                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                          "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "repeating": {
+                                  "version": "1.1.3",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                  "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                                  "requires": {
+                                    "is-finite": "1.0.1"
+                                  },
+                                  "dependencies": {
+                                    "is-finite": {
+                                      "version": "1.0.1",
+                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                      "requires": {
+                                        "number-is-nan": "1.0.0"
+                                      },
+                                      "dependencies": {
+                                        "number-is-nan": {
+                                          "version": "1.0.0",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                          "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                         }
                                       }
                                     }
@@ -4186,529 +6649,18 @@
                             },
                             "esutils": {
                               "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                             },
                             "lodash": {
                               "version": "3.10.1",
-                              "from": "lodash@>=3.10.1 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                             },
                             "to-fast-properties": {
                               "version": "1.0.1",
-                              "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "babel-helper-define-map": {
-                          "version": "6.3.13",
-                          "from": "babel-helper-define-map@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.3.13.tgz",
-                          "dependencies": {
-                            "lodash": {
-                              "version": "3.10.1",
-                              "from": "lodash@>=3.10.1 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                            },
-                            "babel-helper-function-name": {
-                              "version": "6.3.15",
-                              "from": "babel-helper-function-name@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
-                              "dependencies": {
-                                "babel-traverse": {
-                                  "version": "6.3.19",
-                                  "from": "babel-traverse@>=6.3.15 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                                  "dependencies": {
-                                    "babel-code-frame": {
-                                      "version": "6.3.13",
-                                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                                      "dependencies": {
-                                        "chalk": {
-                                          "version": "1.1.1",
-                                          "from": "chalk@>=1.1.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                                          "dependencies": {
-                                            "ansi-styles": {
-                                              "version": "2.1.0",
-                                              "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                            },
-                                            "escape-string-regexp": {
-                                              "version": "1.0.3",
-                                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                            },
-                                            "has-ansi": {
-                                              "version": "2.0.0",
-                                              "from": "has-ansi@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                              "dependencies": {
-                                                "ansi-regex": {
-                                                  "version": "2.0.0",
-                                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                                }
-                                              }
-                                            },
-                                            "strip-ansi": {
-                                              "version": "3.0.0",
-                                              "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                              "dependencies": {
-                                                "ansi-regex": {
-                                                  "version": "2.0.0",
-                                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                                }
-                                              }
-                                            },
-                                            "supports-color": {
-                                              "version": "2.0.0",
-                                              "from": "supports-color@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "esutils": {
-                                          "version": "2.0.2",
-                                          "from": "esutils@>=2.0.2 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                        },
-                                        "js-tokens": {
-                                          "version": "1.0.2",
-                                          "from": "js-tokens@>=1.0.1 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                        },
-                                        "line-numbers": {
-                                          "version": "0.2.0",
-                                          "from": "line-numbers@>=0.2.0 <0.3.0",
-                                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                                          "dependencies": {
-                                            "left-pad": {
-                                              "version": "0.0.3",
-                                              "from": "left-pad@0.0.3",
-                                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "babel-messages": {
-                                      "version": "6.3.18",
-                                      "from": "babel-messages@>=6.3.13 <7.0.0",
-                                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                                    },
-                                    "babylon": {
-                                      "version": "6.3.20",
-                                      "from": "babylon@>=6.3.15 <7.0.0",
-                                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                                    },
-                                    "debug": {
-                                      "version": "2.2.0",
-                                      "from": "debug@>=2.2.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                                      "dependencies": {
-                                        "ms": {
-                                          "version": "0.7.1",
-                                          "from": "ms@0.7.1",
-                                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                                        }
-                                      }
-                                    },
-                                    "globals": {
-                                      "version": "8.15.0",
-                                      "from": "globals@>=8.3.0 <9.0.0",
-                                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                                    },
-                                    "invariant": {
-                                      "version": "2.2.0",
-                                      "from": "invariant@>=2.2.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                                      "dependencies": {
-                                        "loose-envify": {
-                                          "version": "1.1.0",
-                                          "from": "loose-envify@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                                          "dependencies": {
-                                            "js-tokens": {
-                                              "version": "1.0.2",
-                                              "from": "js-tokens@>=1.0.1 <2.0.0",
-                                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "repeating": {
-                                      "version": "1.1.3",
-                                      "from": "repeating@>=1.1.3 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                                      "dependencies": {
-                                        "is-finite": {
-                                          "version": "1.0.1",
-                                          "from": "is-finite@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                          "dependencies": {
-                                            "number-is-nan": {
-                                              "version": "1.0.0",
-                                              "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "babel-helper-get-function-arity": {
-                                  "version": "6.3.13",
-                                  "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "babel-plugin-syntax-decorators": {
-                          "version": "6.3.13",
-                          "from": "babel-plugin-syntax-decorators@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.3.13.tgz"
-                        },
-                        "babel-helper-explode-class": {
-                          "version": "6.3.13",
-                          "from": "babel-helper-explode-class@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.3.13.tgz",
-                          "dependencies": {
-                            "babel-traverse": {
-                              "version": "6.3.19",
-                              "from": "babel-traverse@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                              "dependencies": {
-                                "babel-code-frame": {
-                                  "version": "6.3.13",
-                                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                                  "dependencies": {
-                                    "chalk": {
-                                      "version": "1.1.1",
-                                      "from": "chalk@>=1.1.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                                      "dependencies": {
-                                        "ansi-styles": {
-                                          "version": "2.1.0",
-                                          "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                        },
-                                        "escape-string-regexp": {
-                                          "version": "1.0.3",
-                                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                        },
-                                        "has-ansi": {
-                                          "version": "2.0.0",
-                                          "from": "has-ansi@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "strip-ansi": {
-                                          "version": "3.0.0",
-                                          "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "supports-color": {
-                                          "version": "2.0.0",
-                                          "from": "supports-color@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "esutils": {
-                                      "version": "2.0.2",
-                                      "from": "esutils@>=2.0.2 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                    },
-                                    "js-tokens": {
-                                      "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                    },
-                                    "line-numbers": {
-                                      "version": "0.2.0",
-                                      "from": "line-numbers@>=0.2.0 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                                      "dependencies": {
-                                        "left-pad": {
-                                          "version": "0.0.3",
-                                          "from": "left-pad@0.0.3",
-                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "babel-messages": {
-                                  "version": "6.3.18",
-                                  "from": "babel-messages@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                                },
-                                "babylon": {
-                                  "version": "6.3.20",
-                                  "from": "babylon@>=6.3.15 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                                },
-                                "debug": {
-                                  "version": "2.2.0",
-                                  "from": "debug@>=2.2.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                                  "dependencies": {
-                                    "ms": {
-                                      "version": "0.7.1",
-                                      "from": "ms@0.7.1",
-                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                                    }
-                                  }
-                                },
-                                "globals": {
-                                  "version": "8.15.0",
-                                  "from": "globals@>=8.3.0 <9.0.0",
-                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                                },
-                                "invariant": {
-                                  "version": "2.2.0",
-                                  "from": "invariant@>=2.2.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                                  "dependencies": {
-                                    "loose-envify": {
-                                      "version": "1.1.0",
-                                      "from": "loose-envify@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                                      "dependencies": {
-                                        "js-tokens": {
-                                          "version": "1.0.2",
-                                          "from": "js-tokens@>=1.0.1 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "lodash": {
-                                  "version": "3.10.1",
-                                  "from": "lodash@>=3.10.1 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                                },
-                                "repeating": {
-                                  "version": "1.1.3",
-                                  "from": "repeating@>=1.1.3 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                                  "dependencies": {
-                                    "is-finite": {
-                                      "version": "1.0.1",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                      "dependencies": {
-                                        "number-is-nan": {
-                                          "version": "1.0.0",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "babel-helper-bindify-decorators": {
-                              "version": "6.3.13",
-                              "from": "babel-helper-bindify-decorators@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.3.13.tgz"
-                            }
-                          }
-                        },
-                        "babel-template": {
-                          "version": "6.3.13",
-                          "from": "babel-template@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
-                          "dependencies": {
-                            "babylon": {
-                              "version": "6.3.20",
-                              "from": "babylon@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                            },
-                            "babel-traverse": {
-                              "version": "6.3.19",
-                              "from": "babel-traverse@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
-                              "dependencies": {
-                                "babel-code-frame": {
-                                  "version": "6.3.13",
-                                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
-                                  "dependencies": {
-                                    "chalk": {
-                                      "version": "1.1.1",
-                                      "from": "chalk@>=1.1.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                                      "dependencies": {
-                                        "ansi-styles": {
-                                          "version": "2.1.0",
-                                          "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                                        },
-                                        "escape-string-regexp": {
-                                          "version": "1.0.3",
-                                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                                        },
-                                        "has-ansi": {
-                                          "version": "2.0.0",
-                                          "from": "has-ansi@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "strip-ansi": {
-                                          "version": "3.0.0",
-                                          "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "supports-color": {
-                                          "version": "2.0.0",
-                                          "from": "supports-color@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "esutils": {
-                                      "version": "2.0.2",
-                                      "from": "esutils@>=2.0.2 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                    },
-                                    "js-tokens": {
-                                      "version": "1.0.2",
-                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                    },
-                                    "line-numbers": {
-                                      "version": "0.2.0",
-                                      "from": "line-numbers@>=0.2.0 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-                                      "dependencies": {
-                                        "left-pad": {
-                                          "version": "0.0.3",
-                                          "from": "left-pad@0.0.3",
-                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "babel-messages": {
-                                  "version": "6.3.18",
-                                  "from": "babel-messages@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
-                                },
-                                "debug": {
-                                  "version": "2.2.0",
-                                  "from": "debug@>=2.2.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                                  "dependencies": {
-                                    "ms": {
-                                      "version": "0.7.1",
-                                      "from": "ms@0.7.1",
-                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                                    }
-                                  }
-                                },
-                                "globals": {
-                                  "version": "8.15.0",
-                                  "from": "globals@>=8.3.0 <9.0.0",
-                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
-                                },
-                                "invariant": {
-                                  "version": "2.2.0",
-                                  "from": "invariant@>=2.2.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
-                                  "dependencies": {
-                                    "loose-envify": {
-                                      "version": "1.1.0",
-                                      "from": "loose-envify@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
-                                      "dependencies": {
-                                        "js-tokens": {
-                                          "version": "1.0.2",
-                                          "from": "js-tokens@>=1.0.1 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "repeating": {
-                                  "version": "1.1.3",
-                                  "from": "repeating@>=1.1.3 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-                                  "dependencies": {
-                                    "is-finite": {
-                                      "version": "1.0.1",
-                                      "from": "is-finite@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                                      "dependencies": {
-                                        "number-is-nan": {
-                                          "version": "1.0.0",
-                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "lodash": {
-                              "version": "3.10.1",
-                              "from": "lodash@>=3.10.1 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                            }
-                          }
-                        },
-                        "babel-runtime": {
-                          "version": "5.8.34",
-                          "from": "babel-runtime@>=5.0.0 <6.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
-                          "dependencies": {
-                            "core-js": {
-                              "version": "1.2.6",
-                              "from": "core-js@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                              "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
                             }
                           }
                         }
@@ -4716,23 +6668,33 @@
                     },
                     "babel-plugin-transform-export-extensions": {
                       "version": "6.3.13",
-                      "from": "babel-plugin-transform-export-extensions@>=6.3.13 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.3.13.tgz",
+                      "integrity": "sha1-YipkxdTQRTA9kA9RPLZ+mLa9Bfk=",
+                      "requires": {
+                        "babel-plugin-syntax-export-extensions": "6.3.13",
+                        "babel-runtime": "5.8.34"
+                      },
                       "dependencies": {
                         "babel-plugin-syntax-export-extensions": {
                           "version": "6.3.13",
-                          "from": "babel-plugin-syntax-export-extensions@>=6.3.13 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.3.13.tgz"
+                          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.3.13.tgz",
+                          "integrity": "sha1-NJTUch1KpeuQUK7dW+tdEX4c1F0=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          }
                         },
                         "babel-runtime": {
                           "version": "5.8.34",
-                          "from": "babel-runtime@>=5.0.0 <6.0.0",
                           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                          "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                          "requires": {
+                            "core-js": "1.2.6"
+                          },
                           "dependencies": {
                             "core-js": {
                               "version": "1.2.6",
-                              "from": "core-js@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                              "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
                             }
                           }
                         }
@@ -4740,23 +6702,34 @@
                     },
                     "babel-preset-stage-2": {
                       "version": "6.3.13",
-                      "from": "babel-preset-stage-2@>=6.3.13 <7.0.0",
                       "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.3.13.tgz",
+                      "integrity": "sha1-NlfbY9EYBkVvZNTQsOmoF4N67qc=",
+                      "requires": {
+                        "babel-plugin-syntax-trailing-function-commas": "6.3.13",
+                        "babel-plugin-transform-object-rest-spread": "6.3.13",
+                        "babel-preset-stage-3": "6.3.13"
+                      },
                       "dependencies": {
                         "babel-plugin-syntax-trailing-function-commas": {
                           "version": "6.3.13",
-                          "from": "babel-plugin-syntax-trailing-function-commas@>=6.3.13 <7.0.0",
                           "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.3.13.tgz",
+                          "integrity": "sha1-5Ex/w2pXfYPWyJjdTiFJldViDgo=",
+                          "requires": {
+                            "babel-runtime": "5.8.34"
+                          },
                           "dependencies": {
                             "babel-runtime": {
                               "version": "5.8.34",
-                              "from": "babel-runtime@>=5.0.0 <6.0.0",
                               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                              "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                              "requires": {
+                                "core-js": "1.2.6"
+                              },
                               "dependencies": {
                                 "core-js": {
                                   "version": "1.2.6",
-                                  "from": "core-js@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                                  "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
                                 }
                               }
                             }
@@ -4764,23 +6737,33 @@
                         },
                         "babel-plugin-transform-object-rest-spread": {
                           "version": "6.3.13",
-                          "from": "babel-plugin-transform-object-rest-spread@>=6.3.13 <7.0.0",
                           "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.3.13.tgz",
+                          "integrity": "sha1-EMVbq4oAK6sPBML60rn+qyR/jPs=",
+                          "requires": {
+                            "babel-plugin-syntax-object-rest-spread": "6.3.13",
+                            "babel-runtime": "5.8.34"
+                          },
                           "dependencies": {
                             "babel-plugin-syntax-object-rest-spread": {
                               "version": "6.3.13",
-                              "from": "babel-plugin-syntax-object-rest-spread@>=6.3.13 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.3.13.tgz"
+                              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.3.13.tgz",
+                              "integrity": "sha1-97JVSHzxwWqMUcnb86XcuBu9yxQ=",
+                              "requires": {
+                                "babel-runtime": "5.8.34"
+                              }
                             },
                             "babel-runtime": {
                               "version": "5.8.34",
-                              "from": "babel-runtime@>=5.0.0 <6.0.0",
                               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                              "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                              "requires": {
+                                "core-js": "1.2.6"
+                              },
                               "dependencies": {
                                 "core-js": {
                                   "version": "1.2.6",
-                                  "from": "core-js@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                                  "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
                                 }
                               }
                             }
@@ -4788,133 +6771,196 @@
                         },
                         "babel-preset-stage-3": {
                           "version": "6.3.13",
-                          "from": "babel-preset-stage-3@>=6.3.13 <7.0.0",
                           "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.3.13.tgz",
+                          "integrity": "sha1-XwqnDj1Bdv+rCLHVzBy4IQd3uj4=",
+                          "requires": {
+                            "babel-plugin-transform-async-to-generator": "6.3.13",
+                            "babel-plugin-transform-exponentiation-operator": "6.3.13"
+                          },
                           "dependencies": {
                             "babel-plugin-transform-async-to-generator": {
                               "version": "6.3.13",
-                              "from": "babel-plugin-transform-async-to-generator@>=6.3.13 <7.0.0",
                               "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.3.13.tgz",
+                              "integrity": "sha1-qnKeSU6qRZ1uL8FJulyuMynaTyU=",
+                              "requires": {
+                                "babel-helper-remap-async-to-generator": "6.3.13",
+                                "babel-plugin-syntax-async-functions": "6.3.13",
+                                "babel-runtime": "5.8.34"
+                              },
                               "dependencies": {
                                 "babel-helper-remap-async-to-generator": {
                                   "version": "6.3.13",
-                                  "from": "babel-helper-remap-async-to-generator@>=6.3.13 <7.0.0",
                                   "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.3.13.tgz",
+                                  "integrity": "sha1-p4LZOP0pV1yJk5TXKgDFVvY6l5k=",
+                                  "requires": {
+                                    "babel-helper-function-name": "6.3.15",
+                                    "babel-runtime": "5.8.34",
+                                    "babel-template": "6.3.13",
+                                    "babel-traverse": "6.3.19",
+                                    "babel-types": "6.3.20"
+                                  },
                                   "dependencies": {
-                                    "babel-template": {
-                                      "version": "6.3.13",
-                                      "from": "babel-template@>=6.3.13 <7.0.0",
-                                      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                                    "babel-helper-function-name": {
+                                      "version": "6.3.15",
+                                      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
+                                      "integrity": "sha1-WDNPTimTd7uk+EJAyq97+axxDto=",
+                                      "requires": {
+                                        "babel-helper-get-function-arity": "6.3.13",
+                                        "babel-runtime": "5.8.34",
+                                        "babel-template": "6.3.13",
+                                        "babel-traverse": "6.3.19",
+                                        "babel-types": "6.3.20"
+                                      },
                                       "dependencies": {
-                                        "babylon": {
-                                          "version": "6.3.20",
-                                          "from": "babylon@>=6.3.13 <7.0.0",
-                                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
-                                        },
-                                        "lodash": {
-                                          "version": "3.10.1",
-                                          "from": "lodash@>=3.10.1 <4.0.0",
-                                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                                        "babel-helper-get-function-arity": {
+                                          "version": "6.3.13",
+                                          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz",
+                                          "integrity": "sha1-skc2lFI+Q1ueGBdtGkYD5sCUwGI=",
+                                          "requires": {
+                                            "babel-runtime": "5.8.34",
+                                            "babel-types": "6.3.20"
+                                          }
                                         }
                                       }
                                     },
-                                    "babel-types": {
-                                      "version": "6.3.20",
-                                      "from": "babel-types@>=6.3.13 <7.0.0",
-                                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                                    "babel-template": {
+                                      "version": "6.3.13",
+                                      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                                      "integrity": "sha1-hXXxaGepKKna6E87vNyn54Bvwiw=",
+                                      "requires": {
+                                        "babel-runtime": "5.8.34",
+                                        "babel-traverse": "6.3.19",
+                                        "babel-types": "6.3.20",
+                                        "babylon": "6.3.20",
+                                        "lodash": "3.10.1"
+                                      },
                                       "dependencies": {
-                                        "esutils": {
-                                          "version": "2.0.2",
-                                          "from": "esutils@>=2.0.2 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                        "babylon": {
+                                          "version": "6.3.20",
+                                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                                          "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                                          "requires": {
+                                            "babel-runtime": "5.8.34"
+                                          }
                                         },
                                         "lodash": {
                                           "version": "3.10.1",
-                                          "from": "lodash@>=3.10.1 <4.0.0",
-                                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                                        },
-                                        "to-fast-properties": {
-                                          "version": "1.0.1",
-                                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                                         }
                                       }
                                     },
                                     "babel-traverse": {
                                       "version": "6.3.19",
-                                      "from": "babel-traverse@>=6.3.13 <7.0.0",
                                       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                                      "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                                      "requires": {
+                                        "babel-code-frame": "6.3.13",
+                                        "babel-messages": "6.3.18",
+                                        "babel-runtime": "5.8.34",
+                                        "babel-types": "6.3.20",
+                                        "babylon": "6.3.20",
+                                        "debug": "2.2.0",
+                                        "globals": "8.15.0",
+                                        "invariant": "2.2.0",
+                                        "lodash": "3.10.1",
+                                        "repeating": "1.1.3"
+                                      },
                                       "dependencies": {
                                         "babel-code-frame": {
                                           "version": "6.3.13",
-                                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
                                           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                          "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                                          "requires": {
+                                            "babel-runtime": "5.8.34",
+                                            "chalk": "1.1.1",
+                                            "esutils": "2.0.2",
+                                            "js-tokens": "1.0.2",
+                                            "line-numbers": "0.2.0",
+                                            "repeating": "1.1.3"
+                                          },
                                           "dependencies": {
                                             "chalk": {
                                               "version": "1.1.1",
-                                              "from": "chalk@>=1.1.0 <2.0.0",
                                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                              "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                              "requires": {
+                                                "ansi-styles": "2.1.0",
+                                                "escape-string-regexp": "1.0.3",
+                                                "has-ansi": "2.0.0",
+                                                "strip-ansi": "3.0.0",
+                                                "supports-color": "2.0.0"
+                                              },
                                               "dependencies": {
                                                 "ansi-styles": {
                                                   "version": "2.1.0",
-                                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                                  "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                                 },
                                                 "escape-string-regexp": {
                                                   "version": "1.0.3",
-                                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                                  "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
                                                 },
                                                 "has-ansi": {
                                                   "version": "2.0.0",
-                                                  "from": "has-ansi@>=2.0.0 <3.0.0",
                                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                                  "requires": {
+                                                    "ansi-regex": "2.0.0"
+                                                  },
                                                   "dependencies": {
                                                     "ansi-regex": {
                                                       "version": "2.0.0",
-                                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                                     }
                                                   }
                                                 },
                                                 "strip-ansi": {
                                                   "version": "3.0.0",
-                                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                                  "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                                  "requires": {
+                                                    "ansi-regex": "2.0.0"
+                                                  },
                                                   "dependencies": {
                                                     "ansi-regex": {
                                                       "version": "2.0.0",
-                                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                                     }
                                                   }
                                                 },
                                                 "supports-color": {
                                                   "version": "2.0.0",
-                                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                                 }
                                               }
                                             },
                                             "esutils": {
                                               "version": "2.0.2",
-                                              "from": "esutils@>=2.0.2 <3.0.0",
-                                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                                             },
                                             "js-tokens": {
                                               "version": "1.0.2",
-                                              "from": "js-tokens@>=1.0.1 <2.0.0",
-                                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                              "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                             },
                                             "line-numbers": {
                                               "version": "0.2.0",
-                                              "from": "line-numbers@>=0.2.0 <0.3.0",
                                               "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                              "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                              "requires": {
+                                                "left-pad": "0.0.3"
+                                              },
                                               "dependencies": {
                                                 "left-pad": {
                                                   "version": "0.0.3",
-                                                  "from": "left-pad@0.0.3",
-                                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                                  "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
                                                 }
                                               }
                                             }
@@ -4922,45 +6968,60 @@
                                         },
                                         "babel-messages": {
                                           "version": "6.3.18",
-                                          "from": "babel-messages@>=6.3.13 <7.0.0",
-                                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                                          "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                                          "requires": {
+                                            "babel-runtime": "5.8.34"
+                                          }
                                         },
                                         "babylon": {
                                           "version": "6.3.20",
-                                          "from": "babylon@>=6.3.15 <7.0.0",
-                                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
+                                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                                          "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                                          "requires": {
+                                            "babel-runtime": "5.8.34"
+                                          }
                                         },
                                         "debug": {
                                           "version": "2.2.0",
-                                          "from": "debug@>=2.2.0 <3.0.0",
                                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                                          "requires": {
+                                            "ms": "0.7.1"
+                                          },
                                           "dependencies": {
                                             "ms": {
                                               "version": "0.7.1",
-                                              "from": "ms@0.7.1",
-                                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
                                             }
                                           }
                                         },
                                         "globals": {
                                           "version": "8.15.0",
-                                          "from": "globals@>=8.3.0 <9.0.0",
-                                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                                          "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
                                         },
                                         "invariant": {
                                           "version": "2.2.0",
-                                          "from": "invariant@>=2.2.0 <3.0.0",
                                           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                          "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                                          "requires": {
+                                            "loose-envify": "1.1.0"
+                                          },
                                           "dependencies": {
                                             "loose-envify": {
                                               "version": "1.1.0",
-                                              "from": "loose-envify@>=1.0.0 <2.0.0",
                                               "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                              "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                              "requires": {
+                                                "js-tokens": "1.0.2"
+                                              },
                                               "dependencies": {
                                                 "js-tokens": {
                                                   "version": "1.0.2",
-                                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                                 }
                                               }
                                             }
@@ -4968,23 +7029,29 @@
                                         },
                                         "lodash": {
                                           "version": "3.10.1",
-                                          "from": "lodash@>=3.10.1 <4.0.0",
-                                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                                         },
                                         "repeating": {
                                           "version": "1.1.3",
-                                          "from": "repeating@>=1.1.3 <2.0.0",
                                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                                          "requires": {
+                                            "is-finite": "1.0.1"
+                                          },
                                           "dependencies": {
                                             "is-finite": {
                                               "version": "1.0.1",
-                                              "from": "is-finite@>=1.0.0 <2.0.0",
                                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                              "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                              "requires": {
+                                                "number-is-nan": "1.0.0"
+                                              },
                                               "dependencies": {
                                                 "number-is-nan": {
                                                   "version": "1.0.0",
-                                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                                 }
                                               }
                                             }
@@ -4992,15 +7059,32 @@
                                         }
                                       }
                                     },
-                                    "babel-helper-function-name": {
-                                      "version": "6.3.15",
-                                      "from": "babel-helper-function-name@>=6.3.13 <7.0.0",
-                                      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
+                                    "babel-types": {
+                                      "version": "6.3.20",
+                                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                                      "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                                      "requires": {
+                                        "babel-runtime": "5.8.34",
+                                        "babel-traverse": "6.3.19",
+                                        "esutils": "2.0.2",
+                                        "lodash": "3.10.1",
+                                        "to-fast-properties": "1.0.1"
+                                      },
                                       "dependencies": {
-                                        "babel-helper-get-function-arity": {
-                                          "version": "6.3.13",
-                                          "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
-                                          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
+                                        "esutils": {
+                                          "version": "2.0.2",
+                                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+                                        },
+                                        "lodash": {
+                                          "version": "3.10.1",
+                                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                                        },
+                                        "to-fast-properties": {
+                                          "version": "1.0.1",
+                                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                                          "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
                                         }
                                       }
                                     }
@@ -5008,18 +7092,24 @@
                                 },
                                 "babel-plugin-syntax-async-functions": {
                                   "version": "6.3.13",
-                                  "from": "babel-plugin-syntax-async-functions@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.3.13.tgz"
+                                  "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.3.13.tgz",
+                                  "integrity": "sha1-Tzf8UeM4c3aafO5Gh2HqMSRMcI4=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
                                 },
                                 "babel-runtime": {
                                   "version": "5.8.34",
-                                  "from": "babel-runtime@>=5.0.0 <6.0.0",
                                   "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                                  "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                                  "requires": {
+                                    "core-js": "1.2.6"
+                                  },
                                   "dependencies": {
                                     "core-js": {
                                       "version": "1.2.6",
-                                      "from": "core-js@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                                      "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
                                     }
                                   }
                                 }
@@ -5027,99 +7117,145 @@
                             },
                             "babel-plugin-transform-exponentiation-operator": {
                               "version": "6.3.13",
-                              "from": "babel-plugin-transform-exponentiation-operator@>=6.3.13 <7.0.0",
                               "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.3.13.tgz",
+                              "integrity": "sha1-IRqVkf5Hf7KRr0At/Wlamf0mpXg=",
+                              "requires": {
+                                "babel-helper-builder-binary-assignment-operator-visitor": "6.3.13",
+                                "babel-plugin-syntax-exponentiation-operator": "6.3.13",
+                                "babel-runtime": "5.8.34"
+                              },
                               "dependencies": {
-                                "babel-plugin-syntax-exponentiation-operator": {
-                                  "version": "6.3.13",
-                                  "from": "babel-plugin-syntax-exponentiation-operator@>=6.3.13 <7.0.0",
-                                  "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.3.13.tgz"
-                                },
                                 "babel-helper-builder-binary-assignment-operator-visitor": {
                                   "version": "6.3.13",
-                                  "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.3.13 <7.0.0",
                                   "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.3.13.tgz",
+                                  "integrity": "sha1-kKiSxPOEuqBy2ufTcmKPDl2Oibw=",
+                                  "requires": {
+                                    "babel-helper-explode-assignable-expression": "6.3.13",
+                                    "babel-runtime": "5.8.34",
+                                    "babel-types": "6.3.20"
+                                  },
                                   "dependencies": {
                                     "babel-helper-explode-assignable-expression": {
                                       "version": "6.3.13",
-                                      "from": "babel-helper-explode-assignable-expression@>=6.3.13 <7.0.0",
                                       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.3.13.tgz",
+                                      "integrity": "sha1-Uh1Qr/MgzE2J7NIv1IdR2f/T+aI=",
+                                      "requires": {
+                                        "babel-runtime": "5.8.34",
+                                        "babel-traverse": "6.3.19",
+                                        "babel-types": "6.3.20"
+                                      },
                                       "dependencies": {
                                         "babel-traverse": {
                                           "version": "6.3.19",
-                                          "from": "babel-traverse@>=6.3.13 <7.0.0",
                                           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                                          "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                                          "requires": {
+                                            "babel-code-frame": "6.3.13",
+                                            "babel-messages": "6.3.18",
+                                            "babel-runtime": "5.8.34",
+                                            "babel-types": "6.3.20",
+                                            "babylon": "6.3.20",
+                                            "debug": "2.2.0",
+                                            "globals": "8.15.0",
+                                            "invariant": "2.2.0",
+                                            "lodash": "3.10.1",
+                                            "repeating": "1.1.3"
+                                          },
                                           "dependencies": {
                                             "babel-code-frame": {
                                               "version": "6.3.13",
-                                              "from": "babel-code-frame@>=6.3.13 <7.0.0",
                                               "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                              "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                                              "requires": {
+                                                "babel-runtime": "5.8.34",
+                                                "chalk": "1.1.1",
+                                                "esutils": "2.0.2",
+                                                "js-tokens": "1.0.2",
+                                                "line-numbers": "0.2.0",
+                                                "repeating": "1.1.3"
+                                              },
                                               "dependencies": {
                                                 "chalk": {
                                                   "version": "1.1.1",
-                                                  "from": "chalk@>=1.1.0 <2.0.0",
                                                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                                  "requires": {
+                                                    "ansi-styles": "2.1.0",
+                                                    "escape-string-regexp": "1.0.3",
+                                                    "has-ansi": "2.0.0",
+                                                    "strip-ansi": "3.0.0",
+                                                    "supports-color": "2.0.0"
+                                                  },
                                                   "dependencies": {
                                                     "ansi-styles": {
                                                       "version": "2.1.0",
-                                                      "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                                     },
                                                     "escape-string-regexp": {
                                                       "version": "1.0.3",
-                                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
                                                     },
                                                     "has-ansi": {
                                                       "version": "2.0.0",
-                                                      "from": "has-ansi@>=2.0.0 <3.0.0",
                                                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                                      "requires": {
+                                                        "ansi-regex": "2.0.0"
+                                                      },
                                                       "dependencies": {
                                                         "ansi-regex": {
                                                           "version": "2.0.0",
-                                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                                         }
                                                       }
                                                     },
                                                     "strip-ansi": {
                                                       "version": "3.0.0",
-                                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
                                                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                                      "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                                      "requires": {
+                                                        "ansi-regex": "2.0.0"
+                                                      },
                                                       "dependencies": {
                                                         "ansi-regex": {
                                                           "version": "2.0.0",
-                                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                                         }
                                                       }
                                                     },
                                                     "supports-color": {
                                                       "version": "2.0.0",
-                                                      "from": "supports-color@>=2.0.0 <3.0.0",
-                                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                                     }
                                                   }
                                                 },
                                                 "esutils": {
                                                   "version": "2.0.2",
-                                                  "from": "esutils@>=2.0.2 <3.0.0",
-                                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                                                 },
                                                 "js-tokens": {
                                                   "version": "1.0.2",
-                                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                                 },
                                                 "line-numbers": {
                                                   "version": "0.2.0",
-                                                  "from": "line-numbers@>=0.2.0 <0.3.0",
                                                   "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                                  "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                                  "requires": {
+                                                    "left-pad": "0.0.3"
+                                                  },
                                                   "dependencies": {
                                                     "left-pad": {
                                                       "version": "0.0.3",
-                                                      "from": "left-pad@0.0.3",
-                                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                                      "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
                                                     }
                                                   }
                                                 }
@@ -5127,45 +7263,60 @@
                                             },
                                             "babel-messages": {
                                               "version": "6.3.18",
-                                              "from": "babel-messages@>=6.3.13 <7.0.0",
-                                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                                              "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                                              "requires": {
+                                                "babel-runtime": "5.8.34"
+                                              }
                                             },
                                             "babylon": {
                                               "version": "6.3.20",
-                                              "from": "babylon@>=6.3.15 <7.0.0",
-                                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
+                                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                                              "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                                              "requires": {
+                                                "babel-runtime": "5.8.34"
+                                              }
                                             },
                                             "debug": {
                                               "version": "2.2.0",
-                                              "from": "debug@>=2.2.0 <3.0.0",
                                               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                                              "requires": {
+                                                "ms": "0.7.1"
+                                              },
                                               "dependencies": {
                                                 "ms": {
                                                   "version": "0.7.1",
-                                                  "from": "ms@0.7.1",
-                                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
                                                 }
                                               }
                                             },
                                             "globals": {
                                               "version": "8.15.0",
-                                              "from": "globals@>=8.3.0 <9.0.0",
-                                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                                              "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
                                             },
                                             "invariant": {
                                               "version": "2.2.0",
-                                              "from": "invariant@>=2.2.0 <3.0.0",
                                               "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                              "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                                              "requires": {
+                                                "loose-envify": "1.1.0"
+                                              },
                                               "dependencies": {
                                                 "loose-envify": {
                                                   "version": "1.1.0",
-                                                  "from": "loose-envify@>=1.0.0 <2.0.0",
                                                   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                                  "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                                  "requires": {
+                                                    "js-tokens": "1.0.2"
+                                                  },
                                                   "dependencies": {
                                                     "js-tokens": {
                                                       "version": "1.0.2",
-                                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                                     }
                                                   }
                                                 }
@@ -5173,23 +7324,29 @@
                                             },
                                             "lodash": {
                                               "version": "3.10.1",
-                                              "from": "lodash@>=3.10.1 <4.0.0",
-                                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                                              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                                             },
                                             "repeating": {
                                               "version": "1.1.3",
-                                              "from": "repeating@>=1.1.3 <2.0.0",
                                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                                              "requires": {
+                                                "is-finite": "1.0.1"
+                                              },
                                               "dependencies": {
                                                 "is-finite": {
                                                   "version": "1.0.1",
-                                                  "from": "is-finite@>=1.0.0 <2.0.0",
                                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                                  "requires": {
+                                                    "number-is-nan": "1.0.0"
+                                                  },
                                                   "dependencies": {
                                                     "number-is-nan": {
                                                       "version": "1.0.0",
-                                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                                     }
                                                   }
                                                 }
@@ -5201,79 +7358,122 @@
                                     },
                                     "babel-types": {
                                       "version": "6.3.20",
-                                      "from": "babel-types@>=6.3.13 <7.0.0",
                                       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.20.tgz",
+                                      "integrity": "sha1-aD00Ls3ykg/0tr+3L1FhwqgxOCY=",
+                                      "requires": {
+                                        "babel-runtime": "5.8.34",
+                                        "babel-traverse": "6.3.19",
+                                        "esutils": "2.0.2",
+                                        "lodash": "3.10.1",
+                                        "to-fast-properties": "1.0.1"
+                                      },
                                       "dependencies": {
                                         "babel-traverse": {
                                           "version": "6.3.19",
-                                          "from": "babel-traverse@>=6.3.17 <7.0.0",
                                           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.19.tgz",
+                                          "integrity": "sha1-ZrWrXycoZ+GauC4hqdgnPVzo5/A=",
+                                          "requires": {
+                                            "babel-code-frame": "6.3.13",
+                                            "babel-messages": "6.3.18",
+                                            "babel-runtime": "5.8.34",
+                                            "babel-types": "6.3.20",
+                                            "babylon": "6.3.20",
+                                            "debug": "2.2.0",
+                                            "globals": "8.15.0",
+                                            "invariant": "2.2.0",
+                                            "lodash": "3.10.1",
+                                            "repeating": "1.1.3"
+                                          },
                                           "dependencies": {
                                             "babel-code-frame": {
                                               "version": "6.3.13",
-                                              "from": "babel-code-frame@>=6.3.13 <7.0.0",
                                               "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                              "integrity": "sha1-ubpk3ryjagUPFSGsVJjzIGwBwnY=",
+                                              "requires": {
+                                                "babel-runtime": "5.8.34",
+                                                "chalk": "1.1.1",
+                                                "esutils": "2.0.2",
+                                                "js-tokens": "1.0.2",
+                                                "line-numbers": "0.2.0",
+                                                "repeating": "1.1.3"
+                                              },
                                               "dependencies": {
                                                 "chalk": {
                                                   "version": "1.1.1",
-                                                  "from": "chalk@>=1.1.0 <2.0.0",
                                                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                                                  "requires": {
+                                                    "ansi-styles": "2.1.0",
+                                                    "escape-string-regexp": "1.0.3",
+                                                    "has-ansi": "2.0.0",
+                                                    "strip-ansi": "3.0.0",
+                                                    "supports-color": "2.0.0"
+                                                  },
                                                   "dependencies": {
                                                     "ansi-styles": {
                                                       "version": "2.1.0",
-                                                      "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                                     },
                                                     "escape-string-regexp": {
                                                       "version": "1.0.3",
-                                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                                                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
                                                     },
                                                     "has-ansi": {
                                                       "version": "2.0.0",
-                                                      "from": "has-ansi@>=2.0.0 <3.0.0",
                                                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                                      "requires": {
+                                                        "ansi-regex": "2.0.0"
+                                                      },
                                                       "dependencies": {
                                                         "ansi-regex": {
                                                           "version": "2.0.0",
-                                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                                         }
                                                       }
                                                     },
                                                     "strip-ansi": {
                                                       "version": "3.0.0",
-                                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
                                                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                                      "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                                      "requires": {
+                                                        "ansi-regex": "2.0.0"
+                                                      },
                                                       "dependencies": {
                                                         "ansi-regex": {
                                                           "version": "2.0.0",
-                                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                                         }
                                                       }
                                                     },
                                                     "supports-color": {
                                                       "version": "2.0.0",
-                                                      "from": "supports-color@>=2.0.0 <3.0.0",
-                                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                                     }
                                                   }
                                                 },
                                                 "js-tokens": {
                                                   "version": "1.0.2",
-                                                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                                  "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                                 },
                                                 "line-numbers": {
                                                   "version": "0.2.0",
-                                                  "from": "line-numbers@>=0.2.0 <0.3.0",
                                                   "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                                  "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+                                                  "requires": {
+                                                    "left-pad": "0.0.3"
+                                                  },
                                                   "dependencies": {
                                                     "left-pad": {
                                                       "version": "0.0.3",
-                                                      "from": "left-pad@0.0.3",
-                                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+                                                      "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
                                                     }
                                                   }
                                                 }
@@ -5281,45 +7481,60 @@
                                             },
                                             "babel-messages": {
                                               "version": "6.3.18",
-                                              "from": "babel-messages@>=6.3.13 <7.0.0",
-                                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz",
+                                              "integrity": "sha1-eVShU76Dwx8Qn2K7pFQT8ETzJBk=",
+                                              "requires": {
+                                                "babel-runtime": "5.8.34"
+                                              }
                                             },
                                             "babylon": {
                                               "version": "6.3.20",
-                                              "from": "babylon@>=6.3.15 <7.0.0",
-                                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz"
+                                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.20.tgz",
+                                              "integrity": "sha1-BBxkAIEUMMaOc7HMDFMk7tgyrOE=",
+                                              "requires": {
+                                                "babel-runtime": "5.8.34"
+                                              }
                                             },
                                             "debug": {
                                               "version": "2.2.0",
-                                              "from": "debug@>=2.2.0 <3.0.0",
                                               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                                              "requires": {
+                                                "ms": "0.7.1"
+                                              },
                                               "dependencies": {
                                                 "ms": {
                                                   "version": "0.7.1",
-                                                  "from": "ms@0.7.1",
-                                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
                                                 }
                                               }
                                             },
                                             "globals": {
                                               "version": "8.15.0",
-                                              "from": "globals@>=8.3.0 <9.0.0",
-                                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz",
+                                              "integrity": "sha1-PPM2cRhusGGeJZ313ErUgX56hGs="
                                             },
                                             "invariant": {
                                               "version": "2.2.0",
-                                              "from": "invariant@>=2.2.0 <3.0.0",
                                               "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                              "integrity": "sha1-yNfoRzZqScwYtiLwWKaJ1IHolfI=",
+                                              "requires": {
+                                                "loose-envify": "1.1.0"
+                                              },
                                               "dependencies": {
                                                 "loose-envify": {
                                                   "version": "1.1.0",
-                                                  "from": "loose-envify@>=1.0.0 <2.0.0",
                                                   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                                  "integrity": "sha1-UnWC1iz/TgTaP5l2xxENM5Lsfgw=",
+                                                  "requires": {
+                                                    "js-tokens": "1.0.2"
+                                                  },
                                                   "dependencies": {
                                                     "js-tokens": {
                                                       "version": "1.0.2",
-                                                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz",
+                                                      "integrity": "sha1-hkf34T9krBXZNXpZo0bIBNU7Pv4="
                                                     }
                                                   }
                                                 }
@@ -5327,18 +7542,24 @@
                                             },
                                             "repeating": {
                                               "version": "1.1.3",
-                                              "from": "repeating@>=1.1.3 <2.0.0",
                                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                                              "requires": {
+                                                "is-finite": "1.0.1"
+                                              },
                                               "dependencies": {
                                                 "is-finite": {
                                                   "version": "1.0.1",
-                                                  "from": "is-finite@>=1.0.0 <2.0.0",
                                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                                  "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                                                  "requires": {
+                                                    "number-is-nan": "1.0.0"
+                                                  },
                                                   "dependencies": {
                                                     "number-is-nan": {
                                                       "version": "1.0.0",
-                                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                                     }
                                                   }
                                                 }
@@ -5348,32 +7569,43 @@
                                         },
                                         "esutils": {
                                           "version": "2.0.2",
-                                          "from": "esutils@>=2.0.2 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                                         },
                                         "lodash": {
                                           "version": "3.10.1",
-                                          "from": "lodash@>=3.10.1 <4.0.0",
-                                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                                          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
                                         },
                                         "to-fast-properties": {
                                           "version": "1.0.1",
-                                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+                                          "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
                                         }
                                       }
                                     }
                                   }
                                 },
+                                "babel-plugin-syntax-exponentiation-operator": {
+                                  "version": "6.3.13",
+                                  "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.3.13.tgz",
+                                  "integrity": "sha1-fppGZ8iVkFdJjnn2rGSlJOu1F7A=",
+                                  "requires": {
+                                    "babel-runtime": "5.8.34"
+                                  }
+                                },
                                 "babel-runtime": {
                                   "version": "5.8.34",
-                                  "from": "babel-runtime@>=5.0.0 <6.0.0",
                                   "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                                  "integrity": "sha1-P6LwhhsypqNw1z0f6/4j20NmRWY=",
+                                  "requires": {
+                                    "core-js": "1.2.6"
+                                  },
                                   "dependencies": {
                                     "core-js": {
                                       "version": "1.2.6",
-                                      "from": "core-js@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+                                      "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
                                     }
                                   }
                                 }
@@ -5393,112 +7625,179 @@
     },
     "classnames": {
       "version": "2.2.1",
-      "from": "classnames@>=2.1.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.1.tgz",
+      "integrity": "sha1-TRo9AtA31F4AsJbAvm9Ulty/KIo="
     },
     "css-loader": {
       "version": "0.15.6",
-      "from": "css-loader@>=0.15.1 <0.16.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.15.6.tgz",
+      "integrity": "sha1-Iofe4oSCnr+4H6wLKU2nKbO/oUQ=",
+      "requires": {
+        "css-selector-tokenizer": "0.5.4",
+        "cssnano": "2.6.1",
+        "loader-utils": "0.2.12",
+        "postcss": "4.1.16",
+        "postcss-modules-extract-imports": "0.0.5",
+        "postcss-modules-local-by-default": "0.0.11",
+        "postcss-modules-scope": "0.0.8",
+        "source-list-map": "0.1.5"
+      },
       "dependencies": {
         "css-selector-tokenizer": {
           "version": "0.5.4",
-          "from": "css-selector-tokenizer@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
+          "integrity": "sha1-E5uv00o1/QwUKEhwSeBpnm9qLCE=",
+          "requires": {
+            "cssesc": "0.1.0",
+            "fastparse": "1.1.1"
+          },
           "dependencies": {
             "cssesc": {
               "version": "0.1.0",
-              "from": "cssesc@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+              "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
             },
             "fastparse": {
               "version": "1.1.1",
-              "from": "fastparse@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+              "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
             }
           }
         },
         "cssnano": {
           "version": "2.6.1",
-          "from": "cssnano@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-2.6.1.tgz",
+          "integrity": "sha1-f7NyEsz/RNPpNuAmxvZ14xR9gCQ=",
+          "requires": {
+            "autoprefixer-core": "5.2.1",
+            "balanced-match": "0.2.1",
+            "css-list": "0.1.3",
+            "decamelize": "1.1.1",
+            "defined": "1.0.0",
+            "indexes-of": "1.0.1",
+            "minimist": "1.2.0",
+            "postcss": "4.1.16",
+            "postcss-calc": "4.1.0",
+            "postcss-colormin": "1.2.7",
+            "postcss-convert-values": "1.3.1",
+            "postcss-discard-comments": "1.2.1",
+            "postcss-discard-duplicates": "1.2.1",
+            "postcss-discard-empty": "1.1.2",
+            "postcss-discard-unused": "1.0.3",
+            "postcss-filter-plugins": "1.0.1",
+            "postcss-font-family": "1.2.1",
+            "postcss-merge-idents": "1.0.2",
+            "postcss-merge-longhand": "1.0.2",
+            "postcss-merge-rules": "1.3.6",
+            "postcss-minify-font-weight": "1.0.1",
+            "postcss-minify-selectors": "1.5.0",
+            "postcss-normalize-url": "2.1.3",
+            "postcss-ordered-values": "1.1.1",
+            "postcss-reduce-idents": "1.0.3",
+            "postcss-single-charset": "0.3.0",
+            "postcss-unique-selectors": "1.0.1",
+            "postcss-zindex": "1.1.3",
+            "read-file-stdin": "0.2.0",
+            "write-file-stdout": "0.0.2"
+          },
           "dependencies": {
             "autoprefixer-core": {
               "version": "5.2.1",
-              "from": "autoprefixer-core@>=5.2.1 <6.0.0",
               "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
+              "integrity": "sha1-5kDEFK5Bmq4hwa1DyOoPPbgqVm0=",
+              "requires": {
+                "browserslist": "0.4.0",
+                "caniuse-db": "1.0.30000377",
+                "num2fraction": "1.2.2",
+                "postcss": "4.1.16"
+              },
               "dependencies": {
                 "browserslist": {
                   "version": "0.4.0",
-                  "from": "browserslist@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
-                },
-                "num2fraction": {
-                  "version": "1.2.2",
-                  "from": "num2fraction@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
+                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
+                  "integrity": "sha1-O9SrkZncG5FQ1NbbpNnTqrvIbdQ=",
+                  "requires": {
+                    "caniuse-db": "1.0.30000377"
+                  }
                 },
                 "caniuse-db": {
                   "version": "1.0.30000377",
-                  "from": "caniuse-db@>=1.0.30000214 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000377.tgz"
+                  "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000377.tgz",
+                  "integrity": "sha1-EFRNqPHD/lCTrDaThgQs2i9QXqk="
+                },
+                "num2fraction": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+                  "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
                 }
               }
             },
             "balanced-match": {
               "version": "0.2.1",
-              "from": "balanced-match@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
+              "integrity": "sha1-e8ZYtL7WHu5CStdPdfXD4sTfPMc="
             },
             "css-list": {
               "version": "0.1.3",
-              "from": "css-list@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/css-list/-/css-list-0.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/css-list/-/css-list-0.1.3.tgz",
+              "integrity": "sha1-p7M7RBn4PUEjIN3pEzoNEASUjXA="
             },
             "decamelize": {
               "version": "1.1.1",
-              "from": "decamelize@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
+              "integrity": "sha1-iHFHmmwEh/VlPUipkvHQOBym8DE="
             },
             "defined": {
               "version": "1.0.0",
-              "from": "defined@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
             },
             "indexes-of": {
               "version": "1.0.1",
-              "from": "indexes-of@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+              "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
             },
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@>=1.1.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
             },
             "postcss-calc": {
               "version": "4.1.0",
-              "from": "postcss-calc@>=4.1.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-4.1.0.tgz",
+              "integrity": "sha1-vuf/ySjHmGmZ7vF7LdiXDIk31HI=",
+              "requires": {
+                "postcss": "4.1.16",
+                "postcss-message-helpers": "2.0.0",
+                "reduce-css-calc": "1.2.0"
+              },
               "dependencies": {
                 "postcss-message-helpers": {
                   "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+                  "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
                 },
                 "reduce-css-calc": {
                   "version": "1.2.0",
-                  "from": "reduce-css-calc@>=1.2.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
+                  "integrity": "sha1-4ZHjYuk9pMDw+ZLeoSkyouENsZE=",
+                  "requires": {
+                    "balanced-match": "0.1.0",
+                    "reduce-function-call": "1.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
+                      "integrity": "sha1-tQS9BYabOSWd0MXvw12EMXbczEo="
                     },
                     "reduce-function-call": {
                       "version": "1.0.1",
-                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
+                      "integrity": "sha1-+gLhJuaVgkJjyrkdOlsP3B3Sepo=",
+                      "requires": {
+                        "balanced-match": "0.1.0"
+                      }
                     }
                   }
                 }
@@ -5506,28 +7805,41 @@
             },
             "postcss-colormin": {
               "version": "1.2.7",
-              "from": "postcss-colormin@>=1.2.5 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-1.2.7.tgz",
+              "integrity": "sha1-63Pb6DgE6pGYNWsTL2+Z9GAP1lQ=",
+              "requires": {
+                "color": "0.10.1",
+                "colormin": "1.0.4",
+                "postcss": "4.1.16",
+                "reduce-function-call": "1.0.1"
+              },
               "dependencies": {
                 "color": {
                   "version": "0.10.1",
-                  "from": "color@>=0.10.1 <0.11.0",
                   "resolved": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
+                  "integrity": "sha1-wEGI34KiCd3rzOzazT7DIPGTc58=",
+                  "requires": {
+                    "color-convert": "0.5.3",
+                    "color-string": "0.3.0"
+                  },
                   "dependencies": {
                     "color-convert": {
                       "version": "0.5.3",
-                      "from": "color-convert@>=0.5.3 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
+                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+                      "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
                     },
                     "color-string": {
                       "version": "0.3.0",
-                      "from": "color-string@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+                      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+                      "requires": {
+                        "color-name": "1.0.1"
+                      },
                       "dependencies": {
                         "color-name": {
                           "version": "1.0.1",
-                          "from": "color-name@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.0.1.tgz",
+                          "integrity": "sha1-azSyspt3FgE5crC51b7c+7Zxjfg="
                         }
                       }
                     }
@@ -5535,25 +7847,32 @@
                 },
                 "colormin": {
                   "version": "1.0.4",
-                  "from": "colormin@>=1.0.3 <2.0.0",
                   "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.0.4.tgz",
+                  "integrity": "sha1-gEOUhKrHUYYZw/eVSMCZldwpT2w=",
+                  "requires": {
+                    "color": "0.10.1",
+                    "css-color-names": "0.0.1"
+                  },
                   "dependencies": {
                     "css-color-names": {
                       "version": "0.0.1",
-                      "from": "css-color-names@0.0.1",
-                      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.1.tgz",
+                      "integrity": "sha1-XQVI+iVkVu3kqaDCrHqxnT6xrYE="
                     }
                   }
                 },
                 "reduce-function-call": {
                   "version": "1.0.1",
-                  "from": "reduce-function-call@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
+                  "integrity": "sha1-+gLhJuaVgkJjyrkdOlsP3B3Sepo=",
+                  "requires": {
+                    "balanced-match": "0.1.0"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
+                      "integrity": "sha1-tQS9BYabOSWd0MXvw12EMXbczEo="
                     }
                   }
                 }
@@ -5561,184 +7880,256 @@
             },
             "postcss-convert-values": {
               "version": "1.3.1",
-              "from": "postcss-convert-values@>=1.2.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-1.3.1.tgz",
+              "integrity": "sha1-I/GHxhP6d7Y3p4BblIteCJlpDkY=",
+              "requires": {
+                "postcss": "4.1.16",
+                "postcss-value-parser": "1.4.2"
+              },
               "dependencies": {
                 "postcss-value-parser": {
                   "version": "1.4.2",
-                  "from": "postcss-value-parser@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-1.4.2.tgz"
+                  "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-1.4.2.tgz",
+                  "integrity": "sha1-GGVjPhNwH4pyHng02tGFyxRKrQw="
                 }
               }
             },
             "postcss-discard-comments": {
               "version": "1.2.1",
-              "from": "postcss-discard-comments@>=1.2.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-1.2.1.tgz",
+              "integrity": "sha1-hR3Ka5NUwPtjFssaEEj29eOWCtA=",
+              "requires": {
+                "node-balanced": "0.0.14",
+                "postcss": "4.1.16"
+              },
               "dependencies": {
                 "node-balanced": {
                   "version": "0.0.14",
-                  "from": "node-balanced@0.0.14",
-                  "resolved": "https://registry.npmjs.org/node-balanced/-/node-balanced-0.0.14.tgz"
+                  "resolved": "https://registry.npmjs.org/node-balanced/-/node-balanced-0.0.14.tgz",
+                  "integrity": "sha1-ozxyeFfTBE8eiL5y3X2anQtPwh8="
                 }
               }
             },
             "postcss-discard-duplicates": {
               "version": "1.2.1",
-              "from": "postcss-discard-duplicates@>=1.1.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-1.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-1.2.1.tgz",
+              "integrity": "sha1-SbsztNNHcQWwDQSDlfc6KQK8miU=",
+              "requires": {
+                "postcss": "4.1.16"
+              }
             },
             "postcss-discard-empty": {
               "version": "1.1.2",
-              "from": "postcss-discard-empty@>=1.1.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-1.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-1.1.2.tgz",
+              "integrity": "sha1-KsVayPy4HCMEPmMQaTT9Y0cNXA0=",
+              "requires": {
+                "postcss": "4.1.16"
+              }
             },
             "postcss-discard-unused": {
               "version": "1.0.3",
-              "from": "postcss-discard-unused@>=1.0.3 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-1.0.3.tgz",
+              "integrity": "sha1-Xsy5v6xGXqa+VjQpepx3gczQmIY=",
+              "requires": {
+                "flatten": "0.0.1",
+                "postcss": "4.1.16",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "flatten": {
                   "version": "0.0.1",
-                  "from": "flatten@0.0.1",
-                  "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
+                  "integrity": "sha1-VURAdm2goNYDmZ9DNFP2wvxqdcE="
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-filter-plugins": {
               "version": "1.0.1",
-              "from": "postcss-filter-plugins@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-1.0.1.tgz",
+              "integrity": "sha1-J/gnnV76t6o8FwmIE5hrS50dUOI=",
+              "requires": {
+                "postcss": "4.1.16",
+                "uniqid": "1.0.0"
+              },
               "dependencies": {
                 "uniqid": {
                   "version": "1.0.0",
-                  "from": "uniqid@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz",
+                  "integrity": "sha1-JYJSTgdASESkLelPviv1SeG3RVU="
                 }
               }
             },
             "postcss-font-family": {
               "version": "1.2.1",
-              "from": "postcss-font-family@>=1.2.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-font-family/-/postcss-font-family-1.2.1.tgz",
+              "integrity": "sha1-dQJSSzmDox5q9k5LqhA07W7YQYw=",
+              "requires": {
+                "object-assign": "3.0.0",
+                "postcss": "4.1.16",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "object-assign": {
                   "version": "3.0.0",
-                  "from": "object-assign@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                  "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-merge-idents": {
               "version": "1.0.2",
-              "from": "postcss-merge-idents@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-1.0.2.tgz",
+              "integrity": "sha1-qToNrXj2UugjfZrew0LkHSwd01s=",
+              "requires": {
+                "css-list": "0.1.3",
+                "postcss": "4.1.16"
+              }
             },
             "postcss-merge-longhand": {
               "version": "1.0.2",
-              "from": "postcss-merge-longhand@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-1.0.2.tgz",
+              "integrity": "sha1-QxcgZfz4We4RztMUH1ZkFMZzBX4=",
+              "requires": {
+                "postcss": "4.1.16"
+              }
             },
             "postcss-merge-rules": {
               "version": "1.3.6",
-              "from": "postcss-merge-rules@>=1.3.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-1.3.6.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-1.3.6.tgz",
+              "integrity": "sha1-sUrRf31AEqMYut032r1ZuT8TUy8=",
+              "requires": {
+                "postcss": "4.1.16"
+              }
             },
             "postcss-minify-font-weight": {
               "version": "1.0.1",
-              "from": "postcss-minify-font-weight@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-minify-font-weight/-/postcss-minify-font-weight-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-minify-font-weight/-/postcss-minify-font-weight-1.0.1.tgz",
+              "integrity": "sha1-aI5CzfI27Osb1WOojPHSTQOgWIg=",
+              "requires": {
+                "postcss": "4.1.16"
+              }
             },
             "postcss-minify-selectors": {
               "version": "1.5.0",
-              "from": "postcss-minify-selectors@>=1.5.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-1.5.0.tgz",
+              "integrity": "sha1-5ZxWxtSVXaFXz30iv4Bptur1Jic=",
+              "requires": {
+                "javascript-natural-sort": "0.7.1",
+                "normalize-selector": "0.2.0",
+                "postcss": "4.1.16",
+                "postcss-selector-parser": "1.3.0",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "javascript-natural-sort": {
                   "version": "0.7.1",
-                  "from": "javascript-natural-sort@>=0.7.1 <0.8.0",
-                  "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz"
+                  "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+                  "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
                 },
                 "normalize-selector": {
                   "version": "0.2.0",
-                  "from": "normalize-selector@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+                  "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM="
                 },
                 "postcss-selector-parser": {
                   "version": "1.3.0",
-                  "from": "postcss-selector-parser@>=1.1.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.0.tgz",
+                  "integrity": "sha1-PfYKh/0xOGkRDw7ksJcS0HA/qIU=",
+                  "requires": {
+                    "flatten": "0.0.1",
+                    "indexes-of": "1.0.1",
+                    "uniq": "1.0.1"
+                  },
                   "dependencies": {
                     "flatten": {
                       "version": "0.0.1",
-                      "from": "flatten@0.0.1",
-                      "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
+                      "integrity": "sha1-VURAdm2goNYDmZ9DNFP2wvxqdcE="
                     },
                     "uniq": {
                       "version": "1.0.1",
-                      "from": "uniq@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+                      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
                     }
                   }
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-normalize-url": {
               "version": "2.1.3",
-              "from": "postcss-normalize-url@>=2.1.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-2.1.3.tgz",
+              "integrity": "sha1-8StfShFDyV6gJfx/jgBQkFmPNgI=",
+              "requires": {
+                "is-absolute-url": "2.0.0",
+                "normalize-url": "1.4.0",
+                "object-assign": "4.0.1",
+                "postcss": "4.1.16",
+                "postcss-value-parser": "1.4.2"
+              },
               "dependencies": {
                 "is-absolute-url": {
                   "version": "2.0.0",
-                  "from": "is-absolute-url@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
+                  "integrity": "sha1-nEsgsOXAy++aR5o2ft5vmRZ581k="
                 },
                 "normalize-url": {
                   "version": "1.4.0",
-                  "from": "normalize-url@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
+                  "integrity": "sha1-iuk+l932bxdUTB8SotwMDktXYv8=",
+                  "requires": {
+                    "object-assign": "4.0.1",
+                    "prepend-http": "1.0.3",
+                    "query-string": "3.0.0",
+                    "sort-keys": "1.1.1"
+                  },
                   "dependencies": {
                     "prepend-http": {
                       "version": "1.0.3",
-                      "from": "prepend-http@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
+                      "integrity": "sha1-TQ0rb5788RkMI5MTJbTzqduoSGk="
                     },
                     "query-string": {
                       "version": "3.0.0",
-                      "from": "query-string@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
+                      "integrity": "sha1-Av0wbwQyBAuRsRBj+UBP4bvUuns=",
+                      "requires": {
+                        "strict-uri-encode": "1.0.2"
+                      },
                       "dependencies": {
                         "strict-uri-encode": {
                           "version": "1.0.2",
-                          "from": "strict-uri-encode@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.0.2.tgz",
+                          "integrity": "sha1-/RnmOdiadmJWoz5hHThBXfjWBY0="
                         }
                       }
                     },
                     "sort-keys": {
                       "version": "1.1.1",
-                      "from": "sort-keys@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
+                      "integrity": "sha1-p5HCYHHfZsNWv13K2c+1ensvgm4=",
+                      "requires": {
+                        "is-plain-obj": "1.1.0"
+                      },
                       "dependencies": {
                         "is-plain-obj": {
                           "version": "1.1.0",
-                          "from": "is-plain-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+                          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
                         }
                       }
                     }
@@ -5746,42 +8137,53 @@
                 },
                 "object-assign": {
                   "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+                  "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
                 },
                 "postcss-value-parser": {
                   "version": "1.4.2",
-                  "from": "postcss-value-parser@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-1.4.2.tgz"
+                  "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-1.4.2.tgz",
+                  "integrity": "sha1-GGVjPhNwH4pyHng02tGFyxRKrQw="
                 }
               }
             },
             "postcss-ordered-values": {
               "version": "1.1.1",
-              "from": "postcss-ordered-values@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-1.1.1.tgz",
+              "integrity": "sha1-nu1PrS55Kr/D0EAs93O6+G/ne4E=",
+              "requires": {
+                "postcss": "4.1.16",
+                "postcss-value-parser": "1.4.2"
+              },
               "dependencies": {
                 "postcss-value-parser": {
                   "version": "1.4.2",
-                  "from": "postcss-value-parser@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-1.4.2.tgz"
+                  "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-1.4.2.tgz",
+                  "integrity": "sha1-GGVjPhNwH4pyHng02tGFyxRKrQw="
                 }
               }
             },
             "postcss-reduce-idents": {
               "version": "1.0.3",
-              "from": "postcss-reduce-idents@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-1.0.3.tgz",
+              "integrity": "sha1-p58bJIXiPZs8x6gfXsY6XCvewg0=",
+              "requires": {
+                "postcss": "4.1.16",
+                "reduce-function-call": "1.0.1"
+              },
               "dependencies": {
                 "reduce-function-call": {
                   "version": "1.0.1",
-                  "from": "reduce-function-call@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
+                  "integrity": "sha1-+gLhJuaVgkJjyrkdOlsP3B3Sepo=",
+                  "requires": {
+                    "balanced-match": "0.1.0"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
+                      "integrity": "sha1-tQS9BYabOSWd0MXvw12EMXbczEo="
                     }
                   }
                 }
@@ -5789,70 +8191,100 @@
             },
             "postcss-single-charset": {
               "version": "0.3.0",
-              "from": "postcss-single-charset@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/postcss-single-charset/-/postcss-single-charset-0.3.0.tgz",
+              "integrity": "sha1-2n/Q3szPYy8bdMei7j41vilFZXM=",
+              "requires": {
+                "fs-extra": "0.14.0",
+                "postcss": "4.1.16"
+              },
               "dependencies": {
                 "fs-extra": {
                   "version": "0.14.0",
-                  "from": "fs-extra@>=0.14.0 <0.15.0",
                   "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.14.0.tgz",
+                  "integrity": "sha1-RmCWxroticIAA4DaskULeFn/Z0M=",
+                  "requires": {
+                    "jsonfile": "2.2.3",
+                    "ncp": "1.0.1",
+                    "rimraf": "2.4.4"
+                  },
                   "dependencies": {
-                    "ncp": {
-                      "version": "1.0.1",
-                      "from": "ncp@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz"
-                    },
                     "jsonfile": {
                       "version": "2.2.3",
-                      "from": "jsonfile@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
+                      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz",
+                      "integrity": "sha1-4lK5mmr5AdPsQfMyWJyQUJp7xgU="
+                    },
+                    "ncp": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+                      "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY="
                     },
                     "rimraf": {
                       "version": "2.4.4",
-                      "from": "rimraf@>=2.2.8 <3.0.0",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
+                      "integrity": "sha1-tSjOLr4ObYn7A7Jl3hHWHaDbz4I=",
+                      "requires": {
+                        "glob": "5.0.15"
+                      },
                       "dependencies": {
                         "glob": {
                           "version": "5.0.15",
-                          "from": "glob@>=5.0.14 <6.0.0",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                          "requires": {
+                            "inflight": "1.0.4",
+                            "inherits": "2.0.1",
+                            "minimatch": "3.0.0",
+                            "once": "1.3.3",
+                            "path-is-absolute": "1.0.0"
+                          },
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.4",
-                              "from": "inflight@>=1.0.4 <2.0.0",
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+                              "requires": {
+                                "once": "1.3.3",
+                                "wrappy": "1.0.1"
+                              },
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                                 }
                               }
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                             },
                             "minimatch": {
                               "version": "3.0.0",
-                              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+                              "requires": {
+                                "brace-expansion": "1.1.2"
+                              },
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.2",
-                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                                  "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                                  "requires": {
+                                    "balanced-match": "0.3.0",
+                                    "concat-map": "0.0.1"
+                                  },
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.3.0",
-                                      "from": "balanced-match@>=0.3.0 <0.4.0",
-                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                      "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                                     },
                                     "concat-map": {
                                       "version": "0.0.1",
-                                      "from": "concat-map@0.0.1",
-                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                                     }
                                   }
                                 }
@@ -5860,20 +8292,23 @@
                             },
                             "once": {
                               "version": "1.3.3",
-                              "from": "once@>=1.3.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                              "requires": {
+                                "wrappy": "1.0.1"
+                              },
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                                 }
                               }
                             },
                             "path-is-absolute": {
                               "version": "1.0.0",
-                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
                             }
                           }
                         }
@@ -5885,213 +8320,1112 @@
             },
             "postcss-unique-selectors": {
               "version": "1.0.1",
-              "from": "postcss-unique-selectors@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-1.0.1.tgz",
+              "integrity": "sha1-SBfnTHtPmZzgTI5mRRoZaRT12zw=",
+              "requires": {
+                "javascript-natural-sort": "0.7.1",
+                "postcss": "4.1.16",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "javascript-natural-sort": {
                   "version": "0.7.1",
-                  "from": "javascript-natural-sort@>=0.7.1 <0.8.0",
-                  "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz"
+                  "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+                  "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-zindex": {
               "version": "1.1.3",
-              "from": "postcss-zindex@>=1.1.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-1.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-1.1.3.tgz",
+              "integrity": "sha1-SVZKtJ092hcGf42sHIM11/LQDOE=",
+              "requires": {
+                "postcss": "4.1.16"
+              }
             },
             "read-file-stdin": {
               "version": "0.2.0",
-              "from": "read-file-stdin@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/read-file-stdin/-/read-file-stdin-0.2.0.tgz",
+              "integrity": "sha1-U2vsbxfgBZyje8W8fjnpcQmoQWY=",
+              "requires": {
+                "gather-stream": "1.0.0"
+              },
               "dependencies": {
                 "gather-stream": {
                   "version": "1.0.0",
-                  "from": "gather-stream@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/gather-stream/-/gather-stream-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/gather-stream/-/gather-stream-1.0.0.tgz",
+                  "integrity": "sha1-szmUr0V6gRVwDUEPMXczy+egkEs="
                 }
               }
             },
             "write-file-stdout": {
               "version": "0.0.2",
-              "from": "write-file-stdout@0.0.2",
-              "resolved": "https://registry.npmjs.org/write-file-stdout/-/write-file-stdout-0.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/write-file-stdout/-/write-file-stdout-0.0.2.tgz",
+              "integrity": "sha1-wlLXx8WxtAKJdjDjRTx7/mkNnKE="
             }
           }
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.2 <0.3.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "integrity": "sha1-+qKlAVY6PCyd2leqjDnYvmKN56I=",
+          "requires": {
+            "big.js": "3.1.3",
+            "json5": "0.4.0"
+          },
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
             }
           }
         },
         "postcss": {
           "version": "4.1.16",
-          "from": "postcss@>=4.1.11 <5.0.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
+          "integrity": "sha1-TESbTIr53zyvbTf44eV10DYXWNw=",
+          "requires": {
+            "es6-promise": "2.3.0",
+            "js-base64": "2.1.9",
+            "source-map": "0.4.4"
+          },
           "dependencies": {
             "es6-promise": {
               "version": "2.3.0",
-              "from": "es6-promise@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "from": "source-map@>=0.4.2 <0.5.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+              "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
             },
             "js-base64": {
               "version": "2.1.9",
-              "from": "js-base64@>=2.1.8 <2.2.0",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+              "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "requires": {
+                "amdefine": "1.0.0"
+              },
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM="
+                }
+              }
             }
           }
         },
         "postcss-modules-extract-imports": {
           "version": "0.0.5",
-          "from": "postcss-modules-extract-imports@0.0.5",
-          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-0.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-0.0.5.tgz",
+          "integrity": "sha1-zMy0Cz3SmFmZOEodumDGLJYKbaA=",
+          "requires": {
+            "postcss": "4.1.16"
+          }
         },
         "postcss-modules-local-by-default": {
           "version": "0.0.11",
-          "from": "postcss-modules-local-by-default@0.0.11",
-          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-0.0.11.tgz"
+          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-0.0.11.tgz",
+          "integrity": "sha1-qACvQyHDpOCFLRrlKeb8mRrTlec=",
+          "requires": {
+            "css-selector-tokenizer": "0.5.4",
+            "postcss": "4.1.16"
+          }
         },
         "postcss-modules-scope": {
           "version": "0.0.8",
-          "from": "postcss-modules-scope@0.0.8",
-          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-0.0.8.tgz"
+          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-0.0.8.tgz",
+          "integrity": "sha1-gck1+/KJJyOIyLoulqEcohugmgQ=",
+          "requires": {
+            "css-selector-tokenizer": "0.5.4",
+            "postcss": "4.1.16"
+          }
         },
         "source-list-map": {
           "version": "0.1.5",
-          "from": "source-list-map@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
+          "integrity": "sha1-3fMvUXP67KMBBWHdfppoLAJ/RZ4="
+        }
+      }
+    },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
         }
       }
     },
     "less": {
       "version": "2.5.3",
-      "from": "less@>=2.5.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/less/-/less-2.5.3.tgz",
+      "integrity": "sha1-n/WG6KcDUV/Bjcmce8SY0vOtSEk=",
+      "requires": {
+        "errno": "0.1.4",
+        "graceful-fs": "3.0.8",
+        "image-size": "0.3.5",
+        "mime": "1.3.4",
+        "mkdirp": "0.5.1",
+        "promise": "6.1.0",
+        "request": "2.67.0",
+        "source-map": "0.4.4"
+      },
       "dependencies": {
         "errno": {
           "version": "0.1.4",
-          "from": "errno@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+          "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+          "optional": true,
+          "requires": {
+            "prr": "0.0.0"
+          },
           "dependencies": {
             "prr": {
               "version": "0.0.0",
-              "from": "prr@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+              "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+              "optional": true
             }
           }
         },
         "graceful-fs": {
           "version": "3.0.8",
-          "from": "graceful-fs@>=3.0.5 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+          "integrity": "sha1-zoE+cl+oL35hR9UcmlymgnBVHCI=",
+          "optional": true
         },
         "image-size": {
           "version": "0.3.5",
-          "from": "image-size@>=0.3.5 <0.4.0",
-          "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz"
+          "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
+          "integrity": "sha1-gyQOqy+1sAsEqrjHSwRx6cunrYw=",
+          "optional": true
         },
         "mime": {
           "version": "1.3.4",
-          "from": "mime@>=1.2.11 <2.0.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "optional": true
             }
           }
         },
         "promise": {
           "version": "6.1.0",
-          "from": "promise@>=6.0.1 <7.0.0",
           "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+          "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY=",
+          "optional": true,
+          "requires": {
+            "asap": "1.0.0"
+          },
           "dependencies": {
             "asap": {
               "version": "1.0.0",
-              "from": "asap@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
+              "integrity": "sha1-sqRdpf36ILBJb8N2jMJ8EvqRan0=",
+              "optional": true
             }
           }
         },
         "request": {
           "version": "2.67.0",
-          "from": "request@>=2.51.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
+          "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "bl": "1.0.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.0",
+            "forever-agent": "0.6.1",
+            "form-data": "1.0.0-rc3",
+            "har-validator": "2.0.3",
+            "hawk": "3.1.2",
+            "http-signature": "1.1.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.8",
+            "node-uuid": "1.4.7",
+            "oauth-sign": "0.8.0",
+            "qs": "5.2.0",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.2.1",
+            "tunnel-agent": "0.4.2"
+          },
           "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+              "optional": true
+            },
             "bl": {
               "version": "1.0.0",
-              "from": "bl@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+              "integrity": "sha1-ramoqJptesYIYvfex9sgeHPgw/U=",
+              "optional": true,
+              "requires": {
+                "readable-stream": "2.0.5"
+              },
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+                  "optional": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "process-nextick-args": "1.0.6",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "optional": true
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                      "optional": true
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                      "optional": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                      "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU=",
+                      "optional": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "optional": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "optional": true
                     }
                   }
                 }
@@ -6099,337 +9433,478 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-            },
-            "extend": {
-              "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "form-data": {
-              "version": "1.0.0-rc3",
-              "from": "form-data@>=1.0.0-rc3 <1.1.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "1.5.0",
-                  "from": "async@>=1.4.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-                }
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.8",
-              "from": "mime-types@>=2.1.7 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.20.0",
-                  "from": "mime-db@>=1.20.0 <1.21.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-            },
-            "qs": {
-              "version": "5.2.0",
-              "from": "qs@>=5.2.0 <5.3.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.2",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.1",
-              "from": "tough-cookie@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-            },
-            "http-signature": {
-              "version": "1.1.0",
-              "from": "http-signature@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "jsprim": {
-                  "version": "1.2.2",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
-                    "json-schema": {
-                      "version": "0.2.2",
-                      "from": "json-schema@0.2.2",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.7.1",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "from": "assert-plus@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                    },
-                    "dashdash": {
-                      "version": "1.10.1",
-                      "from": "dashdash@>=1.10.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.1.5",
-                          "from": "assert-plus@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                        }
-                      }
-                    },
-                    "jsbn": {
-                      "version": "0.1.0",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                    },
-                    "tweetnacl": {
-                      "version": "0.13.2",
-                      "from": "tweetnacl@>=0.13.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.0",
-              "from": "oauth-sign@>=0.8.0 <0.9.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-            },
-            "hawk": {
-              "version": "3.1.2",
-              "from": "hawk@>=3.1.0 <3.2.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+              "optional": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
                 }
               }
             },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "optional": true
             },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+            "forever-agent": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "optional": true
+            },
+            "form-data": {
+              "version": "1.0.0-rc3",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+              "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
+              "optional": true,
+              "requires": {
+                "async": "1.5.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.8"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "1.5.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+                  "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM=",
+                  "optional": true
+                }
+              }
             },
             "har-validator": {
               "version": "2.0.3",
-              "from": "har-validator@>=2.0.2 <2.1.0",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
+              "integrity": "sha1-Wp4SVkpXHPC4Hvk8IVe9FhcWiIM=",
+              "optional": true,
+              "requires": {
+                "chalk": "1.1.1",
+                "commander": "2.9.0",
+                "is-my-json-valid": "2.12.3",
+                "pinkie-promise": "2.0.0"
+              },
               "dependencies": {
                 "chalk": {
                   "version": "1.1.1",
-                  "from": "chalk@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                  "optional": true,
+                  "requires": {
+                    "ansi-styles": "2.1.0",
+                    "escape-string-regexp": "1.0.3",
+                    "has-ansi": "2.0.0",
+                    "strip-ansi": "3.0.0",
+                    "supports-color": "2.0.0"
+                  },
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.1.0",
-                      "from": "ansi-styles@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI=",
+                      "optional": true
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U=",
+                      "optional": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "optional": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "optional": true
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.0",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                      "optional": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "optional": true
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                      "optional": true
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.9.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "optional": true,
+                  "requires": {
+                    "graceful-readlink": "1.0.1"
+                  },
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                      "optional": true
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.12.3",
-                  "from": "is-my-json-valid@>=2.12.3 <3.0.0",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
+                  "integrity": "sha1-WjnR12stu4MUC70Vex1e5L3IWtY=",
+                  "optional": true,
+                  "requires": {
+                    "generate-function": "2.0.0",
+                    "generate-object-property": "1.2.0",
+                    "jsonpointer": "2.0.0",
+                    "xtend": "4.0.1"
+                  },
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                      "optional": true
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                      "optional": true,
+                      "requires": {
+                        "is-property": "1.0.2"
+                      },
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                          "optional": true
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                      "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
+                      "optional": true
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                      "optional": true
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.0",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                  "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                  "optional": true,
+                  "requires": {
+                    "pinkie": "2.0.1"
+                  },
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.1",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                      "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw=",
+                      "optional": true
                     }
                   }
                 }
               }
+            },
+            "hawk": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
+              "integrity": "sha1-kMkBGIhuIZddGtSumz4oTtGaLeg=",
+              "optional": true,
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "optional": true,
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "optional": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
+              "integrity": "sha1-XS1+m270mYCtWxKNjk7wmjHJDZU=",
+              "optional": true,
+              "requires": {
+                "assert-plus": "0.1.5",
+                "jsprim": "1.2.2",
+                "sshpk": "1.7.1"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+                  "optional": true
+                },
+                "jsprim": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+                  "integrity": "sha1-8gyQaskqvVjjt5rIvHCkiDJRLaE=",
+                  "optional": true,
+                  "requires": {
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.2",
+                    "verror": "1.3.6"
+                  },
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+                    },
+                    "json-schema": {
+                      "version": "0.2.2",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                      "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+                      "optional": true
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "optional": true,
+                      "requires": {
+                        "extsprintf": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.7.1",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
+                  "integrity": "sha1-Vl44bEKnfmBi+9FMBHL/Ic1TOYw=",
+                  "optional": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "0.2.0",
+                    "dashdash": "1.10.1",
+                    "ecc-jsbn": "0.1.1",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.0",
+                    "tweetnacl": "0.13.2"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                      "optional": true
+                    },
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                      "optional": true
+                    },
+                    "dashdash": {
+                      "version": "1.10.1",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
+                      "integrity": "sha1-Cr8a+JqPUSmoHxjCs1sh3yJiL2A=",
+                      "optional": true,
+                      "requires": {
+                        "assert-plus": "0.1.5"
+                      },
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+                          "optional": true
+                        }
+                      }
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.0"
+                      }
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.0"
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.2",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz",
+                      "integrity": "sha1-RTFhdwRp1FzSZsNkBOK8maj6mUQ=",
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "optional": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "optional": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "optional": true
+            },
+            "mime-types": {
+              "version": "2.1.8",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
+              "integrity": "sha1-+vV4I94EvHy/9O6CxrY5RugSrnI=",
+              "requires": {
+                "mime-db": "1.20.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.20.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz",
+                  "integrity": "sha1-SW+Q/QH+DgMciCPsOqlFD/2hjtg="
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.7",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+              "optional": true
+            },
+            "oauth-sign": {
+              "version": "0.8.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+              "integrity": "sha1-k4/ch1dlulJxN9iuydF44k3rxVM=",
+              "optional": true
+            },
+            "qs": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+              "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=",
+              "optional": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+              "optional": true
+            },
+            "tough-cookie": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
+              "integrity": "sha1-OwUWt5nnDoFkQ2oURuflh3/aEY4=",
+              "optional": true
+            },
+            "tunnel-agent": {
+              "version": "0.4.2",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+              "integrity": "sha1-EQTj82rIcSXChycAZ9WC0YEzv+4=",
+              "optional": true
             }
           }
         },
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.0"
+          },
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+              "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+              "optional": true
             }
           }
         }
@@ -6437,255 +9912,339 @@
     },
     "less-loader": {
       "version": "2.2.2",
-      "from": "less-loader@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-2.2.2.tgz",
+      "integrity": "sha1-CE8OVJtLq4+hLCWA3qzSdDnqhSk=",
+      "requires": {
+        "loader-utils": "0.2.12"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.5 <0.3.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "integrity": "sha1-+qKlAVY6PCyd2leqjDnYvmKN56I=",
+          "requires": {
+            "big.js": "3.1.3",
+            "json5": "0.4.0"
+          },
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
             }
           }
         }
       }
     },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "optional": true
+    },
     "node-libs-browser": {
       "version": "0.5.3",
-      "from": "node-libs-browser@>=0.5.2 <0.6.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
+      "integrity": "sha1-Ve+oiOyQes24z/xOelFxJ4DhO2o=",
+      "requires": {
+        "assert": "1.3.0",
+        "browserify-zlib": "0.1.4",
+        "buffer": "3.5.5",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "3.2.8",
+        "domain-browser": "1.1.7",
+        "events": "1.1.0",
+        "http-browserify": "1.7.0",
+        "https-browserify": "0.0.0",
+        "os-browserify": "0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "0.11.2",
+        "punycode": "1.4.0",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "1.1.13",
+        "stream-browserify": "1.0.0",
+        "string_decoder": "0.10.31",
+        "timers-browserify": "1.4.2",
+        "tty-browserify": "0.0.0",
+        "url": "0.10.3",
+        "util": "0.10.3",
+        "vm-browserify": "0.0.4"
+      },
       "dependencies": {
         "assert": {
           "version": "1.3.0",
-          "from": "assert@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+          "integrity": "sha1-A5OaYiWCqBLMICMgoLmlbJuBWEk=",
+          "requires": {
+            "util": "0.10.3"
+          }
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "from": "browserify-zlib@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+          "requires": {
+            "pako": "0.2.8"
+          },
           "dependencies": {
             "pako": {
               "version": "0.2.8",
-              "from": "pako@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz",
+              "integrity": "sha1-Fa13KRU2KRPyDeSooWS0qsxhZdY="
             }
           }
         },
         "buffer": {
           "version": "3.5.5",
-          "from": "buffer@>=3.0.3 <4.0.0",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.5.5.tgz",
+          "integrity": "sha1-98VffCxjSqAO+qvYZJaaROuoLPQ=",
+          "requires": {
+            "base64-js": "0.0.8",
+            "ieee754": "1.1.6",
+            "isarray": "1.0.0"
+          },
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
-              "from": "base64-js@0.0.8",
-              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+              "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
             },
             "ieee754": {
               "version": "1.1.6",
-              "from": "ieee754@>=1.1.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
+              "integrity": "sha1-LhATIZxtZxKXPsVNmB7BnlV53pc="
             },
             "isarray": {
               "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
             }
           }
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+          "requires": {
+            "date-now": "0.1.4"
+          },
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@>=0.1.4 <0.2.0",
-              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+              "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
             }
           }
         },
         "constants-browserify": {
           "version": "0.0.1",
-          "from": "constants-browserify@0.0.1",
-          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+          "integrity": "sha1-kld9tSe6bEzwpFaNhLwDH0QeIfI="
         },
         "crypto-browserify": {
           "version": "3.2.8",
-          "from": "crypto-browserify@>=3.2.6 <3.3.0",
           "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
+          "integrity": "sha1-ubEdvm2WUd2IKgHmzEZ99xjs8Yk=",
+          "requires": {
+            "pbkdf2-compat": "2.0.1",
+            "ripemd160": "0.2.0",
+            "sha.js": "2.2.6"
+          },
           "dependencies": {
             "pbkdf2-compat": {
               "version": "2.0.1",
-              "from": "pbkdf2-compat@2.0.1",
-              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
+              "integrity": "sha1-tuDI+plJTZTgURV1gCpZpcFC8og="
             },
             "ripemd160": {
               "version": "0.2.0",
-              "from": "ripemd160@0.2.0",
-              "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
+              "integrity": "sha1-K/GYveFnys+lHAqSjoS2i74XH84="
             },
             "sha.js": {
               "version": "2.2.6",
-              "from": "sha.js@2.2.6",
-              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
+              "integrity": "sha1-F93t3F9yL7ZlAWWIlUYZd4ZzFbo="
             }
           }
         },
         "domain-browser": {
           "version": "1.1.7",
-          "from": "domain-browser@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+          "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
         },
         "events": {
           "version": "1.1.0",
-          "from": "events@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz",
+          "integrity": "sha1-SzifwgD5EHQuv/Orsu/jNpD0VCk="
         },
         "http-browserify": {
           "version": "1.7.0",
-          "from": "http-browserify@>=1.3.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+          "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
+          "requires": {
+            "Base64": "0.2.1",
+            "inherits": "2.0.1"
+          },
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "Base64@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+              "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg="
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
             }
           }
         },
         "https-browserify": {
           "version": "0.0.0",
-          "from": "https-browserify@0.0.0",
-          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
+          "integrity": "sha1-s//f5zSyo9Sp79WOhlTJH86G6v0="
         },
         "os-browserify": {
           "version": "0.1.2",
-          "from": "os-browserify@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+          "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ="
         },
         "path-browserify": {
           "version": "0.0.0",
-          "from": "path-browserify@0.0.0",
-          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+          "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
         },
         "process": {
           "version": "0.11.2",
-          "from": "process@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz",
+          "integrity": "sha1-iljR0SxXPz+JDamEik/o4Wypd7I="
         },
         "punycode": {
           "version": "1.4.0",
-          "from": "punycode@>=1.2.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz",
+          "integrity": "sha1-P4eeoD8kxxjU1LfkfeH7Uc9sPjM="
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "from": "querystring-es3@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+          "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@>=1.1.13 <2.0.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          },
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
             }
           }
         },
         "stream-browserify": {
           "version": "1.0.0",
-          "from": "stream-browserify@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+          "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
+          "requires": {
+            "inherits": "2.0.1",
+            "readable-stream": "1.1.13"
+          },
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
             }
           }
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.25 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "timers-browserify": {
           "version": "1.4.2",
-          "from": "timers-browserify@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+          "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+          "requires": {
+            "process": "0.11.2"
+          }
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "from": "tty-browserify@0.0.0",
-          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+          "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
         },
         "url": {
           "version": "0.10.3",
-          "from": "url@>=0.10.1 <0.11.0",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          },
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "punycode@1.3.2",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
             },
             "querystring": {
               "version": "0.2.0",
-              "from": "querystring@0.2.0",
-              "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+              "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "util@>=0.10.3 <0.11.0",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "requires": {
+            "inherits": "2.0.1"
+          },
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
             }
           }
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "from": "vm-browserify@0.0.4",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+          "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+          "requires": {
+            "indexof": "0.0.1"
+          },
           "dependencies": {
             "indexof": {
               "version": "0.0.1",
-              "from": "indexof@0.0.1",
-              "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+              "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
             }
           }
         }
@@ -6693,23 +10252,30 @@
     },
     "style-loader": {
       "version": "0.12.4",
-      "from": "style-loader@>=0.12.3 <0.13.0",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.12.4.tgz",
+      "integrity": "sha1-rn0GZdxNxlPaov6Xu5CRS8HSLZs=",
+      "requires": {
+        "loader-utils": "0.2.12"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "integrity": "sha1-+qKlAVY6PCyd2leqjDnYvmKN56I=",
+          "requires": {
+            "big.js": "3.1.3",
+            "json5": "0.4.0"
+          },
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
             }
           }
         }
@@ -6717,114 +10283,155 @@
     },
     "webpack": {
       "version": "1.12.9",
-      "from": "webpack@>=1.9.12 <2.0.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.9.tgz",
+      "integrity": "sha1-KgMdZhiYOcxcvyxo+AVm2i4U/04=",
+      "requires": {
+        "async": "1.5.0",
+        "clone": "1.0.2",
+        "enhanced-resolve": "0.9.1",
+        "esprima": "2.7.1",
+        "interpret": "0.6.6",
+        "loader-utils": "0.2.12",
+        "memory-fs": "0.3.0",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "0.5.3",
+        "optimist": "0.6.1",
+        "supports-color": "3.1.2",
+        "tapable": "0.1.10",
+        "uglify-js": "2.6.1",
+        "watchpack": "0.2.9",
+        "webpack-core": "0.6.8"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.0",
-          "from": "async@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+          "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM="
         },
         "clone": {
           "version": "1.0.2",
-          "from": "clone@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
         },
         "enhanced-resolve": {
           "version": "0.9.1",
-          "from": "enhanced-resolve@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+          "requires": {
+            "graceful-fs": "4.1.2",
+            "memory-fs": "0.2.0",
+            "tapable": "0.1.10"
+          },
           "dependencies": {
-            "memory-fs": {
-              "version": "0.2.0",
-              "from": "memory-fs@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
-            },
             "graceful-fs": {
               "version": "4.1.2",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+              "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
+            },
+            "memory-fs": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+              "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA="
             }
           }
         },
         "esprima": {
           "version": "2.7.1",
-          "from": "esprima@>=2.5.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
+          "integrity": "sha1-KrfRVJ7dBtFNaabBoXVKygLpZX4="
         },
         "interpret": {
           "version": "0.6.6",
-          "from": "interpret@>=0.6.4 <0.7.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
+          "integrity": "sha1-/s16GOfOXKar+5U+H4YhOknxYls="
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "integrity": "sha1-+qKlAVY6PCyd2leqjDnYvmKN56I=",
+          "requires": {
+            "big.js": "3.1.3",
+            "json5": "0.4.0"
+          },
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
             }
           }
         },
         "memory-fs": {
           "version": "0.3.0",
-          "from": "memory-fs@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+          "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
+          "requires": {
+            "errno": "0.1.4",
+            "readable-stream": "2.0.5"
+          },
           "dependencies": {
             "errno": {
               "version": "0.1.4",
-              "from": "errno@>=0.1.3 <0.2.0",
               "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+              "requires": {
+                "prr": "0.0.0"
+              },
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
-                  "from": "prr@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+                  "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
                 }
               }
             },
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "process-nextick-args": "1.0.6",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                  "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                 }
               }
             }
@@ -6832,157 +10439,207 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             }
           }
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "requires": {
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
+          },
           "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-            },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
             }
           }
         },
         "supports-color": {
           "version": "3.1.2",
-          "from": "supports-color@>=3.1.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "requires": {
+            "has-flag": "1.0.0"
+          },
           "dependencies": {
             "has-flag": {
               "version": "1.0.0",
-              "from": "has-flag@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
             }
           }
         },
         "tapable": {
           "version": "0.1.10",
-          "from": "tapable@>=0.1.8 <0.2.0",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+          "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q="
         },
         "uglify-js": {
           "version": "2.6.1",
-          "from": "uglify-js@>=2.6.0 <2.7.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+          "integrity": "sha1-7bvhiIujUl3tOnv4NrMLNAXTFhs=",
+          "requires": {
+            "async": "0.2.10",
+            "source-map": "0.5.3",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
             },
             "yargs": {
               "version": "3.10.0",
-              "from": "yargs@>=3.10.0 <3.11.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.1.1",
+                "window-size": "0.1.0"
+              },
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                  "requires": {
+                    "center-align": "0.1.2",
+                    "right-align": "0.1.3",
+                    "wordwrap": "0.0.2"
+                  },
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.2",
-                      "from": "center-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
+                      "integrity": "sha1-dPqFQPwZsmqubtx+AxzWmT1JW6A=",
+                      "requires": {
+                        "align-text": "0.1.3",
+                        "lazy-cache": "0.2.7"
+                      },
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "integrity": "sha1-cts5g4cu7CMTkZyUJqmTpBr+k/c=",
+                          "requires": {
+                            "kind-of": "2.0.1",
+                            "longest": "1.0.1",
+                            "repeat-string": "1.5.2"
+                          },
                           "dependencies": {
                             "kind-of": {
                               "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                              "requires": {
+                                "is-buffer": "1.1.0"
+                              },
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.0",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                                  "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                             }
                           }
                         },
                         "lazy-cache": {
                           "version": "0.2.7",
-                          "from": "lazy-cache@>=0.2.4 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+                          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
                         }
                       }
                     },
                     "right-align": {
                       "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                      "requires": {
+                        "align-text": "0.1.3"
+                      },
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "integrity": "sha1-cts5g4cu7CMTkZyUJqmTpBr+k/c=",
+                          "requires": {
+                            "kind-of": "2.0.1",
+                            "longest": "1.0.1",
+                            "repeat-string": "1.5.2"
+                          },
                           "dependencies": {
                             "kind-of": {
                               "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                              "requires": {
+                                "is-buffer": "1.1.0"
+                              },
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.0",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                                  "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                             }
                           }
                         }
@@ -6990,20 +10647,20 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.1.1",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
+                  "integrity": "sha1-iHFHmmwEh/VlPUipkvHQOBym8DE="
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "window-size@0.1.0",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
                 }
               }
             }
@@ -7011,92 +10668,157 @@
         },
         "watchpack": {
           "version": "0.2.9",
-          "from": "watchpack@>=0.2.1 <0.3.0",
           "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+          "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
+          "requires": {
+            "async": "0.9.2",
+            "chokidar": "1.4.1",
+            "graceful-fs": "4.1.2"
+          },
           "dependencies": {
             "async": {
               "version": "0.9.2",
-              "from": "async@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+              "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
             },
             "chokidar": {
               "version": "1.4.1",
-              "from": "chokidar@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.1.tgz",
+              "integrity": "sha1-3x2QZ2lwGg899JLDfcw8s15kUOQ=",
+              "requires": {
+                "anymatch": "1.3.0",
+                "async-each": "0.1.6",
+                "fsevents": "1.1.3",
+                "glob-parent": "2.0.0",
+                "inherits": "2.0.1",
+                "is-binary-path": "1.0.1",
+                "is-glob": "2.0.1",
+                "path-is-absolute": "1.0.0",
+                "readdirp": "2.0.0"
+              },
               "dependencies": {
                 "anymatch": {
                   "version": "1.3.0",
-                  "from": "anymatch@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                  "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+                  "requires": {
+                    "arrify": "1.0.1",
+                    "micromatch": "2.3.5"
+                  },
                   "dependencies": {
                     "arrify": {
                       "version": "1.0.1",
-                      "from": "arrify@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
                     },
                     "micromatch": {
                       "version": "2.3.5",
-                      "from": "micromatch@>=2.1.5 <3.0.0",
                       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.5.tgz",
+                      "integrity": "sha1-2N/tieKEGdBzSJvlXDPwsFwnMhc=",
+                      "requires": {
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.2",
+                        "expand-brackets": "0.1.4",
+                        "extglob": "0.3.1",
+                        "filename-regex": "2.0.0",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.0.2",
+                        "lazy-cache": "0.2.7",
+                        "normalize-path": "2.0.1",
+                        "object.omit": "2.0.0",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.2"
+                      },
                       "dependencies": {
                         "arr-diff": {
                           "version": "2.0.0",
-                          "from": "arr-diff@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                          "requires": {
+                            "arr-flatten": "1.0.1"
+                          },
                           "dependencies": {
                             "arr-flatten": {
                               "version": "1.0.1",
-                              "from": "arr-flatten@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+                              "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs="
                             }
                           }
                         },
                         "array-unique": {
                           "version": "0.2.1",
-                          "from": "array-unique@>=0.2.1 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
                         },
                         "braces": {
                           "version": "1.8.2",
-                          "from": "braces@>=1.8.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.2.tgz",
+                          "integrity": "sha1-A24CQFHUu8cJZCi01vIOofE3p5Q=",
+                          "requires": {
+                            "expand-range": "1.8.1",
+                            "lazy-cache": "0.2.7",
+                            "preserve": "0.2.0",
+                            "repeat-element": "1.1.2"
+                          },
                           "dependencies": {
                             "expand-range": {
                               "version": "1.8.1",
-                              "from": "expand-range@>=1.8.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                              "integrity": "sha1-rL1j5W79kTlyK3VfCZudtawfM/Y=",
+                              "requires": {
+                                "fill-range": "2.2.3"
+                              },
                               "dependencies": {
                                 "fill-range": {
                                   "version": "2.2.3",
-                                  "from": "fill-range@>=2.1.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                                  "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                                  "requires": {
+                                    "is-number": "2.1.0",
+                                    "isobject": "2.0.0",
+                                    "randomatic": "1.1.5",
+                                    "repeat-element": "1.1.2",
+                                    "repeat-string": "1.5.2"
+                                  },
                                   "dependencies": {
                                     "is-number": {
                                       "version": "2.1.0",
-                                      "from": "is-number@>=2.1.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                                      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                                      "requires": {
+                                        "kind-of": "3.0.2"
+                                      }
                                     },
                                     "isobject": {
                                       "version": "2.0.0",
-                                      "from": "isobject@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+                                      "integrity": "sha1-II3ocr1zeMKpKvlCij9W65GhIsQ=",
+                                      "requires": {
+                                        "isarray": "0.0.1"
+                                      },
                                       "dependencies": {
                                         "isarray": {
                                           "version": "0.0.1",
-                                          "from": "isarray@0.0.1",
-                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                                         }
                                       }
                                     },
                                     "randomatic": {
                                       "version": "1.1.5",
-                                      "from": "randomatic@>=1.1.3 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+                                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
+                                      "integrity": "sha1-Xp718tVzxnvSuBJK6QtRVuRXhAs=",
+                                      "requires": {
+                                        "is-number": "2.1.0",
+                                        "kind-of": "3.0.2"
+                                      }
                                     },
                                     "repeat-string": {
                                       "version": "1.5.2",
-                                      "from": "repeat-string@>=1.5.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                      "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                                     }
                                   }
                                 }
@@ -7104,132 +10826,167 @@
                             },
                             "preserve": {
                               "version": "0.2.0",
-                              "from": "preserve@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                              "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
                             },
                             "repeat-element": {
                               "version": "1.1.2",
-                              "from": "repeat-element@>=1.1.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                              "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
                             }
                           }
                         },
                         "expand-brackets": {
                           "version": "0.1.4",
-                          "from": "expand-brackets@>=0.1.4 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz",
+                          "integrity": "sha1-eXueSEEBIF9BjOyuxjEsEy9R4q4="
                         },
                         "extglob": {
                           "version": "0.3.1",
-                          "from": "extglob@>=0.3.1 <0.4.0",
                           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
+                          "integrity": "sha1-TzEkHA3dyQrIxynLbXyHLe53yPU=",
+                          "requires": {
+                            "ansi-green": "0.1.1",
+                            "is-extglob": "1.0.0",
+                            "success-symbol": "0.1.0"
+                          },
                           "dependencies": {
                             "ansi-green": {
                               "version": "0.1.1",
-                              "from": "ansi-green@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+                              "integrity": "sha1-il2al55FjVfEDjNYCzc5C44Q0Pc=",
+                              "requires": {
+                                "ansi-wrap": "0.1.0"
+                              },
                               "dependencies": {
                                 "ansi-wrap": {
                                   "version": "0.1.0",
-                                  "from": "ansi-wrap@0.1.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+                                  "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
                                 }
                               }
                             },
                             "success-symbol": {
                               "version": "0.1.0",
-                              "from": "success-symbol@>=0.1.0 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
+                              "integrity": "sha1-JAIuSG878c3KCUKDt2nEctO3KJc="
                             }
                           }
                         },
                         "filename-regex": {
                           "version": "2.0.0",
-                          "from": "filename-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+                          "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U="
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
                         },
                         "kind-of": {
                           "version": "3.0.2",
-                          "from": "kind-of@>=3.0.2 <4.0.0",
                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                          "integrity": "sha1-GH20JwRufpCUVpLmdoZovWkA3qA=",
+                          "requires": {
+                            "is-buffer": "1.1.0"
+                          },
                           "dependencies": {
                             "is-buffer": {
                               "version": "1.1.0",
-                              "from": "is-buffer@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                              "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                             }
                           }
                         },
                         "lazy-cache": {
                           "version": "0.2.7",
-                          "from": "lazy-cache@>=0.2.3 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+                          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
                         },
                         "normalize-path": {
                           "version": "2.0.1",
-                          "from": "normalize-path@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+                          "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o="
                         },
                         "object.omit": {
                           "version": "2.0.0",
-                          "from": "object.omit@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
+                          "integrity": "sha1-hoWXMz1U5gZilAu0WGBd1q4S/pQ=",
+                          "requires": {
+                            "for-own": "0.1.3",
+                            "is-extendable": "0.1.1"
+                          },
                           "dependencies": {
                             "for-own": {
                               "version": "0.1.3",
-                              "from": "for-own@>=0.1.3 <0.2.0",
                               "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                              "integrity": "sha1-YGREzed8LwoRCIFp4uNU6vVudP4=",
+                              "requires": {
+                                "for-in": "0.1.4"
+                              },
                               "dependencies": {
                                 "for-in": {
                                   "version": "0.1.4",
-                                  "from": "for-in@>=0.1.4 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
+                                  "integrity": "sha1-n1z3tP/H4a5lkaTpexd6pZ1w+y4="
                                 }
                               }
                             },
                             "is-extendable": {
                               "version": "0.1.1",
-                              "from": "is-extendable@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
                             }
                           }
                         },
                         "parse-glob": {
                           "version": "3.0.4",
-                          "from": "parse-glob@>=3.0.4 <4.0.0",
                           "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+                          "requires": {
+                            "glob-base": "0.3.0",
+                            "is-dotfile": "1.0.2",
+                            "is-extglob": "1.0.0",
+                            "is-glob": "2.0.1"
+                          },
                           "dependencies": {
                             "glob-base": {
                               "version": "0.3.0",
-                              "from": "glob-base@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                              "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+                              "requires": {
+                                "glob-parent": "2.0.0",
+                                "is-glob": "2.0.1"
+                              }
                             },
                             "is-dotfile": {
                               "version": "1.0.2",
-                              "from": "is-dotfile@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+                              "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0="
                             }
                           }
                         },
                         "regex-cache": {
                           "version": "0.4.2",
-                          "from": "regex-cache@>=0.4.2 <0.5.0",
                           "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                          "integrity": "sha1-bk+Jwma8A8M/0SnAYhhGh/RmNIc=",
+                          "requires": {
+                            "is-equal-shallow": "0.1.3",
+                            "is-primitive": "2.0.0"
+                          },
                           "dependencies": {
                             "is-equal-shallow": {
                               "version": "0.1.3",
-                              "from": "is-equal-shallow@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                              "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+                              "requires": {
+                                "is-primitive": "2.0.0"
+                              }
                             },
                             "is-primitive": {
                               "version": "2.0.0",
-                              "from": "is-primitive@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                              "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
                             }
                           }
                         }
@@ -7239,72 +10996,93 @@
                 },
                 "async-each": {
                   "version": "0.1.6",
-                  "from": "async-each@>=0.1.6 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
+                  "integrity": "sha1-tn6Z7c3fllQeRK9WKQzX1cbnBDk="
                 },
                 "glob-parent": {
                   "version": "2.0.0",
-                  "from": "glob-parent@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                  "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                  "requires": {
+                    "is-glob": "2.0.1"
+                  }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "is-binary-path": {
                   "version": "1.0.1",
-                  "from": "is-binary-path@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                  "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+                  "requires": {
+                    "binary-extensions": "1.4.0"
+                  },
                   "dependencies": {
                     "binary-extensions": {
                       "version": "1.4.0",
-                      "from": "binary-extensions@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
+                      "integrity": "sha1-1zPMtiiYbXsybYhlbg3b06rDUbc="
                     }
                   }
                 },
                 "is-glob": {
                   "version": "2.0.1",
-                  "from": "is-glob@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                  "requires": {
+                    "is-extglob": "1.0.0"
+                  },
                   "dependencies": {
                     "is-extglob": {
                       "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
                 },
                 "readdirp": {
                   "version": "2.0.0",
-                  "from": "readdirp@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+                  "integrity": "sha1-zAm6XRLY/rhkvHX24uvBNwYMvYI=",
+                  "requires": {
+                    "graceful-fs": "4.1.2",
+                    "minimatch": "2.0.10",
+                    "readable-stream": "2.0.5"
+                  },
                   "dependencies": {
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "minimatch@>=2.0.10 <3.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                      "requires": {
+                        "brace-expansion": "1.1.2"
+                      },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.2",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                          "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                          "requires": {
+                            "balanced-match": "0.3.0",
+                            "concat-map": "0.0.1"
+                          },
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                             }
                           }
                         }
@@ -7312,33 +11090,41 @@
                     },
                     "readable-stream": {
                       "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.2 <3.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.1",
+                        "isarray": "0.0.1",
+                        "process-nextick-args": "1.0.6",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                      },
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                          "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                         }
                       }
                     }
@@ -7348,32 +11134,39 @@
             },
             "graceful-fs": {
               "version": "4.1.2",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+              "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
             }
           }
         },
         "webpack-core": {
           "version": "0.6.8",
-          "from": "webpack-core@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
+          "integrity": "sha1-7fkTXeAKajwm3Q8UsgivCqSvjQo=",
+          "requires": {
+            "source-list-map": "0.1.5",
+            "source-map": "0.4.4"
+          },
           "dependencies": {
+            "source-list-map": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
+              "integrity": "sha1-3fMvUXP67KMBBWHdfppoLAJ/RZ4="
+            },
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "requires": {
+                "amdefine": "1.0.0"
+              },
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM="
                 }
               }
-            },
-            "source-list-map": {
-              "version": "0.1.5",
-              "from": "source-list-map@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
             }
           }
         }

--- a/shuup/xtheme/npm-shrinkwrap.json
+++ b/shuup/xtheme/npm-shrinkwrap.json
@@ -1,325 +1,516 @@
 {
   "name": "shuup-xtheme",
   "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
     "autoprefixer-loader": {
       "version": "3.1.0",
-      "from": "autoprefixer-loader@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/autoprefixer-loader/-/autoprefixer-loader-3.1.0.tgz",
+      "integrity": "sha1-lFHW+jrTvFyDbIuEPGtK79ps0gI=",
+      "requires": {
+        "autoprefixer": "6.2.3",
+        "loader-utils": "0.2.12",
+        "postcss": "5.0.14",
+        "postcss-safe-parser": "1.0.4"
+      },
       "dependencies": {
         "autoprefixer": {
           "version": "6.2.3",
-          "from": "autoprefixer@>=6.0.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
+          "integrity": "sha1-qezJ/hp7UrCzLRECVzddAvqEHxw=",
+          "requires": {
+            "browserslist": "1.0.1",
+            "caniuse-db": "1.0.30000386",
+            "normalize-range": "0.1.2",
+            "num2fraction": "1.2.2",
+            "postcss": "5.0.14",
+            "postcss-value-parser": "3.2.3"
+          },
           "dependencies": {
-            "postcss-value-parser": {
-              "version": "3.2.3",
-              "from": "postcss-value-parser@>=3.2.3 <4.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
-            },
-            "normalize-range": {
-              "version": "0.1.2",
-              "from": "normalize-range@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
-            },
-            "num2fraction": {
-              "version": "1.2.2",
-              "from": "num2fraction@>=1.2.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-            },
             "browserslist": {
               "version": "1.0.1",
-              "from": "browserslist@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
+              "integrity": "sha1-7w3XCDGM33QyX67qWe/shNlGRxc=",
+              "requires": {
+                "caniuse-db": "1.0.30000386"
+              }
             },
             "caniuse-db": {
               "version": "1.0.30000386",
-              "from": "caniuse-db@>=1.0.30000382 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz"
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz",
+              "integrity": "sha1-iYCHDUQx9M9FTNBHfpKqE3BaE0U="
+            },
+            "normalize-range": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+              "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+            },
+            "num2fraction": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+              "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+            },
+            "postcss-value-parser": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
+              "integrity": "sha1-IW5yR7vSa3Zoq57r0I3muW6ytFM="
             }
           }
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "integrity": "sha1-+qKlAVY6PCyd2leqjDnYvmKN56I=",
+          "requires": {
+            "big.js": "3.1.3",
+            "json5": "0.4.0"
+          },
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
             }
           }
         },
         "postcss": {
           "version": "5.0.14",
-          "from": "postcss@>=5.0.4 <6.0.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
+          "integrity": "sha1-Fk2vqfPGd17lmZGc2mEK3rSV/Ow=",
+          "requires": {
+            "js-base64": "2.1.9",
+            "source-map": "0.5.3",
+            "supports-color": "3.1.2"
+          },
           "dependencies": {
-            "supports-color": {
-              "version": "3.1.2",
-              "from": "supports-color@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                }
-              }
+            "js-base64": {
+              "version": "2.1.9",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+              "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            "supports-color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+              "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+              "requires": {
+                "has-flag": "1.0.0"
+              },
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                  "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+                }
+              }
             }
           }
         },
         "postcss-safe-parser": {
           "version": "1.0.4",
-          "from": "postcss-safe-parser@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-1.0.4.tgz"
+          "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-1.0.4.tgz",
+          "integrity": "sha1-jJZbtbAGFi04s9lGUwJ7BblBChg=",
+          "requires": {
+            "postcss": "5.0.14"
+          }
         }
       }
     },
     "babel-core": {
       "version": "5.8.34",
-      "from": "babel-core@>=5.8.23 <6.0.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.34.tgz",
+      "integrity": "sha1-A5Y3BFh3J3QEHl2771euAoLuYcI=",
+      "requires": {
+        "babel-plugin-constant-folding": "1.0.1",
+        "babel-plugin-dead-code-elimination": "1.0.2",
+        "babel-plugin-eval": "1.0.1",
+        "babel-plugin-inline-environment-variables": "1.0.1",
+        "babel-plugin-jscript": "1.0.4",
+        "babel-plugin-member-expression-literals": "1.0.1",
+        "babel-plugin-property-literals": "1.0.1",
+        "babel-plugin-proto-to-assign": "1.0.4",
+        "babel-plugin-react-constant-elements": "1.0.3",
+        "babel-plugin-react-display-name": "1.0.3",
+        "babel-plugin-remove-console": "1.0.1",
+        "babel-plugin-remove-debugger": "1.0.1",
+        "babel-plugin-runtime": "1.0.7",
+        "babel-plugin-undeclared-variables-check": "1.0.2",
+        "babel-plugin-undefined-to-void": "1.1.6",
+        "babylon": "5.8.34",
+        "bluebird": "2.10.2",
+        "chalk": "1.1.1",
+        "convert-source-map": "1.1.2",
+        "core-js": "1.2.6",
+        "debug": "2.2.0",
+        "detect-indent": "3.0.1",
+        "esutils": "2.0.2",
+        "fs-readdir-recursive": "0.1.2",
+        "globals": "6.4.1",
+        "home-or-tmp": "1.0.0",
+        "is-integer": "1.0.6",
+        "js-tokens": "1.0.1",
+        "json5": "0.4.0",
+        "line-numbers": "0.2.0",
+        "lodash": "3.10.1",
+        "minimatch": "2.0.10",
+        "output-file-sync": "1.1.1",
+        "path-exists": "1.0.0",
+        "path-is-absolute": "1.0.0",
+        "private": "0.1.6",
+        "regenerator": "0.8.40",
+        "regexpu": "1.3.0",
+        "repeating": "1.1.3",
+        "resolve": "1.1.6",
+        "shebang-regex": "1.0.0",
+        "slash": "1.0.0",
+        "source-map": "0.5.3",
+        "source-map-support": "0.2.10",
+        "to-fast-properties": "1.0.1",
+        "trim-right": "1.0.1",
+        "try-resolve": "1.0.1"
+      },
       "dependencies": {
         "babel-plugin-constant-folding": {
           "version": "1.0.1",
-          "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
+          "integrity": "sha1-g2HTZMmORJw2kr26Ue/whEKQqo4="
         },
         "babel-plugin-dead-code-elimination": {
           "version": "1.0.2",
-          "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
+          "integrity": "sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U="
         },
         "babel-plugin-eval": {
           "version": "1.0.1",
-          "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
+          "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo="
         },
         "babel-plugin-inline-environment-variables": {
           "version": "1.0.1",
-          "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
+          "integrity": "sha1-H1jOkSB61qgmqL9kX6/mj/X+P/4="
         },
         "babel-plugin-jscript": {
           "version": "1.0.4",
-          "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
+          "integrity": "sha1-jzQsOCduh6R9X6CovT1etsytj8w="
         },
         "babel-plugin-member-expression-literals": {
           "version": "1.0.1",
-          "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
+          "integrity": "sha1-zF7bD6qNyScXDnTW0cAkQAIWJNM="
         },
         "babel-plugin-property-literals": {
           "version": "1.0.1",
-          "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
+          "integrity": "sha1-AlIwGQAZKYCxwRjv6kjOk6q4MzY="
         },
         "babel-plugin-proto-to-assign": {
           "version": "1.0.4",
-          "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
+          "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
+          "requires": {
+            "lodash": "3.10.1"
+          }
         },
         "babel-plugin-react-constant-elements": {
           "version": "1.0.3",
-          "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
+          "integrity": "sha1-lGc26DeEKcvDSdz/YvUcFDs041o="
         },
         "babel-plugin-react-display-name": {
           "version": "1.0.3",
-          "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
+          "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw="
         },
         "babel-plugin-remove-console": {
           "version": "1.0.1",
-          "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
+          "integrity": "sha1-2PJFVsOgUAXUKqqv0neH9T/wE6c="
         },
         "babel-plugin-remove-debugger": {
           "version": "1.0.1",
-          "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
+          "integrity": "sha1-/S6jzWGkKK0fO5yJiC/0KT6MFMc="
         },
         "babel-plugin-runtime": {
           "version": "1.0.7",
-          "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
+          "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8="
         },
         "babel-plugin-undeclared-variables-check": {
           "version": "1.0.2",
-          "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+          "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
+          "requires": {
+            "leven": "1.0.2"
+          },
           "dependencies": {
             "leven": {
               "version": "1.0.2",
-              "from": "leven@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
+              "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM="
             }
           }
         },
         "babel-plugin-undefined-to-void": {
           "version": "1.1.6",
-          "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+          "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
+          "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E="
         },
         "babylon": {
           "version": "5.8.34",
-          "from": "babylon@>=5.8.34 <6.0.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.34.tgz"
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.34.tgz",
+          "integrity": "sha1-VJ9XP0XDvF51sqV2OQJ9LXJO2qo="
         },
         "bluebird": {
           "version": "2.10.2",
-          "from": "bluebird@>=2.9.33 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+          "integrity": "sha1-AkpVFylTCIV/FPkfEQb8O1VfRGs="
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+          "requires": {
+            "ansi-styles": "2.1.0",
+            "escape-string-regexp": "1.0.3",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.0",
+            "supports-color": "2.0.0"
+          },
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+              "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
         "convert-source-map": {
           "version": "1.1.2",
-          "from": "convert-source-map@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz",
+          "integrity": "sha1-gmY3iDEHOQf6OE8LKuyrC6BYZpM="
         },
         "core-js": {
           "version": "1.2.6",
-          "from": "core-js@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
+          "integrity": "sha1-4jUfbK52T4w05dg5rLamDO+LSkU="
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.1.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "requires": {
+            "ms": "0.7.1"
+          },
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
             }
           }
         },
         "detect-indent": {
           "version": "3.0.1",
-          "from": "detect-indent@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+          "requires": {
+            "get-stdin": "4.0.1",
+            "minimist": "1.2.0",
+            "repeating": "1.1.3"
+          },
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
             },
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
             }
           }
         },
         "esutils": {
           "version": "2.0.2",
-          "from": "esutils@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
         },
         "fs-readdir-recursive": {
           "version": "0.1.2",
-          "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
+          "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk="
         },
         "globals": {
           "version": "6.4.1",
-          "from": "globals@>=6.4.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
         },
         "home-or-tmp": {
           "version": "1.0.0",
-          "from": "home-or-tmp@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
+          "requires": {
+            "os-tmpdir": "1.0.1",
+            "user-home": "1.1.1"
+          },
           "dependencies": {
             "os-tmpdir": {
               "version": "1.0.1",
-              "from": "os-tmpdir@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+              "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24="
             },
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+              "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
             }
           }
         },
         "is-integer": {
           "version": "1.0.6",
-          "from": "is-integer@>=1.0.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+          "integrity": "sha1-UnOBn62ogNEj4awAqTjnFy3Y2V4=",
+          "requires": {
+            "is-finite": "1.0.1"
+          },
           "dependencies": {
             "is-finite": {
               "version": "1.0.1",
-              "from": "is-finite@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+              "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+              "requires": {
+                "number-is-nan": "1.0.0"
+              },
               "dependencies": {
                 "number-is-nan": {
                   "version": "1.0.0",
-                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                 }
               }
             }
@@ -327,50 +518,60 @@
         },
         "js-tokens": {
           "version": "1.0.1",
-          "from": "js-tokens@1.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4="
         },
         "json5": {
           "version": "0.4.0",
-          "from": "json5@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
         },
         "line-numbers": {
           "version": "0.2.0",
-          "from": "line-numbers@0.2.0",
           "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+          "integrity": "sha1-a8AoFJRA5XDUlatQlpKqCL13nG4=",
+          "requires": {
+            "left-pad": "0.0.3"
+          },
           "dependencies": {
             "left-pad": {
               "version": "0.0.3",
-              "from": "left-pad@0.0.3",
-              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
+              "integrity": "sha1-BNmbSh6vnl95wF5ddF1T7dGqiqE="
             }
           }
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.10.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@>=2.0.3 <3.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "requires": {
+            "brace-expansion": "1.1.2"
+          },
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.2",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+              "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+              "requires": {
+                "balanced-match": "0.3.0",
+                "concat-map": "0.0.1"
+              },
               "dependencies": {
                 "balanced-match": {
                   "version": "0.3.0",
-                  "from": "balanced-match@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                  "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                 }
               }
             }
@@ -378,113 +579,160 @@
         },
         "output-file-sync": {
           "version": "1.1.1",
-          "from": "output-file-sync@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+          "integrity": "sha1-pGU5l8LfY8mBH38dehIIQE7TLp4=",
+          "requires": {
+            "mkdirp": "0.5.1",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             }
           }
         },
         "path-exists": {
           "version": "1.0.0",
-          "from": "path-exists@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE="
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
         },
         "private": {
           "version": "0.1.6",
-          "from": "private@>=0.1.6 <0.2.0",
-          "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+          "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
+          "integrity": "sha1-VcapdtD5uvuZJIUTUP5HubX7t8E="
         },
         "regenerator": {
           "version": "0.8.40",
-          "from": "regenerator@0.8.40",
           "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+          "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
+          "requires": {
+            "commoner": "0.10.4",
+            "defs": "1.1.1",
+            "esprima-fb": "15001.1001.0-dev-harmony-fb",
+            "private": "0.1.6",
+            "recast": "0.10.33",
+            "through": "2.3.8"
+          },
           "dependencies": {
             "commoner": {
               "version": "0.10.4",
-              "from": "commoner@>=0.10.3 <0.11.0",
               "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
+              "integrity": "sha1-mPMzPdOtOZWWuy04Sng7tyE9aPg=",
+              "requires": {
+                "commander": "2.9.0",
+                "detective": "4.3.1",
+                "glob": "5.0.15",
+                "graceful-fs": "4.1.2",
+                "iconv-lite": "0.4.13",
+                "mkdirp": "0.5.1",
+                "private": "0.1.6",
+                "q": "1.4.1",
+                "recast": "0.10.33"
+              },
               "dependencies": {
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.5.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "requires": {
+                    "graceful-readlink": "1.0.1"
+                  },
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
                     }
                   }
                 },
                 "detective": {
                   "version": "4.3.1",
-                  "from": "detective@>=4.3.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                  "integrity": "sha1-n7Bt0e6PDqTbzGB82jnZzh1Pcm8=",
+                  "requires": {
+                    "acorn": "1.2.2",
+                    "defined": "1.0.0"
+                  },
                   "dependencies": {
                     "acorn": {
                       "version": "1.2.2",
-                      "from": "acorn@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                      "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ="
                     },
                     "defined": {
                       "version": "1.0.0",
-                      "from": "defined@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+                      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
                     }
                   }
                 },
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.15 <6.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                  "requires": {
+                    "inflight": "1.0.4",
+                    "inherits": "2.0.1",
+                    "minimatch": "2.0.10",
+                    "once": "1.3.3",
+                    "path-is-absolute": "1.0.0"
+                  },
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+                      "requires": {
+                        "once": "1.3.3",
+                        "wrappy": "1.0.1"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                      "requires": {
+                        "wrappy": "1.0.1"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                         }
                       }
                     }
@@ -492,172 +740,226 @@
                 },
                 "graceful-fs": {
                   "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                  "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
                 },
                 "iconv-lite": {
                   "version": "0.4.13",
-                  "from": "iconv-lite@>=0.4.5 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                  "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                     }
                   }
                 },
                 "q": {
                   "version": "1.4.1",
-                  "from": "q@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+                  "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                  "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
                 }
               }
             },
             "defs": {
               "version": "1.1.1",
-              "from": "defs@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+              "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
+              "requires": {
+                "alter": "0.2.0",
+                "ast-traverse": "0.1.1",
+                "breakable": "1.0.0",
+                "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                "simple-fmt": "0.1.0",
+                "simple-is": "0.2.0",
+                "stringmap": "0.2.2",
+                "stringset": "0.2.1",
+                "tryor": "0.1.2",
+                "yargs": "3.27.0"
+              },
               "dependencies": {
                 "alter": {
                   "version": "0.2.0",
-                  "from": "alter@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                  "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
+                  "requires": {
+                    "stable": "0.1.5"
+                  },
                   "dependencies": {
                     "stable": {
                       "version": "0.1.5",
-                      "from": "stable@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
+                      "integrity": "sha1-CCMvYMcy6YkHhLW+0HNPizKoh7k="
                     }
                   }
                 },
                 "ast-traverse": {
                   "version": "0.1.1",
-                  "from": "ast-traverse@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
+                  "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY="
                 },
                 "breakable": {
                   "version": "1.0.0",
-                  "from": "breakable@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
+                  "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME="
                 },
                 "simple-fmt": {
                   "version": "0.1.0",
-                  "from": "simple-fmt@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
+                  "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms="
                 },
                 "simple-is": {
                   "version": "0.2.0",
-                  "from": "simple-is@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+                  "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA="
                 },
                 "stringmap": {
                   "version": "0.2.2",
-                  "from": "stringmap@>=0.2.2 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+                  "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
+                  "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE="
                 },
                 "stringset": {
                   "version": "0.2.1",
-                  "from": "stringset@>=0.2.1 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+                  "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+                  "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU="
                 },
                 "tryor": {
                   "version": "0.1.2",
-                  "from": "tryor@>=0.1.2 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+                  "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys="
                 },
                 "yargs": {
                   "version": "3.27.0",
-                  "from": "yargs@>=3.27.0 <3.28.0",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                  "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.1.1",
+                    "os-locale": "1.4.0",
+                    "window-size": "0.1.4",
+                    "y18n": "3.2.0"
+                  },
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.2.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                      "requires": {
+                        "center-align": "0.1.2",
+                        "right-align": "0.1.3",
+                        "wordwrap": "0.0.2"
+                      },
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.2",
-                          "from": "center-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
+                          "integrity": "sha1-dPqFQPwZsmqubtx+AxzWmT1JW6A=",
+                          "requires": {
+                            "align-text": "0.1.3",
+                            "lazy-cache": "0.2.7"
+                          },
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "integrity": "sha1-cts5g4cu7CMTkZyUJqmTpBr+k/c=",
+                              "requires": {
+                                "kind-of": "2.0.1",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.5.2"
+                              },
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.1",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                  "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                                  "requires": {
+                                    "is-buffer": "1.1.0"
+                                  },
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.0",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                                      "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                                 }
                               }
                             },
                             "lazy-cache": {
                               "version": "0.2.7",
-                              "from": "lazy-cache@>=0.2.4 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+                              "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
                             }
                           }
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "right-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                          "requires": {
+                            "align-text": "0.1.3"
+                          },
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "integrity": "sha1-cts5g4cu7CMTkZyUJqmTpBr+k/c=",
+                              "requires": {
+                                "kind-of": "2.0.1",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.5.2"
+                              },
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.1",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                  "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                                  "requires": {
+                                    "is-buffer": "1.1.0"
+                                  },
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.0",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                                      "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                                 }
                               }
                             }
@@ -665,30 +967,36 @@
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.1.1",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
+                      "integrity": "sha1-iHFHmmwEh/VlPUipkvHQOBym8DE="
                     },
                     "os-locale": {
                       "version": "1.4.0",
-                      "from": "os-locale@>=1.4.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+                      "requires": {
+                        "lcid": "1.0.0"
+                      },
                       "dependencies": {
                         "lcid": {
                           "version": "1.0.0",
-                          "from": "lcid@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                          "requires": {
+                            "invert-kv": "1.0.0"
+                          },
                           "dependencies": {
                             "invert-kv": {
                               "version": "1.0.0",
-                              "from": "invert-kv@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                              "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
                             }
                           }
                         }
@@ -696,13 +1004,13 @@
                     },
                     "window-size": {
                       "version": "0.1.4",
-                      "from": "window-size@>=0.1.2 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+                      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
                     },
                     "y18n": {
                       "version": "3.2.0",
-                      "from": "y18n@>=3.2.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+                      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz",
+                      "integrity": "sha1-O+xkyTtzDZJKYUjHZXV5MkM+NMg="
                     }
                   }
                 }
@@ -710,74 +1018,96 @@
             },
             "esprima-fb": {
               "version": "15001.1001.0-dev-harmony-fb",
-              "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+              "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
             },
             "recast": {
               "version": "0.10.33",
-              "from": "recast@0.10.33",
               "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+              "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
+              "requires": {
+                "ast-types": "0.8.12",
+                "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                "private": "0.1.6",
+                "source-map": "0.5.3"
+              },
               "dependencies": {
                 "ast-types": {
                   "version": "0.8.12",
-                  "from": "ast-types@0.8.12",
-                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+                  "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w="
                 }
               }
             },
             "through": {
               "version": "2.3.8",
-              "from": "through@>=2.3.8 <2.4.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
             }
           }
         },
         "regexpu": {
           "version": "1.3.0",
-          "from": "regexpu@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+          "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
+          "requires": {
+            "esprima": "2.7.1",
+            "recast": "0.10.39",
+            "regenerate": "1.2.1",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
+          },
           "dependencies": {
             "esprima": {
               "version": "2.7.1",
-              "from": "esprima@>=2.6.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
+              "integrity": "sha1-KrfRVJ7dBtFNaabBoXVKygLpZX4="
             },
             "recast": {
               "version": "0.10.39",
-              "from": "recast@>=0.10.10 <0.11.0",
               "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.39.tgz",
+              "integrity": "sha1-9jcjTaHtPQ+gB7HEZnjhWIh7jaQ=",
+              "requires": {
+                "ast-types": "0.8.12",
+                "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                "private": "0.1.6",
+                "source-map": "0.5.3"
+              },
               "dependencies": {
-                "esprima-fb": {
-                  "version": "15001.1001.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
-                },
                 "ast-types": {
                   "version": "0.8.12",
-                  "from": "ast-types@0.8.12",
-                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+                  "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w="
+                },
+                "esprima-fb": {
+                  "version": "15001.1001.0-dev-harmony-fb",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                  "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
                 }
               }
             },
             "regenerate": {
               "version": "1.2.1",
-              "from": "regenerate@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
+              "integrity": "sha1-njC6aKa9lqw9y6YqsJ1V1LL8vgQ="
             },
             "regjsgen": {
               "version": "0.2.0",
-              "from": "regjsgen@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+              "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
             },
             "regjsparser": {
               "version": "0.1.5",
-              "from": "regjsparser@>=0.1.4 <0.2.0",
               "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+              "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+              "requires": {
+                "jsesc": "0.5.0"
+              },
               "dependencies": {
                 "jsesc": {
                   "version": "0.5.0",
-                  "from": "jsesc@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                  "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                  "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
                 }
               }
             }
@@ -785,18 +1115,24 @@
         },
         "repeating": {
           "version": "1.1.3",
-          "from": "repeating@>=1.1.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+          "requires": {
+            "is-finite": "1.0.1"
+          },
           "dependencies": {
             "is-finite": {
               "version": "1.0.1",
-              "from": "is-finite@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+              "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+              "requires": {
+                "number-is-nan": "1.0.0"
+              },
               "dependencies": {
                 "number-is-nan": {
                   "version": "1.0.0",
-                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                 }
               }
             }
@@ -804,38 +1140,44 @@
         },
         "resolve": {
           "version": "1.1.6",
-          "from": "resolve@>=1.1.6 <2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
+          "integrity": "sha1-00kq0FTKgA9b76YS5hvqwe7Jj48="
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "from": "shebang-regex@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "slash": {
           "version": "1.0.0",
-          "from": "slash@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
         },
         "source-map": {
           "version": "0.5.3",
-          "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+          "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
         },
         "source-map-support": {
           "version": "0.2.10",
-          "from": "source-map-support@>=0.2.10 <0.3.0",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+          "requires": {
+            "source-map": "0.1.32"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "from": "source-map@0.1.32",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+              "requires": {
+                "amdefine": "1.0.0"
+              },
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM="
                 }
               }
             }
@@ -843,155 +1185,364 @@
         },
         "to-fast-properties": {
           "version": "1.0.1",
-          "from": "to-fast-properties@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
+          "integrity": "sha1-SkFVTSsvS74teUBg3Ec5axC7SKg="
         },
         "trim-right": {
           "version": "1.0.1",
-          "from": "trim-right@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
         },
         "try-resolve": {
           "version": "1.0.1",
-          "from": "try-resolve@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
+          "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI="
         }
       }
     },
     "babel-loader": {
       "version": "5.4.0",
-      "from": "babel-loader@>=5.3.2 <6.0.0",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.4.0.tgz",
+      "integrity": "sha1-NjxTtPumiijFTzygvMmbt/XEz1g=",
+      "requires": {
+        "babel-core": "5.8.34",
+        "loader-utils": "0.2.12",
+        "object-assign": "3.0.0"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.9 <0.3.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "integrity": "sha1-+qKlAVY6PCyd2leqjDnYvmKN56I=",
+          "requires": {
+            "big.js": "3.1.3",
+            "json5": "0.4.0"
+          },
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
             }
           }
         },
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         }
       }
     },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
     "bower": {
       "version": "1.8.0",
-      "from": "bower@latest",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz"
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
+      "integrity": "sha1-Vdvr7wrZFVOC2enT5JfBNyNFtEo="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true,
+      "optional": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-width": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
+      "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "1.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "css-loader": {
       "version": "0.23.1",
-      "from": "css-loader@>=0.23.1 <0.24.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.23.1.tgz",
+      "integrity": "sha1-n6I/K1wJZSNZEK1ezvO4o2OQ/lA=",
+      "requires": {
+        "css-selector-tokenizer": "0.5.4",
+        "cssnano": "3.4.0",
+        "loader-utils": "0.2.12",
+        "lodash.camelcase": "3.0.1",
+        "object-assign": "4.0.1",
+        "postcss": "5.0.14",
+        "postcss-modules-extract-imports": "1.0.0",
+        "postcss-modules-local-by-default": "1.0.1",
+        "postcss-modules-scope": "1.0.0",
+        "postcss-modules-values": "1.1.1",
+        "source-list-map": "0.1.5"
+      },
       "dependencies": {
         "css-selector-tokenizer": {
           "version": "0.5.4",
-          "from": "css-selector-tokenizer@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
+          "integrity": "sha1-E5uv00o1/QwUKEhwSeBpnm9qLCE=",
+          "requires": {
+            "cssesc": "0.1.0",
+            "fastparse": "1.1.1"
+          },
           "dependencies": {
             "cssesc": {
               "version": "0.1.0",
-              "from": "cssesc@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+              "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
             },
             "fastparse": {
               "version": "1.1.1",
-              "from": "fastparse@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+              "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
             }
           }
         },
         "cssnano": {
           "version": "3.4.0",
-          "from": "cssnano@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.4.0.tgz",
+          "integrity": "sha1-FNORAy3kdg0i5dufH+wfCGjku7c=",
+          "requires": {
+            "autoprefixer": "6.2.3",
+            "decamelize": "1.1.2",
+            "defined": "1.0.0",
+            "indexes-of": "1.0.1",
+            "object-assign": "4.0.1",
+            "postcss": "5.0.14",
+            "postcss-calc": "5.2.0",
+            "postcss-colormin": "2.1.8",
+            "postcss-convert-values": "2.3.4",
+            "postcss-discard-comments": "2.0.3",
+            "postcss-discard-duplicates": "2.0.0",
+            "postcss-discard-empty": "2.0.0",
+            "postcss-discard-unused": "2.1.0",
+            "postcss-filter-plugins": "2.0.0",
+            "postcss-merge-idents": "2.1.3",
+            "postcss-merge-longhand": "2.0.1",
+            "postcss-merge-rules": "2.0.3",
+            "postcss-minify-font-values": "1.0.2",
+            "postcss-minify-gradients": "1.0.1",
+            "postcss-minify-params": "1.0.4",
+            "postcss-minify-selectors": "2.0.2",
+            "postcss-normalize-charset": "1.1.0",
+            "postcss-normalize-url": "3.0.4",
+            "postcss-ordered-values": "2.0.2",
+            "postcss-reduce-idents": "2.2.1",
+            "postcss-reduce-transforms": "1.0.3",
+            "postcss-svgo": "2.1.1",
+            "postcss-unique-selectors": "2.0.1",
+            "postcss-value-parser": "3.2.3",
+            "postcss-zindex": "2.0.1"
+          },
           "dependencies": {
             "autoprefixer": {
               "version": "6.2.3",
-              "from": "autoprefixer@>=6.0.3 <7.0.0",
               "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
+              "integrity": "sha1-qezJ/hp7UrCzLRECVzddAvqEHxw=",
+              "requires": {
+                "browserslist": "1.0.1",
+                "caniuse-db": "1.0.30000386",
+                "normalize-range": "0.1.2",
+                "num2fraction": "1.2.2",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              },
               "dependencies": {
-                "normalize-range": {
-                  "version": "0.1.2",
-                  "from": "normalize-range@>=0.1.2 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
-                },
-                "num2fraction": {
-                  "version": "1.2.2",
-                  "from": "num2fraction@>=1.2.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-                },
                 "browserslist": {
                   "version": "1.0.1",
-                  "from": "browserslist@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
+                  "integrity": "sha1-7w3XCDGM33QyX67qWe/shNlGRxc=",
+                  "requires": {
+                    "caniuse-db": "1.0.30000386"
+                  }
                 },
                 "caniuse-db": {
                   "version": "1.0.30000386",
-                  "from": "caniuse-db@>=1.0.30000382 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz"
+                  "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz",
+                  "integrity": "sha1-iYCHDUQx9M9FTNBHfpKqE3BaE0U="
+                },
+                "normalize-range": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+                  "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+                },
+                "num2fraction": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+                  "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
                 }
               }
             },
             "decamelize": {
               "version": "1.1.2",
-              "from": "decamelize@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+              "integrity": "sha1-3Mk3J74gljLpiwJxjvTLeWAjIvI=",
+              "requires": {
+                "escape-string-regexp": "1.0.4"
+              },
               "dependencies": {
                 "escape-string-regexp": {
                   "version": "1.0.4",
-                  "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
+                  "integrity": "sha1-uF5nm0b3LQP7voo79yWdU1whti8="
                 }
               }
             },
             "defined": {
               "version": "1.0.0",
-              "from": "defined@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
             },
             "indexes-of": {
               "version": "1.0.1",
-              "from": "indexes-of@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+              "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
             },
             "postcss-calc": {
               "version": "5.2.0",
-              "from": "postcss-calc@>=5.0.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.0.tgz",
+              "integrity": "sha1-C2FTt5OQujt7mOrd/2Pxef/m+vU=",
+              "requires": {
+                "postcss": "5.0.14",
+                "postcss-message-helpers": "2.0.0",
+                "reduce-css-calc": "1.2.0"
+              },
               "dependencies": {
                 "postcss-message-helpers": {
                   "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+                  "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
                 },
                 "reduce-css-calc": {
                   "version": "1.2.0",
-                  "from": "reduce-css-calc@>=1.2.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
+                  "integrity": "sha1-4ZHjYuk9pMDw+ZLeoSkyouENsZE=",
+                  "requires": {
+                    "balanced-match": "0.1.0",
+                    "reduce-function-call": "1.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
+                      "integrity": "sha1-tQS9BYabOSWd0MXvw12EMXbczEo="
                     },
                     "reduce-function-call": {
                       "version": "1.0.1",
-                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
+                      "integrity": "sha1-+gLhJuaVgkJjyrkdOlsP3B3Sepo=",
+                      "requires": {
+                        "balanced-match": "0.1.0"
+                      }
                     }
                   }
                 }
@@ -999,33 +1550,49 @@
             },
             "postcss-colormin": {
               "version": "2.1.8",
-              "from": "postcss-colormin@>=2.1.7 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.1.8.tgz",
+              "integrity": "sha1-N9N51eP3Oeu7hIUWmqEmbRxgivU=",
+              "requires": {
+                "colormin": "1.0.7",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              },
               "dependencies": {
                 "colormin": {
                   "version": "1.0.7",
-                  "from": "colormin@>=1.0.5 <2.0.0",
                   "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.0.7.tgz",
+                  "integrity": "sha1-cMTajDzbw5tfMmMOl6xiXgX4NWM=",
+                  "requires": {
+                    "color": "0.11.1",
+                    "css-color-names": "0.0.3"
+                  },
                   "dependencies": {
                     "color": {
                       "version": "0.11.1",
-                      "from": "color@>=0.11.0 <0.12.0",
                       "resolved": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
+                      "integrity": "sha1-GeNXzhhy4ZHoqRcCtO4bDthEGHo=",
+                      "requires": {
+                        "color-convert": "0.5.3",
+                        "color-string": "0.3.0"
+                      },
                       "dependencies": {
                         "color-convert": {
                           "version": "0.5.3",
-                          "from": "color-convert@>=0.5.3 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
+                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+                          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
                         },
                         "color-string": {
                           "version": "0.3.0",
-                          "from": "color-string@>=0.3.0 <0.4.0",
                           "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+                          "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+                          "requires": {
+                            "color-name": "1.1.1"
+                          },
                           "dependencies": {
                             "color-name": {
                               "version": "1.1.1",
-                              "from": "color-name@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
+                              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+                              "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
                             }
                           }
                         }
@@ -1033,8 +1600,8 @@
                     },
                     "css-color-names": {
                       "version": "0.0.3",
-                      "from": "css-color-names@0.0.3",
-                      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
+                      "integrity": "sha1-3gzvFvTYqoIioyDVttfpu62nufY="
                     }
                   }
                 }
@@ -1042,133 +1609,192 @@
             },
             "postcss-convert-values": {
               "version": "2.3.4",
-              "from": "postcss-convert-values@>=2.3.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz",
+              "integrity": "sha1-IyG6A5fzIleRMNi58OiaQtguYjk=",
+              "requires": {
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-discard-comments": {
               "version": "2.0.3",
-              "from": "postcss-discard-comments@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz",
+              "integrity": "sha1-WXl6UXR+BeK+wgjyLWNaaYMGiwQ=",
+              "requires": {
+                "postcss": "5.0.14"
+              }
             },
             "postcss-discard-duplicates": {
               "version": "2.0.0",
-              "from": "postcss-discard-duplicates@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz",
+              "integrity": "sha1-FqGQHl15GUexmOSmsp1+EjgU3RI=",
+              "requires": {
+                "postcss": "5.0.14"
+              }
             },
             "postcss-discard-empty": {
               "version": "2.0.0",
-              "from": "postcss-discard-empty@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz",
+              "integrity": "sha1-QEdovgWpEzBJARVIbh1SGRjI52E=",
+              "requires": {
+                "postcss": "5.0.14"
+              }
             },
             "postcss-discard-unused": {
               "version": "2.1.0",
-              "from": "postcss-discard-unused@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.1.0.tgz",
+              "integrity": "sha1-Vfdq6tVxwAvHQZ4wViacDRIT8Ug=",
+              "requires": {
+                "flatten": "0.0.1",
+                "postcss": "5.0.14",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "flatten": {
                   "version": "0.0.1",
-                  "from": "flatten@0.0.1",
-                  "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
+                  "integrity": "sha1-VURAdm2goNYDmZ9DNFP2wvxqdcE="
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-filter-plugins": {
               "version": "2.0.0",
-              "from": "postcss-filter-plugins@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
+              "integrity": "sha1-rM5dGMQOUb5ZiRG27Ki1TZ5b3t8=",
+              "requires": {
+                "postcss": "5.0.14",
+                "uniqid": "1.0.0"
+              },
               "dependencies": {
                 "uniqid": {
                   "version": "1.0.0",
-                  "from": "uniqid@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz",
+                  "integrity": "sha1-JYJSTgdASESkLelPviv1SeG3RVU="
                 }
               }
             },
             "postcss-merge-idents": {
               "version": "2.1.3",
-              "from": "postcss-merge-idents@>=2.1.3 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.3.tgz",
+              "integrity": "sha1-Ri1cz7en3+/b1int1n3TABCUqQ0=",
+              "requires": {
+                "has-own": "1.0.0",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              },
               "dependencies": {
                 "has-own": {
                   "version": "1.0.0",
-                  "from": "has-own@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz",
+                  "integrity": "sha1-MGIkbjHP2Iepph7m04ylcok3jNE="
                 }
               }
             },
             "postcss-merge-longhand": {
               "version": "2.0.1",
-              "from": "postcss-merge-longhand@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
+              "integrity": "sha1-/1m13sbVhs4s6hgxOPVcWHb6nNw=",
+              "requires": {
+                "postcss": "5.0.14"
+              }
             },
             "postcss-merge-rules": {
               "version": "2.0.3",
-              "from": "postcss-merge-rules@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz",
+              "integrity": "sha1-ku/377WhMCmFPrtKozCb5SXzGeY=",
+              "requires": {
+                "postcss": "5.0.14"
+              }
             },
             "postcss-minify-font-values": {
               "version": "1.0.2",
-              "from": "postcss-minify-font-values@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.2.tgz",
+              "integrity": "sha1-n2oEX/QWChbaYGF90/wyq9vufYs=",
+              "requires": {
+                "object-assign": "4.0.1",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-minify-gradients": {
               "version": "1.0.1",
-              "from": "postcss-minify-gradients@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz",
+              "integrity": "sha1-PbMiSjlXEXMrwK6XtMdll0gaQPg=",
+              "requires": {
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-minify-params": {
               "version": "1.0.4",
-              "from": "postcss-minify-params@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
+              "integrity": "sha1-Kne5bbgEh/Ff75QVlbEbWVNo1UM=",
+              "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+                  "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-minify-selectors": {
               "version": "2.0.2",
-              "from": "postcss-minify-selectors@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.2.tgz",
+              "integrity": "sha1-mGeYU3CO8yx0/F345cmcGl5F1Rc=",
+              "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.0.14",
+                "postcss-selector-parser": "1.3.0"
+              },
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+                  "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
                 },
                 "postcss-selector-parser": {
                   "version": "1.3.0",
-                  "from": "postcss-selector-parser@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.0.tgz",
+                  "integrity": "sha1-PfYKh/0xOGkRDw7ksJcS0HA/qIU=",
+                  "requires": {
+                    "flatten": "0.0.1",
+                    "indexes-of": "1.0.1",
+                    "uniq": "1.0.1"
+                  },
                   "dependencies": {
                     "flatten": {
                       "version": "0.0.1",
-                      "from": "flatten@0.0.1",
-                      "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
+                      "integrity": "sha1-VURAdm2goNYDmZ9DNFP2wvxqdcE="
                     },
                     "uniq": {
                       "version": "1.0.1",
-                      "from": "uniq@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+                      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
                     }
                   }
                 }
@@ -1176,50 +1802,72 @@
             },
             "postcss-normalize-charset": {
               "version": "1.1.0",
-              "from": "postcss-normalize-charset@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz",
+              "integrity": "sha1-L70w4SJIxEKYHTHqJITUb9BiiXA=",
+              "requires": {
+                "postcss": "5.0.14"
+              }
             },
             "postcss-normalize-url": {
               "version": "3.0.4",
-              "from": "postcss-normalize-url@>=3.0.4 <4.0.0",
               "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.4.tgz",
+              "integrity": "sha1-0EUeiYFmqUeTaHSOxPEL91PftyA=",
+              "requires": {
+                "is-absolute-url": "2.0.0",
+                "normalize-url": "1.4.0",
+                "object-assign": "4.0.1",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              },
               "dependencies": {
                 "is-absolute-url": {
                   "version": "2.0.0",
-                  "from": "is-absolute-url@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
+                  "integrity": "sha1-nEsgsOXAy++aR5o2ft5vmRZ581k="
                 },
                 "normalize-url": {
                   "version": "1.4.0",
-                  "from": "normalize-url@>=1.3.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
+                  "integrity": "sha1-iuk+l932bxdUTB8SotwMDktXYv8=",
+                  "requires": {
+                    "object-assign": "4.0.1",
+                    "prepend-http": "1.0.3",
+                    "query-string": "3.0.0",
+                    "sort-keys": "1.1.1"
+                  },
                   "dependencies": {
                     "prepend-http": {
                       "version": "1.0.3",
-                      "from": "prepend-http@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
+                      "integrity": "sha1-TQ0rb5788RkMI5MTJbTzqduoSGk="
                     },
                     "query-string": {
                       "version": "3.0.0",
-                      "from": "query-string@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
+                      "integrity": "sha1-Av0wbwQyBAuRsRBj+UBP4bvUuns=",
+                      "requires": {
+                        "strict-uri-encode": "1.1.0"
+                      },
                       "dependencies": {
                         "strict-uri-encode": {
                           "version": "1.1.0",
-                          "from": "strict-uri-encode@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+                          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
                         }
                       }
                     },
                     "sort-keys": {
                       "version": "1.1.1",
-                      "from": "sort-keys@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
+                      "integrity": "sha1-p5HCYHHfZsNWv13K2c+1ensvgm4=",
+                      "requires": {
+                        "is-plain-obj": "1.1.0"
+                      },
                       "dependencies": {
                         "is-plain-obj": {
                           "version": "1.1.0",
-                          "from": "is-plain-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+                          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
                         }
                       }
                     }
@@ -1229,166 +1877,227 @@
             },
             "postcss-ordered-values": {
               "version": "2.0.2",
-              "from": "postcss-ordered-values@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz",
+              "integrity": "sha1-//PE55yrXr84RQZX4282F6UCNUo=",
+              "requires": {
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-reduce-idents": {
               "version": "2.2.1",
-              "from": "postcss-reduce-idents@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz",
+              "integrity": "sha1-7NgvcZ+0DtoisLbUHD/C2sataps=",
+              "requires": {
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-reduce-transforms": {
               "version": "1.0.3",
-              "from": "postcss-reduce-transforms@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz",
+              "integrity": "sha1-/Bk+Q1qXPBD5gBx0cAqDD3lkM0M=",
+              "requires": {
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-svgo": {
               "version": "2.1.1",
-              "from": "postcss-svgo@>=2.0.4 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.1.tgz",
+              "integrity": "sha1-2sWzddCSeJ1ku/yr6dx0hriqjs0=",
+              "requires": {
+                "is-svg": "1.1.1",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3",
+                "svgo": "0.6.1"
+              },
               "dependencies": {
                 "is-svg": {
                   "version": "1.1.1",
-                  "from": "is-svg@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz",
+                  "integrity": "sha1-rA76r7ZTrFhHNwix+HNjbKEQ4xs="
                 },
                 "svgo": {
                   "version": "0.6.1",
-                  "from": "svgo@>=0.6.1 <0.7.0",
                   "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.1.tgz",
+                  "integrity": "sha1-ud2NRQZgyl+IsiJx+9yLKpZmN6k=",
+                  "requires": {
+                    "coa": "1.0.1",
+                    "colors": "1.1.2",
+                    "csso": "1.4.4",
+                    "js-yaml": "3.4.6",
+                    "mkdirp": "0.5.1",
+                    "sax": "1.1.4",
+                    "whet.extend": "0.9.9"
+                  },
                   "dependencies": {
-                    "sax": {
-                      "version": "1.1.4",
-                      "from": "sax@>=1.1.4 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz"
-                    },
                     "coa": {
                       "version": "1.0.1",
-                      "from": "coa@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
+                      "integrity": "sha1-f5WTRs/IcZ4/cjPNaFKFSnxn2KM=",
+                      "requires": {
+                        "q": "1.4.1"
+                      },
                       "dependencies": {
                         "q": {
                           "version": "1.4.1",
-                          "from": "q@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-                        }
-                      }
-                    },
-                    "js-yaml": {
-                      "version": "3.4.6",
-                      "from": "js-yaml@>=3.4.3 <3.5.0",
-                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
-                      "dependencies": {
-                        "argparse": {
-                          "version": "1.0.3",
-                          "from": "argparse@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
-                          "dependencies": {
-                            "lodash": {
-                              "version": "3.10.1",
-                              "from": "lodash@>=3.2.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                            },
-                            "sprintf-js": {
-                              "version": "1.0.3",
-                              "from": "sprintf-js@>=1.0.2 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "esprima": {
-                          "version": "2.7.1",
-                          "from": "esprima@>=2.6.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
-                        },
-                        "inherit": {
-                          "version": "2.2.3",
-                          "from": "inherit@>=2.2.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz"
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
                         }
                       }
                     },
                     "colors": {
                       "version": "1.1.2",
-                      "from": "colors@>=1.1.2 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
-                    },
-                    "whet.extend": {
-                      "version": "0.9.9",
-                      "from": "whet.extend@>=0.9.9 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.1 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+                      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
                     },
                     "csso": {
                       "version": "1.4.4",
-                      "from": "csso@>=1.4.2 <1.5.0",
                       "resolved": "https://registry.npmjs.org/csso/-/csso-1.4.4.tgz",
+                      "integrity": "sha1-Cuv6UJPvMMysbbP/V1nfymIba2o=",
+                      "requires": {
+                        "clap": "1.0.10"
+                      },
                       "dependencies": {
                         "clap": {
                           "version": "1.0.10",
-                          "from": "clap@>=1.0.9 <2.0.0",
                           "resolved": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
+                          "integrity": "sha1-T3qT4URUWvhd/SnZL9l04yVIYyo=",
+                          "requires": {
+                            "chalk": "1.1.1"
+                          },
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@1.1.1",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                              "requires": {
+                                "ansi-styles": "2.1.0",
+                                "escape-string-regexp": "1.0.4",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.0",
+                                "supports-color": "2.0.0"
+                              },
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                  "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.4",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
+                                  "integrity": "sha1-uF5nm0b3LQP7voo79yWdU1whti8="
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                 }
                               }
                             }
                           }
                         }
                       }
+                    },
+                    "js-yaml": {
+                      "version": "3.4.6",
+                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
+                      "integrity": "sha1-a+GyP2JJ9T0pM3D9TRqqY84bTrA=",
+                      "requires": {
+                        "argparse": "1.0.3",
+                        "esprima": "2.7.1",
+                        "inherit": "2.2.3"
+                      },
+                      "dependencies": {
+                        "argparse": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
+                          "integrity": "sha1-FDid7rDCj8TNqUBbn1MqTjeFzoQ=",
+                          "requires": {
+                            "lodash": "3.10.1",
+                            "sprintf-js": "1.0.3"
+                          },
+                          "dependencies": {
+                            "lodash": {
+                              "version": "3.10.1",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                            },
+                            "sprintf-js": {
+                              "version": "1.0.3",
+                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                              "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+                            }
+                          }
+                        },
+                        "esprima": {
+                          "version": "2.7.1",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
+                          "integrity": "sha1-KrfRVJ7dBtFNaabBoXVKygLpZX4="
+                        },
+                        "inherit": {
+                          "version": "2.2.3",
+                          "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz",
+                          "integrity": "sha1-MyNPkSrDJ26nunrXEjGWfHrkXA0="
+                        }
+                      }
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                      "requires": {
+                        "minimist": "0.0.8"
+                      },
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                        }
+                      }
+                    },
+                    "sax": {
+                      "version": "1.1.4",
+                      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+                      "integrity": "sha1-dLbTPJrh4AFRDxeakRaFiPGu2qk="
+                    },
+                    "whet.extend": {
+                      "version": "0.9.9",
+                      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+                      "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
                     }
                   }
                 }
@@ -1396,35 +2105,44 @@
             },
             "postcss-unique-selectors": {
               "version": "2.0.1",
-              "from": "postcss-unique-selectors@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.1.tgz",
+              "integrity": "sha1-bN71L+F2CIVFquZw3+fRRgS+CTE=",
+              "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.0.14",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+                  "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-value-parser": {
               "version": "3.2.3",
-              "from": "postcss-value-parser@>=3.1.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
+              "integrity": "sha1-IW5yR7vSa3Zoq57r0I3muW6ytFM="
             },
             "postcss-zindex": {
               "version": "2.0.1",
-              "from": "postcss-zindex@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.1.tgz",
+              "integrity": "sha1-HJsiJpaRqHVX91Zd/m47hHPlMLw=",
+              "requires": {
+                "postcss": "5.0.14",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             }
@@ -1432,259 +2150,1508 @@
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "integrity": "sha1-+qKlAVY6PCyd2leqjDnYvmKN56I=",
+          "requires": {
+            "big.js": "3.1.3",
+            "json5": "0.4.0"
+          },
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+            }
+          }
+        },
+        "lodash.camelcase": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
+          "integrity": "sha1-kyyLh/ikN3iXxnGXUzKC+Xrqwpg=",
+          "requires": {
+            "lodash._createcompounder": "3.0.0"
+          },
+          "dependencies": {
+            "lodash._createcompounder": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
+              "integrity": "sha1-XdLLVTctbnDg4jkvsjBNZjEJEHU=",
+              "requires": {
+                "lodash.deburr": "3.1.0",
+                "lodash.words": "3.1.0"
+              },
+              "dependencies": {
+                "lodash.deburr": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.1.0.tgz",
+                  "integrity": "sha1-0wn3+0PKzh3jARkeImM5z139ZjM="
+                },
+                "lodash.words": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.1.0.tgz",
+                  "integrity": "sha1-k8EssgjRK63Hz614RYGVjSnN8FM="
+                }
+              }
             }
           }
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
-        },
-        "lodash.camelcase": {
-          "version": "3.0.1",
-          "from": "lodash.camelcase@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
-          "dependencies": {
-            "lodash._createcompounder": {
-              "version": "3.0.0",
-              "from": "lodash._createcompounder@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
-              "dependencies": {
-                "lodash.deburr": {
-                  "version": "3.1.0",
-                  "from": "lodash.deburr@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.1.0.tgz"
-                },
-                "lodash.words": {
-                  "version": "3.1.0",
-                  "from": "lodash.words@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.1.0.tgz"
-                }
-              }
-            }
-          }
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+          "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
         },
         "postcss": {
           "version": "5.0.14",
-          "from": "postcss@>=5.0.4 <6.0.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
+          "integrity": "sha1-Fk2vqfPGd17lmZGc2mEK3rSV/Ow=",
+          "requires": {
+            "js-base64": "2.1.9",
+            "source-map": "0.5.3",
+            "supports-color": "3.1.2"
+          },
           "dependencies": {
-            "supports-color": {
-              "version": "3.1.2",
-              "from": "supports-color@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                }
-              }
+            "js-base64": {
+              "version": "2.1.9",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+              "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            "supports-color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+              "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+              "requires": {
+                "has-flag": "1.0.0"
+              },
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                  "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+                }
+              }
             }
           }
         },
         "postcss-modules-extract-imports": {
           "version": "1.0.0",
-          "from": "postcss-modules-extract-imports@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.0.tgz",
+          "integrity": "sha1-WwfzaONQzab9XIhEt5Ejp70+N74=",
+          "requires": {
+            "postcss": "5.0.14"
+          }
         },
         "postcss-modules-local-by-default": {
           "version": "1.0.1",
-          "from": "postcss-modules-local-by-default@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.0.1.tgz",
+          "integrity": "sha1-XsuJD+Umn3D8O5gPYgLN6XcdR5k=",
+          "requires": {
+            "css-selector-tokenizer": "0.5.4",
+            "postcss": "5.0.14"
+          }
         },
         "postcss-modules-scope": {
           "version": "1.0.0",
-          "from": "postcss-modules-scope@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.0.tgz",
+          "integrity": "sha1-0Xuu+bNFEtBqMWSSyz6nzOkHIlU=",
+          "requires": {
+            "css-selector-tokenizer": "0.5.4",
+            "postcss": "5.0.14"
+          }
         },
         "postcss-modules-values": {
           "version": "1.1.1",
-          "from": "postcss-modules-values@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.1.1.tgz",
+          "integrity": "sha1-UjHSgzGOIFT2XWAEMNLHQSm1lps=",
+          "requires": {
+            "icss-replace-symbols": "1.0.2",
+            "postcss": "5.0.14"
+          },
           "dependencies": {
             "icss-replace-symbols": {
               "version": "1.0.2",
-              "from": "icss-replace-symbols@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz",
+              "integrity": "sha1-ywtgVOs69u3Jqx1i0Bkz4tTIv6U="
             }
           }
         },
         "source-list-map": {
           "version": "0.1.5",
-          "from": "source-list-map@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
+          "integrity": "sha1-3fMvUXP67KMBBWHdfppoLAJ/RZ4="
         }
+      }
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.42"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "optional": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "doctrine": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+      "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+      "dev": true,
+      "requires": {
+        "esutils": "1.1.6",
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "esutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+          "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.42",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.42"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.42",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.10.3.tgz",
+      "integrity": "sha1-+xmpGxPBWAgrvKKUsX2Xm8g1Ogo=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "doctrine": "0.7.2",
+        "escape-string-regexp": "1.0.5",
+        "escope": "3.6.0",
+        "espree": "2.2.5",
+        "estraverse": "4.2.0",
+        "estraverse-fb": "1.3.2",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.3.1",
+        "glob": "5.0.15",
+        "globals": "8.18.0",
+        "handlebars": "4.0.11",
+        "inquirer": "0.11.4",
+        "is-my-json-valid": "2.17.2",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.4.5",
+        "json-stable-stringify": "1.0.1",
+        "lodash.clonedeep": "3.0.2",
+        "lodash.merge": "3.3.2",
+        "lodash.omit": "3.1.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "optionator": "0.6.0",
+        "path-is-absolute": "1.0.1",
+        "path-is-inside": "1.0.2",
+        "shelljs": "0.5.3",
+        "strip-json-comments": "1.0.4",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0",
+        "xml-escape": "1.0.0"
+      }
+    },
+    "espree": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
+      "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
+      "dev": true
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "estraverse-fb": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
+      "integrity": "sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.42"
+      }
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+      "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+      "dev": true
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
+    },
+    "file-entry-cache": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "file-loader": {
       "version": "0.8.5",
-      "from": "file-loader@>=0.8.4 <0.9.0",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
+      "integrity": "sha1-knXQMf54DyfUf19K8CvUNxPMFRs=",
+      "requires": {
+        "loader-utils": "0.2.12"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.5 <0.3.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "integrity": "sha1-+qKlAVY6PCyd2leqjDnYvmKN56I=",
+          "requires": {
+            "big.js": "3.1.3",
+            "json5": "0.4.0"
+          },
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
             }
           }
         }
       }
     },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
+      }
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "dev": true,
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "globals": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz",
+      "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
+      "dev": true
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
     "gulp": {
       "version": "3.9.1",
-      "from": "gulp@>=3.9.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+      "requires": {
+        "archy": "1.0.0",
+        "chalk": "1.1.1",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.7",
+        "interpret": "0.6.6",
+        "liftoff": "2.2.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.7",
+        "pretty-hrtime": "1.0.1",
+        "semver": "4.3.6",
+        "tildify": "1.1.2",
+        "v8flags": "2.0.10",
+        "vinyl-fs": "0.3.14"
+      },
       "dependencies": {
         "archy": {
           "version": "1.0.0",
-          "from": "archy@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+          "requires": {
+            "ansi-styles": "2.1.0",
+            "escape-string-regexp": "1.0.3",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.0",
+            "supports-color": "2.0.0"
+          },
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+              "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
         "deprecated": {
           "version": "0.0.1",
-          "from": "deprecated@>=0.0.1 <0.0.2",
-          "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+          "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk="
         },
         "interpret": {
           "version": "0.6.6",
-          "from": "interpret@>=0.6.2 <0.7.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
+          "integrity": "sha1-/s16GOfOXKar+5U+H4YhOknxYls="
         },
         "liftoff": {
           "version": "2.2.0",
-          "from": "liftoff@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
+          "integrity": "sha1-9fz6RYMRMVnRKTWooGFvUBKLV1M=",
+          "requires": {
+            "extend": "2.0.1",
+            "findup-sync": "0.3.0",
+            "flagged-respawn": "0.3.1",
+            "rechoir": "0.6.2",
+            "resolve": "1.1.6"
+          },
           "dependencies": {
             "extend": {
               "version": "2.0.1",
-              "from": "extend@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
+              "integrity": "sha1-HugBBonnOV/5RIJByYZSvHWagmA="
             },
             "findup-sync": {
               "version": "0.3.0",
-              "from": "findup-sync@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+              "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+              "requires": {
+                "glob": "5.0.15"
+              },
               "dependencies": {
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.0 <5.1.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                  "requires": {
+                    "inflight": "1.0.4",
+                    "inherits": "2.0.1",
+                    "minimatch": "3.0.0",
+                    "once": "1.3.3",
+                    "path-is-absolute": "1.0.0"
+                  },
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+                      "requires": {
+                        "once": "1.3.3",
+                        "wrappy": "1.0.1"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                     },
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+                      "requires": {
+                        "brace-expansion": "1.1.2"
+                      },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.2",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                          "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                          "requires": {
+                            "balanced-match": "0.3.0",
+                            "concat-map": "0.0.1"
+                          },
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                             }
                           }
                         }
@@ -1692,20 +3659,23 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                      "requires": {
+                        "wrappy": "1.0.1"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
                     }
                   }
                 }
@@ -1713,45 +3683,59 @@
             },
             "flagged-respawn": {
               "version": "0.3.1",
-              "from": "flagged-respawn@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
+              "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz",
+              "integrity": "sha1-OXcAkl324SRSICpx6J2JVF+7vp0="
             },
             "rechoir": {
               "version": "0.6.2",
-              "from": "rechoir@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+              "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+              "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+              "requires": {
+                "resolve": "1.1.6"
+              }
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@>=1.1.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
+              "integrity": "sha1-00kq0FTKgA9b76YS5hvqwe7Jj48="
             }
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "orchestrator": {
           "version": "0.3.7",
-          "from": "orchestrator@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
+          "integrity": "sha1-xFBk4ixaKnuZc09AmpX/7cfTw98=",
+          "requires": {
+            "end-of-stream": "0.1.5",
+            "sequencify": "0.0.7",
+            "stream-consume": "0.1.0"
+          },
           "dependencies": {
             "end-of-stream": {
               "version": "0.1.5",
-              "from": "end-of-stream@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+              "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+              "requires": {
+                "once": "1.3.3"
+              },
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "requires": {
+                    "wrappy": "1.0.1"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                     }
                   }
                 }
@@ -1759,127 +3743,189 @@
             },
             "sequencify": {
               "version": "0.0.7",
-              "from": "sequencify@>=0.0.7 <0.1.0",
-              "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
+              "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+              "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw="
             },
             "stream-consume": {
               "version": "0.1.0",
-              "from": "stream-consume@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
+              "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8="
             }
           }
         },
         "pretty-hrtime": {
           "version": "1.0.1",
-          "from": "pretty-hrtime@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz",
+          "integrity": "sha1-Hk+VKm3XHnkZmzpz8l15l7aUuoM="
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
         },
         "tildify": {
           "version": "1.1.2",
-          "from": "tildify@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
+          "integrity": "sha1-n2Edii6TpeUHVtsEDxzSt/2AhZ0=",
+          "requires": {
+            "os-homedir": "1.0.1"
+          },
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
-              "from": "os-homedir@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
+              "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac="
             }
           }
         },
         "v8flags": {
           "version": "2.0.10",
-          "from": "v8flags@>=2.0.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.10.tgz",
+          "integrity": "sha1-ZKFhN06XSRAJx43vL5ZJAOltnO8=",
+          "requires": {
+            "user-home": "1.1.1"
+          },
           "dependencies": {
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+              "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
             }
           }
         },
         "vinyl-fs": {
           "version": "0.3.14",
-          "from": "vinyl-fs@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+          "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+          "requires": {
+            "defaults": "1.0.3",
+            "glob-stream": "3.1.18",
+            "glob-watcher": "0.0.6",
+            "graceful-fs": "3.0.8",
+            "mkdirp": "0.5.1",
+            "strip-bom": "1.0.0",
+            "through2": "0.6.5",
+            "vinyl": "0.4.6"
+          },
           "dependencies": {
             "defaults": {
               "version": "1.0.3",
-              "from": "defaults@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+              "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+              "requires": {
+                "clone": "1.0.2"
+              },
               "dependencies": {
                 "clone": {
                   "version": "1.0.2",
-                  "from": "clone@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                  "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
                 }
               }
             },
             "glob-stream": {
               "version": "3.1.18",
-              "from": "glob-stream@>=3.1.5 <4.0.0",
               "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+              "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+              "requires": {
+                "glob": "4.5.3",
+                "glob2base": "0.0.12",
+                "minimatch": "2.0.10",
+                "ordered-read-streams": "0.1.0",
+                "through2": "0.6.5",
+                "unique-stream": "1.0.0"
+              },
               "dependencies": {
                 "glob": {
                   "version": "4.5.3",
-                  "from": "glob@>=4.3.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+                  "requires": {
+                    "inflight": "1.0.4",
+                    "inherits": "2.0.1",
+                    "minimatch": "2.0.10",
+                    "once": "1.3.3"
+                  },
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+                      "requires": {
+                        "once": "1.3.3",
+                        "wrappy": "1.0.1"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                      "requires": {
+                        "wrappy": "1.0.1"
+                      },
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                         }
                       }
                     }
                   }
                 },
+                "glob2base": {
+                  "version": "0.0.12",
+                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+                  "requires": {
+                    "find-index": "0.1.1"
+                  },
+                  "dependencies": {
+                    "find-index": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+                      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
+                    }
+                  }
+                },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                  "requires": {
+                    "brace-expansion": "1.1.2"
+                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.2",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                      "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                      "requires": {
+                        "balanced-match": "0.3.0",
+                        "concat-map": "0.0.1"
+                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                          "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                         }
                       }
                     }
@@ -1887,79 +3933,87 @@
                 },
                 "ordered-read-streams": {
                   "version": "0.1.0",
-                  "from": "ordered-read-streams@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
-                },
-                "glob2base": {
-                  "version": "0.0.12",
-                  "from": "glob2base@>=0.0.12 <0.0.13",
-                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-                  "dependencies": {
-                    "find-index": {
-                      "version": "0.1.1",
-                      "from": "find-index@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+                  "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY="
                 },
                 "unique-stream": {
                   "version": "1.0.0",
-                  "from": "unique-stream@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+                  "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
                 }
               }
             },
             "glob-watcher": {
               "version": "0.0.6",
-              "from": "glob-watcher@>=0.0.6 <0.0.7",
               "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+              "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+              "requires": {
+                "gaze": "0.5.2"
+              },
               "dependencies": {
                 "gaze": {
                   "version": "0.5.2",
-                  "from": "gaze@>=0.5.1 <0.6.0",
                   "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+                  "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
+                  "requires": {
+                    "globule": "0.1.0"
+                  },
                   "dependencies": {
                     "globule": {
                       "version": "0.1.0",
-                      "from": "globule@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                      "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
+                      "requires": {
+                        "glob": "3.1.21",
+                        "lodash": "1.0.2",
+                        "minimatch": "0.2.14"
+                      },
                       "dependencies": {
-                        "lodash": {
-                          "version": "1.0.2",
-                          "from": "lodash@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                        },
                         "glob": {
                           "version": "3.1.21",
-                          "from": "glob@>=3.1.21 <3.2.0",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+                          "requires": {
+                            "graceful-fs": "1.2.3",
+                            "inherits": "1.0.2",
+                            "minimatch": "0.2.14"
+                          },
                           "dependencies": {
                             "graceful-fs": {
                               "version": "1.2.3",
-                              "from": "graceful-fs@>=1.2.0 <1.3.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                              "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
                             },
                             "inherits": {
                               "version": "1.0.2",
-                              "from": "inherits@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+                              "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
                             }
                           }
                         },
+                        "lodash": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
+                        },
                         "minimatch": {
                           "version": "0.2.14",
-                          "from": "minimatch@>=0.2.11 <0.3.0",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+                          "requires": {
+                            "lru-cache": "2.7.3",
+                            "sigmund": "1.0.1"
+                          },
                           "dependencies": {
                             "lru-cache": {
                               "version": "2.7.3",
-                              "from": "lru-cache@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
                             },
                             "sigmund": {
                               "version": "1.0.1",
-                              "from": "sigmund@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
                             }
                           }
                         }
@@ -1971,91 +4025,112 @@
             },
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+              "integrity": "sha1-zoE+cl+oL35hR9UcmlymgnBVHCI="
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              },
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                 }
               }
             },
             "strip-bom": {
               "version": "1.0.0",
-              "from": "strip-bom@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+              "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+              "requires": {
+                "first-chunk-stream": "1.0.0",
+                "is-utf8": "0.2.0"
+              },
               "dependencies": {
                 "first-chunk-stream": {
                   "version": "1.0.0",
-                  "from": "first-chunk-stream@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+                  "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
                 },
                 "is-utf8": {
                   "version": "0.2.0",
-                  "from": "is-utf8@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+                  "integrity": "sha1-uKpUElrmJr/k4765ZfFqicWKETc="
                 }
               }
             },
             "through2": {
               "version": "0.6.5",
-              "from": "through2@>=0.6.1 <0.7.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+              "requires": {
+                "readable-stream": "1.0.33",
+                "xtend": "4.0.1"
+              },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "integrity": "sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=",
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <4.1.0-0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                 }
               }
             },
             "vinyl": {
               "version": "0.4.6",
-              "from": "vinyl@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+              "requires": {
+                "clone": "0.2.0",
+                "clone-stats": "0.0.1"
+              },
               "dependencies": {
                 "clone": {
                   "version": "0.2.0",
-                  "from": "clone@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                  "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
                 },
                 "clone-stats": {
                   "version": "0.0.1",
-                  "from": "clone-stats@>=0.0.1 <0.0.2",
-                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
                 }
               }
             }
@@ -2065,128 +4140,169 @@
     },
     "gulp-autoprefixer": {
       "version": "3.1.0",
-      "from": "gulp-autoprefixer@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.0.tgz",
+      "integrity": "sha1-KzraQ5/bEg7U6zpXSxIiNKi6KDo=",
+      "requires": {
+        "autoprefixer": "6.2.3",
+        "gulp-util": "3.0.7",
+        "postcss": "5.0.14",
+        "through2": "2.0.0",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      },
       "dependencies": {
         "autoprefixer": {
           "version": "6.2.3",
-          "from": "autoprefixer@>=6.0.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
+          "integrity": "sha1-qezJ/hp7UrCzLRECVzddAvqEHxw=",
+          "requires": {
+            "browserslist": "1.0.1",
+            "caniuse-db": "1.0.30000386",
+            "normalize-range": "0.1.2",
+            "num2fraction": "1.2.2",
+            "postcss": "5.0.14",
+            "postcss-value-parser": "3.2.3"
+          },
           "dependencies": {
-            "postcss-value-parser": {
-              "version": "3.2.3",
-              "from": "postcss-value-parser@>=3.2.3 <4.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
-            },
-            "normalize-range": {
-              "version": "0.1.2",
-              "from": "normalize-range@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
-            },
-            "num2fraction": {
-              "version": "1.2.2",
-              "from": "num2fraction@>=1.2.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-            },
             "browserslist": {
               "version": "1.0.1",
-              "from": "browserslist@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
+              "integrity": "sha1-7w3XCDGM33QyX67qWe/shNlGRxc=",
+              "requires": {
+                "caniuse-db": "1.0.30000386"
+              }
             },
             "caniuse-db": {
               "version": "1.0.30000386",
-              "from": "caniuse-db@>=1.0.30000382 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz"
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz",
+              "integrity": "sha1-iYCHDUQx9M9FTNBHfpKqE3BaE0U="
+            },
+            "normalize-range": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+              "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+            },
+            "num2fraction": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+              "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+            },
+            "postcss-value-parser": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
+              "integrity": "sha1-IW5yR7vSa3Zoq57r0I3muW6ytFM="
             }
           }
         },
         "postcss": {
           "version": "5.0.14",
-          "from": "postcss@>=5.0.4 <6.0.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
+          "integrity": "sha1-Fk2vqfPGd17lmZGc2mEK3rSV/Ow=",
+          "requires": {
+            "js-base64": "2.1.9",
+            "source-map": "0.5.3",
+            "supports-color": "3.1.2"
+          },
           "dependencies": {
-            "supports-color": {
-              "version": "3.1.2",
-              "from": "supports-color@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                }
-              }
+            "js-base64": {
+              "version": "2.1.9",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+              "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            "supports-color": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+              "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+              "requires": {
+                "has-flag": "1.0.0"
+              },
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                  "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+                }
+              }
             }
           }
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+          "integrity": "sha1-9BocMd9eEp5DFERvZuygXNajBIA=",
+          "requires": {
+            "readable-stream": "2.0.5",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "process-nextick-args": "1.0.6",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                  "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             }
           }
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.2.1",
-          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+          "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+          "requires": {
+            "source-map": "0.5.3"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             }
           }
         }
@@ -2194,116 +4310,188 @@
     },
     "gulp-cssnano": {
       "version": "2.1.0",
-      "from": "gulp-cssnano@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.0.tgz",
+      "integrity": "sha1-mqeYeSp6N6fT32vIi+7uF6Urv8M=",
+      "requires": {
+        "cssnano": "3.4.0",
+        "gulp-util": "3.0.7",
+        "object-assign": "4.0.1",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      },
       "dependencies": {
         "cssnano": {
           "version": "3.4.0",
-          "from": "cssnano@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.4.0.tgz",
+          "integrity": "sha1-FNORAy3kdg0i5dufH+wfCGjku7c=",
+          "requires": {
+            "autoprefixer": "6.2.3",
+            "decamelize": "1.1.2",
+            "defined": "1.0.0",
+            "indexes-of": "1.0.1",
+            "object-assign": "4.0.1",
+            "postcss": "5.0.14",
+            "postcss-calc": "5.2.0",
+            "postcss-colormin": "2.1.8",
+            "postcss-convert-values": "2.3.4",
+            "postcss-discard-comments": "2.0.3",
+            "postcss-discard-duplicates": "2.0.0",
+            "postcss-discard-empty": "2.0.0",
+            "postcss-discard-unused": "2.1.0",
+            "postcss-filter-plugins": "2.0.0",
+            "postcss-merge-idents": "2.1.3",
+            "postcss-merge-longhand": "2.0.1",
+            "postcss-merge-rules": "2.0.3",
+            "postcss-minify-font-values": "1.0.2",
+            "postcss-minify-gradients": "1.0.1",
+            "postcss-minify-params": "1.0.4",
+            "postcss-minify-selectors": "2.0.2",
+            "postcss-normalize-charset": "1.1.0",
+            "postcss-normalize-url": "3.0.4",
+            "postcss-ordered-values": "2.0.2",
+            "postcss-reduce-idents": "2.2.1",
+            "postcss-reduce-transforms": "1.0.3",
+            "postcss-svgo": "2.1.1",
+            "postcss-unique-selectors": "2.0.1",
+            "postcss-value-parser": "3.2.3",
+            "postcss-zindex": "2.0.1"
+          },
           "dependencies": {
             "autoprefixer": {
               "version": "6.2.3",
-              "from": "autoprefixer@>=6.0.3 <7.0.0",
               "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
+              "integrity": "sha1-qezJ/hp7UrCzLRECVzddAvqEHxw=",
+              "requires": {
+                "browserslist": "1.0.1",
+                "caniuse-db": "1.0.30000386",
+                "normalize-range": "0.1.2",
+                "num2fraction": "1.2.2",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              },
               "dependencies": {
-                "normalize-range": {
-                  "version": "0.1.2",
-                  "from": "normalize-range@>=0.1.2 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
-                },
-                "num2fraction": {
-                  "version": "1.2.2",
-                  "from": "num2fraction@>=1.2.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-                },
                 "browserslist": {
                   "version": "1.0.1",
-                  "from": "browserslist@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
+                  "integrity": "sha1-7w3XCDGM33QyX67qWe/shNlGRxc=",
+                  "requires": {
+                    "caniuse-db": "1.0.30000386"
+                  }
                 },
                 "caniuse-db": {
                   "version": "1.0.30000386",
-                  "from": "caniuse-db@>=1.0.30000382 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz"
+                  "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz",
+                  "integrity": "sha1-iYCHDUQx9M9FTNBHfpKqE3BaE0U="
+                },
+                "normalize-range": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+                  "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+                },
+                "num2fraction": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+                  "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
                 }
               }
             },
             "decamelize": {
               "version": "1.1.2",
-              "from": "decamelize@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+              "integrity": "sha1-3Mk3J74gljLpiwJxjvTLeWAjIvI=",
+              "requires": {
+                "escape-string-regexp": "1.0.4"
+              },
               "dependencies": {
                 "escape-string-regexp": {
                   "version": "1.0.4",
-                  "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
+                  "integrity": "sha1-uF5nm0b3LQP7voo79yWdU1whti8="
                 }
               }
             },
             "defined": {
               "version": "1.0.0",
-              "from": "defined@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
             },
             "indexes-of": {
               "version": "1.0.1",
-              "from": "indexes-of@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+              "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
             },
             "postcss": {
               "version": "5.0.14",
-              "from": "postcss@>=5.0.10 <6.0.0",
               "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
+              "integrity": "sha1-Fk2vqfPGd17lmZGc2mEK3rSV/Ow=",
+              "requires": {
+                "js-base64": "2.1.9",
+                "source-map": "0.5.3",
+                "supports-color": "3.1.2"
+              },
               "dependencies": {
-                "supports-color": {
-                  "version": "3.1.2",
-                  "from": "supports-color@>=3.1.2 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "1.0.0",
-                      "from": "has-flag@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                    }
-                  }
+                "js-base64": {
+                  "version": "2.1.9",
+                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+                  "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
                 },
                 "source-map": {
                   "version": "0.5.3",
-                  "from": "source-map@>=0.5.1 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+                  "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
                 },
-                "js-base64": {
-                  "version": "2.1.9",
-                  "from": "js-base64@>=2.1.9 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+                "supports-color": {
+                  "version": "3.1.2",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+                  "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+                  "requires": {
+                    "has-flag": "1.0.0"
+                  },
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+                    }
+                  }
                 }
               }
             },
             "postcss-calc": {
               "version": "5.2.0",
-              "from": "postcss-calc@>=5.0.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.0.tgz",
+              "integrity": "sha1-C2FTt5OQujt7mOrd/2Pxef/m+vU=",
+              "requires": {
+                "postcss": "5.0.14",
+                "postcss-message-helpers": "2.0.0",
+                "reduce-css-calc": "1.2.0"
+              },
               "dependencies": {
                 "postcss-message-helpers": {
                   "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+                  "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
                 },
                 "reduce-css-calc": {
                   "version": "1.2.0",
-                  "from": "reduce-css-calc@>=1.2.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
+                  "integrity": "sha1-4ZHjYuk9pMDw+ZLeoSkyouENsZE=",
+                  "requires": {
+                    "balanced-match": "0.1.0",
+                    "reduce-function-call": "1.0.1"
+                  },
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
+                      "integrity": "sha1-tQS9BYabOSWd0MXvw12EMXbczEo="
                     },
                     "reduce-function-call": {
                       "version": "1.0.1",
-                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
+                      "integrity": "sha1-+gLhJuaVgkJjyrkdOlsP3B3Sepo=",
+                      "requires": {
+                        "balanced-match": "0.1.0"
+                      }
                     }
                   }
                 }
@@ -2311,33 +4499,49 @@
             },
             "postcss-colormin": {
               "version": "2.1.8",
-              "from": "postcss-colormin@>=2.1.7 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.1.8.tgz",
+              "integrity": "sha1-N9N51eP3Oeu7hIUWmqEmbRxgivU=",
+              "requires": {
+                "colormin": "1.0.7",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              },
               "dependencies": {
                 "colormin": {
                   "version": "1.0.7",
-                  "from": "colormin@>=1.0.5 <2.0.0",
                   "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.0.7.tgz",
+                  "integrity": "sha1-cMTajDzbw5tfMmMOl6xiXgX4NWM=",
+                  "requires": {
+                    "color": "0.11.1",
+                    "css-color-names": "0.0.3"
+                  },
                   "dependencies": {
                     "color": {
                       "version": "0.11.1",
-                      "from": "color@>=0.11.0 <0.12.0",
                       "resolved": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
+                      "integrity": "sha1-GeNXzhhy4ZHoqRcCtO4bDthEGHo=",
+                      "requires": {
+                        "color-convert": "0.5.3",
+                        "color-string": "0.3.0"
+                      },
                       "dependencies": {
                         "color-convert": {
                           "version": "0.5.3",
-                          "from": "color-convert@>=0.5.3 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
+                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+                          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
                         },
                         "color-string": {
                           "version": "0.3.0",
-                          "from": "color-string@>=0.3.0 <0.4.0",
                           "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+                          "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+                          "requires": {
+                            "color-name": "1.1.1"
+                          },
                           "dependencies": {
                             "color-name": {
                               "version": "1.1.1",
-                              "from": "color-name@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
+                              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+                              "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
                             }
                           }
                         }
@@ -2345,8 +4549,8 @@
                     },
                     "css-color-names": {
                       "version": "0.0.3",
-                      "from": "css-color-names@0.0.3",
-                      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
+                      "integrity": "sha1-3gzvFvTYqoIioyDVttfpu62nufY="
                     }
                   }
                 }
@@ -2354,133 +4558,192 @@
             },
             "postcss-convert-values": {
               "version": "2.3.4",
-              "from": "postcss-convert-values@>=2.3.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz",
+              "integrity": "sha1-IyG6A5fzIleRMNi58OiaQtguYjk=",
+              "requires": {
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-discard-comments": {
               "version": "2.0.3",
-              "from": "postcss-discard-comments@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz",
+              "integrity": "sha1-WXl6UXR+BeK+wgjyLWNaaYMGiwQ=",
+              "requires": {
+                "postcss": "5.0.14"
+              }
             },
             "postcss-discard-duplicates": {
               "version": "2.0.0",
-              "from": "postcss-discard-duplicates@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz",
+              "integrity": "sha1-FqGQHl15GUexmOSmsp1+EjgU3RI=",
+              "requires": {
+                "postcss": "5.0.14"
+              }
             },
             "postcss-discard-empty": {
               "version": "2.0.0",
-              "from": "postcss-discard-empty@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz",
+              "integrity": "sha1-QEdovgWpEzBJARVIbh1SGRjI52E=",
+              "requires": {
+                "postcss": "5.0.14"
+              }
             },
             "postcss-discard-unused": {
               "version": "2.1.0",
-              "from": "postcss-discard-unused@>=2.1.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.1.0.tgz",
+              "integrity": "sha1-Vfdq6tVxwAvHQZ4wViacDRIT8Ug=",
+              "requires": {
+                "flatten": "0.0.1",
+                "postcss": "5.0.14",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "flatten": {
                   "version": "0.0.1",
-                  "from": "flatten@0.0.1",
-                  "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
+                  "integrity": "sha1-VURAdm2goNYDmZ9DNFP2wvxqdcE="
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-filter-plugins": {
               "version": "2.0.0",
-              "from": "postcss-filter-plugins@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
+              "integrity": "sha1-rM5dGMQOUb5ZiRG27Ki1TZ5b3t8=",
+              "requires": {
+                "postcss": "5.0.14",
+                "uniqid": "1.0.0"
+              },
               "dependencies": {
                 "uniqid": {
                   "version": "1.0.0",
-                  "from": "uniqid@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz",
+                  "integrity": "sha1-JYJSTgdASESkLelPviv1SeG3RVU="
                 }
               }
             },
             "postcss-merge-idents": {
               "version": "2.1.3",
-              "from": "postcss-merge-idents@>=2.1.3 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.3.tgz",
+              "integrity": "sha1-Ri1cz7en3+/b1int1n3TABCUqQ0=",
+              "requires": {
+                "has-own": "1.0.0",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              },
               "dependencies": {
                 "has-own": {
                   "version": "1.0.0",
-                  "from": "has-own@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz",
+                  "integrity": "sha1-MGIkbjHP2Iepph7m04ylcok3jNE="
                 }
               }
             },
             "postcss-merge-longhand": {
               "version": "2.0.1",
-              "from": "postcss-merge-longhand@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
+              "integrity": "sha1-/1m13sbVhs4s6hgxOPVcWHb6nNw=",
+              "requires": {
+                "postcss": "5.0.14"
+              }
             },
             "postcss-merge-rules": {
               "version": "2.0.3",
-              "from": "postcss-merge-rules@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz",
+              "integrity": "sha1-ku/377WhMCmFPrtKozCb5SXzGeY=",
+              "requires": {
+                "postcss": "5.0.14"
+              }
             },
             "postcss-minify-font-values": {
               "version": "1.0.2",
-              "from": "postcss-minify-font-values@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.2.tgz",
+              "integrity": "sha1-n2oEX/QWChbaYGF90/wyq9vufYs=",
+              "requires": {
+                "object-assign": "4.0.1",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-minify-gradients": {
               "version": "1.0.1",
-              "from": "postcss-minify-gradients@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz",
+              "integrity": "sha1-PbMiSjlXEXMrwK6XtMdll0gaQPg=",
+              "requires": {
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-minify-params": {
               "version": "1.0.4",
-              "from": "postcss-minify-params@>=1.0.4 <2.0.0",
               "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
+              "integrity": "sha1-Kne5bbgEh/Ff75QVlbEbWVNo1UM=",
+              "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+                  "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-minify-selectors": {
               "version": "2.0.2",
-              "from": "postcss-minify-selectors@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.2.tgz",
+              "integrity": "sha1-mGeYU3CO8yx0/F345cmcGl5F1Rc=",
+              "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.0.14",
+                "postcss-selector-parser": "1.3.0"
+              },
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+                  "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
                 },
                 "postcss-selector-parser": {
                   "version": "1.3.0",
-                  "from": "postcss-selector-parser@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.0.tgz",
+                  "integrity": "sha1-PfYKh/0xOGkRDw7ksJcS0HA/qIU=",
+                  "requires": {
+                    "flatten": "0.0.1",
+                    "indexes-of": "1.0.1",
+                    "uniq": "1.0.1"
+                  },
                   "dependencies": {
                     "flatten": {
                       "version": "0.0.1",
-                      "from": "flatten@0.0.1",
-                      "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
+                      "integrity": "sha1-VURAdm2goNYDmZ9DNFP2wvxqdcE="
                     },
                     "uniq": {
                       "version": "1.0.1",
-                      "from": "uniq@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+                      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
                     }
                   }
                 }
@@ -2488,50 +4751,72 @@
             },
             "postcss-normalize-charset": {
               "version": "1.1.0",
-              "from": "postcss-normalize-charset@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz",
+              "integrity": "sha1-L70w4SJIxEKYHTHqJITUb9BiiXA=",
+              "requires": {
+                "postcss": "5.0.14"
+              }
             },
             "postcss-normalize-url": {
               "version": "3.0.4",
-              "from": "postcss-normalize-url@>=3.0.4 <4.0.0",
               "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.4.tgz",
+              "integrity": "sha1-0EUeiYFmqUeTaHSOxPEL91PftyA=",
+              "requires": {
+                "is-absolute-url": "2.0.0",
+                "normalize-url": "1.4.0",
+                "object-assign": "4.0.1",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              },
               "dependencies": {
                 "is-absolute-url": {
                   "version": "2.0.0",
-                  "from": "is-absolute-url@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
+                  "integrity": "sha1-nEsgsOXAy++aR5o2ft5vmRZ581k="
                 },
                 "normalize-url": {
                   "version": "1.4.0",
-                  "from": "normalize-url@>=1.3.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
+                  "integrity": "sha1-iuk+l932bxdUTB8SotwMDktXYv8=",
+                  "requires": {
+                    "object-assign": "4.0.1",
+                    "prepend-http": "1.0.3",
+                    "query-string": "3.0.0",
+                    "sort-keys": "1.1.1"
+                  },
                   "dependencies": {
                     "prepend-http": {
                       "version": "1.0.3",
-                      "from": "prepend-http@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
+                      "integrity": "sha1-TQ0rb5788RkMI5MTJbTzqduoSGk="
                     },
                     "query-string": {
                       "version": "3.0.0",
-                      "from": "query-string@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
+                      "integrity": "sha1-Av0wbwQyBAuRsRBj+UBP4bvUuns=",
+                      "requires": {
+                        "strict-uri-encode": "1.1.0"
+                      },
                       "dependencies": {
                         "strict-uri-encode": {
                           "version": "1.1.0",
-                          "from": "strict-uri-encode@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+                          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
                         }
                       }
                     },
                     "sort-keys": {
                       "version": "1.1.1",
-                      "from": "sort-keys@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
+                      "integrity": "sha1-p5HCYHHfZsNWv13K2c+1ensvgm4=",
+                      "requires": {
+                        "is-plain-obj": "1.1.0"
+                      },
                       "dependencies": {
                         "is-plain-obj": {
                           "version": "1.1.0",
-                          "from": "is-plain-obj@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+                          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
                         }
                       }
                     }
@@ -2541,166 +4826,227 @@
             },
             "postcss-ordered-values": {
               "version": "2.0.2",
-              "from": "postcss-ordered-values@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz",
+              "integrity": "sha1-//PE55yrXr84RQZX4282F6UCNUo=",
+              "requires": {
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-reduce-idents": {
               "version": "2.2.1",
-              "from": "postcss-reduce-idents@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz",
+              "integrity": "sha1-7NgvcZ+0DtoisLbUHD/C2sataps=",
+              "requires": {
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-reduce-transforms": {
               "version": "1.0.3",
-              "from": "postcss-reduce-transforms@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz",
+              "integrity": "sha1-/Bk+Q1qXPBD5gBx0cAqDD3lkM0M=",
+              "requires": {
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3"
+              }
             },
             "postcss-svgo": {
               "version": "2.1.1",
-              "from": "postcss-svgo@>=2.0.4 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.1.tgz",
+              "integrity": "sha1-2sWzddCSeJ1ku/yr6dx0hriqjs0=",
+              "requires": {
+                "is-svg": "1.1.1",
+                "postcss": "5.0.14",
+                "postcss-value-parser": "3.2.3",
+                "svgo": "0.6.1"
+              },
               "dependencies": {
                 "is-svg": {
                   "version": "1.1.1",
-                  "from": "is-svg@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz",
+                  "integrity": "sha1-rA76r7ZTrFhHNwix+HNjbKEQ4xs="
                 },
                 "svgo": {
                   "version": "0.6.1",
-                  "from": "svgo@>=0.6.1 <0.7.0",
                   "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.1.tgz",
+                  "integrity": "sha1-ud2NRQZgyl+IsiJx+9yLKpZmN6k=",
+                  "requires": {
+                    "coa": "1.0.1",
+                    "colors": "1.1.2",
+                    "csso": "1.4.4",
+                    "js-yaml": "3.4.6",
+                    "mkdirp": "0.5.1",
+                    "sax": "1.1.4",
+                    "whet.extend": "0.9.9"
+                  },
                   "dependencies": {
-                    "sax": {
-                      "version": "1.1.4",
-                      "from": "sax@>=1.1.4 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz"
-                    },
                     "coa": {
                       "version": "1.0.1",
-                      "from": "coa@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
+                      "integrity": "sha1-f5WTRs/IcZ4/cjPNaFKFSnxn2KM=",
+                      "requires": {
+                        "q": "1.4.1"
+                      },
                       "dependencies": {
                         "q": {
                           "version": "1.4.1",
-                          "from": "q@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-                        }
-                      }
-                    },
-                    "js-yaml": {
-                      "version": "3.4.6",
-                      "from": "js-yaml@>=3.4.3 <3.5.0",
-                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
-                      "dependencies": {
-                        "argparse": {
-                          "version": "1.0.3",
-                          "from": "argparse@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
-                          "dependencies": {
-                            "lodash": {
-                              "version": "3.10.1",
-                              "from": "lodash@>=3.2.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-                            },
-                            "sprintf-js": {
-                              "version": "1.0.3",
-                              "from": "sprintf-js@>=1.0.2 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "esprima": {
-                          "version": "2.7.1",
-                          "from": "esprima@>=2.6.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
-                        },
-                        "inherit": {
-                          "version": "2.2.3",
-                          "from": "inherit@>=2.2.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz"
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
                         }
                       }
                     },
                     "colors": {
                       "version": "1.1.2",
-                      "from": "colors@>=1.1.2 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
-                    },
-                    "whet.extend": {
-                      "version": "0.9.9",
-                      "from": "whet.extend@>=0.9.9 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.1 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+                      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
                     },
                     "csso": {
                       "version": "1.4.4",
-                      "from": "csso@>=1.4.2 <1.5.0",
                       "resolved": "https://registry.npmjs.org/csso/-/csso-1.4.4.tgz",
+                      "integrity": "sha1-Cuv6UJPvMMysbbP/V1nfymIba2o=",
+                      "requires": {
+                        "clap": "1.0.10"
+                      },
                       "dependencies": {
                         "clap": {
                           "version": "1.0.10",
-                          "from": "clap@>=1.0.9 <2.0.0",
                           "resolved": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
+                          "integrity": "sha1-T3qT4URUWvhd/SnZL9l04yVIYyo=",
+                          "requires": {
+                            "chalk": "1.1.1"
+                          },
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@1.1.1",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                              "requires": {
+                                "ansi-styles": "2.1.0",
+                                "escape-string-regexp": "1.0.4",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.0",
+                                "supports-color": "2.0.0"
+                              },
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                                  "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.4",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
+                                  "integrity": "sha1-uF5nm0b3LQP7voo79yWdU1whti8="
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                 }
                               }
                             }
                           }
                         }
                       }
+                    },
+                    "js-yaml": {
+                      "version": "3.4.6",
+                      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
+                      "integrity": "sha1-a+GyP2JJ9T0pM3D9TRqqY84bTrA=",
+                      "requires": {
+                        "argparse": "1.0.3",
+                        "esprima": "2.7.1",
+                        "inherit": "2.2.3"
+                      },
+                      "dependencies": {
+                        "argparse": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
+                          "integrity": "sha1-FDid7rDCj8TNqUBbn1MqTjeFzoQ=",
+                          "requires": {
+                            "lodash": "3.10.1",
+                            "sprintf-js": "1.0.3"
+                          },
+                          "dependencies": {
+                            "lodash": {
+                              "version": "3.10.1",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+                            },
+                            "sprintf-js": {
+                              "version": "1.0.3",
+                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                              "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+                            }
+                          }
+                        },
+                        "esprima": {
+                          "version": "2.7.1",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
+                          "integrity": "sha1-KrfRVJ7dBtFNaabBoXVKygLpZX4="
+                        },
+                        "inherit": {
+                          "version": "2.2.3",
+                          "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz",
+                          "integrity": "sha1-MyNPkSrDJ26nunrXEjGWfHrkXA0="
+                        }
+                      }
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                      "requires": {
+                        "minimist": "0.0.8"
+                      },
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                        }
+                      }
+                    },
+                    "sax": {
+                      "version": "1.1.4",
+                      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+                      "integrity": "sha1-dLbTPJrh4AFRDxeakRaFiPGu2qk="
+                    },
+                    "whet.extend": {
+                      "version": "0.9.9",
+                      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+                      "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE="
                     }
                   }
                 }
@@ -2708,35 +5054,44 @@
             },
             "postcss-unique-selectors": {
               "version": "2.0.1",
-              "from": "postcss-unique-selectors@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.1.tgz",
+              "integrity": "sha1-bN71L+F2CIVFquZw3+fRRgS+CTE=",
+              "requires": {
+                "alphanum-sort": "1.0.2",
+                "postcss": "5.0.14",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+                  "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             },
             "postcss-value-parser": {
               "version": "3.2.3",
-              "from": "postcss-value-parser@>=3.1.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
+              "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
+              "integrity": "sha1-IW5yR7vSa3Zoq57r0I3muW6ytFM="
             },
             "postcss-zindex": {
               "version": "2.0.1",
-              "from": "postcss-zindex@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.1.tgz",
+              "integrity": "sha1-HJsiJpaRqHVX91Zd/m47hHPlMLw=",
+              "requires": {
+                "postcss": "5.0.14",
+                "uniqs": "2.0.0"
+              },
               "dependencies": {
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+                  "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
                 }
               }
             }
@@ -2744,18 +5099,21 @@
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+          "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.2.1",
-          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+          "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+          "requires": {
+            "source-map": "0.5.3"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             }
           }
         }
@@ -2763,72 +5121,114 @@
     },
     "gulp-less": {
       "version": "3.0.5",
-      "from": "gulp-less@>=3.0.3 <4.0.0",
       "resolved": "https://registry.npmjs.org/gulp-less/-/gulp-less-3.0.5.tgz",
+      "integrity": "sha1-gpSiB+Xo0m8L+pdsunZir1yZvQE=",
+      "requires": {
+        "accord": "0.20.5",
+        "gulp-util": "3.0.7",
+        "less": "2.5.3",
+        "object-assign": "4.0.1",
+        "through2": "2.0.0",
+        "vinyl-sourcemaps-apply": "0.2.0"
+      },
       "dependencies": {
         "accord": {
           "version": "0.20.5",
-          "from": "accord@>=0.20.1 <0.21.0",
           "resolved": "https://registry.npmjs.org/accord/-/accord-0.20.5.tgz",
+          "integrity": "sha1-pP2ObnJB4G73pjyoOUHNjkndrIw=",
+          "requires": {
+            "convert-source-map": "1.1.2",
+            "fobject": "0.0.3",
+            "glob": "5.0.15",
+            "indx": "0.2.3",
+            "lodash": "3.10.1",
+            "resolve": "1.1.6",
+            "semver": "4.3.6",
+            "uglify-js": "2.6.1",
+            "when": "3.7.5"
+          },
           "dependencies": {
             "convert-source-map": {
               "version": "1.1.2",
-              "from": "convert-source-map@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz",
+              "integrity": "sha1-gmY3iDEHOQf6OE8LKuyrC6BYZpM="
             },
             "fobject": {
               "version": "0.0.3",
-              "from": "fobject@0.0.3",
               "resolved": "https://registry.npmjs.org/fobject/-/fobject-0.0.3.tgz",
+              "integrity": "sha1-nRPrA9hr8JvdPRQxccrKiLPzgww=",
+              "requires": {
+                "graceful-fs": "3.0.8",
+                "semver": "4.3.6",
+                "when": "3.7.5"
+              },
               "dependencies": {
                 "graceful-fs": {
                   "version": "3.0.8",
-                  "from": "graceful-fs@>=3.0.2 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+                  "integrity": "sha1-zoE+cl+oL35hR9UcmlymgnBVHCI="
                 }
               }
             },
             "glob": {
               "version": "5.0.15",
-              "from": "glob@>=5.0.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "requires": {
+                "inflight": "1.0.4",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.0",
+                "once": "1.3.3",
+                "path-is-absolute": "1.0.0"
+              },
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+                  "requires": {
+                    "once": "1.3.3",
+                    "wrappy": "1.0.1"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "minimatch": {
                   "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+                  "requires": {
+                    "brace-expansion": "1.1.2"
+                  },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.2",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                      "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                      "requires": {
+                        "balanced-match": "0.3.0",
+                        "concat-map": "0.0.1"
+                      },
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                          "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                         }
                       }
                     }
@@ -2836,150 +5236,193 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "requires": {
+                    "wrappy": "1.0.1"
+                  },
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk="
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
                 }
               }
             },
             "indx": {
               "version": "0.2.3",
-              "from": "indx@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz"
+              "resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz",
+              "integrity": "sha1-Fdz1bunPZcAjTFE8J/vVgOcPvFA="
             },
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
+              "integrity": "sha1-00kq0FTKgA9b76YS5hvqwe7Jj48="
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=4.3.4 <5.0.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
             },
             "uglify-js": {
               "version": "2.6.1",
-              "from": "uglify-js@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+              "integrity": "sha1-7bvhiIujUl3tOnv4NrMLNAXTFhs=",
+              "requires": {
+                "async": "0.2.10",
+                "source-map": "0.5.3",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
                 },
                 "source-map": {
                   "version": "0.5.3",
-                  "from": "source-map@>=0.5.1 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+                  "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
                 },
                 "yargs": {
                   "version": "3.10.0",
-                  "from": "yargs@>=3.10.0 <3.11.0",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.1.1",
+                    "window-size": "0.1.0"
+                  },
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                      "requires": {
+                        "center-align": "0.1.2",
+                        "right-align": "0.1.3",
+                        "wordwrap": "0.0.2"
+                      },
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.2",
-                          "from": "center-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
+                          "integrity": "sha1-dPqFQPwZsmqubtx+AxzWmT1JW6A=",
+                          "requires": {
+                            "align-text": "0.1.3",
+                            "lazy-cache": "0.2.7"
+                          },
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "integrity": "sha1-cts5g4cu7CMTkZyUJqmTpBr+k/c=",
+                              "requires": {
+                                "kind-of": "2.0.1",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.5.2"
+                              },
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.1",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                  "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                                  "requires": {
+                                    "is-buffer": "1.1.0"
+                                  },
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.0",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                                      "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                                 }
                               }
                             },
                             "lazy-cache": {
                               "version": "0.2.7",
-                              "from": "lazy-cache@>=0.2.4 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+                              "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
                             }
                           }
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "right-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                          "requires": {
+                            "align-text": "0.1.3"
+                          },
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "integrity": "sha1-cts5g4cu7CMTkZyUJqmTpBr+k/c=",
+                              "requires": {
+                                "kind-of": "2.0.1",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.5.2"
+                              },
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.1",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                  "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                                  "requires": {
+                                    "is-buffer": "1.1.0"
+                                  },
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.0",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                                      "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                  "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                                 }
                               }
                             }
@@ -2987,20 +5430,20 @@
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.1.1",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
+                      "integrity": "sha1-iHFHmmwEh/VlPUipkvHQOBym8DE="
                     },
                     "window-size": {
                       "version": "0.1.0",
-                      "from": "window-size@0.1.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
                     }
                   }
                 }
@@ -3008,74 +5451,89 @@
             },
             "when": {
               "version": "3.7.5",
-              "from": "when@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/when/-/when-3.7.5.tgz"
+              "resolved": "https://registry.npmjs.org/when/-/when-3.7.5.tgz",
+              "integrity": "sha1-GZ/xFCmJYklXv/YawaLnFa8/YQo="
             }
           }
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+          "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+          "integrity": "sha1-9BocMd9eEp5DFERvZuygXNajBIA=",
+          "requires": {
+            "readable-stream": "2.0.5",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "process-nextick-args": "1.0.6",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                  "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             }
           }
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.2.0",
-          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
+          "integrity": "sha1-FGyxqfF+mumlR0D0du5XXdKlIpQ=",
+          "requires": {
+            "source-map": "0.5.3"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             }
           }
         }
@@ -3083,177 +5541,251 @@
     },
     "gulp-rename": {
       "version": "1.2.2",
-      "from": "gulp-rename@>=1.2.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
+      "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc="
     },
     "gulp-util": {
       "version": "3.0.7",
-      "from": "gulp-util@>=3.0.6 <4.0.0",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
+      "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.2",
+        "beeper": "1.1.0",
+        "chalk": "1.1.1",
+        "dateformat": "1.0.12",
+        "fancy-log": "1.1.0",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.0",
+        "vinyl": "0.5.3"
+      },
       "dependencies": {
         "array-differ": {
           "version": "1.0.0",
-          "from": "array-differ@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+          "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
         },
         "array-uniq": {
           "version": "1.0.2",
-          "from": "array-uniq@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+          "integrity": "sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0="
         },
         "beeper": {
           "version": "1.1.0",
-          "from": "beeper@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
+          "integrity": "sha1-nub8HOf1T+qs585zWIsFYDeGaiw="
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+          "requires": {
+            "ansi-styles": "2.1.0",
+            "escape-string-regexp": "1.0.3",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.0",
+            "supports-color": "2.0.0"
+          },
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+              "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI="
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U="
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+              "requires": {
+                "ansi-regex": "2.0.0"
+              },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
             }
           }
         },
         "dateformat": {
           "version": "1.0.12",
-          "from": "dateformat@>=1.0.11 <2.0.0",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+          "requires": {
+            "get-stdin": "4.0.1",
+            "meow": "3.6.0"
+          },
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
             },
             "meow": {
               "version": "3.6.0",
-              "from": "meow@>=3.3.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
+              "integrity": "sha1-56U1KVy4nbDgeCQo5V+oYVv54VA=",
+              "requires": {
+                "camelcase-keys": "2.0.0",
+                "loud-rejection": "1.2.0",
+                "minimist": "1.2.0",
+                "normalize-package-data": "2.3.5",
+                "object-assign": "4.0.1",
+                "read-pkg-up": "1.0.1",
+                "redent": "1.0.0",
+                "trim-newlines": "1.0.0"
+              },
               "dependencies": {
                 "camelcase-keys": {
                   "version": "2.0.0",
-                  "from": "camelcase-keys@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                  "integrity": "sha1-q4fnQNcqH/yxKkPMBMFLOdVJ6rk=",
+                  "requires": {
+                    "camelcase": "2.0.1",
+                    "map-obj": "1.0.1"
+                  },
                   "dependencies": {
                     "camelcase": {
                       "version": "2.0.1",
-                      "from": "camelcase@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz",
+                      "integrity": "sha1-V1aNaHuNpWxMHRe0x0o87ibXOus="
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
                     }
                   }
                 },
                 "loud-rejection": {
                   "version": "1.2.0",
-                  "from": "loud-rejection@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
+                  "integrity": "sha1-9Ph9tqvsO3/keDRTHs9qARFD5Y0=",
+                  "requires": {
+                    "signal-exit": "2.1.2"
+                  },
                   "dependencies": {
                     "signal-exit": {
                       "version": "2.1.2",
-                      "from": "signal-exit@>=2.1.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
+                      "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ="
                     }
                   }
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                  "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                  "requires": {
+                    "hosted-git-info": "2.1.4",
+                    "is-builtin-module": "1.0.0",
+                    "semver": "5.1.0",
+                    "validate-npm-package-license": "3.0.1"
+                  },
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.4",
-                      "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
+                      "integrity": "sha1-2elTsmmIvogJbEbpJklNlgTDAPg="
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                      "requires": {
+                        "builtin-modules": "1.1.0"
+                      },
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.0",
-                          "from": "builtin-modules@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
+                          "integrity": "sha1-EFOVX9mUpXRuUl5Kxxe4HK8HSRw="
                         }
                       }
                     },
                     "semver": {
                       "version": "5.1.0",
-                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
+                      "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU="
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                      "requires": {
+                        "spdx-correct": "1.0.2",
+                        "spdx-expression-parse": "1.0.2"
+                      },
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                          "requires": {
+                            "spdx-license-ids": "1.1.0"
+                          },
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+                              "integrity": "sha1-KGlKzfOf4n3kUUP/+B8h9sZtRKw="
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.2",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                          "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
+                          "requires": {
+                            "spdx-exceptions": "1.0.4",
+                            "spdx-license-ids": "1.1.0"
+                          },
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.4",
-                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
+                              "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0="
                             },
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
+                              "integrity": "sha1-KGlKzfOf4n3kUUP/+B8h9sZtRKw="
                             }
                           }
                         }
@@ -3263,33 +5795,47 @@
                 },
                 "object-assign": {
                   "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
+                  "integrity": "sha1-mVBEVsNZi1ytT8WcJuipuxB/4L0="
                 },
                 "read-pkg-up": {
                   "version": "1.0.1",
-                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                  "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                  "requires": {
+                    "find-up": "1.1.0",
+                    "read-pkg": "1.1.0"
+                  },
                   "dependencies": {
                     "find-up": {
                       "version": "1.1.0",
-                      "from": "find-up@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                      "integrity": "sha1-pjsO7EYlopAlNImKX57siq7QRuk=",
+                      "requires": {
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.0"
+                      },
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
-                          "from": "path-exists@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                          "requires": {
+                            "pinkie-promise": "2.0.0"
+                          }
                         },
                         "pinkie-promise": {
                           "version": "2.0.0",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                          "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                          "requires": {
+                            "pinkie": "2.0.1"
+                          },
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.1",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                              "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw="
                             }
                           }
                         }
@@ -3297,33 +5843,51 @@
                     },
                     "read-pkg": {
                       "version": "1.1.0",
-                      "from": "read-pkg@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                      "requires": {
+                        "load-json-file": "1.1.0",
+                        "normalize-package-data": "2.3.5",
+                        "path-type": "1.1.0"
+                      },
                       "dependencies": {
                         "load-json-file": {
                           "version": "1.1.0",
-                          "from": "load-json-file@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                          "requires": {
+                            "graceful-fs": "4.1.2",
+                            "parse-json": "2.2.0",
+                            "pify": "2.3.0",
+                            "pinkie-promise": "2.0.0",
+                            "strip-bom": "2.0.0"
+                          },
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                              "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
                             },
                             "parse-json": {
                               "version": "2.2.0",
-                              "from": "parse-json@>=2.2.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                              "requires": {
+                                "error-ex": "1.3.0"
+                              },
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.3.0",
-                                  "from": "error-ex@>=1.2.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                  "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                                  "requires": {
+                                    "is-arrayish": "0.2.1"
+                                  },
                                   "dependencies": {
                                     "is-arrayish": {
                                       "version": "0.2.1",
-                                      "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
                                     }
                                   }
                                 }
@@ -3331,30 +5895,36 @@
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                             },
                             "pinkie-promise": {
                               "version": "2.0.0",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                              "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                              "requires": {
+                                "pinkie": "2.0.1"
+                              },
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.1",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                                  "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw="
                                 }
                               }
                             },
                             "strip-bom": {
                               "version": "2.0.0",
-                              "from": "strip-bom@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                              "requires": {
+                                "is-utf8": "0.2.0"
+                              },
                               "dependencies": {
                                 "is-utf8": {
                                   "version": "0.2.0",
-                                  "from": "is-utf8@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+                                  "integrity": "sha1-uKpUElrmJr/k4765ZfFqicWKETc="
                                 }
                               }
                             }
@@ -3362,28 +5932,36 @@
                         },
                         "path-type": {
                           "version": "1.1.0",
-                          "from": "path-type@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                          "requires": {
+                            "graceful-fs": "4.1.2",
+                            "pify": "2.3.0",
+                            "pinkie-promise": "2.0.0"
+                          },
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+                              "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                             },
                             "pinkie-promise": {
                               "version": "2.0.0",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                              "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                              "requires": {
+                                "pinkie": "2.0.1"
+                              },
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.1",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                                  "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw="
                                 }
                               }
                             }
@@ -3395,28 +5973,41 @@
                 },
                 "redent": {
                   "version": "1.0.0",
-                  "from": "redent@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                  "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+                  "requires": {
+                    "indent-string": "2.1.0",
+                    "strip-indent": "1.0.1"
+                  },
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
-                      "from": "indent-string@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+                      "requires": {
+                        "repeating": "2.0.0"
+                      },
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.0",
-                          "from": "repeating@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                          "integrity": "sha1-/SfW0mTRj76/qlZVPde4JTWlA04=",
+                          "requires": {
+                            "is-finite": "1.0.1"
+                          },
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                              "requires": {
+                                "number-is-nan": "1.0.0"
+                              },
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
                                 }
                               }
                             }
@@ -3426,15 +6017,18 @@
                     },
                     "strip-indent": {
                       "version": "1.0.1",
-                      "from": "strip-indent@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+                      "requires": {
+                        "get-stdin": "4.0.1"
+                      }
                     }
                   }
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
-                  "from": "trim-newlines@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                  "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
                 }
               }
             }
@@ -3442,23 +6036,33 @@
         },
         "fancy-log": {
           "version": "1.1.0",
-          "from": "fancy-log@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
+          "integrity": "sha1-CMTzYH/jFCCHzPQl7sbj+TV6Rts=",
+          "requires": {
+            "chalk": "1.1.1",
+            "dateformat": "1.0.12"
+          }
         },
         "gulplog": {
           "version": "1.0.0",
-          "from": "gulplog@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+          "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+          "requires": {
+            "glogg": "1.0.0"
+          },
           "dependencies": {
             "glogg": {
               "version": "1.0.0",
-              "from": "glogg@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+              "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+              "requires": {
+                "sparkles": "1.0.0"
+              },
               "dependencies": {
                 "sparkles": {
                   "version": "1.0.0",
-                  "from": "sparkles@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                  "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
                 }
               }
             }
@@ -3466,134 +6070,172 @@
         },
         "has-gulplog": {
           "version": "0.1.0",
-          "from": "has-gulplog@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+          "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+          "requires": {
+            "sparkles": "1.0.0"
+          },
           "dependencies": {
             "sparkles": {
               "version": "1.0.0",
-              "from": "sparkles@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+              "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
             }
           }
         },
         "lodash._reescape": {
           "version": "3.0.0",
-          "from": "lodash._reescape@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+          "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
         },
         "lodash._reevaluate": {
           "version": "3.0.0",
-          "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+          "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
         },
         "lodash._reinterpolate": {
           "version": "3.0.0",
-          "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+          "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
         },
         "lodash.template": {
           "version": "3.6.2",
-          "from": "lodash.template@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+          "requires": {
+            "lodash._basecopy": "3.0.1",
+            "lodash._basetostring": "3.0.1",
+            "lodash._basevalues": "3.0.0",
+            "lodash._isiterateecall": "3.0.9",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.escape": "3.0.0",
+            "lodash.keys": "3.1.2",
+            "lodash.restparam": "3.6.1",
+            "lodash.templatesettings": "3.1.0"
+          },
           "dependencies": {
             "lodash._basecopy": {
               "version": "3.0.1",
-              "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+              "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
             },
             "lodash._basetostring": {
               "version": "3.0.1",
-              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+              "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
             },
             "lodash._basevalues": {
               "version": "3.0.0",
-              "from": "lodash._basevalues@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+              "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
             },
             "lodash._isiterateecall": {
               "version": "3.0.9",
-              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+              "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
             },
             "lodash.escape": {
               "version": "3.0.0",
-              "from": "lodash.escape@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
+              "integrity": "sha1-+ylMmae/tYYDn2bWucJ+2HTLe1E=",
+              "requires": {
+                "lodash._basetostring": "3.0.1"
+              }
             },
             "lodash.keys": {
               "version": "3.1.2",
-              "from": "lodash.keys@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+              "requires": {
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.0.4",
+                "lodash.isarray": "3.0.4"
+              },
               "dependencies": {
                 "lodash._getnative": {
                   "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                  "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
                 },
                 "lodash.isarguments": {
                   "version": "3.0.4",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
+                  "integrity": "sha1-67uITEjSc2akTqb+5X7XtaMqgeA="
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
                 }
               }
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "from": "lodash.restparam@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
             },
             "lodash.templatesettings": {
               "version": "3.1.0",
-              "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
+              "integrity": "sha1-U4Uv2DK5IGBaLrYZGby7+484W7Y=",
+              "requires": {
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.0.0"
+              }
             }
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "multipipe": {
           "version": "0.1.2",
-          "from": "multipipe@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+          "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+          "requires": {
+            "duplexer2": "0.0.2"
+          },
           "dependencies": {
             "duplexer2": {
               "version": "0.0.2",
-              "from": "duplexer2@0.0.2",
               "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+              "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+              "requires": {
+                "readable-stream": "1.1.13"
+              },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                     }
                   }
                 }
@@ -3603,182 +6245,464 @@
         },
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         },
         "replace-ext": {
           "version": "0.0.1",
-          "from": "replace-ext@0.0.1",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+          "integrity": "sha1-9BocMd9eEp5DFERvZuygXNajBIA=",
+          "requires": {
+            "readable-stream": "2.0.5",
+            "xtend": "4.0.1"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "process-nextick-args": "1.0.6",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                  "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
             }
           }
         },
         "vinyl": {
           "version": "0.5.3",
-          "from": "vinyl@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+          "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+          "requires": {
+            "clone": "1.0.2",
+            "clone-stats": "0.0.1",
+            "replace-ext": "0.0.1"
+          },
           "dependencies": {
             "clone": {
               "version": "1.0.2",
-              "from": "clone@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+              "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
             },
             "clone-stats": {
               "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2",
-              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+              "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
             }
           }
         }
       }
     },
+    "handlebars": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
+      "integrity": "sha1-geM3ToNhvq/y2XAWIG01nQsy+k0=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "1.1.1",
+        "figures": "1.7.0",
+        "lodash": "3.10.1",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.5.tgz",
+      "integrity": "sha1-w0A3l98SuRhmV08t4jZG/oyvtE0=",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "2.7.3"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        }
+      }
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
     "less": {
       "version": "2.5.3",
-      "from": "less@>=2.5.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/less/-/less-2.5.3.tgz",
+      "integrity": "sha1-n/WG6KcDUV/Bjcmce8SY0vOtSEk=",
+      "requires": {
+        "errno": "0.1.4",
+        "graceful-fs": "3.0.8",
+        "image-size": "0.3.5",
+        "mime": "1.3.4",
+        "mkdirp": "0.5.1",
+        "promise": "6.1.0",
+        "request": "2.67.0",
+        "source-map": "0.4.4"
+      },
       "dependencies": {
         "errno": {
           "version": "0.1.4",
-          "from": "errno@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+          "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+          "optional": true,
+          "requires": {
+            "prr": "0.0.0"
+          },
           "dependencies": {
             "prr": {
               "version": "0.0.0",
-              "from": "prr@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+              "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+              "optional": true
             }
           }
         },
         "graceful-fs": {
           "version": "3.0.8",
-          "from": "graceful-fs@>=3.0.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+          "integrity": "sha1-zoE+cl+oL35hR9UcmlymgnBVHCI=",
+          "optional": true
         },
         "image-size": {
           "version": "0.3.5",
-          "from": "image-size@>=0.3.5 <0.4.0",
-          "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz"
+          "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
+          "integrity": "sha1-gyQOqy+1sAsEqrjHSwRx6cunrYw=",
+          "optional": true
         },
         "mime": {
           "version": "1.3.4",
-          "from": "mime@>=1.2.11 <2.0.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "optional": true
             }
           }
         },
         "promise": {
           "version": "6.1.0",
-          "from": "promise@>=6.0.1 <7.0.0",
           "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+          "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY=",
+          "optional": true,
+          "requires": {
+            "asap": "1.0.0"
+          },
           "dependencies": {
             "asap": {
               "version": "1.0.0",
-              "from": "asap@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
+              "integrity": "sha1-sqRdpf36ILBJb8N2jMJ8EvqRan0=",
+              "optional": true
             }
           }
         },
         "request": {
           "version": "2.67.0",
-          "from": "request@>=2.51.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
+          "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "bl": "1.0.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.0",
+            "forever-agent": "0.6.1",
+            "form-data": "1.0.0-rc3",
+            "har-validator": "2.0.3",
+            "hawk": "3.1.2",
+            "http-signature": "1.1.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.8",
+            "node-uuid": "1.4.7",
+            "oauth-sign": "0.8.0",
+            "qs": "5.2.0",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.2.1",
+            "tunnel-agent": "0.4.2"
+          },
           "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+              "optional": true
+            },
             "bl": {
               "version": "1.0.0",
-              "from": "bl@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+              "integrity": "sha1-ramoqJptesYIYvfex9sgeHPgw/U=",
+              "optional": true,
+              "requires": {
+                "readable-stream": "2.0.5"
+              },
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+                  "optional": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "process-nextick-args": "1.0.6",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "optional": true
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                      "optional": true
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                      "optional": true
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                      "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU=",
+                      "optional": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "optional": true
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "optional": true
                     }
                   }
                 }
@@ -3786,337 +6710,478 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-            },
-            "extend": {
-              "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "form-data": {
-              "version": "1.0.0-rc3",
-              "from": "form-data@>=1.0.0-rc3 <1.1.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-              "dependencies": {
-                "async": {
-                  "version": "1.5.0",
-                  "from": "async@>=1.4.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-                }
-              }
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.8",
-              "from": "mime-types@>=2.1.7 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.20.0",
-                  "from": "mime-db@>=1.20.0 <1.21.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-            },
-            "qs": {
-              "version": "5.2.0",
-              "from": "qs@>=5.2.0 <5.3.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.4.2",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.2.1",
-              "from": "tough-cookie@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-            },
-            "http-signature": {
-              "version": "1.1.0",
-              "from": "http-signature@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                },
-                "jsprim": {
-                  "version": "1.2.2",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
-                    "json-schema": {
-                      "version": "0.2.2",
-                      "from": "json-schema@0.2.2",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.7.1",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "from": "assert-plus@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                    },
-                    "dashdash": {
-                      "version": "1.10.1",
-                      "from": "dashdash@>=1.10.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.1.5",
-                          "from": "assert-plus@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                        }
-                      }
-                    },
-                    "jsbn": {
-                      "version": "0.1.0",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                    },
-                    "tweetnacl": {
-                      "version": "0.13.2",
-                      "from": "tweetnacl@>=0.13.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.0",
-              "from": "oauth-sign@>=0.8.0 <0.9.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-            },
-            "hawk": {
-              "version": "3.1.2",
-              "from": "hawk@>=3.1.0 <3.2.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+              "optional": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
                 }
               }
             },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "optional": true
             },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+            "forever-agent": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "optional": true
+            },
+            "form-data": {
+              "version": "1.0.0-rc3",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+              "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
+              "optional": true,
+              "requires": {
+                "async": "1.5.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.8"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "1.5.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+                  "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM=",
+                  "optional": true
+                }
+              }
             },
             "har-validator": {
               "version": "2.0.3",
-              "from": "har-validator@>=2.0.2 <2.1.0",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
+              "integrity": "sha1-Wp4SVkpXHPC4Hvk8IVe9FhcWiIM=",
+              "optional": true,
+              "requires": {
+                "chalk": "1.1.1",
+                "commander": "2.9.0",
+                "is-my-json-valid": "2.12.3",
+                "pinkie-promise": "2.0.0"
+              },
               "dependencies": {
                 "chalk": {
                   "version": "1.1.1",
-                  "from": "chalk@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "integrity": "sha1-UJr7ZwZudJn36zU1x3RFdyri0Bk=",
+                  "optional": true,
+                  "requires": {
+                    "ansi-styles": "2.1.0",
+                    "escape-string-regexp": "1.0.3",
+                    "has-ansi": "2.0.0",
+                    "strip-ansi": "3.0.0",
+                    "supports-color": "2.0.0"
+                  },
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.1.0",
-                      "from": "ansi-styles@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
+                      "integrity": "sha1-mQ90cUaSe1Wakyv5KVkWPWDA0OI=",
+                      "optional": true
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                      "integrity": "sha1-ni2LJbwlVcMzZyN1DgPwmcJzW7U=",
+                      "optional": true
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "optional": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "optional": true
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.0",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "integrity": "sha1-dRC2ZVZ8qRTMtdfgcnY6yWi+NyQ=",
+                      "optional": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "optional": true
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                      "optional": true
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.9.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "optional": true,
+                  "requires": {
+                    "graceful-readlink": "1.0.1"
+                  },
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                      "optional": true
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.12.3",
-                  "from": "is-my-json-valid@>=2.12.3 <3.0.0",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
+                  "integrity": "sha1-WjnR12stu4MUC70Vex1e5L3IWtY=",
+                  "optional": true,
+                  "requires": {
+                    "generate-function": "2.0.0",
+                    "generate-object-property": "1.2.0",
+                    "jsonpointer": "2.0.0",
+                    "xtend": "4.0.1"
+                  },
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                      "optional": true
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                      "optional": true,
+                      "requires": {
+                        "is-property": "1.0.2"
+                      },
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                          "optional": true
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                      "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
+                      "optional": true
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                      "optional": true
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.0",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                  "integrity": "sha1-TINTjeH25mDCngoTRGhE96foglk=",
+                  "optional": true,
+                  "requires": {
+                    "pinkie": "2.0.1"
+                  },
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.1",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
+                      "integrity": "sha1-QjbIb8KfJhwgRbvoH3jLsqXoMGw=",
+                      "optional": true
                     }
                   }
                 }
               }
+            },
+            "hawk": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
+              "integrity": "sha1-kMkBGIhuIZddGtSumz4oTtGaLeg=",
+              "optional": true,
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "optional": true,
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "optional": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
+              "integrity": "sha1-XS1+m270mYCtWxKNjk7wmjHJDZU=",
+              "optional": true,
+              "requires": {
+                "assert-plus": "0.1.5",
+                "jsprim": "1.2.2",
+                "sshpk": "1.7.1"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+                  "optional": true
+                },
+                "jsprim": {
+                  "version": "1.2.2",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+                  "integrity": "sha1-8gyQaskqvVjjt5rIvHCkiDJRLaE=",
+                  "optional": true,
+                  "requires": {
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.2",
+                    "verror": "1.3.6"
+                  },
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+                    },
+                    "json-schema": {
+                      "version": "0.2.2",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                      "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+                      "optional": true
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "optional": true,
+                      "requires": {
+                        "extsprintf": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.7.1",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
+                  "integrity": "sha1-Vl44bEKnfmBi+9FMBHL/Ic1TOYw=",
+                  "optional": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "0.2.0",
+                    "dashdash": "1.10.1",
+                    "ecc-jsbn": "0.1.1",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.0",
+                    "tweetnacl": "0.13.2"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                      "optional": true
+                    },
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                      "optional": true
+                    },
+                    "dashdash": {
+                      "version": "1.10.1",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
+                      "integrity": "sha1-Cr8a+JqPUSmoHxjCs1sh3yJiL2A=",
+                      "optional": true,
+                      "requires": {
+                        "assert-plus": "0.1.5"
+                      },
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+                          "optional": true
+                        }
+                      }
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.0"
+                      }
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.0"
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.2",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz",
+                      "integrity": "sha1-RTFhdwRp1FzSZsNkBOK8maj6mUQ=",
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "optional": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "optional": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "optional": true
+            },
+            "mime-types": {
+              "version": "2.1.8",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
+              "integrity": "sha1-+vV4I94EvHy/9O6CxrY5RugSrnI=",
+              "requires": {
+                "mime-db": "1.20.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.20.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz",
+                  "integrity": "sha1-SW+Q/QH+DgMciCPsOqlFD/2hjtg="
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.7",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+              "optional": true
+            },
+            "oauth-sign": {
+              "version": "0.8.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
+              "integrity": "sha1-k4/ch1dlulJxN9iuydF44k3rxVM=",
+              "optional": true
+            },
+            "qs": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+              "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=",
+              "optional": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+              "optional": true
+            },
+            "tough-cookie": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
+              "integrity": "sha1-OwUWt5nnDoFkQ2oURuflh3/aEY4=",
+              "optional": true
+            },
+            "tunnel-agent": {
+              "version": "0.4.2",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+              "integrity": "sha1-EQTj82rIcSXChycAZ9WC0YEzv+4=",
+              "optional": true
             }
           }
         },
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.0"
+          },
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+              "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+              "optional": true
             }
           }
         }
@@ -4124,196 +7189,913 @@
     },
     "less-loader": {
       "version": "2.2.2",
-      "from": "less-loader@>=2.2.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-2.2.2.tgz",
+      "integrity": "sha1-CE8OVJtLq4+hLCWA3qzSdDnqhSk=",
+      "requires": {
+        "loader-utils": "0.2.12"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.5 <0.3.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "integrity": "sha1-+qKlAVY6PCyd2leqjDnYvmKN56I=",
+          "requires": {
+            "big.js": "3.1.3",
+            "json5": "0.4.0"
+          },
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
             }
           }
         }
       }
+    },
+    "levn": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+      "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+      "dev": true
+    },
+    "lodash._arraycopy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+      "dev": true
+    },
+    "lodash._arrayeach": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+      "dev": true
+    },
+    "lodash._arraymap": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+      "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=",
+      "dev": true
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._baseclone": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+      "dev": true,
+      "requires": {
+        "lodash._arraycopy": "3.0.0",
+        "lodash._arrayeach": "3.0.0",
+        "lodash._baseassign": "3.2.0",
+        "lodash._basefor": "3.0.3",
+        "lodash.isarray": "3.0.4",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basedifference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+      "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
+      "dev": true,
+      "requires": {
+        "lodash._baseindexof": "3.1.0",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2"
+      }
+    },
+    "lodash._baseflatten": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+      "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+      "dev": true
+    },
+    "lodash._baseindexof": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+      "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+      "dev": true
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "dev": true
+    },
+    "lodash._cacheindexof": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+      "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+      "dev": true
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "dev": true,
+      "requires": {
+        "lodash._bindcallback": "3.0.1",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash.restparam": "3.6.1"
+      }
+    },
+    "lodash._createcache": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1"
+      }
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash._pickbyarray": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+      "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU=",
+      "dev": true
+    },
+    "lodash._pickbycallback": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+      "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
+      "dev": true,
+      "requires": {
+        "lodash._basefor": "3.0.3",
+        "lodash.keysin": "3.0.8"
+      }
+    },
+    "lodash.clonedeep": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+      "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+      "dev": true,
+      "requires": {
+        "lodash._baseclone": "3.3.0",
+        "lodash._bindcallback": "3.0.1"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+      "dev": true,
+      "requires": {
+        "lodash._basefor": "3.0.3",
+        "lodash.isarguments": "3.1.0",
+        "lodash.keysin": "3.0.8"
+      }
+    },
+    "lodash.istypedarray": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.keysin": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.merge": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+      "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
+      "dev": true,
+      "requires": {
+        "lodash._arraycopy": "3.0.0",
+        "lodash._arrayeach": "3.0.0",
+        "lodash._createassigner": "3.1.1",
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4",
+        "lodash.isplainobject": "3.2.0",
+        "lodash.istypedarray": "3.0.6",
+        "lodash.keys": "3.1.2",
+        "lodash.keysin": "3.0.8",
+        "lodash.toplainobject": "3.0.0"
+      }
+    },
+    "lodash.omit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+      "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
+      "dev": true,
+      "requires": {
+        "lodash._arraymap": "3.0.0",
+        "lodash._basedifference": "3.0.3",
+        "lodash._baseflatten": "3.1.4",
+        "lodash._bindcallback": "3.0.1",
+        "lodash._pickbyarray": "3.0.2",
+        "lodash._pickbycallback": "3.0.0",
+        "lodash.keysin": "3.0.8",
+        "lodash.restparam": "3.6.1"
+      }
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
+    "lodash.toplainobject": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+      "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keysin": "3.0.8"
+      }
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
     },
     "merge": {
       "version": "1.2.0",
-      "from": "merge@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "optional": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      }
+    },
+    "optionator": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz",
+      "integrity": "sha1-tj7Lvw4xX61LyYJ7Rdx7pFKE/LY=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "1.0.7",
+        "levn": "0.2.5",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "0.0.3"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+      "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "dev": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
     },
     "style-loader": {
       "version": "0.13.0",
-      "from": "style-loader@>=0.13.0 <0.14.0",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.0.tgz",
+      "integrity": "sha1-q6wRogRQ893qIitEwMY0Kohi20c=",
+      "requires": {
+        "loader-utils": "0.2.12"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "integrity": "sha1-+qKlAVY6PCyd2leqjDnYvmKN56I=",
+          "requires": {
+            "big.js": "3.1.3",
+            "json5": "0.4.0"
+          },
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
             }
           }
         }
       }
     },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
     "url-loader": {
       "version": "0.5.7",
-      "from": "url-loader@>=0.5.6 <0.6.0",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.7.tgz",
+      "integrity": "sha1-Z+h3l1n4AA2nSZSQZoDJQ6mwkl0=",
+      "requires": {
+        "loader-utils": "0.2.12",
+        "mime": "1.2.11"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.5 <0.3.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "integrity": "sha1-+qKlAVY6PCyd2leqjDnYvmKN56I=",
+          "requires": {
+            "big.js": "3.1.3",
+            "json5": "0.4.0"
+          },
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
             }
           }
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@>=1.2.0 <1.3.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
         }
       }
     },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
     "webpack": {
       "version": "1.12.9",
-      "from": "webpack@>=1.11.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.9.tgz",
+      "integrity": "sha1-KgMdZhiYOcxcvyxo+AVm2i4U/04=",
+      "requires": {
+        "async": "1.5.0",
+        "clone": "1.0.2",
+        "enhanced-resolve": "0.9.1",
+        "esprima": "2.7.1",
+        "interpret": "0.6.6",
+        "loader-utils": "0.2.12",
+        "memory-fs": "0.3.0",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "0.5.3",
+        "optimist": "0.6.1",
+        "supports-color": "3.1.2",
+        "tapable": "0.1.10",
+        "uglify-js": "2.6.1",
+        "watchpack": "0.2.9",
+        "webpack-core": "0.6.8"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.0",
-          "from": "async@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
+          "integrity": "sha1-J5ZkJyNXOFlWVjP8YnRES+4vjOM="
         },
         "clone": {
           "version": "1.0.2",
-          "from": "clone@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
         },
         "enhanced-resolve": {
           "version": "0.9.1",
-          "from": "enhanced-resolve@>=0.9.0 <0.10.0",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+          "requires": {
+            "graceful-fs": "4.1.2",
+            "memory-fs": "0.2.0",
+            "tapable": "0.1.10"
+          },
           "dependencies": {
-            "memory-fs": {
-              "version": "0.2.0",
-              "from": "memory-fs@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
-            },
             "graceful-fs": {
               "version": "4.1.2",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+              "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
+            },
+            "memory-fs": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+              "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA="
             }
           }
         },
         "esprima": {
           "version": "2.7.1",
-          "from": "esprima@>=2.5.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
+          "integrity": "sha1-KrfRVJ7dBtFNaabBoXVKygLpZX4="
         },
         "interpret": {
           "version": "0.6.6",
-          "from": "interpret@>=0.6.4 <0.7.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
+          "integrity": "sha1-/s16GOfOXKar+5U+H4YhOknxYls="
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.11 <0.3.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "integrity": "sha1-+qKlAVY6PCyd2leqjDnYvmKN56I=",
+          "requires": {
+            "big.js": "3.1.3",
+            "json5": "0.4.0"
+          },
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+              "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg="
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
             }
           }
         },
         "memory-fs": {
           "version": "0.3.0",
-          "from": "memory-fs@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+          "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
+          "requires": {
+            "errno": "0.1.4",
+            "readable-stream": "2.0.5"
+          },
           "dependencies": {
             "errno": {
               "version": "0.1.4",
-              "from": "errno@>=0.1.3 <0.2.0",
               "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+              "requires": {
+                "prr": "0.0.0"
+              },
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
-                  "from": "prr@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+                  "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
                 }
               }
             },
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "process-nextick-args": "1.0.6",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                  "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                 }
               }
             }
@@ -4321,243 +8103,317 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             }
           }
         },
         "node-libs-browser": {
           "version": "0.5.3",
-          "from": "node-libs-browser@>=0.4.0 <=0.6.0",
           "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
+          "integrity": "sha1-Ve+oiOyQes24z/xOelFxJ4DhO2o=",
+          "requires": {
+            "assert": "1.3.0",
+            "browserify-zlib": "0.1.4",
+            "buffer": "3.5.5",
+            "console-browserify": "1.1.0",
+            "constants-browserify": "0.0.1",
+            "crypto-browserify": "3.2.8",
+            "domain-browser": "1.1.7",
+            "events": "1.1.0",
+            "http-browserify": "1.7.0",
+            "https-browserify": "0.0.0",
+            "os-browserify": "0.1.2",
+            "path-browserify": "0.0.0",
+            "process": "0.11.2",
+            "punycode": "1.4.0",
+            "querystring-es3": "0.2.1",
+            "readable-stream": "1.1.13",
+            "stream-browserify": "1.0.0",
+            "string_decoder": "0.10.31",
+            "timers-browserify": "1.4.2",
+            "tty-browserify": "0.0.0",
+            "url": "0.10.3",
+            "util": "0.10.3",
+            "vm-browserify": "0.0.4"
+          },
           "dependencies": {
             "assert": {
               "version": "1.3.0",
-              "from": "assert@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+              "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+              "integrity": "sha1-A5OaYiWCqBLMICMgoLmlbJuBWEk=",
+              "requires": {
+                "util": "0.10.3"
+              }
             },
             "browserify-zlib": {
               "version": "0.1.4",
-              "from": "browserify-zlib@>=0.1.4 <0.2.0",
               "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+              "requires": {
+                "pako": "0.2.8"
+              },
               "dependencies": {
                 "pako": {
                   "version": "0.2.8",
-                  "from": "pako@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz",
+                  "integrity": "sha1-Fa13KRU2KRPyDeSooWS0qsxhZdY="
                 }
               }
             },
             "buffer": {
               "version": "3.5.5",
-              "from": "buffer@>=3.0.3 <4.0.0",
               "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.5.5.tgz",
+              "integrity": "sha1-98VffCxjSqAO+qvYZJaaROuoLPQ=",
+              "requires": {
+                "base64-js": "0.0.8",
+                "ieee754": "1.1.6",
+                "isarray": "1.0.0"
+              },
               "dependencies": {
                 "base64-js": {
                   "version": "0.0.8",
-                  "from": "base64-js@0.0.8",
-                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+                  "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
                 },
                 "ieee754": {
                   "version": "1.1.6",
-                  "from": "ieee754@>=1.1.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
+                  "integrity": "sha1-LhATIZxtZxKXPsVNmB7BnlV53pc="
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                 }
               }
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "console-browserify@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+              "requires": {
+                "date-now": "0.1.4"
+              },
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "date-now@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+                  "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
                 }
               }
             },
             "constants-browserify": {
               "version": "0.0.1",
-              "from": "constants-browserify@0.0.1",
-              "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+              "integrity": "sha1-kld9tSe6bEzwpFaNhLwDH0QeIfI="
             },
             "crypto-browserify": {
               "version": "3.2.8",
-              "from": "crypto-browserify@>=3.2.6 <3.3.0",
               "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
+              "integrity": "sha1-ubEdvm2WUd2IKgHmzEZ99xjs8Yk=",
+              "requires": {
+                "pbkdf2-compat": "2.0.1",
+                "ripemd160": "0.2.0",
+                "sha.js": "2.2.6"
+              },
               "dependencies": {
                 "pbkdf2-compat": {
                   "version": "2.0.1",
-                  "from": "pbkdf2-compat@2.0.1",
-                  "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
+                  "integrity": "sha1-tuDI+plJTZTgURV1gCpZpcFC8og="
                 },
                 "ripemd160": {
                   "version": "0.2.0",
-                  "from": "ripemd160@0.2.0",
-                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
+                  "integrity": "sha1-K/GYveFnys+lHAqSjoS2i74XH84="
                 },
                 "sha.js": {
                   "version": "2.2.6",
-                  "from": "sha.js@2.2.6",
-                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
+                  "integrity": "sha1-F93t3F9yL7ZlAWWIlUYZd4ZzFbo="
                 }
               }
             },
             "domain-browser": {
               "version": "1.1.7",
-              "from": "domain-browser@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+              "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+              "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
             },
             "events": {
               "version": "1.1.0",
-              "from": "events@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz",
+              "integrity": "sha1-SzifwgD5EHQuv/Orsu/jNpD0VCk="
             },
             "http-browserify": {
               "version": "1.7.0",
-              "from": "http-browserify@>=1.3.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+              "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
+              "requires": {
+                "Base64": "0.2.1",
+                "inherits": "2.0.1"
+              },
               "dependencies": {
                 "Base64": {
                   "version": "0.2.1",
-                  "from": "Base64@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+                  "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+                  "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 }
               }
             },
             "https-browserify": {
               "version": "0.0.0",
-              "from": "https-browserify@0.0.0",
-              "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
+              "integrity": "sha1-s//f5zSyo9Sp79WOhlTJH86G6v0="
             },
             "os-browserify": {
               "version": "0.1.2",
-              "from": "os-browserify@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+              "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ="
             },
             "path-browserify": {
               "version": "0.0.0",
-              "from": "path-browserify@0.0.0",
-              "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+              "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
             },
             "process": {
               "version": "0.11.2",
-              "from": "process@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz",
+              "integrity": "sha1-iljR0SxXPz+JDamEik/o4Wypd7I="
             },
             "punycode": {
               "version": "1.4.0",
-              "from": "punycode@>=1.2.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz",
+              "integrity": "sha1-P4eeoD8kxxjU1LfkfeH7Uc9sPjM="
             },
             "querystring-es3": {
               "version": "0.2.1",
-              "from": "querystring-es3@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+              "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.13 <2.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "integrity": "sha1-9u73ZPUUyJ4rniMUanW6EGdW0j4=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 }
               }
             },
             "stream-browserify": {
               "version": "1.0.0",
-              "from": "stream-browserify@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+              "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
+              "requires": {
+                "inherits": "2.0.1",
+                "readable-stream": "1.1.13"
+              },
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 }
               }
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.25 <0.11.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
             },
             "timers-browserify": {
               "version": "1.4.2",
-              "from": "timers-browserify@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+              "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+              "requires": {
+                "process": "0.11.2"
+              }
             },
             "tty-browserify": {
               "version": "0.0.0",
-              "from": "tty-browserify@0.0.0",
-              "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+              "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
             },
             "url": {
               "version": "0.10.3",
-              "from": "url@>=0.10.1 <0.11.0",
               "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+              "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+              "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+              },
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "punycode@1.3.2",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                  "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
                 },
                 "querystring": {
                   "version": "0.2.0",
-                  "from": "querystring@0.2.0",
-                  "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+                  "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
                 }
               }
             },
             "util": {
               "version": "0.10.3",
-              "from": "util@>=0.10.3 <0.11.0",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+              "requires": {
+                "inherits": "2.0.1"
+              },
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 }
               }
             },
             "vm-browserify": {
               "version": "0.0.4",
-              "from": "vm-browserify@0.0.4",
               "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+              "requires": {
+                "indexof": "0.0.1"
+              },
               "dependencies": {
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "indexof@0.0.1",
-                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                  "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
                 }
               }
             }
@@ -4565,145 +8421,192 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "requires": {
+            "minimist": "0.0.10",
+            "wordwrap": "0.0.3"
+          },
           "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-            },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
             }
           }
         },
         "supports-color": {
           "version": "3.1.2",
-          "from": "supports-color@>=3.1.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "requires": {
+            "has-flag": "1.0.0"
+          },
           "dependencies": {
             "has-flag": {
               "version": "1.0.0",
-              "from": "has-flag@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
             }
           }
         },
         "tapable": {
           "version": "0.1.10",
-          "from": "tapable@>=0.1.8 <0.2.0",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+          "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q="
         },
         "uglify-js": {
           "version": "2.6.1",
-          "from": "uglify-js@>=2.6.0 <2.7.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+          "integrity": "sha1-7bvhiIujUl3tOnv4NrMLNAXTFhs=",
+          "requires": {
+            "async": "0.2.10",
+            "source-map": "0.5.3",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+              "integrity": "sha1-gmdLhacbC+dsPnQW0V6fUlLrO+A="
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+              "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
             },
             "yargs": {
               "version": "3.10.0",
-              "from": "yargs@>=3.10.0 <3.11.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.1.1",
+                "window-size": "0.1.0"
+              },
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                  "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                  "requires": {
+                    "center-align": "0.1.2",
+                    "right-align": "0.1.3",
+                    "wordwrap": "0.0.2"
+                  },
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.2",
-                      "from": "center-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
+                      "integrity": "sha1-dPqFQPwZsmqubtx+AxzWmT1JW6A=",
+                      "requires": {
+                        "align-text": "0.1.3",
+                        "lazy-cache": "0.2.7"
+                      },
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "integrity": "sha1-cts5g4cu7CMTkZyUJqmTpBr+k/c=",
+                          "requires": {
+                            "kind-of": "2.0.1",
+                            "longest": "1.0.1",
+                            "repeat-string": "1.5.2"
+                          },
                           "dependencies": {
                             "kind-of": {
                               "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                              "requires": {
+                                "is-buffer": "1.1.0"
+                              },
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.0",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                                  "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                             }
                           }
                         },
                         "lazy-cache": {
                           "version": "0.2.7",
-                          "from": "lazy-cache@>=0.2.4 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+                          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
                         }
                       }
                     },
                     "right-align": {
                       "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                      "requires": {
+                        "align-text": "0.1.3"
+                      },
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "integrity": "sha1-cts5g4cu7CMTkZyUJqmTpBr+k/c=",
+                          "requires": {
+                            "kind-of": "2.0.1",
+                            "longest": "1.0.1",
+                            "repeat-string": "1.5.2"
+                          },
                           "dependencies": {
                             "kind-of": {
                               "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                              "requires": {
+                                "is-buffer": "1.1.0"
+                              },
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.0",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                                  "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                              "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                              "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                             }
                           }
                         }
@@ -4711,20 +8614,20 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.1.1",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
+                  "integrity": "sha1-iHFHmmwEh/VlPUipkvHQOBym8DE="
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "window-size@0.1.0",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                  "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
                 }
               }
             }
@@ -4732,92 +8635,157 @@
         },
         "watchpack": {
           "version": "0.2.9",
-          "from": "watchpack@>=0.2.1 <0.3.0",
           "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+          "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
+          "requires": {
+            "async": "0.9.2",
+            "chokidar": "1.4.1",
+            "graceful-fs": "4.1.2"
+          },
           "dependencies": {
             "async": {
               "version": "0.9.2",
-              "from": "async@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+              "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
             },
             "chokidar": {
               "version": "1.4.1",
-              "from": "chokidar@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.1.tgz",
+              "integrity": "sha1-3x2QZ2lwGg899JLDfcw8s15kUOQ=",
+              "requires": {
+                "anymatch": "1.3.0",
+                "async-each": "0.1.6",
+                "fsevents": "1.1.3",
+                "glob-parent": "2.0.0",
+                "inherits": "2.0.1",
+                "is-binary-path": "1.0.1",
+                "is-glob": "2.0.1",
+                "path-is-absolute": "1.0.0",
+                "readdirp": "2.0.0"
+              },
               "dependencies": {
                 "anymatch": {
                   "version": "1.3.0",
-                  "from": "anymatch@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                  "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+                  "requires": {
+                    "arrify": "1.0.1",
+                    "micromatch": "2.3.5"
+                  },
                   "dependencies": {
                     "arrify": {
                       "version": "1.0.1",
-                      "from": "arrify@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
                     },
                     "micromatch": {
                       "version": "2.3.5",
-                      "from": "micromatch@>=2.1.5 <3.0.0",
                       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.5.tgz",
+                      "integrity": "sha1-2N/tieKEGdBzSJvlXDPwsFwnMhc=",
+                      "requires": {
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.2",
+                        "expand-brackets": "0.1.4",
+                        "extglob": "0.3.1",
+                        "filename-regex": "2.0.0",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.0.2",
+                        "lazy-cache": "0.2.7",
+                        "normalize-path": "2.0.1",
+                        "object.omit": "2.0.0",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.2"
+                      },
                       "dependencies": {
                         "arr-diff": {
                           "version": "2.0.0",
-                          "from": "arr-diff@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                          "requires": {
+                            "arr-flatten": "1.0.1"
+                          },
                           "dependencies": {
                             "arr-flatten": {
                               "version": "1.0.1",
-                              "from": "arr-flatten@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+                              "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs="
                             }
                           }
                         },
                         "array-unique": {
                           "version": "0.2.1",
-                          "from": "array-unique@>=0.2.1 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
                         },
                         "braces": {
                           "version": "1.8.2",
-                          "from": "braces@>=1.8.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.2.tgz",
+                          "integrity": "sha1-A24CQFHUu8cJZCi01vIOofE3p5Q=",
+                          "requires": {
+                            "expand-range": "1.8.1",
+                            "lazy-cache": "0.2.7",
+                            "preserve": "0.2.0",
+                            "repeat-element": "1.1.2"
+                          },
                           "dependencies": {
                             "expand-range": {
                               "version": "1.8.1",
-                              "from": "expand-range@>=1.8.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                              "integrity": "sha1-rL1j5W79kTlyK3VfCZudtawfM/Y=",
+                              "requires": {
+                                "fill-range": "2.2.3"
+                              },
                               "dependencies": {
                                 "fill-range": {
                                   "version": "2.2.3",
-                                  "from": "fill-range@>=2.1.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                                  "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                                  "requires": {
+                                    "is-number": "2.1.0",
+                                    "isobject": "2.0.0",
+                                    "randomatic": "1.1.5",
+                                    "repeat-element": "1.1.2",
+                                    "repeat-string": "1.5.2"
+                                  },
                                   "dependencies": {
                                     "is-number": {
                                       "version": "2.1.0",
-                                      "from": "is-number@>=2.1.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                                      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                                      "requires": {
+                                        "kind-of": "3.0.2"
+                                      }
                                     },
                                     "isobject": {
                                       "version": "2.0.0",
-                                      "from": "isobject@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+                                      "integrity": "sha1-II3ocr1zeMKpKvlCij9W65GhIsQ=",
+                                      "requires": {
+                                        "isarray": "0.0.1"
+                                      },
                                       "dependencies": {
                                         "isarray": {
                                           "version": "0.0.1",
-                                          "from": "isarray@0.0.1",
-                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                                         }
                                       }
                                     },
                                     "randomatic": {
                                       "version": "1.1.5",
-                                      "from": "randomatic@>=1.1.3 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+                                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
+                                      "integrity": "sha1-Xp718tVzxnvSuBJK6QtRVuRXhAs=",
+                                      "requires": {
+                                        "is-number": "2.1.0",
+                                        "kind-of": "3.0.2"
+                                      }
                                     },
                                     "repeat-string": {
                                       "version": "1.5.2",
-                                      "from": "repeat-string@>=1.5.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
+                                      "integrity": "sha1-IQZfcHJ60FOg3V6VesngDHVg2Qo="
                                     }
                                   }
                                 }
@@ -4825,132 +8793,167 @@
                             },
                             "preserve": {
                               "version": "0.2.0",
-                              "from": "preserve@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                              "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
                             },
                             "repeat-element": {
                               "version": "1.1.2",
-                              "from": "repeat-element@>=1.1.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                              "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
                             }
                           }
                         },
                         "expand-brackets": {
                           "version": "0.1.4",
-                          "from": "expand-brackets@>=0.1.4 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz",
+                          "integrity": "sha1-eXueSEEBIF9BjOyuxjEsEy9R4q4="
                         },
                         "extglob": {
                           "version": "0.3.1",
-                          "from": "extglob@>=0.3.1 <0.4.0",
                           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
+                          "integrity": "sha1-TzEkHA3dyQrIxynLbXyHLe53yPU=",
+                          "requires": {
+                            "ansi-green": "0.1.1",
+                            "is-extglob": "1.0.0",
+                            "success-symbol": "0.1.0"
+                          },
                           "dependencies": {
                             "ansi-green": {
                               "version": "0.1.1",
-                              "from": "ansi-green@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+                              "integrity": "sha1-il2al55FjVfEDjNYCzc5C44Q0Pc=",
+                              "requires": {
+                                "ansi-wrap": "0.1.0"
+                              },
                               "dependencies": {
                                 "ansi-wrap": {
                                   "version": "0.1.0",
-                                  "from": "ansi-wrap@0.1.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+                                  "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
                                 }
                               }
                             },
                             "success-symbol": {
                               "version": "0.1.0",
-                              "from": "success-symbol@>=0.1.0 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
+                              "integrity": "sha1-JAIuSG878c3KCUKDt2nEctO3KJc="
                             }
                           }
                         },
                         "filename-regex": {
                           "version": "2.0.0",
-                          "from": "filename-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+                          "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U="
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
                         },
                         "kind-of": {
                           "version": "3.0.2",
-                          "from": "kind-of@>=3.0.2 <4.0.0",
                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                          "integrity": "sha1-GH20JwRufpCUVpLmdoZovWkA3qA=",
+                          "requires": {
+                            "is-buffer": "1.1.0"
+                          },
                           "dependencies": {
                             "is-buffer": {
                               "version": "1.1.0",
-                              "from": "is-buffer@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
+                              "integrity": "sha1-NveFDA0HenGwQfNWVmQVXwcDW9A="
                             }
                           }
                         },
                         "lazy-cache": {
                           "version": "0.2.7",
-                          "from": "lazy-cache@>=0.2.3 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+                          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
                         },
                         "normalize-path": {
                           "version": "2.0.1",
-                          "from": "normalize-path@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+                          "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o="
                         },
                         "object.omit": {
                           "version": "2.0.0",
-                          "from": "object.omit@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
+                          "integrity": "sha1-hoWXMz1U5gZilAu0WGBd1q4S/pQ=",
+                          "requires": {
+                            "for-own": "0.1.3",
+                            "is-extendable": "0.1.1"
+                          },
                           "dependencies": {
                             "for-own": {
                               "version": "0.1.3",
-                              "from": "for-own@>=0.1.3 <0.2.0",
                               "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                              "integrity": "sha1-YGREzed8LwoRCIFp4uNU6vVudP4=",
+                              "requires": {
+                                "for-in": "0.1.4"
+                              },
                               "dependencies": {
                                 "for-in": {
                                   "version": "0.1.4",
-                                  "from": "for-in@>=0.1.4 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
+                                  "integrity": "sha1-n1z3tP/H4a5lkaTpexd6pZ1w+y4="
                                 }
                               }
                             },
                             "is-extendable": {
                               "version": "0.1.1",
-                              "from": "is-extendable@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
                             }
                           }
                         },
                         "parse-glob": {
                           "version": "3.0.4",
-                          "from": "parse-glob@>=3.0.4 <4.0.0",
                           "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+                          "requires": {
+                            "glob-base": "0.3.0",
+                            "is-dotfile": "1.0.2",
+                            "is-extglob": "1.0.0",
+                            "is-glob": "2.0.1"
+                          },
                           "dependencies": {
                             "glob-base": {
                               "version": "0.3.0",
-                              "from": "glob-base@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                              "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+                              "requires": {
+                                "glob-parent": "2.0.0",
+                                "is-glob": "2.0.1"
+                              }
                             },
                             "is-dotfile": {
                               "version": "1.0.2",
-                              "from": "is-dotfile@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+                              "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0="
                             }
                           }
                         },
                         "regex-cache": {
                           "version": "0.4.2",
-                          "from": "regex-cache@>=0.4.2 <0.5.0",
                           "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                          "integrity": "sha1-bk+Jwma8A8M/0SnAYhhGh/RmNIc=",
+                          "requires": {
+                            "is-equal-shallow": "0.1.3",
+                            "is-primitive": "2.0.0"
+                          },
                           "dependencies": {
                             "is-equal-shallow": {
                               "version": "0.1.3",
-                              "from": "is-equal-shallow@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                              "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+                              "requires": {
+                                "is-primitive": "2.0.0"
+                              }
                             },
                             "is-primitive": {
                               "version": "2.0.0",
-                              "from": "is-primitive@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                              "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
                             }
                           }
                         }
@@ -4960,72 +8963,93 @@
                 },
                 "async-each": {
                   "version": "0.1.6",
-                  "from": "async-each@>=0.1.6 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
+                  "integrity": "sha1-tn6Z7c3fllQeRK9WKQzX1cbnBDk="
                 },
                 "glob-parent": {
                   "version": "2.0.0",
-                  "from": "glob-parent@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                  "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                  "requires": {
+                    "is-glob": "2.0.1"
+                  }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
                 },
                 "is-binary-path": {
                   "version": "1.0.1",
-                  "from": "is-binary-path@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                  "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+                  "requires": {
+                    "binary-extensions": "1.4.0"
+                  },
                   "dependencies": {
                     "binary-extensions": {
                       "version": "1.4.0",
-                      "from": "binary-extensions@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
+                      "integrity": "sha1-1zPMtiiYbXsybYhlbg3b06rDUbc="
                     }
                   }
                 },
                 "is-glob": {
                   "version": "2.0.1",
-                  "from": "is-glob@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                  "requires": {
+                    "is-extglob": "1.0.0"
+                  },
                   "dependencies": {
                     "is-extglob": {
                       "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
                 },
                 "readdirp": {
                   "version": "2.0.0",
-                  "from": "readdirp@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+                  "integrity": "sha1-zAm6XRLY/rhkvHX24uvBNwYMvYI=",
+                  "requires": {
+                    "graceful-fs": "4.1.2",
+                    "minimatch": "2.0.10",
+                    "readable-stream": "2.0.5"
+                  },
                   "dependencies": {
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "minimatch@>=2.0.10 <3.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                      "requires": {
+                        "brace-expansion": "1.1.2"
+                      },
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.2",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                          "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
+                          "requires": {
+                            "balanced-match": "0.3.0",
+                            "concat-map": "0.0.1"
+                          },
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                              "integrity": "sha1-qRzdHr7xqGZZ5w/03vAWJfwtZ1Y="
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                             }
                           }
                         }
@@ -5033,33 +9057,41 @@
                     },
                     "readable-stream": {
                       "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.2 <3.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "integrity": "sha1-okJvjc1FUcd6M/lu3yiGojyClmk=",
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.1",
+                        "isarray": "0.0.1",
+                        "process-nextick-args": "1.0.6",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                      },
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                          "integrity": "sha1-D5awAc6pCxJZLOVm7bl+wR5pvQU="
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                         }
                       }
                     }
@@ -5069,35 +9101,95 @@
             },
             "graceful-fs": {
               "version": "4.1.2",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+              "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc="
             }
           }
         },
         "webpack-core": {
           "version": "0.6.8",
-          "from": "webpack-core@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
+          "integrity": "sha1-7fkTXeAKajwm3Q8UsgivCqSvjQo=",
+          "requires": {
+            "source-list-map": "0.1.5",
+            "source-map": "0.4.4"
+          },
           "dependencies": {
+            "source-list-map": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
+              "integrity": "sha1-3fMvUXP67KMBBWHdfppoLAJ/RZ4="
+            },
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.1 <0.5.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "requires": {
+                "amdefine": "1.0.0"
+              },
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM="
                 }
               }
-            },
-            "source-list-map": {
-              "version": "0.1.5",
-              "from": "source-list-map@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
             }
           }
         }
+      }
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
+    "xml-escape": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
+      "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
       }
     }
   }


### PR DESCRIPTION
Update the npm-shrinkwarp.json files to lockfileVersion 1.

Currently the best Node.js version to build Shuup resources is 6, but
then a more fresh npm is also needed compared to the version which was
used to create the shrinkwraps.  Newer npm expects a new lock file
format and these shrinkwraps will therefore be regenerated every time
when building the resources.

Committing those regenerated contents here so that they wouldn't change
after each build anymore.