### PR TITLE
Validate stocks based on supplier stock managed attribute and make sure shipments supplier matches with the order line

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -58,6 +58,7 @@ Core
 Admin
 ~~~~~
 
+- Allow shipments only for suppliers assigned to order lines
 - Add JavaScript Mass Action type
 - Add multi shop support for media browser
 - Improve admin order creator translations

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,8 @@ Unrealeased
 Core
 ~~~~
 
+- Base supplier: Only check stocks for stock managed suppliers when
+  creating shipments.
 - Make core basket command return the added line id
 - Provides: add setting to blacklist undesired provides
 - Refund: check the max refundable items when doing partial refunds

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-09 00:35+0000\n"
+"POT-Creation-Date: 2018-05-18 19:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -919,6 +919,15 @@ msgid "Create Shipment -- %s"
 msgstr ""
 
 msgid "Supplier"
+msgstr ""
+
+msgid ""
+"Select the shipment supplier. You can only ship the suppliers assigned to "
+"order lines."
+msgstr ""
+
+#, python-format
+msgid "%(product_name)s (%(supplier)s)"
 msgstr ""
 
 msgid "No products to ship."
@@ -3148,6 +3157,9 @@ msgid "Refunded"
 msgstr ""
 
 msgid "Add Another Refund"
+msgstr ""
+
+msgid "Order Line"
 msgstr ""
 
 msgid "To Ship"

--- a/shuup/admin/templates/shuup/admin/orders/create_shipment.jinja
+++ b/shuup/admin/templates/shuup/admin/orders/create_shipment.jinja
@@ -9,7 +9,7 @@
                 <table class="table table-condensed table-shuup table-striped table-bordered">
                 <thead>
                     <tr>
-                        <th>{% trans %}Product{% endtrans %}</th>
+                        <th>{% trans %}Order Line{% endtrans %}</th>
                         <th class="text-right">{% trans %}To Ship{% endtrans %}</th>
                         <th class="text-right hidden-xs">{% trans %}Ordered{% endtrans %}</th>
                         <th class="text-right hidden-xs">{% trans %}Shipped{% endtrans %}</th>
@@ -42,7 +42,7 @@
                     {% for product_id, info in form.product_summary.items() %}
                         {% set field = form["q_" ~ product_id] %}
                         <tr>
-                            <td>{{ form.product_names.get(product_id) }}</td>
+                            <td>{{ field.label }}</td>
                             <td class="text-right quantity-column">
                                 <div class="{% if field.errors %}has-error{% endif %}">
                                     {{ field }}

--- a/shuup/core/models/_orders.py
+++ b/shuup/core/models/_orders.py
@@ -1061,9 +1061,14 @@ class Order(MoneyPropped, models.Model):
 
         lines_to_ship = (
             self.lines.filter(type=OrderLineType.PRODUCT, product__shipping_mode=ShippingMode.SHIPPED)
-            .values_list("product_id", "quantity"))
-        for product_id, quantity in lines_to_ship:
+            .values_list("product_id", "quantity", "supplier__name"))
+
+        for product_id, quantity, supplier in lines_to_ship:
             products[product_id]['unshipped'] += quantity
+            if not products[product_id]['suppliers']:
+                products[product_id]['suppliers'] = [supplier]
+            else:
+                products[product_id]['suppliers'].append(supplier)
 
         from ._shipments import ShipmentProduct, ShipmentStatus
 

--- a/shuup/core/suppliers/base.py
+++ b/shuup/core/suppliers/base.py
@@ -9,7 +9,6 @@ from django.core.exceptions import ValidationError
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
-from shuup.core.models import StockBehavior
 from shuup.core.stocks import ProductStockStatus
 from shuup.utils.excs import Problem
 
@@ -65,7 +64,8 @@ class BaseSupplierModule(object):
         backorder_maximum = shop_product.backorder_maximum
         if stock_status.error:
             yield ValidationError(stock_status.error, code="stock_error")
