### PR TITLE
Admin: add specific form to request and reset staff user password

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -58,6 +58,7 @@ Core
 Admin
 ~~~~~
 
+- Add specific form to request and reset staff user password
 - Allow shipments only for suppliers assigned to order lines
 - Add JavaScript Mass Action type
 - Add multi shop support for media browser

--- a/shuup/admin/forms/_auth.py
+++ b/shuup/admin/forms/_auth.py
@@ -7,8 +7,12 @@
 # LICENSE file in the root directory of this source tree.
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
+from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
+
+from shuup.core.utils.forms import RecoverPasswordForm
 
 
 class EmailAuthenticationForm(AuthenticationForm):
@@ -43,3 +47,29 @@ class EmailAuthenticationForm(AuthenticationForm):
             return getattr(user_by_email, user_model.USERNAME_FIELD)
 
         return username
+
+
+class RequestPasswordForm(RecoverPasswordForm):
+    token_generator = default_token_generator
+    subject_template_name = "shuup/admin/auth/recover_password_mail_subject.jinja"
+    email_template_name = "shuup/admin/auth/recover_password_mail_content.jinja"
+    from_email = None
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request")
+        super(RequestPasswordForm, self).__init__(*args, **kwargs)
+
+    def save(self):
+        user_model = get_user_model()
+        username = self.cleaned_data.get("username")
+        email = self.cleaned_data.get("email")
+        username_filter = {
+            "{0}__iexact".format(user_model.USERNAME_FIELD): username
+        }
+        # only staff and active users
+        active_users = user_model.objects.filter(
+            Q(is_active=True, is_staff=True),
+            Q(**username_filter) | Q(email__iexact=email)
+        )
+        for user in active_users:
+            self.process_user(user)

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-18 19:11+0000\n"
+"POT-Creation-Date: 2018-05-21 20:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -1952,6 +1952,32 @@ msgstr ""
 msgid "Visit shop"
 msgstr ""
 
+#, python-format
+msgid "Hi %(fullname)s"
+msgstr ""
+
+#, python-format
+msgid "In case you've forgotten, your username is %(username)s."
+msgstr ""
+
+#, python-format
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at %(site_name)s."
+msgstr ""
+
+msgid "Please go to the following page and choose a new password:"
+msgstr ""
+
+msgid "Password Recovery"
+msgstr ""
+
+msgid "Reset Password"
+msgstr ""
+
+msgid "Send password recovery instructions"
+msgstr ""
+
 msgid "Quicklinks"
 msgstr ""
 
@@ -3680,6 +3706,17 @@ msgid "Let customers browse your store and make purchases"
 msgstr ""
 
 msgid "Publish shop"
+msgstr ""
+
+msgid ""
+"A reset password email was sent. Please, follow the instructions to set a "
+"new password."
+msgstr ""
+
+msgid "This recovery link is invalid."
+msgstr ""
+
+msgid "Password changed successfully!"
 msgstr ""
 
 #, python-format

--- a/shuup/admin/templates/shuup/admin/auth/recover_password_mail_content.jinja
+++ b/shuup/admin/templates/shuup/admin/auth/recover_password_mail_content.jinja
@@ -1,0 +1,5 @@
+{% trans fullname=user_to_recover.get_full_name() %}Hi {{ fullname }}{% endtrans %},
+{% trans username=user_to_recover.username %}In case you've forgotten, your username is {{ username }}.{% endtrans %}
+{% trans %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endtrans %}
+{% trans %}Please go to the following page and choose a new password:{% endtrans %}
+{{ request.build_absolute_uri(url("shuup_admin:recover_password", uidb64=uid, token=token)) }}

--- a/shuup/admin/templates/shuup/admin/auth/recover_password_mail_subject.jinja
+++ b/shuup/admin/templates/shuup/admin/auth/recover_password_mail_subject.jinja
@@ -1,0 +1,1 @@
+{% trans %}Password Recovery{% endtrans %}

