### PR TITLE
Admin: do not add or remove superusers from shop staff members

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,6 +17,7 @@ Core
 Admin
 ~~~~~
 
+- Do not add or remove superusers from shop staff members
 - Fixed shop checkout config to skip form when creating a new shop
 
 Front

--- a/shuup/admin/modules/users/views/permissions.py
+++ b/shuup/admin/modules/users/views/permissions.py
@@ -19,6 +19,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.generic.edit import UpdateView
 
 from shuup.admin.forms.fields import Select2MultipleField
+from shuup.admin.shop_provider import get_shop
 from shuup.admin.toolbar import get_default_edit_toolbar
 from shuup.admin.utils.urls import get_model_url
 
@@ -134,10 +135,12 @@ class UserChangePermissionsView(UpdateView):
     def form_valid(self, form):
         form.save()
 
-        if getattr(self.object, "is_staff", False):
-            self.request.shop.staff_members.add(self.object)
-        else:
-            self.request.shop.staff_members.remove(self.object)
+        if not getattr(self.object, "is_superuser", False):
+            shop = get_shop(self.request)
+            if getattr(self.object, "is_staff", False):
+                shop.staff_members.add(self.object)
+            else:
+                shop.staff_members.remove(self.object)
 
         messages.success(self.request, _("Permissions changed for %s.") % self.object)
         return HttpResponseRedirect(self.get_success_url())

--- a/shuup_tests/admin/test_user_module.py
+++ b/shuup_tests/admin/test_user_module.py
@@ -118,6 +118,40 @@ def test_user_create(rf, admin_user):
     last_user = get_user_model().objects.last()
     assert last_user in shop.staff_members.all()
 
+    # create a superuser
+    view_func = UserDetailView.as_view()
+    response = view_func(apply_request_middleware(rf.post("/", {
+        "username": "test4",
+        "email": "test4@test.com",
+        "first_name": "test",
+        "last_name": "test",
+        "password": "test",
+        "is_staff": True,
+        "is_superuser": True,
+        "send_confirmation": False
+    }), user=admin_user))
+    assert response.status_code == 302
+    assert get_user_model().objects.count() == before_count + 4
+    last_user = get_user_model().objects.last()
+    # superuser shouldn't be added to staff members
+    assert last_user not in shop.staff_members.all()
+
+    # change the superuser
+    response = view_func(apply_request_middleware(rf.post("/", {
+        "username": "test487",
+        "email": "test4@test.com",
+        "first_name": "test2",
+        "last_name": "test",
+        "password": "test",
+        "is_staff": True,
+        "is_superuser": True,
+    }), user=admin_user), pk=last_user.pk)
+    assert response.status_code == 302
+    assert get_user_model().objects.count() == before_count + 4
+    last_user = get_user_model().objects.last()
+    # superuser shouldn't be added to staff members
+    assert last_user not in shop.staff_members.all()
+
 
 @pytest.mark.django_db
 def test_user_detail_contact_seed(rf, admin_user):


### PR DESCRIPTION
When managing a superuser, do not add or remove it from the current shop staff member list.

Refs POS-2414