-        if shop_product.product.stock_behavior == StockBehavior.STOCKED:
+
+        if self.supplier.stock_managed:
             if backorder_maximum is not None and quantity > stock_status.logical_count + backorder_maximum:
                 yield ValidationError(stock_status.message or _(u"Insufficient stock"), code="stock_insufficient")
 
@@ -81,26 +81,33 @@ class BaseSupplierModule(object):
             self.update_stock(product_id)
 
     def ship_products(self, shipment, product_quantities):
-        insufficient_stocks = {}
-        for product, quantity in product_quantities.items():
-            if quantity > 0:
-                stock_status = self.get_stock_status(product.pk)
-                if (product.stock_behavior == StockBehavior.STOCKED) and (stock_status.physical_count < quantity):
-                    insufficient_stocks[product] = stock_status.physical_count
-                sp = shipment.products.create(product=product, quantity=quantity)
-                sp.cache_values()
-                sp.save()
+        if self.supplier.stock_managed:  # Check stocks for stock managed supplier
+            insufficient_stocks = {}
+            for product, quantity in product_quantities.items():
+                if quantity > 0:
+                    if self.supplier.stock_managed:  # Check stocks for stock managed supplier
+                        stock_status = self.get_stock_status(product.pk)
+                        if stock_status.physical_count < quantity:
+                            insufficient_stocks[product] = stock_status.physical_count
 
-        if insufficient_stocks:
-            formatted_counts = [_("%(name)s (physical stock: %(quantity)s)") % {
-                "name": force_text(name),
-                "quantity": force_text(quantity)
-            }
-                                for (name, quantity) in insufficient_stocks.items()]
-            raise Problem(
-                _("Insufficient physical stock count for following products: %(product_counts)s") % {
-                    "product_counts": ", ".join(formatted_counts)
-                })
+            if insufficient_stocks:
+                formatted_counts = [_("%(name)s (physical stock: %(quantity)s)") % {
+                    "name": force_text(name),
+                    "quantity": force_text(quantity)
+                }
+                                    for (name, quantity) in insufficient_stocks.items()]
+                raise Problem(
+                    _("Insufficient physical stock count for following products: %(product_counts)s") % {
+                        "product_counts": ", ".join(formatted_counts)
+                    })
+
+        for product, quantity in product_quantities.items():
+            if quantity == 0:
+                continue
+
+            sp = shipment.products.create(product=product, quantity=quantity)
+            sp.cache_values()
+            sp.save()
 
         shipment.cache_values()
         shipment.save()

--- a/shuup_tests/api/test_basket_api.py
+++ b/shuup_tests/api/test_basket_api.py
@@ -355,19 +355,15 @@ def test_quantity_has_to_be_in_stock(admin_user):
     with override_settings(**REQUIRED_SETTINGS):
         set_configuration()
         from shuup_tests.simple_supplier.utils import get_simple_supplier
-        from shuup.core.models import StockBehavior
         shop = factories.get_default_shop()
         basket = factories.get_basket()
 
-        supplier = get_simple_supplier()
+        supplier = get_simple_supplier(stock_managed=True)
         product = factories.create_product("simple-test-product", shop, supplier)
         quantity = 256
         supplier.adjust_stock(product.pk, quantity)
-        product.stock_behavior = StockBehavior.STOCKED
-        product.save()
         shop_product = product.shop_products.first()