--- a/shuup/admin/templates/shuup/admin/auth/request_password.jinja
+++ b/shuup/admin/templates/shuup/admin/auth/request_password.jinja
@@ -1,5 +1,5 @@
 {% extends "shuup/admin/base_small_dialog.jinja" %}
-{% block title %}{% trans %}Login{% endtrans %}{% endblock %}
+{% block title %}{% trans %}Reset Password{% endtrans %}{% endblock %}
 {% from "shuup/admin/macros/general.jinja" import auth_block %}
 {% block content %}
     {% call auth_block("subtle-slide-in") %}
@@ -17,19 +17,14 @@
                     {% endfor %}
                 </div>
             {% endif %}
-            {{ bs3.field(form.username) }}
-            {{ bs3.field(form.password) }}
+            {{ bs3.field(form.email) }}
             <input type="hidden" name="next" value="{{ next }}">
             <div class="actions">
                 <button class="btn btn-primary btn-lg btn-block" type="submit">
-                    <i class="fa fa-sign-in"></i>
-                    {% trans %}Login{% endtrans %}
+                    {% trans %}Send password recovery instructions{% endtrans %}
                 </button>
             </div>
             <hr>
-            <a href="{{ url("shuup_admin:request_password") }}">
-                {% trans %}Forgot your password?{% endtrans %}
-            </a>
         </form>
     {% endcall %}
 {% endblock %}

--- a/shuup/admin/templates/shuup/admin/auth/reset_password.jinja
+++ b/shuup/admin/templates/shuup/admin/auth/reset_password.jinja
@@ -1,5 +1,5 @@
 {% extends "shuup/admin/base_small_dialog.jinja" %}
-{% block title %}{% trans %}Login{% endtrans %}{% endblock %}
+{% block title %}{% trans %}Reset Password{% endtrans %}{% endblock %}
 {% from "shuup/admin/macros/general.jinja" import auth_block %}
 {% block content %}
     {% call auth_block("subtle-slide-in") %}
@@ -17,19 +17,18 @@
                     {% endfor %}
                 </div>
             {% endif %}
-            {{ bs3.field(form.username) }}
-            {{ bs3.field(form.password) }}
+            <div class="actions">
+                {{ bs3.field(form.new_password1) }}
+                {{ bs3.field(form.new_password2) }}
+            </div>
             <input type="hidden" name="next" value="{{ next }}">
             <div class="actions">
                 <button class="btn btn-primary btn-lg btn-block" type="submit">
                     <i class="fa fa-sign-in"></i>
-                    {% trans %}Login{% endtrans %}
+                    {% trans %}Reset password{% endtrans %}
                 </button>
             </div>
             <hr>
-            <a href="{{ url("shuup_admin:request_password") }}">
-                {% trans %}Forgot your password?{% endtrans %}
-            </a>
         </form>
     {% endcall %}
 {% endblock %}

--- a/shuup/admin/urls.py
+++ b/shuup/admin/urls.py
@@ -22,6 +22,7 @@ from shuup.admin.utils.urls import admin_url, AdminRegexURLPattern
 from shuup.admin.views.dashboard import DashboardView
 from shuup.admin.views.home import HomeView
 from shuup.admin.views.menu import MenuView
+from shuup.admin.views.password import RequestPasswordView, ResetPasswordView
 from shuup.admin.views.search import SearchView
 from shuup.admin.views.select import MultiselectAjaxView
 from shuup.admin.views.tour import TourView
@@ -60,6 +61,18 @@ def get_urls():
             auth_views.logout,
             kwargs={"template_name": "shuup/admin/auth/logout.jinja"},
             name='logout',
