### PR TITLE
General: cache object ids instead of the model instances

### DIFF
--- a/shuup/core/models/_products.py
+++ b/shuup/core/models/_products.py
@@ -21,7 +21,6 @@ from shuup.core.excs import ImpossibleProductModeException
 from shuup.core.fields import InternalIdentifierField, MeasurementField
 from shuup.core.signals import post_clean, pre_clean
 from shuup.core.taxing import TaxableItem
-from shuup.core.utils import context_cache
 from shuup.core.utils.slugs import generate_multilanguage_slugs
 from shuup.utils.analog import define_log_model, LogEntryKind
 
@@ -381,12 +380,18 @@ class Product(TaxableItem, AttributableMixin, TranslatableModel):
         :type shop: shuup.core.models.Shop
         :rtype: shuup.core.models.ShopProduct
         """
-        key, val = context_cache.get_cached_value(
-            identifier="shop_product", item=self, context={"shop": shop}, allow_cache=allow_cache)
-        if val is not None:
-            return val
+
+        # FIXME: Temporary removed the cache to prevent parler issues
+        # Uncomment this as soon as https://github.com/shuup/shuup/issues/1323 is fixed
+        # and Django Parler version is bumped with the fix
+
+        # from shuup.core.utils import context_cache
+        # key, val = context_cache.get_cached_value(
+        #     identifier="shop_product", item=self, context={"shop": shop}, allow_cache=allow_cache)
+        # if val is not None:
+        #     return val
         shop_inst = self.shop_products.get(shop_id=shop.id)
-        context_cache.set_cached_value(key, shop_inst)
+        # context_cache.set_cached_value(key, shop_inst)
         return shop_inst
 
     def get_priced_children(self, context, quantity=1):

--- a/shuup/xtheme/plugins/products.py
+++ b/shuup/xtheme/plugins/products.py
@@ -10,8 +10,8 @@ from django.utils.translation import ugettext_lazy as _
 
 from shuup.core.models import Category, ProductCrossSell, ProductCrossSellType
 from shuup.front.template_helpers.general import (
-    get_best_selling_products, get_newest_products, get_products_for_category,
-    get_random_products
+    get_best_selling_products, get_newest_products,
+    get_products_for_categories, get_random_products
 )
 from shuup.front.template_helpers.product import map_relation_type
 from shuup.xtheme import TemplatedPlugin
@@ -138,7 +138,7 @@ class ProductsFromCategoryPlugin(TemplatedPlugin):
         count = self.config.get("count")
         category = Category.objects.filter(id=category_id).first() if category_id else None
         if category:
-            products = get_products_for_category(context, [category], n_products=count)
+            products = get_products_for_categories(context, [category], n_products=count)
         return {
             "request": context["request"],
             "title": self.get_translated_value("title"),

--- a/shuup_tests/browser/front/test_category_view.py
+++ b/shuup_tests/browser/front/test_category_view.py
@@ -395,6 +395,7 @@ def second_category_sort_test(browser, live_server, shop, category):
         sp.visibility = ShopProductVisibility.NOT_VISIBLE
         sp.save()
 
+    cache.clear()
     browser.reload()
     wait_until_condition(browser, lambda x: len(x.find_by_css(".product-card")) == 10)
 
@@ -402,6 +403,7 @@ def second_category_sort_test(browser, live_server, shop, category):
         sp.visibility = ShopProductVisibility.ALWAYS_VISIBLE
         sp.save()
 
+    cache.clear()
     browser.reload()
     wait_until_condition(browser, lambda x: len(x.find_by_css(".product-card")) == 13, timeout=30)
 

--- a/shuup_tests/core/test_products_in_shops.py
+++ b/shuup_tests/core/test_products_in_shops.py
@@ -350,3 +350,14 @@ def test_get_safe_strings(key):
     shop_product.refresh_from_db()
 
     assert func() == new_value  # returns value from shop product
+
+
+@pytest.mark.django_db
+def test_shop_instance_cache():
+    from shuup.core import cache
+    cache.clear()
+
+    shop = get_default_shop()
+    product = create_product("product", shop)
+    shop_product = product.get_shop_instance(shop)
+    assert shop_product == product.get_shop_instance(shop)

--- a/shuup_tests/front/test_utils.py
+++ b/shuup_tests/front/test_utils.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from shuup.core import cache
+from shuup.core.models import Product, ShopProduct, ProductVariationVariable, ProductVariationVariableValue
+from shuup.front.utils.sorts_and_filters import get_product_queryset
+from shuup.front.utils.product import get_orderable_variation_children
+from shuup.testing.factories import (
+    create_product, get_default_shop, get_default_supplier
+)
+from shuup.testing.utils import apply_request_middleware
+from shuup_tests.front.fixtures import get_jinja_context
+
+
+@pytest.mark.django_db
+def test_get_sorts_and_filters(rf):
+    context = get_jinja_context()
+
+    supplier = get_default_supplier()
+    shop = get_default_shop()
+    product1 = create_product("product1", shop, supplier, 10)
+    product2 = create_product("product2", shop, supplier, 20)
+
+    request = apply_request_middleware(rf.get("/"))
+    queryset = Product.objects.all()
+
+    cache.clear()
+    for time in range(2):
+        products = list(get_product_queryset(queryset, request, None, {}))
+        assert len(products) == 2
+        assert product1 in products
+        assert product2 in products
+
+
+@pytest.mark.django_db
+def test_get_orderable_variation_children(rf):
+    supplier = get_default_supplier()
+    shop = get_default_shop()
+
+    variable_name = "Color"
+    parent = create_product("test-sku-1", shop=shop)
+    variation_variable = ProductVariationVariable.objects.create(product=parent, identifier="color", name=variable_name)
+    red_value = ProductVariationVariableValue.objects.create(variable=variation_variable, identifier="red", value="Red")
+    blue_value =ProductVariationVariableValue.objects.create(variable=variation_variable, identifier="blue", value="Blue")
+    combinations = list(parent.get_all_available_combinations())
+    assert len(combinations) == 2
+    for combo in combinations:
+        assert not combo["result_product_pk"]
+        child = create_product("xyz-%s" % combo["sku_part"], shop=shop, supplier=get_default_supplier(), default_price=20)
+        child.link_to_parent(parent, combination_hash=combo["hash"])
+
+    combinations = list(parent.get_all_available_combinations())
+    assert len(combinations) == 2
+    parent.refresh_from_db()
+    assert parent.is_variation_parent()
+    request = apply_request_middleware(rf.get("/"))
+
+    cache.clear()
+    for time in range(2):
+        orderable_children, is_orderable = get_orderable_variation_children(parent, request, None)
+        assert len(orderable_children)
+        for var_variable, var_values in dict(orderable_children).items():
+            assert var_variable == variation_variable
+            assert red_value in var_values
+            assert blue_value in var_values


### PR DESCRIPTION
Parler has a bug that fails to load translations after they are fetched from cache

Check the PR that fixes the bug in Parler https://github.com/django-parler/django-parler/pull/228