### PR TITLE
Browser tests: Disable `test_category_product_filters_3`

### DIFF
--- a/shuup_tests/browser/front/test_category_view.py
+++ b/shuup_tests/browser/front/test_category_view.py
@@ -106,6 +106,7 @@ def test_category_product_filters_2(browser, live_server, settings):
 
 @pytest.mark.browser
 @pytest.mark.djangodb
+@pytest.mark.skipif(os.environ.get("SHUUP_TESTS_TRAVIS", "0") == "1", reason="Disable when run through tox.")
 def test_category_product_filters_3(browser, live_server, settings):
     cache.clear()  # Avoid cache from past tests
     shop, first_cat, second_cat, third_cat, first_manufacturer = initialize_db()


### PR DESCRIPTION
Way too inconcistent. Let's consider activating this at next round of browser tests fixes.