+            require_authentication=False
+        ),
+        admin_url(
+            r'^recover-password/(?P<uidb64>.+)/(?P<token>.+)/$',
+            ResetPasswordView,
+            name='recover_password',
+            require_authentication=False
+        ),
+        admin_url(
+            r'^request-password/$',
+            RequestPasswordView,
+            name='request_password',
             require_authentication=False
         ),
         admin_url(

--- a/shuup/admin/views/password.py
+++ b/shuup/admin/views/password.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import unicode_literals
+
+from django.contrib import messages
+from django.contrib.auth import get_user_model, login
+from django.contrib.auth.tokens import default_token_generator
+from django.core.urlresolvers import reverse, reverse_lazy
+from django.db.transaction import atomic
+from django.http.response import HttpResponseRedirect
+from django.utils.http import urlsafe_base64_decode
+from django.utils.translation import ugettext_lazy as _
+from django.views.generic import FormView
+
+from shuup.utils.excs import Problem
+
+
+class RequestPasswordView(FormView):
+    template_name = "shuup/admin/auth/request_password.jinja"
+
+    def get_form_class(self):
+        from shuup.admin.forms._auth import RequestPasswordForm
+        return RequestPasswordForm
+
+    def get_success_url(self):
+        return "{}?email={}".format(reverse("shuup_admin:recover_password"), self.request.POST.get("email"))
+
+    def get_form_kwargs(self):
+        kwargs = super(RequestPasswordView, self).get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
+
+    def form_valid(self, form):
+        form.save()
+        msg = _("A reset password email was sent. Please, follow the instructions to set a new password.")
+        messages.success(self.request, msg)
+        return HttpResponseRedirect(reverse("shuup_admin:login"))
+
+
+class ResetPasswordView(FormView):
+    template_name = "shuup/admin/auth/reset_password.jinja"
+    success_url = reverse_lazy("shuup_admin:login")
+    token_generator = default_token_generator
+
+    def get_form_class(self):
+        from django.contrib.auth.forms import SetPasswordForm
+        return SetPasswordForm
+
+    def get_form_kwargs(self):
+        kwargs = super(ResetPasswordView, self).get_form_kwargs()
+        kwargs["user"] = self.get_target_user()
+        return kwargs
+
+    def get_target_user(self):
+        uidb64 = self.kwargs["uidb64"]
+        user_model = get_user_model()
+        try:
+            uid = urlsafe_base64_decode(uidb64)
+            user = user_model._default_manager.get(pk=uid)
+        except (TypeError, ValueError, OverflowError, user_model.DoesNotExist):
+            user = None
+        return user
+
+    def dispatch(self, request, *args, **kwargs):
+        user = self.get_target_user()
+        token = self.kwargs["token"]
+
+        valid = (user is not None and self.token_generator.check_token(user, token))
+        if not valid:
+            raise Problem(_("This recovery link is invalid."))
+
+        return super(ResetPasswordView, self).dispatch(request, *args, **kwargs)
+
+    @atomic
+    def form_valid(self, form):
+        form.save()
+        form.user.backend = "django.contrib.auth.backends.ModelBackend"
+        login(self.request, form.user)
+        messages.success(self.request, _("Password changed successfully!"))
+        return HttpResponseRedirect(self.get_success_url())

--- a/shuup/core/utils/forms.py
+++ b/shuup/core/utils/forms.py
@@ -92,7 +92,7 @@ class RecoverPasswordForm(forms.Form):
     username = forms.CharField(label=_("Username"), max_length=254, required=False)
     email = forms.EmailField(label=_("Email"), max_length=254, required=False)
     token_generator = default_token_generator
-    subject_template_name = "shuup/user/recover_password_mail_subject.jinja",
+    subject_template_name = "shuup/user/recover_password_mail_subject.jinja"
     email_template_name = "shuup/user/recover_password_mail_content.jinja"
     from_email = None
 

--- a/shuup_tests/admin/test_password_reset.py
+++ b/shuup_tests/admin/test_password_reset.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from django.utils.html import escape
+from django.core import mail
+from django.core.urlresolvers import reverse
+
+from shuup.testing import factories
+from shuup.testing.factories import get_default_shop
+from shuup_tests.utils.fixtures import REGULAR_USER_PASSWORD, REGULAR_USER_EMAIL
+
+
+@pytest.mark.django_db
+def test_reset_admin_user_password(client):
+    get_default_shop()
+
+    user = factories.create_random_user("en", is_staff=True, is_active=True, email=REGULAR_USER_EMAIL)
+    user.set_password(REGULAR_USER_PASSWORD)
+    user.save(update_fields=("password",))
+
+    assert len(mail.outbox) == 0
+    response = client.post(reverse("shuup_admin:request_password"), data={
+        "email": user.email
+    })
+    assert response.status_code == 302
+    assert response.get("location")
+    assert response.get("location").endswith(reverse("shuup_admin:login"))
+    assert len(mail.outbox) == 1
+    email_content = mail.outbox[0].body
+    url = email_content[email_content.find("http"):]
+    _, _, _, _, _, uid, token, _ = url.split("/")
+
+    new_password = "new_pass"
+    response = client.post(reverse("shuup_admin:recover_password", kwargs=dict(uidb64=uid, token=token)), data={
+        "new_password1": new_password,
+        "new_password2": new_password
+    })
+    assert response.status_code == 302
+    assert response.get("location")
+    assert response.get("location").endswith(reverse("shuup_admin:login"))
+    assert len(mail.outbox) == 1
+
+    user.refresh_from_db()
+    assert user.check_password(new_password)
+
+
+@pytest.mark.django_db
+def test_reset_admin_user_password_errors(client):
+    get_default_shop()
+
+    user = factories.create_random_user("en", is_staff=True, is_active=False, email=REGULAR_USER_EMAIL)
+    user.set_password(REGULAR_USER_PASSWORD)
+    user.save()
+
+    assert len(mail.outbox) == 0
+
+    # user not active
+    response = client.post(reverse("shuup_admin:request_password"), data={"email": user.email})
+    assert response.status_code == 302
+    assert len(mail.outbox) == 0
+
+    user.is_active = True
+    user.is_staff = False
+    user.save()
+
+    # user not staff
+    response = client.post(reverse("shuup_admin:request_password"), data={"email": user.email})
+    assert response.status_code == 302
+    assert len(mail.outbox) == 0
+
+    # non-existent email
+    response = client.post(reverse("shuup_admin:request_password"), data={"email": "doesntexist@email.ok"})
+    assert response.status_code == 302
+    assert len(mail.outbox) == 0
+
+    user.is_staff = True
+    user.save()
+
+    # all set
+    response = client.post(reverse("shuup_admin:request_password"), data={"email": user.email})
+    assert response.status_code == 302
+    assert len(mail.outbox) == 1
+    email_content = mail.outbox[0].body
+    url = email_content[email_content.find("http"):]
+    _, _, _, _, _, uid, token, _ = url.split("/")
+
+    # invalid token
+    new_password = "new_pass"
+    response = client.post(
+        reverse("shuup_admin:recover_password", kwargs=dict(uidb64=uid, token="invalid")),
+        data={"new_password1": new_password, "new_password2": new_password}
+    )
+    assert response.status_code == 200
+    assert "This recovery link is invalid" in response.content.decode("utf-8")
+
+    # invalid uid
+    response = client.post(
+        reverse("shuup_admin:recover_password", kwargs=dict(uidb64="uid", token=token)),
+        data={"new_password1": new_password, "new_password2": new_password}
+    )
+    assert response.status_code == 200
+    assert "This recovery link is invalid" in response.content.decode("utf-8")
+
+    # invalid passwords
+    response = client.post(
+        reverse("shuup_admin:recover_password", kwargs=dict(uidb64=uid, token=token)),
+        data={"new_password1": new_password, "new_password2": "wrong"}
+    )
+    assert response.status_code == 200
+    assert escape("The two password fields didn't match.") in response.content.decode("utf-8")
+
+    # all good
+    response = client.post(
+        reverse("shuup_admin:recover_password", kwargs=dict(uidb64=uid, token=token)),
+        data={"new_password1": new_password, "new_password2": new_password}
+    )
+    assert response.status_code == 302


### PR DESCRIPTION
Staff users can request to change their passwords directly through Shuup admin interface.

The user emails are used to send the reset email link