### PR TITLE
GDPR: Show consent changes

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,11 @@ Unrealeased
   When releasing next version, the "Unreleased" header will be replaced
   with appropriate version header and this help text will be removed.
 
+GDPR
+~~~~
+
+- When making changes to consent pages, the customer is now being shown (s)he should re-consent.
+
 Core
 ~~~~
 

--- a/shuup/gdpr/locale/en/LC_MESSAGES/django.po
+++ b/shuup/gdpr/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-22 21:27+0000\n"
+"POT-Creation-Date: 2018-06-25 20:47+0000\n"
 "PO-Revision-Date: 2018-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -140,7 +140,13 @@ msgstr ""
 msgid "Read the <a href='{}' target='_blank'>{}</a>."
 msgstr ""
 
-msgid "You must accept to this to register or authenticate."
+msgid "You must accept to this to register."
+msgstr ""
+
+msgid "You must accept to this to order."
+msgstr ""
+
+msgid "You must accept to this to authenticate."
 msgstr ""
 
 msgid ""
@@ -793,6 +799,13 @@ msgid "Cookies: "
 msgstr ""
 
 msgid "Save preferences"
+msgstr ""
+
+#, python-format
+msgid ""
+"Our privacy policy has been updated since your last consent. Please read the "
+"updated version <a href=\"%(url)s\">here</a>. <a class=\"btn btn-primary\" "
+"href=\"%(accept_url)s\">Accept changes</a>"
 msgstr ""
 
 msgid "Required"

--- a/shuup/gdpr/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shuup/gdpr/locale/fi_FI/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-22 21:27+0000\n"
+"POT-Creation-Date: 2018-06-25 20:48+0000\n"
 "PO-Revision-Date: 2018-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Panu Tulimäki <panu@shuup.com>, 2018\n"
 "Language-Team: Finnish (Finland) (https://www.transifex.com/shuup/"
@@ -138,10 +138,10 @@ msgid "GDPR user consents"
 msgstr "GDPR käyttäjäsuostumukset"
 
 msgid "GDPR user consent in {} for user {} in shop {}"
-msgstr "GDPR käyttäjäsuostumus {} käyttäjälle {} kaupalle {}"
+msgstr "GDPR-käyttäjäsuostumus {} käyttäjälle {} kaupassa {}"
 
 msgid "GDPR user consent document for {} (Version: {})"
-msgstr "GDPR-käyttäjäsuostumus {} (Versio: {})"
+msgstr "GDPR-käyttäjäsuostumus dokumentille {} (Versio: {})"
 
 msgid "I have read and accept the {}"
 msgstr "Olen lukenut, ja hyväksyn {}"
@@ -149,8 +149,14 @@ msgstr "Olen lukenut, ja hyväksyn {}"
 msgid "Read the <a href='{}' target='_blank'>{}</a>."
 msgstr "Lue <a href='{}' target='_blank'>{}</a>."
 
-msgid "You must accept to this to register or authenticate."
-msgstr "Sinun pitää hyväksyä tämä, jotta voit rekisteröityä tai kirjautua."
+msgid "You must accept to this to register."
+msgstr "Sinun pitää hyväksyä tämä, jotta voit rekisteröityä."
+
+msgid "You must accept to this to order."
+msgstr "Sinun pitää hyväksyä tämä, jotta voit tilata."
+
+msgid "You must accept to this to authenticate."
+msgstr "Sinun pitää hyväksyä tämä, jotta voit kirjautua."
 
 msgid ""
 "<p>This website stores cookies on your computer. These cookies are used to "
@@ -1070,6 +1076,16 @@ msgstr "Evästeet:"
 
 msgid "Save preferences"
 msgstr "Tallenna asetukset"
+
+#, python-format
+msgid ""
+"Our privacy policy has been updated since your last consent. Please read the "
+"updated version <a href=\"%(url)s\">here</a>. <a class=\"btn btn-primary\" "
+"href=\"%(accept_url)s\">Accept changes</a>"
+msgstr ""
+"Tietosuojakäytäntömme on päivittynyt viimeisen hyväksymisesi jälkeen. Ole "
+"hyvä, ja lue päivitetty versio <a href=\"%(url)s\">täältä</a>. <a class="
+"\"btn btn-primary\" href=\"%(accept_url)s\">Hyväksyn muutokset</a>"
 
 msgid "Required"
 msgstr "Vaadittu"

