### PR TITLE
Improve unit tests

### DIFF
--- a/shuup/testing/__init__.py
+++ b/shuup/testing/__init__.py
@@ -8,6 +8,14 @@
 from shuup.apps import AppConfig
 
 
+def activate_sqlite_fk_constraint(sender, connection, **kwargs):
+    """Enable integrity constraint with SQLite and not running browser tests."""
+    import os
+    if connection.vendor == 'sqlite' and os.environ.get("SHUUP_BROWSER_TESTS") != "1":
+        cursor = connection.cursor()
+        cursor.execute('PRAGMA foreign_keys = ON;')
+
+
 class ShuupTestingAppConfig(AppConfig):
     name = "shuup.testing"
     verbose_name = "Shuup Testing & Demo Utilities"
@@ -45,6 +53,10 @@ class ShuupTestingAppConfig(AppConfig):
             __name__ + ".themes:ShuupTestingThemeWithCustomBase",
         ],
     }
+
+    def ready(self):
+        from django.db.backends.signals import connection_created
+        connection_created.connect(activate_sqlite_fk_constraint)
 
 
 default_app_config = "shuup.testing.ShuupTestingAppConfig"

--- a/shuup_tests/admin/test_category_module.py
+++ b/shuup_tests/admin/test_category_module.py
@@ -196,7 +196,7 @@ def test_products_form_remove():
     assert (shop_product.categories.first() == category)
 
     data = {
-        "remove_products": ["%s" % shop_product.id]
+        "remove_products": ["%s" % product.id]
     }
     form = CategoryProductForm(shop=shop, category=category, data=data)
     form.full_clean()
@@ -237,7 +237,7 @@ def test_products_form_remove_with_parent():
     assert (category.shop_products.count() == 2)
 
     data = {
-        "remove_products": ["%s" % shop_product.id]
+        "remove_products": ["%s" % product.id]
     }
     form = CategoryProductForm(shop=shop, category=category, data=data)
     form.full_clean()

--- a/shuup_tests/admin/test_product_mass_edit.py
+++ b/shuup_tests/admin/test_product_mass_edit.py
@@ -38,7 +38,7 @@ def test_mass_edit_products(rf, admin_user):
     assert shop_product2.primary_category is None
 
     request = apply_request_middleware(rf.post("/", data={"primary_category": category.pk}), user=admin_user)
-    request.session["mass_action_ids"] = [product1.pk, product2.pk]
+    request.session["mass_action_ids"] = [shop_product1.pk, shop_product2.pk]
 
     view = ProductMassEditView.as_view()
     response = view(request=request)

--- a/shuup_tests/api/test_basket_api.py
+++ b/shuup_tests/api/test_basket_api.py
@@ -368,7 +368,7 @@ def test_quantity_has_to_be_in_stock(admin_user):
         client = get_client(admin_user)
         payload = {
             'shop': shop.id,
-            'product': shop_product.id,
+            'product': product.id,
             'quantity': 493020
         }
         response = client.post('/api/shuup/basket/{}-{}/add/'.format(shop.pk, basket.key), payload)
@@ -449,7 +449,7 @@ def test_basket_can_be_cleared(admin_user):
         client = get_client(admin_user)
         payload = {
             'shop': shop.id,
-            'product': shop_product.id,
+            'product': shop_product.product.id,
         }
         response = client.post('/api/shuup/basket/{}-{}/add/'.format(shop.id, basket.key), payload)
         assert response.status_code == status.HTTP_200_OK

--- a/shuup_tests/conftest.py
+++ b/shuup_tests/conftest.py
@@ -52,6 +52,15 @@ def enable_db_access(db):
     pass
 
 
+# always make ShopProduct id different from Product id
+@pytest.fixture(autouse=True)
+def break_shop_product_id_sequence(db):
+    from shuup.core.models import ShopProduct
+    from django.db import connection
+    cursor = connection.cursor()
+    cursor.execute("INSERT INTO SQLITE_SEQUENCE (name, seq) values ('%s', 1500)" % ShopProduct._meta.db_table)
+
+
 @pytest.fixture()
 def staff_user():
     from django.contrib.auth import get_user_model

--- a/shuup_tests/core/test_fk_constraint.py
+++ b/shuup_tests/core/test_fk_constraint.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from shuup.core.models import SavedAddress
+from django.db.utils import IntegrityError
+
+
+@pytest.mark.django_db
+def test_fk_constraint():
+    """
+    Test that FK constraint should be on and objects MUST exist
+    """
+    with pytest.raises(IntegrityError):
+        SavedAddress.objects.create(owner_id=78472384723847218, address_id=4723847283)

--- a/shuup_tests/importer/test_product_import.py
+++ b/shuup_tests/importer/test_product_import.py
@@ -51,7 +51,6 @@ def test_sample_import_all_match(filename):
     for product in products:
         shop_product = product.get_shop_instance(shop)
         assert shop_product.pk
-        assert shop_product.pk == product.pk
         assert shop_product.default_price_value == 150
         assert shop_product.default_price == shop.create_price(150)
         assert product.type == product_type  # product type comes from importer defaults
@@ -97,7 +96,6 @@ def test_sample_import_no_match(stock_managed):
         assert product.gtin == "1280x720"
         shop_product = product.get_shop_instance(shop)
         assert shop_product.pk
-        assert shop_product.pk == product.pk  # new shop product created for all products
         assert shop_product.default_price_value == 150
         assert shop_product.default_price == shop.create_price(150)
         assert product.type == product_type  # product type comes from importer defaults


### PR DESCRIPTION
- Re-enable ForeignKey constraint for SQLite database backends. The constraint is not enabled for browser tests
- Change the shop product id sequence when testing. It is very important that product and shop product ids are not mixed together. This adds a auto fixture to start shop product ids in #1500

No Refs