### PR TITLE
Core: enable ForeignKey constraint for SQLite database backends

### DIFF
--- a/shuup/testing/__init__.py
+++ b/shuup/testing/__init__.py
@@ -8,6 +8,13 @@
 from shuup.apps import AppConfig
 
 
+def activate_sqlite_fk_constraint(sender, connection, **kwargs):
+    """Enable integrity constraint with SQLite."""
+    if connection.vendor == 'sqlite':
+        cursor = connection.cursor()
+        cursor.execute('PRAGMA foreign_keys = ON;')
+
+
 class ShuupTestingAppConfig(AppConfig):
     name = "shuup.testing"
     verbose_name = "Shuup Testing & Demo Utilities"
@@ -45,6 +52,10 @@ class ShuupTestingAppConfig(AppConfig):
             __name__ + ".themes:ShuupTestingThemeWithCustomBase",
         ],
     }
+
+    def ready(self):
+        from django.db.backends.signals import connection_created
+        connection_created.connect(activate_sqlite_fk_constraint)
 
 
 default_app_config = "shuup.testing.ShuupTestingAppConfig"

--- a/shuup_tests/core/test_fk_constraint.py
+++ b/shuup_tests/core/test_fk_constraint.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from shuup.core.models import SavedAddress
+from django.db.utils import IntegrityError
+
+
+@pytest.mark.django_db
+def test_fk_constraint():
+    """
+    Test that FK constraint should be on and objects MUST exist
+    """
+    with pytest.raises(IntegrityError):
+        SavedAddress.objects.create(owner_id=78472384723847218, address_id=4723847283)


### PR DESCRIPTION
This prevents bugs when developing and prevents errors when in production