### PR TITLE
Front: add shop option to limit storefront language options

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -25,6 +25,7 @@ Core
 Front
 ~~~~~
 
+- Add shop option to limit storefront language options
 - Add option to hide prices and set catalog mode with xtheme settings
 - Add new signal `checkout_complete`. Fires when the checkout process is complete.
 - Add new signal `login_allowed`. Fires when login allowed is being checked.

--- a/shuup/core/api/front_products.py
+++ b/shuup/core/api/front_products.py
@@ -194,22 +194,13 @@ class CompleteShopProductSerializer(serializers.ModelSerializer):
         return NormalShopProductSerializer
 
     def get_name(self, shop_product):
-        return (
-            shop_product.safe_translation_getter("name") or
-            shop_product.product.safe_translation_getter("name")
-        )
+        return shop_product.get_name()
 
     def get_description(self, shop_product):
-        return (
-            shop_product.safe_translation_getter("description") or
-            shop_product.product.safe_translation_getter("description")
-        )
+        return shop_product.get_description()
 
     def get_short_description(self, shop_product):
-        return (
-            shop_product.safe_translation_getter("short_description") or
-            shop_product.product.safe_translation_getter("short_description")
-        )
+        return shop_product.get_short_description()
 
     def _get_pricing_context(self, request, shop):
         return PricingContext(shop=shop, customer=self.context["customer"])

--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -540,7 +540,10 @@ class ShopProduct(MoneyPropped, TranslatableModel):
         return self._safe_get_string("short_description")
 
     def _safe_get_string(self, key):
-        return self.safe_translation_getter(key) or self.product.safe_translation_getter(key)
+        return (
+            self.safe_translation_getter(key, any_language=True) or
+            self.product.safe_translation_getter(key, any_language=True)
+        )
 
 
 ShopProductLogEntry = define_log_model(ShopProduct)