-        shop_product.suppliers.add(supplier)
-        shop_product.save()
+        shop_product.suppliers = [supplier]
 
         client = get_client(admin_user)
         payload = {

--- a/shuup_tests/api/test_basket_packages.py
+++ b/shuup_tests/api/test_basket_packages.py
@@ -15,7 +15,7 @@ from django.test import override_settings
 from rest_framework import status
 
 from shuup.core import cache
-from shuup.core.models import Order, OrderStatusManager, StockBehavior
+from shuup.core.models import Order, OrderStatusManager
 from shuup.simple_supplier.module import SimpleSupplierModule
 from shuup.testing import factories
 from shuup.testing.basket_helpers import get_client, REQUIRED_SETTINGS
@@ -39,7 +39,7 @@ def test_basket_with_package_product(admin_user):
         assert response.status_code == status.HTTP_201_CREATED
         basket_uuid = response.data["uuid"]
 
-        supplier = factories.get_supplier(SimpleSupplierModule.identifier, shop=shop)
+        supplier = factories.get_supplier(SimpleSupplierModule.identifier, shop=shop, stock_managed=True)
 
         # base product - 1kg of sand
         base_sand_product = factories.create_product(
@@ -47,8 +47,7 @@ def test_basket_with_package_product(admin_user):
             shop=shop,
             supplier=supplier,
             default_price="15.2",
-            net_weight=Decimal(1),
-            stock_behavior=StockBehavior.STOCKED
+            net_weight=Decimal(1)
         )
 
         # 10kg bag of sand - package made by 10kg of sand

--- a/shuup_tests/core/test_suppliers.py
+++ b/shuup_tests/core/test_suppliers.py
@@ -32,9 +32,9 @@ def test_get_suppliable_products():
     # Check for default orderable shop product with unstocked behavior
     assert len(list(supplier.get_suppliable_products(shop, customer=customer))) == 1
 
-    product = shop_product.product
-    product.stock_behavior = StockBehavior.STOCKED
-    product.save()
+    supplier.stock_managed = True
+    supplier.save()
+
     # Make sure supplier now omits unorderable product
     assert not list(supplier.get_suppliable_products(shop, customer=customer))
     assert len(list(supplier.get_orderability_errors(shop_product, quantity=1, customer=customer))) == 1

--- a/shuup_tests/simple_supplier/test_simple_supplier.py
+++ b/shuup_tests/simple_supplier/test_simple_supplier.py
@@ -57,7 +57,7 @@ def test_simple_supplier(rf):
 
 @pytest.mark.django_db
 def test_supplier_with_stock_counts(rf):
-    supplier = get_simple_supplier()
+    supplier = get_simple_supplier(stock_managed=False)
     shop = get_default_shop()
     product = create_product("simple-test-product", shop, supplier)
     quantity = random.randint(100, 600)
@@ -66,8 +66,8 @@ def test_supplier_with_stock_counts(rf):
     # No orderability errors since product is not stocked
     assert not list(supplier.get_orderability_errors(product.get_shop_instance(shop), quantity+1, customer=None))
 
-    product.stock_behavior = StockBehavior.STOCKED  # Make product stocked
-    product.save()
+    supplier.stock_managed = True
+    supplier.save()
 
     assert not list(supplier.get_orderability_errors(product.get_shop_instance(shop), quantity, customer=None))
     # Now since product is stocked we get orderability error with quantity + 1

--- a/shuup_tests/simple_supplier/utils.py
+++ b/shuup_tests/simple_supplier/utils.py
@@ -11,13 +11,14 @@ from shuup.testing.factories import get_default_shop
 IDENTIFIER = "test_simple_supplier"
 
 
-def get_simple_supplier():
+def get_simple_supplier(stock_managed=True):
     supplier = Supplier.objects.filter(identifier=IDENTIFIER).first()
     if not supplier:
         supplier = Supplier.objects.create(
             identifier=IDENTIFIER,
             name="Simple Supplier",
             module_identifier="simple_supplier",
+            stock_managed=stock_managed
         )
     shop = get_default_shop()
     supplier.shops.add(shop)


### PR DESCRIPTION
Core: Validate stocks for stock managed suppliers only
* Also only check stocks for stock managed suppliers when
creating shipments.
* Skip supplier checks for variation parents and package
parents. Variation parents is not meant to be added to
basket and package parent supplier availability is
determined by the package components.
* Add supplier stock managed info to shop product
is orderable cache to avoid issues when supplier stock
managed attribute is changed.

Admin: Match shipment supplier to order line supplier