### PR TITLE
Core: make core basket command return added basket line id

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unrealeased
 Core
 ~~~~
 
+- Make core basket command return the added line id
 - Provides: add setting to blacklist undesired provides
 - Refund: check the max refundable items when doing partial refunds
 - Add customer related fields account manager, tax group and customer

--- a/shuup/core/basket/commands.py
+++ b/shuup/core/basket/commands.py
@@ -110,12 +110,15 @@ def handle_add(  # noqa (C901)
         "quantity": quantity,
         "supplier": supplier,
         "shop": request.shop,
+        "force_new_line": kwargs.get("force_new_line", False),
+        "extra": kwargs.get("extra"),
+        "parent_line": kwargs.get("parent_line")
     }
-
-    basket.add_product(**add_product_kwargs)
+    line = basket.add_product(**add_product_kwargs)
 
     return {
         'ok': basket.smart_product_count,
+        'line_id': line.line_id,
         'added': quantity
     }
 
@@ -140,7 +143,7 @@ def handle_add_var(
     # and hand it off to handle_add like we're used to
     return handle_add(
         request=request, basket=basket, product_id=var_product.pk,
-        quantity=quantity, unit_type=unit_type)
+        quantity=quantity, unit_type=unit_type, **kwargs)
 
 
 def handle_del(request, basket, line_id, **kwargs):

--- a/shuup/core/order_creator/_creator.py
+++ b/shuup/core/order_creator/_creator.py
@@ -72,6 +72,7 @@ class OrderProcessor(object):
         order_line.verified = (not order_line.require_verification)
         order_line.source_line = source_line
         order_line.parent_source_line = source_line.parent_line
+        order_line.extra_data = {"source_line_id": source_line.line_id}
         self._check_orderability(order_line)
 
         yield order_line

--- a/shuup_tests/api/test_basket_api.py
+++ b/shuup_tests/api/test_basket_api.py
@@ -140,6 +140,7 @@ def test_add_product_to_basket(admin_user):
         assert response.status_code == status.HTTP_200_OK
 
         response_data = json.loads(response.content.decode("utf-8"))
+        assert response_data["add_line_id"]
         assert len(response_data["items"]) == 1
         assert response_data["items"][0]["shop_product"] == shop_product.pk
         assert not response_data["validation_errors"]


### PR DESCRIPTION
This is useful to track the products added to the basket

Add option to pass additional arguments to add command like `extra`, `force_new_line` and `parent_line`