### PR TITLE
Use hash of string in section name in case non latin symbols

### DIFF
--- a/shuup/admin/static_src/base/js/side-nav.js
+++ b/shuup/admin/static_src/base/js/side-nav.js
@@ -14,6 +14,18 @@ $(function() {
     function getSectionNavigatorModule($navigateeForm) {
         const $sections = $navigateeForm.find(".content-block");
 
+        const hashCode = function(s) {
+			var h = 0, l = s.length, i = 0;
+			if ( l > 0 )
+			  while (i < l)
+				h = (h << 5) - h + s.charCodeAt(i++) | 0;
+			if ( h < 0 )
+			{
+				h = 0 - h;
+			}
+			return h;
+		  };
+
         const navigationListItems = _.compact(_.map($sections, function(section) {
             const $section = $(section);
             const $blockTitle = $section.find(".block-title");
@@ -22,7 +34,11 @@ $(function() {
                 return;
             }
             if (!section.id) {
-                section.id = _.kebabCase(titleText) + "-section";
+                section_name = _.kebabCase(titleText);
+                if (section_name == "") {
+                    section_name = hashCode(titleText);
+                }
+                section.id = section_name + "-section";
             }
 
             return {


### PR DESCRIPTION
When using translations with non latin charset (in my case russian) kebabCase in js return empty string. All sections that not have defined id in jinja templates have the same url like "-section" and become not active. So use hash function to define some name