--- a/shuup/gdpr/models.py
+++ b/shuup/gdpr/models.py
@@ -164,6 +164,10 @@ class GDPRUserConsent(models.Model):
         consent.documents = documents
         return consent
 
+    @classmethod
+    def get_for_user(cls, user, shop):
+        return cls.objects.filter(user=user, shop=shop).order_by("-created_on").first()
+
     def should_reconsent(self, shop, user):
         consent_pages_ids = set([page.id for page in get_active_consent_pages(shop)])
         page_ids = set([doc.page.id for doc in self.documents.all()])

--- a/shuup/gdpr/resources.py
+++ b/shuup/gdpr/resources.py
@@ -8,10 +8,14 @@
 from django.conf import settings
 from django.template import loader
 from django.templatetags.static import static
+from rest_framework.reverse import reverse
 
 from shuup.core.shop_provider import get_shop
 from shuup.gdpr.models import GDPRCookieCategory, GDPRSettings
-from shuup.gdpr.utils import get_active_consent_pages
+from shuup.gdpr.utils import (
+    get_active_consent_pages, get_privacy_policy_page,
+    should_reconsent_privacy_policy
+)
 from shuup.utils.djangoenv import has_installed
 from shuup.xtheme.resources import add_resource, InlineMarkupResource
 
@@ -30,6 +34,7 @@ def valid_view(context):
     view_name = getattr(view_class, "__name__", "")
     if view_name == "EditorView":
         return False
+
     return True
 
 
@@ -37,16 +42,33 @@ def add_gdpr_consent_resources(context, content):
     if not valid_view(context):
         return
 
-    shop = get_shop(context["request"])
+    request = context["request"]
+    shop = get_shop(request)
     gdpr_settings = GDPRSettings.get_for_shop(shop)
 
-    # GDPR not enabled
+    # GDPR not enabled, nothing to do
     if not gdpr_settings.enabled:
         return
 
+    # always add styles
+    add_resource(context, "head_end", static("shuup_gdpr/shuup_gdpr_styles.css"))
+
+    user = request.user
+    if not user.is_anonymous() and should_reconsent_privacy_policy(shop, user):
+        consent_page = get_privacy_policy_page(shop)
+        render_context = {
+            "request": request,
+            "csrf_token": context["csrf_token"],
+            "url": "/%s" % consent_page.url,
+            "accept_url": reverse("shuup:gdpr_policy_consent", kwargs=dict(page_id=consent_page.id))
+        }
+        update_resource = InlineMarkupResource(
+            loader.render_to_string("shuup/gdpr/privacy_policy_update.jinja", context=render_context)
+        )
+        add_resource(context, "body_end", update_resource)
+
     # consent already added
-    # TODO: Should we check for changes and ask the consent again here?
-    if settings.SHUUP_GDPR_CONSENT_COOKIE_NAME in context["request"].COOKIES:
+    if settings.SHUUP_GDPR_CONSENT_COOKIE_NAME in request.COOKIES:
         return
 
     gdpr_documents = []
@@ -54,7 +76,7 @@ def add_gdpr_consent_resources(context, content):
         gdpr_documents = get_active_consent_pages(shop)
 
     render_context = {
-        "request": context["request"],
+        "request": request,
         "csrf_token": context["csrf_token"],
         "gdpr_settings": gdpr_settings,
         "gdpr_documents": gdpr_documents,
@@ -65,4 +87,3 @@ def add_gdpr_consent_resources(context, content):
     )
     add_resource(context, "body_end", html_resource)
     add_resource(context, "body_end", static("shuup_gdpr/shuup_gdpr.js"))
-    add_resource(context, "head_end", static("shuup_gdpr/shuup_gdpr_styles.css"))

