### PR TITLE
Admin: fixed checkout form to skip if there is no form at all

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,11 @@ Unrealeased
   When releasing next version, the "Unreleased" header will be replaced
   with appropriate version header and this help text will be removed.
 
+Admin
+~~~~~
+
+- Fixed shop checkout config to skip form when creating a new shop
+
 Shuup 1.6.0
 -----------
 

--- a/shuup/front/admin_module/checkout/form_parts.py
+++ b/shuup/front/admin_module/checkout/form_parts.py
@@ -50,6 +50,8 @@ class CheckoutShopFormPart(FormPart):
         )
 
     def form_valid(self, form):
-        data = form[self.name].cleaned_data
+        if self.name not in form.forms:
+            return
+        data = form.forms[self.name].cleaned_data
         configuration.set(self.object, SHIPPING_METHOD_REQUIRED_CONFIG_KEY, data.get("shipping_method_required", False))
         configuration.set(self.object, PAYMENT_METHOD_REQUIRED_CONFIG_KEY, data.get("payment_method_required", False))


### PR DESCRIPTION
An error raises when creating a new shop from admin view.

No Refs