--- a/shuup/front/__init__.py
+++ b/shuup/front/__init__.py
@@ -24,7 +24,8 @@ class ShuupFrontAppConfig(AppConfig):
         "admin_shop_form_part": [
             "shuup.front.admin_module.sorts_and_filters.form_parts.ConfigurationShopFormPart",
             "shuup.front.admin_module.checkout.form_parts.CheckoutShopFormPart",
-            "shuup.front.admin_module.companies.form_parts.RegistrationSettingsFormPart"
+            "shuup.front.admin_module.companies.form_parts.RegistrationSettingsFormPart",
+            "shuup.front.admin_module.translation.form_parts.TranslationSettingsFormPart"
         ],
         "notify_event": [
             "shuup.front.notify_events:OrderReceived",

--- a/shuup/front/admin_module/translation/form_parts.py
+++ b/shuup/front/admin_module/translation/form_parts.py
@@ -1,0 +1,51 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django import forms
+from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.admin.form_part import FormPart, TemplatedFormDef
+from shuup.front.utils.translation import (
+    get_shop_available_languages, set_shop_available_languages
+)
+
+
+class TranslationSettingsForm(forms.Form):
+    available_languages = forms.MultipleChoiceField(
+        choices=settings.LANGUAGES,
+        required=False,
+        label=_("Available languages in storefront"),
+        help_text=_(
+            "Select all the languages that should be available in storefront. "
+            "Blank means that all languages should be available."
+        )
+    )
+
+
+class TranslationSettingsFormPart(FormPart):
+    priority = 9
+    name = "translation_config"
+    form = TranslationSettingsForm
+
+    def get_form_defs(self):
+        if not self.object.pk:
+            return
+        yield TemplatedFormDef(
+            name=self.name,
+            form_class=self.form,
+            template_name="shuup/front/admin/translation.jinja",
+            required=False,
+            kwargs={"initial": dict(available_languages=get_shop_available_languages(self.object))}
+        )
+
+    def form_valid(self, form):
+        if self.name not in form.forms:
+            return
+        data = form.forms[self.name].cleaned_data
+        set_shop_available_languages(self.object, data.get("available_languages", []))

--- a/shuup/front/apps/auth/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/apps/auth/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-28 11:50+0000\n"
+"POT-Creation-Date: 2018-06-26 18:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -30,15 +30,6 @@ msgid "This account is inactive."
 msgstr ""
 
 msgid "Username or email address"
-msgstr ""
-
-msgid "I have read and accept the {}"
-msgstr ""
-
-msgid "Read the <a href='{}' target='_blank'>{}</a>."
-msgstr ""
-
-msgid "You must accept to this to authenticate."
 msgstr ""
 
 msgid "You are not allowed to login to this shop."

--- a/shuup/front/apps/registration/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/apps/registration/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-28 11:50+0000\n"
+"POT-Creation-Date: 2018-06-26 18:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -20,18 +20,6 @@ msgstr ""
 "Generated-By: Babel 2.1.1\n"
 
 msgid "Name of the company"
-msgstr ""
-
-msgid "I have read and accept the {}"
-msgstr ""
-
-msgid "Read the <a href='{}' target='_blank'>{}</a>."
-msgstr ""
-
-msgid "You must accept to this to register."
-msgstr ""
-
-msgid "You must accept this to register."
 msgstr ""
 
 msgid "Registration Received"

--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-22 18:31+0000\n"
+"POT-Creation-Date: 2018-06-26 18:06+0000\n"
 "PO-Revision-Date: 2016-08-04 10:51-0700\n"
 "Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
@@ -101,6 +101,14 @@ msgstr ""
 msgid "Company tax number format is validated for European countries."
 msgstr ""
 
+msgid "Available languages in storefront"
+msgstr ""
+
+msgid ""
+"Select all the languages that should be available in storefront. Blank means "
+"that all languages should be available."
+msgstr ""
+
 #, python-format
 msgid "Basket loading failed: Incompatible basket (%s)"
 msgstr ""
@@ -147,15 +155,6 @@ msgid "I want to receive marketing material"
 msgstr ""
 
 msgid "Comment"
-msgstr ""
-
-msgid "I have read and accept the {}"
-msgstr ""
-
-msgid "Read the <a href='{}' target='_blank'>{}</a>."
-msgstr ""
-
-msgid "You must accept to this to confirm the order."
 msgstr ""
 
 msgid ""
@@ -585,6 +584,9 @@ msgstr ""
 msgid "Product list sorts and filters"
 msgstr ""
 
+msgid "Storefront Languages"
+msgstr ""
+
 msgid "Shopping cart"
 msgstr ""
 
@@ -857,9 +859,6 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-msgid "I have read and accept the <a href='{}' target='_blank'>{}</a>"
-msgstr ""
-
 msgid "New user? Register here!"
 msgstr ""
 
@@ -1039,6 +1038,10 @@ msgid "Tax number is not valid."
 msgstr ""
 
 msgid "Edit"
+msgstr ""
+
+#, python-brace-format
+msgid "{language_code} is an invalid language code"
 msgstr ""
 
 msgid "This product is not available in this shop."

--- a/shuup/front/template_helpers/general.py
+++ b/shuup/front/template_helpers/general.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 import six
 from django.conf import settings
 from django.core.paginator import Paginator
-from django.utils.translation import get_language, get_language_info, ugettext
+from django.utils.translation import get_language
 from jinja2.utils import contextfunction
 
 from shuup.core.models import (
@@ -19,6 +19,7 @@ from shuup.core.models import (
 from shuup.core.utils import context_cache
 from shuup.front.utils.companies import allow_company_registration
 from shuup.front.utils.product_statistics import get_best_selling_product_info
+from shuup.front.utils.translation import get_language_choices
 from shuup.front.utils.user import is_admin_user
 from shuup.front.utils.views import cache_product_things
 from shuup.utils.mptt import get_cached_trees
@@ -307,13 +308,8 @@ def _get_page_range(current_page, num_pages, range_gap=5):
 
 @contextfunction
 def get_shop_language_choices(context):
-    languages = []
-    for code, name in settings.LANGUAGES:
-        lang_info = get_language_info(code)
-        name_in_current_lang = ugettext(name)
-        local_name = lang_info["name_local"]
-        languages.append((code, name_in_current_lang, local_name))
-    return languages
+    request = context["request"]
+    return get_language_choices(request.shop)
 
 
 @contextfunction

--- a/shuup/front/templates/shuup/front/admin/translation.jinja
+++ b/shuup/front/templates/shuup/front/admin/translation.jinja
@@ -1,0 +1,7 @@
+{% from "shuup/admin/macros/general.jinja" import content_block %}
+{% from "shuup/admin/macros/multilanguage.jinja" import render_monolingual_fields %}
+{% set translation_form = form["translation_config"] %}
+
+{% call content_block(_("Storefront Languages"), icon="fa-language") %}
+    {{ render_monolingual_fields(translation_form) }}
+{% endcall %}

--- a/shuup/front/utils/translation.py
+++ b/shuup/front/utils/translation.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import get_language_info, ugettext
+
+from shuup import configuration
+
+FRONT_AVAILABLE_LANGUAGES_CONFIG_KEY = "front:available_languages"
+
+
+def get_language_choices(shop=None):
+    """
+    Returns a list of the available language choices, e.g.:
+        [("en", "English", "English"])
+
+    If shot is passed, the languages will be filtered by those
+    enabled for the shop.
+
+    :rtype iterable[(str, str, str)]
+    """
+    available_languages = []
+    languages = []
+
+    if shop:
+        available_languages = configuration.get(shop, FRONT_AVAILABLE_LANGUAGES_CONFIG_KEY)
+        if available_languages:
+            available_languages = available_languages.split(",")
+
+    for code, name in settings.LANGUAGES:
+        if available_languages and code not in available_languages:
+            continue
+
+        lang_info = get_language_info(code)
+        name_in_current_lang = ugettext(name)
+        local_name = lang_info["name_local"]
+        languages.append((code, name_in_current_lang, local_name))
+    return languages
+
+
+def set_shop_available_languages(shop, languages):
+    available_codes = [code for code, name in settings.LANGUAGES]
+
+    # validate languages
+    for language in languages:
+        if language not in available_codes:
+            msg = _("{language_code} is an invalid language code").format(language_code=language)
+            raise ValueError(msg)
+
+    configuration.set(shop, FRONT_AVAILABLE_LANGUAGES_CONFIG_KEY, ",".join(languages))
+
+
+def get_shop_available_languages(shop):
+    available_languages = configuration.get(shop, FRONT_AVAILABLE_LANGUAGES_CONFIG_KEY, "")
+    if available_languages:
+        return available_languages.split(",")
+    return []

--- a/shuup_tests/conftest.py
+++ b/shuup_tests/conftest.py
@@ -46,10 +46,12 @@ def splinter_make_screenshot_on_failure():
     return False
 
 
-# use django_db in the whole tests
+# use django_db on every test
+# activate the EN language by default
 @pytest.fixture(autouse=True)
 def enable_db_access(db):
-    pass
+    from django.utils.translation import activate
+    activate("en")
 
 
 # always make ShopProduct id different from Product id

--- a/shuup_tests/front/test_languages.py
+++ b/shuup_tests/front/test_languages.py
@@ -1,0 +1,128 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from django.conf import settings
+from django.contrib.auth import logout
+from django.contrib.auth.models import AnonymousUser
+from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
+from django.utils import timezone
+from django.utils.translation import get_language, activate
+
+import shuup.core.models
+from shuup.admin.urls import login
+from shuup.admin.views.home import HomeView as AdminHomeView
+from shuup.core import cache
+from shuup.core.models import (
+    AnonymousContact, CompanyContact, Contact, get_company_contact,
+    get_person_contact, PersonContact, Shop
+)
+from shuup.front.middleware import ShuupFrontMiddleware
+from shuup.front.utils.translation import (
+    get_shop_available_languages, set_shop_available_languages
+)
+from shuup.front.views.index import IndexView
+from shuup.testing import factories
+from shuup.testing.soup_utils import extract_form_fields
+from shuup_tests.utils import SmartClient
+from shuup_tests.utils.fixtures import regular_user
+
+
+def setup_function(fn):
+    cache.clear()
+
+
+@pytest.mark.django_db
+def test_shop_available_languages(admin_user):
+    original_language = get_language()
+    shop = factories.get_default_shop()
+    client = SmartClient()
+
+    with override_settings(
+        LANGUAGES=[
+            ("it", "Italian"),
+            ("fr", "French"),
+            ("fi", "Finnish"),
+            ("pt", "Portuguese")
+        ],
+        LANGUAGE_CODE="it",
+        PARLER_DEFAULT_LANGUAGE_CODE = "it"
+    ):
+        # there is no language set for the shop, the first one will be used
+        client.get(reverse("shuup:index"))
+        assert get_language() == "it"
+
+        # set an invalid language code
+        with pytest.raises(ValueError):
+            set_shop_available_languages(shop, ["xpto"])
+
+        # limit the langauges for the shop to "fi" and "pt"
+        set_shop_available_languages(shop, ["fi", "pt"])
+
+        # the middleware will automatically set the language to "fi" as that is the first one available for the shop
+        client.get(reverse("shuup:index"))
+        assert get_language() == "fi"
+
+        # the same won't happen for any other url - the middleware will only affect front urls
+        client.get("shuup_admin:index")
+        assert get_language() == "it"
+
+        # test againt front again
+        client.get(reverse("shuup:index"))
+        assert get_language() == "fi"
+
+        # again for admin
+        client.get("shuup_admin:index")
+        assert get_language() == "it"
+
+    activate(original_language)
+
+
+@pytest.mark.django_db
+def test_admin_set_shop_language(admin_user):
+    original_language = get_language()
+    shop = factories.get_default_shop()
+    client = SmartClient()
+    admin_user.set_password("admin")
+    admin_user.save()
+    client.login(username=admin_user.username, password="admin")
+
+    with override_settings(
+        LANGUAGES=[
+            ("it", "Italian"),
+            ("fr", "French"),
+            ("fi", "Finnish"),
+            ("pt-br", "Portuguese (Brazil)")
+        ],
+        LANGUAGE_CODE="it",
+        PARLER_DEFAULT_LANGUAGE_CODE = "it"
+    ):
+        assert get_shop_available_languages(shop) == []
+        edit_url = reverse("shuup_admin:shop.edit", kwargs=dict(pk=shop.id))
+        payload = {
+            "translation_config-available_languages": ["pt-br", "fi"],
+            "base-public_name__it": shop.public_name,
+            "base-name__it": shop.name,
+            "base-status": "1",
+            "base-currency": shop.currency,
+            "product_list_facets-filter_products_by_category_ordering": "1",
+            "product_list_facets-filter_products_by_price_ordering": "1",
+            "product_list_facets-limit_product_list_page_size_ordering": "1",
+            "product_list_facets-sort_products_by_price_ordering": "1",
+            "product_list_facets-sort_products_by_name_ordering": "1",
+            "product_list_facets-sort_products_by_ascending_created_date_ordering": "1",
+            "product_list_facets-sort_products_by_date_created_ordering": "1",
+            "product_list_facets-filter_products_by_manufacturer_ordering": "1",
+            "product_list_facets-filter_products_by_variation_value_ordering": "1",
+            "order_configuration-order_reference_number_length": "20",
+            "order_configuration-order_reference_number_prefix": "10"
+        }
+        response = client.post(edit_url, data=payload)
+        assert response.status_code == 302
+        assert get_shop_available_languages(shop) == ["pt-br", "fi"]
+
+    activate(original_language)

--- a/shuup_tests/functional/test_admin_orders.py
+++ b/shuup_tests/functional/test_admin_orders.py
@@ -12,7 +12,6 @@ import json
 
 import pytest
 from django.core import serializers
-from django.utils import translation
 from django.utils.translation import activate
 
 from shuup.core.models import (
@@ -33,12 +32,13 @@ def encode_address(address):
     return json.loads(serializers.serialize("json", [address]))[0].get("fields")
 
 
+@pytest.mark.django_db
 def get_frontend_order_state(contact, payment_method, product_price, valid_lines=True):
     """
     Get a dict structure mirroring what the frontend JavaScript would submit.
     :type contact: Contact|None
     """
-    translation.activate("en")
+    activate("en")
     shop = get_default_shop()
     tax = Tax.objects.create(code="test_code", rate=decimal.Decimal("0.20"), name="Default")
     tax_class = TaxClass.objects.create(identifier="test_tax_class", name="Default")
@@ -118,7 +118,6 @@ def test_admin_cash_order(rf, admin_user, price, target, mode):
     get_initial_order_status()  # Needed for the API
     shop = get_default_shop()
     contact = create_random_person(locale="en_US", minimum_name_comp_len=5)
-
 
     processor = CustomPaymentProcessor.objects.create(rounding_mode=mode)
     cash_method = PaymentMethod.objects.create(


### PR DESCRIPTION
Merchants can now limit the language options to be selected in storefront by users.

Refs POS-2438

Requires https://github.com/django-parler/django-parler/pull/228