### PR TITLE
Data import: require only shop change permission to execute data imports

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,10 +9,16 @@ Unrealeased
   When releasing next version, the "Unreleased" header will be replaced
   with appropriate version header and this help text will be removed.
 
+Importer
+--------
+
+- Require only shop change permission to execute data imports
+
 Simple CMS
 ~~~~~~~~~~
 
 - Add support for choosing whether the timestamps are shown if the `list_children_on_page` has been set to `True`.
+
 
 Shuup 1.6.2
 -----------

--- a/shuup/importer/admin_module/__init__.py
+++ b/shuup/importer/admin_module/__init__.py
@@ -11,9 +11,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from shuup.admin.base import AdminModule, MenuEntry
 from shuup.admin.menu import SETTINGS_MENU_CATEGORY
-from shuup.admin.utils.permissions import get_default_model_permissions
 from shuup.admin.utils.urls import admin_url
-from shuup.core.models import Shop
 
 
 class ImportAdminModule(AdminModule):
@@ -26,13 +24,13 @@ class ImportAdminModule(AdminModule):
                 "^importer/import$",
                 "shuup.importer.admin_module.import_views.ImportView",
                 name="importer.import",
-                permissions=get_default_model_permissions(Shop)
+                permissions=["shuup.change_shop"]
             ),
             admin_url(
                 "^importer/import/process$",
                 "shuup.importer.admin_module.import_views.ImportProcessView",
                 name="importer.import_process",
-                permissions=get_default_model_permissions(Shop)
+                permissions=["shuup.change_shop"]
             ),
         ]
 


### PR DESCRIPTION
Require only `shuup.change_shop` permission to execute data imports 

Refs POS-2349