--- a/shuup/gdpr/static_src/less/index.less
+++ b/shuup/gdpr/static_src/less/index.less
@@ -178,3 +178,26 @@ label.gdpr-option {
 .list-group-item > .gdpr-switch {
     float: right;
 }
+
+.privacy-policy-update {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 100000;
+    background-color: #ffbf00;
+    padding: 5px 10px;
+    border: 1px solid #000;
+    font-size: 1.2rem;
+    text-align: center;
+
+    .btn {
+        font-size: 1.2rem;
+        text-decoration: none;
+    }
+
+    a {
+        font-weight: bold;
+        text-decoration: underline;
+    }
+}

--- a/shuup/gdpr/templates/shuup/gdpr/privacy_policy_update.jinja
+++ b/shuup/gdpr/templates/shuup/gdpr/privacy_policy_update.jinja
@@ -1,0 +1,3 @@
+<div class="privacy-policy-update">
+    {% trans url=url, accept_url=accept_url %}Our privacy policy has been updated since your last consent. Please read the updated version <a href="{{ url }}">here</a>. <a class="btn btn-primary" href="{{ accept_url }}">Accept changes</a>{% endtrans %}
+</div>

--- a/shuup/gdpr/urls.py
+++ b/shuup/gdpr/urls.py
@@ -9,10 +9,11 @@ from django.conf.urls import url
 
 from .views import (
     GDPRAnonymizeView, GDPRCookieConsentView, GDPRCustomerDashboardView,
-    GDPRDownloadDataView
+    GDPRDownloadDataView, GDPRPolicyConsentView
 )
 
 urlpatterns = [
+    url(r'^gdpr/policy-consent/(?P<page_id>\d+)/?$', GDPRPolicyConsentView.as_view(), name='gdpr_policy_consent'),
     url(r'^gdpr/consent/?$', GDPRCookieConsentView.as_view(), name='gdpr_consent'),
     url(r'^gdpr/download_data/?$', GDPRDownloadDataView.as_view(), name='gdpr_download_data'),
     url(r'^gdpr/anonymize/?$', GDPRAnonymizeView.as_view(), name='gdpr_anonymize_account'),

--- a/shuup_tests/gdpr/test_consent_requirements.py
+++ b/shuup_tests/gdpr/test_consent_requirements.py
@@ -13,7 +13,7 @@ from shuup.gdpr.models import GDPRSettings, GDPRUserConsent
 from shuup.gdpr.utils import (
     create_user_consent_for_all_documents, ensure_gdpr_privacy_policy,
     get_active_consent_pages, get_possible_consent_pages,
-    get_privacy_policy_page, has_privacy_policy_consent,
+    get_privacy_policy_page, should_reconsent_privacy_policy,
     is_documents_consent_in_sync
 )
 from shuup.simple_cms.models import Page
@@ -31,7 +31,7 @@ def test_consent_required(rf):
     assert not gdpr_settings.enabled
     assert gdpr_settings.privacy_policy_page == page
 
-    assert not has_privacy_policy_consent(shop, user)
+    assert not should_reconsent_privacy_policy(shop, user)
     assert is_documents_consent_in_sync(shop, user)  # settings not enabled
 
     assert page in get_possible_consent_pages(shop)

--- a/shuup_tests/gdpr/test_data_download.py
+++ b/shuup_tests/gdpr/test_data_download.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.translation import activate
+
+from shuup.gdpr.views import GDPRDownloadDataView
+from shuup.testing import factories
+from shuup.testing.utils import apply_request_middleware
+
+
+def test_data_download(rf):
+    activate("en")
+    shop = factories.get_default_shop()
+    user = factories.create_random_user()
+
+    view = GDPRDownloadDataView.as_view()
+
+    request = apply_request_middleware(rf.post("/"), user=user, shop=shop)
+    response = view(request=request)
+    assert response.status_code == 200
+
+    request = apply_request_middleware(rf.post("/"), shop=shop)
+    response = view(request=request)
+    assert response.status_code == 404


### PR DESCRIPTION
Before this PR, user had no idea the consent pages were changed. This PR adds a top bar on the front prompting for new consent.