### PR TITLE
General: add model url resolver as a setting for Front and Admin

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,11 @@ Unrealeased
   When releasing next version, the "Unreleased" header will be replaced
   with appropriate version header and this help text will be removed.
 
+General
+~~~~~~~
+
+- Add `front_model_url_resolver` and `admin_model_url_resolver` provides key to resolve models URLs
+
 Shuup 1.6.5
 -----------
 
@@ -21,7 +26,7 @@ Shuup 1.6.4
 -----------
 
 General
-~~~~~~
+~~~~~~~
 
 - Changed the way regions script is inject into templates.
    Now it is a static source script that can be cached by browser.

--- a/doc/ref/provides.rst
+++ b/doc/ref/provides.rst
@@ -158,6 +158,14 @@ Core
 ``admin_order_section``
     Additional ``Section`` subclasses for Order detail sections.
 
+``front_model_url_resolver``
+    List of functions that resolve a model instance into an object URL.
+    The first valid url returned by a provide will be used by the called.
+
+``admin_model_url_resolver``
+    List of functions that resolve a model instance into an object URL.
+    The first valid url returned by a provide will be used by the called.
+
 ``front_menu_extender``
     Additional menu items provided by addons. These should be subclassed from
     `~shuup.xtheme.extenders.FrontMenuExtender`.

--- a/shuup/admin/__init__.py
+++ b/shuup/admin/__init__.py
@@ -90,6 +90,9 @@ class ShuupAdminAppConfig(AppConfig):
             "shuup.admin.modules.orders.toolbar:CreateShipmentAction",
             "shuup.admin.modules.orders.toolbar:CreateRefundAction",
             "shuup.admin.modules.orders.toolbar:EditAddresses",
+        ],
+        "admin_model_url_resolver": [
+            "shuup.admin.utils.urls.get_model_url"
         ]
     }
 

--- a/shuup/admin/utils/urls.py
+++ b/shuup/admin/utils/urls.py
@@ -174,7 +174,7 @@ class NoModelUrl(ValueError):
     pass
 
 
-def get_model_url(object, kind="detail", user=None, required_permissions=None, shop=None):
+def get_model_url(object, kind="detail", user=None, required_permissions=None, shop=None, **kwargs):
     """
     Get a an admin object URL for the given object or object class by
     interrogating each admin module.

--- a/shuup/front/__init__.py
+++ b/shuup/front/__init__.py
@@ -57,6 +57,9 @@ class ShuupFrontAppConfig(AppConfig):
             "shuup.front.forms.order_forms:SimpleVariationProductOrderForm",
             "shuup.front.forms.order_forms:SimpleProductOrderForm",
         ],
+        "front_model_url_resolver": [
+            "shuup.front.utils.urls.model_url"
+        ]
     }
 
     def ready(self):

--- a/shuup/front/utils/urls.py
+++ b/shuup/front/utils/urls.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import with_statement
+
+from django.core.urlresolvers import reverse
+
+from shuup.core.models import Category, Product
+
+
+def model_url(context, model, absolute=False, **kwargs):
+    uri = None
+
+    if isinstance(model, Product):
+        uri = reverse("shuup:product", kwargs=dict(pk=model.pk, slug=model.slug))
+
+    if isinstance(model, Category):
+        uri = reverse("shuup:category", kwargs=dict(pk=model.pk, slug=model.slug))
+
+    if hasattr(model, "pk") and model.pk and hasattr(model, "url"):
+        uri = "/%s" % model.url
+
+    if not uri:  # pragma: no cover
+        raise ValueError("Unable to figure out `model_url` for %r" % model)
+
+    if absolute:
+        request = context.get("request")
+        if not request:  # pragma: no cover
+            raise ValueError("Unable to use `absolute=True` when request does not exist")
+        uri = request.build_absolute_uri(uri)
+
+    return uri

--- a/shuup_tests/front/test_model_resolver.py
+++ b/shuup_tests/front/test_model_resolver.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from django.core.urlresolvers import reverse
+
+from shuup.testing import factories
+
+
+@pytest.mark.django_db
+def test_category_page(client):
+    factories.get_default_shop()
+    category = factories.get_default_category()
+    response = client.get(reverse('shuup:category', kwargs={'pk': category.pk, 'slug': category.slug}))
+    assert b'no such element' not in response.content, 'All items are not rendered correctly'
+
+
+@pytest.mark.django_db
+def test_resolve_product_url():
+    shop = factories.get_default_shop()
+    product = factories.create_product("product", shop, factories.get_default_supplier(), "10")
+    from shuup.front.template_helpers.urls import model_url
+    assert model_url({}, product) == reverse("shuup:product", kwargs=dict(pk=product.pk, slug=product.slug))


### PR DESCRIPTION
Now it is possible to customize the way model URLs are resolved.

Replaces https://github.com/shuup/shuup/pull/1336