### PR TITLE
Introduce per object placeholders

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -22,6 +22,7 @@ Bug fixes
 Front
 ~~~~~
 
+- Add option to edit front as anonymous, person or company contact.
 - Change the way SVG files are detected in thumnailer. From now on the SVG
   check is done purely based on filename instead of checking the file
   content.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -41,6 +41,7 @@ Xtheme
 
 - Add option to render extra templates in theme configuration.
 - Add option for per object placeholders
+- Fix bug deleting last row from placeholder
 
 Shuup 1.6.6
 -----------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -30,6 +30,7 @@ Xtheme
 ~~~~~~
 
 - Add option to render extra templates in theme configuration.
+- Add option for per object placeholders
 
 Shuup 1.6.6
 -----------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -42,6 +42,7 @@ Xtheme
 - Add option to render extra templates in theme configuration.
 - Add option for per object placeholders
 - Fix bug deleting last row from placeholder
+- Do not render placeholders that can't be edited
 
 Shuup 1.6.6
 -----------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -26,6 +26,16 @@ Front
   check is done purely based on filename instead of checking the file
   content.
 
+Classic Gray Theme
+~~~~~~~~~~~~~~~~~~
+
+- Add option to configure shop logo size styles
+
+Simple CMS
+~~~~~~~~~~
+
+- Introduce Xtheme per object layout for pages
+
 Xtheme
 ~~~~~~
 

--- a/doc/ref/provides.rst
+++ b/doc/ref/provides.rst
@@ -260,8 +260,11 @@ Core
 ``xtheme``
     XTheme themes (full theme sets).
 
+``xtheme_layout``
+    XTheme layouts (to split placeholders different types of layouts with different visibilities).
+
 ``xtheme_plugin``
-    XTheme plugins (that are placed into placeholders within themes).
+    XTheme plugins (that are placed into layouts within themes).
 
 ``xtheme_resource_injection``
     XTheme resources injection function that takes current context and content as parameters.

--- a/shuup/core/models/__init__.py
+++ b/shuup/core/models/__init__.py
@@ -20,7 +20,8 @@ from ._categories import Category, CategoryStatus, CategoryVisibility
 from ._configurations import ConfigurationItem
 from ._contacts import (
     AnonymousContact, CompanyContact, Contact, ContactGroup, Gender,
-    get_company_contact, get_person_contact, PersonContact
+    get_company_contact, get_company_contact_for_shop_staff,
+    get_person_contact, PersonContact
 )
 from ._counters import Counter, CounterType
 from ._currencies import Currency, get_currency_precision
@@ -97,6 +98,7 @@ __all__ = [
     "DisplayUnit",
     "FixedCostBehaviorComponent",
     "get_company_contact",
+    "get_company_contact_for_shop_staff",
     "get_currency_precision",
     "get_person_contact",
     "Gender",

--- a/shuup/core/utils/users.py
+++ b/shuup/core/utils/users.py
@@ -5,8 +5,13 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-
 from django.contrib.auth import get_user_model
+
+from shuup import configuration
+
+ALL_SEEING_FORMAT = "is_all_seeing:%(user_id)s"
+FORCE_ANONYMOYS_FORMAT = "force_anonymous_contact:%(user_id)s"
+FORCE_PERSON_FORMAT = "force_person_contact:%(user_id)s"
 
 
 def real_user_or_none(user):
@@ -18,3 +23,34 @@ def real_user_or_none(user):
     assert (user is None or user.is_anonymous() or
             isinstance(user, get_user_model()))
     return user if (user and not user.is_anonymous()) else None
+
+
+def toggle_all_seeing_for_user(user):
+    if not getattr(user, "is_superuser", False):
+        return
+
+    all_seeing_key = ALL_SEEING_FORMAT % {"user_id": user.pk}
+    is_all_seeing = configuration.get(None, all_seeing_key, False)
+    configuration.set(None, all_seeing_key, not is_all_seeing)
+
+
+def is_user_all_seeing(user):
+    if user and user.pk and getattr(user, "is_superuser", False):
+        return configuration.get(None, ALL_SEEING_FORMAT % {"user_id": user.pk}, False)
+    return False
+
+
+def should_force_anonymous_contact(user):
+    return configuration.get(None, FORCE_ANONYMOYS_FORMAT % {"user_id": user.pk}, False)
+
+
+def should_force_person_contact(user):
+    return configuration.get(None, FORCE_PERSON_FORMAT % {"user_id": user.pk}, False)
+
+
+def force_anonymous_contact_for_user(user, value=True):
+    configuration.set(None, FORCE_ANONYMOYS_FORMAT % {"user_id": user.pk}, value)
+
+
+def force_person_contact_for_user(user, value=True):
+    configuration.set(None, FORCE_PERSON_FORMAT % {"user_id": user.pk}, value)

--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-13 17:48+0000\n"
+"POT-Creation-Date: 2018-07-11 03:36+0000\n"
 "PO-Revision-Date: 2016-08-04 10:51-0700\n"
 "Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
@@ -801,6 +801,27 @@ msgstr ""
 msgid "Items %(start_index)d of %(end_index)d of %(count)d total"
 msgstr ""
 
+msgid "Change visibility limit to"
+msgstr ""
+
+msgid "show only visible products and categories"
+msgstr ""
+
+msgid "show all products and categories"
+msgstr ""
+
+msgid "Change customer to person contact mode"
+msgstr ""
+
+msgid "Change customer to company contact mode"
+msgstr ""
+
+msgid "Change customer mode to guest"
+msgstr ""
+
+msgid "Change customer to person contact mode "
+msgstr ""
+
 msgid "Toggle navigation"
 msgstr ""
 
@@ -816,16 +837,25 @@ msgstr ""
 msgid "OFF"
 msgstr ""
 
+msgid "Visibility limit"
+msgstr ""
+
+msgid "Customer mode"
+msgstr ""
+
+msgid "GUEST"
+msgstr ""
+
+msgid "COMPANY CONTACT"
+msgstr ""
+
+msgid "PERSON CONTACT"
+msgstr ""
+
 msgid "Shop Administration"
 msgstr ""
 
 msgid "Tools"
-msgstr ""
-
-msgid "Show only visible products and categories"
-msgstr ""
-
-msgid "Show all products and categories"
 msgstr ""
 
 msgid ""

--- a/shuup/front/static_src/less/front/navigation.less
+++ b/shuup/front/static_src/less/front/navigation.less
@@ -303,15 +303,19 @@
 .navbar-admin-tools {
     .navbar-brand {
         padding-top: 5px;
-        small {
-            font-size: 60%;
+        .admin-tools-info {
+            font-size: 80%;
         }
-        .maintenance-on {
+        .maintenance-on, .visibility-limit-on {
             color: green;
             font-weight: bold;
         }
-        .maintenance-off {
+        .maintenance-off, .visibility-limit-off {
             color: red;
+            font-weight: bold;
+        }
+        .anonymous-contact-mode, .company-contact-mode, .person-contact-mode {
+            color: green;
             font-weight: bold;
         }
     }

--- a/shuup/front/template_helpers/general.py
+++ b/shuup/front/template_helpers/general.py
@@ -398,3 +398,14 @@ def is_shop_admin(context):
 def is_company_registration_allowed(context, request=None):
     current_request = request or context["request"]  # From macros it doesn't seem to always pass context correctly
     return allow_company_registration(current_request.shop)
+
+
+@contextfunction
+def can_toggle_all_seeing(context):
+    request = context["request"]
+    if request.customer.is_anonymous or request.is_company_member:
+        # Looks like the user is currently forcing anonymous or company
+        # mode which means that the visibility limit can't be used since
+        # 'is all seeing' is purely person contact feature.
+        return False
+    return getattr(request.user, "is_superuser", False)

--- a/shuup/front/templates/shuup/front/macros/general.jinja
+++ b/shuup/front/templates/shuup/front/macros/general.jinja
@@ -154,8 +154,65 @@
     {{ render_admin_tools() }}
 {% endmacro %}
 
+{% macro render_toggle_all_seeing_list_item(is_all_seeing) %}
+    <li>
+        <a href="{{ url("shuup:toggle-all-seeing") }}">
+            {% trans %}Change visibility limit to{% endtrans %}&nbsp;
+            {% if is_all_seeing %}
+                {% trans %}show only visible products and categories{% endtrans %}
+            {% else %}
+                {% trans %}show all products and categories{% endtrans %}
+            {% endif %}
+        </a>
+    </li>
+{% endmacro %}
+
+{% macro render_customer_mode_change_from_anonymous() %}
+    <li>
+        <a href="{{ url("shuup:force-person-contact") }}">
+            {% trans %}Change customer to person contact mode{% endtrans %}
+        </a>
+    </li>
+    <li>
+        <a href="{{ url("shuup:force-company-contact") }}">
+            {% trans %}Change customer to company contact mode{% endtrans %}
+        </a>
+    </li>
+{% endmacro %}
+
+{% macro render_customer_mode_change_from_company() %}
+    <li>
+        <a href="{{ url("shuup:force-anonymous-contact") }}">
+            {% trans %}Change customer mode to guest{% endtrans %}
+        </a>
+    </li>
+    <li>
+        <a href="{{ url("shuup:force-person-contact") }}">
+            {% trans %}Change customer to person contact mode {% endtrans %}
+        </a>
+    </li>
+{% endmacro %}
+
+{% macro render_customer_mode_change_from_person() %}
+    <li>
+        <a href="{{ url("shuup:force-anonymous-contact") }}">
+            {% trans %}Change customer mode to guest{% endtrans %}
+        </a>
+    </li>
+    <li>
+        <a href="{{ url("shuup:force-company-contact") }}">
+            {% trans %}Change customer to company contact mode{% endtrans %}
+        </a>
+    </li>
+{% endmacro %}
+
 {% macro render_admin_tools() %}
     {% if shuup.general.is_shop_admin() %}
+    {%- set is_maintenance_mode = request.shop.maintenance_mode -%}
+    {%- set can_toggle_all_seeing = shuup.general.can_toggle_all_seeing() %}
+    {%- set is_all_seeing = request.customer.is_all_seeing -%}
+    {%- set is_anonymous = request.person.is_anonymous -%}
+    {%- set is_company = request.is_company_member -%}
     <nav class="navbar navbar-default navbar-admin-tools navbar-fixed-top">
         <div class="container-fluid">
             <div class="navbar-header">
@@ -170,18 +227,38 @@
                     <span class="icon-bar"></span>
                 </button>
                 <a class="navbar-brand" href="#">
-                    {% trans %}Administration Tools{% endtrans %}
+                    <strong>{% trans %}Administration Tools{% endtrans %}</strong>
                     <br>
-                    <small>{% trans %}Maintenance mode{% endtrans %}:
-                        {% if request.shop.maintenance_mode %}
-                            <span class="maintenance-on">{% trans %}ON{% endtrans %}</span>
+                    <span class="admin-tools-info">
+                    {% trans %}Maintenance mode{% endtrans %}:
+                    {% if is_maintenance_mode %}
+                        <span class="maintenance-on">{% trans %}ON{% endtrans %}</span>
+                    {% else %}
+                        <span class="maintenance-off">{% trans %}OFF{% endtrans %}</span>
+                    {% endif %}
+                    </span>
+                    {% if can_toggle_all_seeing %}
+                        <span class="admin-tools-info">
+                        {% trans %}Visibility limit{% endtrans %}:
+                        {% if is_all_seeing %}
+                            <span class="visibility-limit-off">{% trans %}OFF{% endtrans %}</span>
                         {% else %}
-                            <span class="maintenance-off">{% trans %}OFF{% endtrans %}</span>
+                            <span class="visibility-limit-on">{% trans %}ON{% endtrans %}</span>
                         {% endif %}
-                    </small>
+                        </span>
+                    {% endif %}
+                    <span class="admin-tools-info">
+                    {% trans %}Customer mode{% endtrans %}:
+                    {% if is_anonymous %}
+                        <span class="anonymous-contact-mode">{% trans %}GUEST{% endtrans %}</span>
+                    {% elif is_company %}
+                        <span class="company-contact-mode">{% trans %}COMPANY CONTACT{% endtrans %}</span>
+                    {% else %}
+                        <span class="person-contact-mode">{% trans %}PERSON CONTACT{% endtrans %}</span>
+                    {% endif %}
+                    </span>
                 </a>
             </div>
-            {%- set allseeing = request.customer.is_all_seeing -%}
             <div class="collapse navbar-collapse" id="admin-tools-menu">
                 <ul class="nav navbar-nav navbar-right">
                     <li>
@@ -194,15 +271,16 @@
                            aria-haspopup="true"
                            aria-expanded="false">{% trans %}Tools{% endtrans %} <span class="caret"></span></a>
                         <ul class="dropdown-menu">
-                            <li>
-                                <a href="{{ url("shuup:toggle-all-seeing") }}">
-                                {% if allseeing %}
-                                {% trans %}Show only visible products and categories{% endtrans %}
-                                {% else %}
-                                {% trans %}Show all products and categories{% endtrans %}
-                                {% endif %}
-                                </a>
-                            </li>
+                            {% if can_toggle_all_seeing %}
+                                {{ render_toggle_all_seeing_list_item(is_all_seeing) }}
+                            {% endif %}
+                            {% if is_anonymous %}
+                                {{ render_customer_mode_change_from_anonymous() }}
+                            {% elif is_company %}
+                                {{ render_customer_mode_change_from_company() }}
+                            {% else %}
+                                {{ render_customer_mode_change_from_person() }}
+                            {% endif %}
                         </ul>
                     </li>
                 </ul>

--- a/shuup/front/templates/shuup/front/macros/navigation.jinja
+++ b/shuup/front/templates/shuup/front/macros/navigation.jinja
@@ -121,7 +121,7 @@
 {% endmacro %}
 
 {% macro _render_info_for_anonymous_users() %}
-    <li class="dropdown">
+    <li class="dropdown" id="login-dropdown">
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
             <i class="menu-icon fa fa-user"></i> <span class="hidden-xs">{% trans %}Log in{% endtrans %}</span>
             <i class="dropdown-icon fa fa-angle-down"></i>

--- a/shuup/front/urls.py
+++ b/shuup/front/urls.py
@@ -22,7 +22,10 @@ from .views.category import CategoryView
 from .views.checkout import get_checkout_view
 from .views.dashboard import DashboardView
 from .views.index import IndexView
-from .views.misc import toggle_all_seeing
+from .views.misc import (
+    force_anonymous_contact, force_company_contact, force_person_contact,
+    toggle_all_seeing
+)
 from .views.order import OrderCompleteView
 from .views.payment import ProcessPaymentView
 from .views.product import ProductDetailView
@@ -55,6 +58,9 @@ urlpatterns = [
     url(r'^basket/$', csrf_exempt(BasketView.as_view()), name='basket'),
     url(r'^dashboard/$', login_required(DashboardView.as_view()), name="dashboard"),
     url(r'^toggle-allseeing/$', login_required(toggle_all_seeing), name="toggle-all-seeing"),
+    url(r'^force-anonymous-contact/$', login_required(force_anonymous_contact), name="force-anonymous-contact"),
+    url(r'^force-company-contact/$', login_required(force_company_contact), name="force-company-contact"),
+    url(r'^force-person-contact/$', login_required(force_person_contact), name="force-person-contact"),
     url(r'^order/payment/(?P<pk>.+?)/(?P<key>.+?)/$',
         csrf_exempt(ProcessPaymentView.as_view()),
         kwargs={"mode": "payment"},

--- a/shuup/front/views/misc.py
+++ b/shuup/front/views/misc.py
@@ -7,7 +7,11 @@
 # LICENSE file in the root directory of this source tree.
 from django.http import HttpResponseRedirect
 
-from shuup import configuration
+from shuup.core.models import get_company_contact_for_shop_staff
+from shuup.core.utils.users import (
+    force_anonymous_contact_for_user, force_person_contact_for_user,
+    toggle_all_seeing_for_user
+)
 from shuup.front.utils.user import is_admin_user
 
 
@@ -15,7 +19,41 @@ def toggle_all_seeing(request):
     return_url = request.META["HTTP_REFERER"]
     if not is_admin_user(request):
         return HttpResponseRedirect(return_url)
-    all_seeing_key = "is_all_seeing:%d" % request.user.pk
-    is_all_seeing = not configuration.get(None, all_seeing_key, False)
-    configuration.set(None, all_seeing_key, is_all_seeing)
+
+    toggle_all_seeing_for_user(request.user)
+    return HttpResponseRedirect(return_url)
+
+
+def force_anonymous_contact(request):
+    return_url = request.META["HTTP_REFERER"]
+    if not is_admin_user(request):
+        return HttpResponseRedirect(return_url)
+
+    user = request.user
+    force_anonymous_contact_for_user(user, True)
+    force_person_contact_for_user(user, False)
+    return HttpResponseRedirect(return_url)
+
+
+def force_person_contact(request):
+    return_url = request.META["HTTP_REFERER"]
+    if not is_admin_user(request):
+        return HttpResponseRedirect(return_url)
+
+    user = request.user
+    force_person_contact_for_user(user, True)
+    force_anonymous_contact_for_user(user, False)
+    return HttpResponseRedirect(return_url)
+
+
+def force_company_contact(request):
+    return_url = request.META["HTTP_REFERER"]
+    if not is_admin_user(request):
+        return HttpResponseRedirect(return_url)
+
+    user = request.user
+    force_anonymous_contact_for_user(user, False)
+    force_person_contact_for_user(user, False)
+
+    get_company_contact_for_shop_staff(request.shop, user)
     return HttpResponseRedirect(return_url)

--- a/shuup/simple_cms/__init__.py
+++ b/shuup/simple_cms/__init__.py
@@ -24,6 +24,9 @@ class AppConfig(shuup.apps.AppConfig):
         "front_template_helper_namespace": [
             "shuup.simple_cms.template_helpers:SimpleCMSTemplateHelpers"
         ],
+        "xtheme_layout": [
+            "shuup.simple_cms.layout:PageLayout",
+        ],
         "xtheme_plugin": [
             "shuup.simple_cms.plugins:PageLinksPlugin"
         ],

--- a/shuup/simple_cms/layout.py
+++ b/shuup/simple_cms/layout.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.xtheme.layout import Layout
+
+
+class PageLayout(Layout):
+    identifier = "simple-cms-page-layout"
+    help_text = _("Content in this placeholder is shown for this page only.")
+
+    def get_help_text(self, context):
+        page = context.get("page")
+        if not page:
+            return ""
+        return _("Content in this placeholder is shown for %(title)s only." % {"title": page.title})
+
+    def is_valid_context(self, context):
+        return bool(context.get("page"))
+
+    def get_layout_data_suffix(self, context):
+        return "%s-%s" % (self.identifier, context["page"].pk)

--- a/shuup/simple_cms/locale/en/LC_MESSAGES/django.po
+++ b/shuup/simple_cms/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-20 18:02+0000\n"
+"POT-Creation-Date: 2018-07-11 03:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -68,10 +68,11 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-msgid "normal"
+msgid "Content in this placeholder is shown for this page only."
 msgstr ""
 
-msgid "revisioned"
+#, python-format
+msgid "Content in this placeholder is shown for %(title)s only."
 msgstr ""
 
 msgid "shop"
@@ -140,9 +141,6 @@ msgid ""
 "that this requires the children to be listed on the page as well."
 msgstr ""
 
-msgid "page type"
-msgstr ""
-
 msgid "deleted"
 msgstr ""
 
@@ -175,10 +173,6 @@ msgstr ""
 msgid "pages"
 msgstr ""
 
-msgid ""
-"This page is protected against changes because it is a GDPR consent document."
-msgstr ""
-
 msgid "Untitled"
 msgstr ""
 
@@ -195,15 +189,6 @@ msgid "Hide expired pages"
 msgstr ""
 
 msgid "New Page"
-msgstr ""
-
-msgid "General Information"
-msgstr ""
-
-msgid "Availability"
-msgstr ""
-
-msgid "Extras"
 msgstr ""
 
 msgid "Home"

--- a/shuup/simple_cms/templates/shuup/simple_cms/page.jinja
+++ b/shuup/simple_cms/templates/shuup/simple_cms/page.jinja
@@ -28,5 +28,5 @@
             </div>
         {% endfor %}
     {% endif %}
-    {% placeholder "cms_page" global %}{% endplaceholder %}
+    {% placeholder "cms_page" %}{% endplaceholder %}
 {% endblock %}

--- a/shuup/testing/locale/en/LC_MESSAGES/django.po
+++ b/shuup/testing/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-25 05:02+0000\n"
+"POT-Creation-Date: 2018-07-11 03:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -31,6 +31,12 @@ msgstr ""
 
 #, python-format
 msgid "This is %(sku)s"
+msgstr ""
+
+msgid "Dummy Importer"
+msgstr ""
+
+msgid "Dummy File Importer"
 msgstr ""
 
 msgid "Shuup Testing Theme"

--- a/shuup/utils/locale/en/LC_MESSAGES/django.po
+++ b/shuup/utils/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-11-28 18:00+0000\n"
+"POT-Creation-Date: 2018-07-11 03:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -75,6 +75,10 @@ msgstr[1] ""
 
 #, python-format
 msgid "%(min)s--%(max)s days"
+msgstr ""
+
+#, python-format
+msgid "Node %s not in depth-first order"
 msgstr ""
 
 msgid "This field is required."

--- a/shuup/xtheme/__init__.py
+++ b/shuup/xtheme/__init__.py
@@ -47,6 +47,14 @@ class XThemeAppConfig(AppConfig):
             "shuup.xtheme.plugins.social_media_links:SocialMediaLinksPlugin",
             "shuup.xtheme.plugins.text:TextPlugin",
         ],
+        "xtheme_layout": [
+            "shuup.xtheme.layout.ProductLayout",
+            "shuup.xtheme.layout.CategoryLayout",
+            "shuup.xtheme.layout.AnonymousContactLayout",
+            "shuup.xtheme.layout.ContactLayout",
+            "shuup.xtheme.layout.PersonContactLayout",
+            "shuup.xtheme.layout.CompanyContactLayout",
+        ],
         "admin_module": [
             "shuup.xtheme.admin_module:XthemeAdminModule"
         ]

--- a/shuup/xtheme/layout/__init__.py
+++ b/shuup/xtheme/layout/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from ._base import Layout, LayoutCell, LayoutRow
+from ._category import CategoryLayout
+from ._contact_group import (
+    AnonymousContactLayout, CompanyContactLayout, ContactLayout,
+    PersonContactLayout
+)
+from ._product import ProductLayout
+
+__all__ = [
+    "AnonymousContactLayout",
+    "CategoryLayout",
+    "CompanyContactLayout",
+    "ContactLayout",
+    "Layout",
+    "LayoutCell",
+    "LayoutRow",
+    "PersonContactLayout",
+    "ProductLayout"
+]

--- a/shuup/xtheme/layout/_base.py
+++ b/shuup/xtheme/layout/_base.py
@@ -409,7 +409,15 @@ class Layout(object):
         y = int(y)
         if not (0 <= y < len(self.rows)):
             return False
+
         self.rows.pop(y)
+
+        if len(self.rows) == 0:
+            # In case is deleting last row we don't want the
+            # placeholder defaults to kick in. Instead let's add
+            # empty row here to prevent that.
+            self.rows.append(LayoutRow(self.theme))
+
         return True
 
     def move_row_to_index(self, from_y, to_y):

--- a/shuup/xtheme/layout/_base.py
+++ b/shuup/xtheme/layout/_base.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext_lazy as _
 
 from shuup.xtheme.plugins._base import Plugin
 
@@ -197,7 +198,7 @@ class Layout(object):
     """
     The layout (row, cell and plugin configuration) for a single placeholder.
     """
-
+    identifier = "xtheme-default-layout"
     row_class = "row"
     cell_class_template = "col-%(breakpoint)s-%(width)s"
     hide_cell_class_template = "hidden-%(breakpoint)s"
@@ -214,6 +215,41 @@ class Layout(object):
         self.rows = []
         if rows:
             self.rows.extend(rows)
+
+    def get_help_text(self, context):
+        """
+        Help text for this placeholder shown at the top of the
+        editable layout.
+
+        :param context: Jinja2 rendering context
+        :type context: jinja2.runtime.Context
+        :return: Help text for this layout
+        :rtype: str
+        """
+        return _("Content in this placeholder is shown without limitations.")
+
+    def is_valid_context(self, context):
+        """
+        :param context: Jinja2 rendering context
+        :type context: jinja2.runtime.Context
+        :return: Whether the current context is valid for this layout
+        :rtype: bool
+        """
+        return True
+
+    def get_layout_data_suffix(self, context):
+        """
+        Layout data suffix which is used to save layout data to view config
+
+        With layout data suffix you can define data keys that is only available
+        for certain contexts. Make sure that you validate the context for
+        variables that is used to form this suffix.
+
+        :param context: Jinja2 rendering context
+        :type context: jinja2.runtime.Context
+        :rtype: str
+        """
+        return ""
 
     @classmethod
     def unserialize(cls, theme, data, placeholder_name=None):

--- a/shuup/xtheme/layout/_category.py
+++ b/shuup/xtheme/layout/_category.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.xtheme.layout import Layout
+
+
+class CategoryLayout(Layout):
+    identifier = "xtheme-category-layout"
+
+    def get_help_text(self, context):
+        category = context.get("category")
+        if not category:
+            return ""
+        return _("Content in this placeholder is shown for %(category_name)s category only." % {
+            "category_name": category.name})
+
+    def is_valid_context(self, context):
+        return bool(context.get("category"))
+
+    def get_layout_data_suffix(self, context):
+        return "%s-%s" % (self.identifier, context["category"].pk)

--- a/shuup/xtheme/layout/_contact_group.py
+++ b/shuup/xtheme/layout/_contact_group.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.core.models import CompanyContact, PersonContact
+from shuup.xtheme.layout import Layout
+from shuup.xtheme.layout.utils import get_customer_from_context
+
+
+class AnonymousContactLayout(Layout):
+    identifier = "xtheme-anonymous-contact-layout"
+
+    def get_help_text(self, context):
+        return _("Content in this placeholder is shown for guests.")
+
+    def is_valid_context(self, context):
+        customer = get_customer_from_context(context)
+        return bool(customer.is_anonymous)
+
+    def get_layout_data_suffix(self, context):
+        return self.identifier
+
+
+class CompanyContactLayout(Layout):
+    identifier = "xtheme-company-contact-layout"
+
+    def get_help_text(self, context):
+        return _("Content in this placeholder is shown for company contacts.")
+
+    def is_valid_context(self, context):
+        customer = get_customer_from_context(context)
+        return (isinstance(customer, CompanyContact) if customer else False)
+
+    def get_layout_data_suffix(self, context):
+        return self.identifier
+
+
+class ContactLayout(Layout):
+    identifier = "xtheme-contact-layout"
+
+    def get_help_text(self, context):
+        return _("Content in this placeholder is shown for all logged in contacts.")
+
+    def is_valid_context(self, context):
+        customer = get_customer_from_context(context)
+        return bool(not customer.is_anonymous)
+
+    def get_layout_data_suffix(self, context):
+        return self.identifier
+
+
+class PersonContactLayout(Layout):
+    identifier = "xtheme-person-contact-layout"
+
+    def get_help_text(self, context):
+        return _("Content in this placeholder is shown for person contacts.")
+
+    def is_valid_context(self, context):
+        customer = get_customer_from_context(context)
+        return (isinstance(customer, PersonContact) if customer else False)
+
+    def get_layout_data_suffix(self, context):
+        return self.identifier

--- a/shuup/xtheme/layout/_product.py
+++ b/shuup/xtheme/layout/_product.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.xtheme.layout import Layout
+
+
+class ProductLayout(Layout):
+    identifier = "xtheme-product-layout"
+
+    def get_help_text(self, context):
+        product = context.get("product")
+        if not product:
+            return ""
+        return _("Content in this placeholder is shown for %(product_name)s only." % {"product_name": product.name})
+
+    def is_valid_context(self, context):
+        return bool(context.get("product"))
+
+    def get_layout_data_suffix(self, context):
+        return "%s-%s" % (self.identifier, context["product"].pk)

--- a/shuup/xtheme/layout/utils.py
+++ b/shuup/xtheme/layout/utils.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from shuup.apps.provides import get_provide_objects
+
+
+def get_customer_from_context(context):
+    request = context.get("request")
+    return (request.customer if request else None)
+
+
+def get_layout_data_key(placeholder_name, layout, context):
+    if isinstance(layout, dict):
+        return placeholder_name
+
+    data_suffix = layout.get_layout_data_suffix(context)
+    if data_suffix:
+        return "%s-%s" % (placeholder_name, layout.get_layout_data_suffix(context))
+
+    return placeholder_name
+
+
+def get_provided_layouts():
+    return get_provide_objects("xtheme_layout")

--- a/shuup/xtheme/locale/en/LC_MESSAGES/django.po
+++ b/shuup/xtheme/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-10 18:00+0000\n"
+"POT-Creation-Date: 2018-07-11 03:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -65,6 +65,30 @@ msgid "Stylesheets"
 msgstr ""
 
 msgid "The fonts, colors, and styles to use with your theme."
+msgstr ""
+
+msgid "Content in this placeholder is shown without limitations."
+msgstr ""
+
+#, python-format
+msgid ""
+"Content in this placeholder is shown for %(category_name)s category only."
+msgstr ""
+
+msgid "Content in this placeholder is shown for guests."
+msgstr ""
+
+msgid "Content in this placeholder is shown for company contacts."
+msgstr ""
+
+msgid "Content in this placeholder is shown for all logged in contacts."
+msgstr ""
+
+msgid "Content in this placeholder is shown for person contacts."
+msgstr ""
+
+#, python-format
+msgid "Content in this placeholder is shown for %(product_name)s only."
 msgstr ""
 
 msgid "Shop '{}' has no active theme"
@@ -229,6 +253,11 @@ msgstr ""
 
 #, python-format
 msgid "Click to edit placeholder: %s"
+msgstr ""
+
+msgid ""
+"This placeholder is global and content of this placeholder is shown on all "
+"pages."
 msgstr ""
 
 msgid "Delete This Cell"

--- a/shuup/xtheme/models.py
+++ b/shuup/xtheme/models.py
@@ -115,7 +115,7 @@ class SavedViewConfig(models.Model):
         if self.pk:
             self.delete()
 
-    def set_layout_data(self, placeholder_name, layout):
+    def set_layout_data(self, layout_data_key, layout):
         if not layout:  # pragma: no cover
             return None
         if not self.draft:
@@ -123,10 +123,10 @@ class SavedViewConfig(models.Model):
         if hasattr(layout, "serialize"):
             layout = layout.serialize()
         assert isinstance(layout, dict)
-        self._data.setdefault("layouts", {})[placeholder_name] = layout
+        self._data.setdefault("layouts", {})[layout_data_key] = layout
 
-    def get_layout_data(self, placeholder_name):
-        return self._data.get("layouts", {}).get(placeholder_name)
+    def get_layout_data(self, layout_data_key):
+        return self._data.get("layouts", {}).get(layout_data_key)
 
     def clear_layout_data(self, placeholder_name):
         if not self.draft:

--- a/shuup/xtheme/rendering.py
+++ b/shuup/xtheme/rendering.py
@@ -14,6 +14,7 @@ from markupsafe import Markup
 from shuup.core.fields.tagged_json import TaggedJSONEncoder
 from shuup.xtheme._theme import get_current_theme
 from shuup.xtheme.editing import is_edit_mode
+from shuup.xtheme.layout.utils import get_layout_data_key
 from shuup.xtheme.utils import get_html_attrs
 from shuup.xtheme.view_config import ViewConfig
 
@@ -97,7 +98,8 @@ class PlaceholderRenderer(object):
         self.placeholder_name = placeholder_name
         self.template_name = ("_xtheme_global_template_name" if global_type else template_name)
         self.default_layout = default_layout
-        self.layout = self.view_config.get_placeholder_layout(placeholder_name, self.default_layout)
+        # Fetch all layouts for this placeholder context combination
+        self.layouts = self.view_config.get_placeholder_layouts(context, placeholder_name, self.default_layout)
         self.global_type = global_type
         # For non-global placeholders, editing is only available for placeholders in the "base" template, i.e.
         # one that is not an `extend` parent.  Declaring placeholders in `include`d templates is fine,
@@ -115,35 +117,58 @@ class PlaceholderRenderer(object):
         :return: Rendered markup.
         :rtype: markupsafe.Markup
         """
-        wrapper_start = "<div%s>" % get_html_attrs(self._get_wrapper_attrs())
-        buffer = []
-        write = buffer.append
-        self._render_layout(write)
-        content = "".join(buffer)
-        return Markup("%(wrapper_start)s%(content)s%(wrapper_end)s" % {
-            "wrapper_start": wrapper_start,
-            "content": content,
-            "wrapper_end": "</div>",
-        })
+        full_content = ""
+        for layout in self.layouts:
+            wrapper_start = "<div%s>" % get_html_attrs(self._get_wrapper_attrs(layout))
+            buffer = []
+            write = buffer.append
+            self._render_layout(write, layout)
+            content = "".join(buffer)
+            full_content += (
+                "%(wrapper_start)s%(content)s%(wrapper_end)s" % {
+                    "wrapper_start": wrapper_start,
+                    "content": content,
+                    "wrapper_end": "</div>",
+                })
 
-    def _get_wrapper_attrs(self):
+        return Markup(full_content)
+
+    def _get_wrapper_attrs(self, layout):
+        layout_data_key = get_layout_data_key(self.placeholder_name, layout, self.context)
         attrs = {
             "class": ["xt-ph", "xt-ph-edit" if self.edit else None, "xt-global-ph" if self.global_type else None],
-            "id": "xt-ph-%s" % self.placeholder_name
+            "id": "xt-ph-%s" % layout_data_key
         }
         if self.edit:
+            # Pass layout editor to editor so we can fetch
+            # correct layout for editing.
+            attrs["data-xt-layout-identifier"] = layout.identifier
+
+            # We need to pass layout data key here since this is the last
+            # place whe have the context available before editor.
+            attrs["data-xt-layout-data-key"] = layout_data_key
             attrs["data-xt-placeholder-name"] = self.placeholder_name
             attrs["data-xt-global-type"] = "global" if self.global_type else None
             attrs["title"] = _("Click to edit placeholder: %s") % self.placeholder_name.title()
         return attrs
 
-    def _render_layout(self, write):
+    def _render_layout(self, write, layout):
+        if self.edit:
+            help_text = layout.get_help_text(self.context)
+            if self.global_type:
+                glopal_help_text = _(
+                    "This placeholder is global and content of this placeholder is shown on all pages.")
+                help_text += " " + force_text(glopal_help_text)
+
+            write("<p>%s</p>" % help_text)
+
         if self.edit and self.default_layout:
             self._render_default_layout_script_tag(write)
-        for y, row in enumerate(self.layout):
-            self._render_row(write, y, row)
 
-    def _render_row(self, write, y, row):
+        for y, row in enumerate(layout):
+            self._render_row(write, layout, y, row)
+
+    def _render_row(self, write, layout, y, row):
         """
         Render a layout row into HTML.
 
@@ -155,16 +180,16 @@ class PlaceholderRenderer(object):
         :type row: shuup.xtheme.view_config.LayoutRow
         """
         row_attrs = {
-            "class": [self.layout.row_class, "xt-ph-row"]
+            "class": [layout.row_class, "xt-ph-row"]
         }
         if self.edit:
             row_attrs["data-xt-row"] = str(y)
         write("<div%s>" % get_html_attrs(row_attrs))
         for x, cell in enumerate(row):
-            self._render_cell(write, x, cell)
+            self._render_cell(write, layout, x, cell)
         write("</div>\n")
 
-    def _render_cell(self, write, x, cell):
+    def _render_cell(self, write, layout, x, cell):
         """
         Render a layout cell into HTML.
 
@@ -180,9 +205,9 @@ class PlaceholderRenderer(object):
             if width is None:
                 continue
             if width <= 0:
-                classes.append(self.layout.hide_cell_class_template % {"breakpoint": breakpoint, "width": width})
+                classes.append(layout.hide_cell_class_template % {"breakpoint": breakpoint, "width": width})
             else:
-                classes.append(self.layout.cell_class_template % {"breakpoint": breakpoint, "width": width})
+                classes.append(layout.cell_class_template % {"breakpoint": breakpoint, "width": width})
 
         classes.append(cell.align)
 

--- a/shuup/xtheme/rendering.py
+++ b/shuup/xtheme/rendering.py
@@ -13,7 +13,7 @@ from markupsafe import Markup
 
 from shuup.core.fields.tagged_json import TaggedJSONEncoder
 from shuup.xtheme._theme import get_current_theme
-from shuup.xtheme.editing import is_edit_mode
+from shuup.xtheme.editing import is_edit_mode, may_inject
 from shuup.xtheme.layout.utils import get_layout_data_key
 from shuup.xtheme.utils import get_html_attrs
 from shuup.xtheme.view_config import ViewConfig
@@ -117,6 +117,9 @@ class PlaceholderRenderer(object):
         :return: Rendered markup.
         :rtype: markupsafe.Markup
         """
+        if not may_inject(self.context):
+            return ""
+
         full_content = ""
         for layout in self.layouts:
             wrapper_start = "<div%s>" % get_html_attrs(self._get_wrapper_attrs(layout))

--- a/shuup/xtheme/static_src/injection/index.js
+++ b/shuup/xtheme/static_src/injection/index.js
@@ -25,7 +25,7 @@ function getSidebarDiv() {
                     }
                 }
             }, [el("i.fa"), "Toggle Editor"]),
-            (_sidebarIframe = el("iframe"))
+            (_sidebarIframe = el("iframe", {id: "xt-edit-sidebar-iframe"}))
         ]);
         document.body.appendChild(_sidebarDiv);
     }

--- a/shuup/xtheme/static_src/injection/index.js
+++ b/shuup/xtheme/static_src/injection/index.js
@@ -47,8 +47,11 @@ function setSidebarVisibility(visible) {
 }
 
 function openPlaceholderEditor(domElement) {
+    const layoutIdentifier = domElement.dataset.xtLayoutIdentifier;
+    const layoutDataKey = domElement.dataset.xtLayoutDataKey;
     const placeholderName = domElement.dataset.xtPlaceholderName;
     const globalType = domElement.dataset.xtGlobalType;
+    const contentTypeId = domElement.dataset.xtContentTypeId;
     if (!placeholderName) {
         return;
     }
@@ -60,7 +63,8 @@ function openPlaceholderEditor(domElement) {
         theme: window.XthemeEditorConfig.themeIdentifier,
         ph: placeholderName,
         "global_type": globalType,
-
+        "layout_identifier": layoutIdentifier,
+        "layout_data_key": layoutDataKey,
         // TODO: Hopefully we won't get any problems with too-long query strings (2048 is the maximum for IE):
         "default_config": defaultConfigJSON
     };

--- a/shuup/xtheme/static_src/injection/style.less
+++ b/shuup/xtheme/static_src/injection/style.less
@@ -2,6 +2,13 @@
 @color-blue: #55ACCC;
 @editor-bg-color: #fff;
 
+
+.footer-bottom {
+    .xt-ph-edit {
+        color: #eeeeee;
+    }
+}
+
 .xt-ph-edit {
     border: 2px dashed @color-blue;
     min-height: 20px;

--- a/shuup_tests/browser/front/test_checkout_addresses.py
+++ b/shuup_tests/browser/front/test_checkout_addresses.py
@@ -108,6 +108,8 @@ def test_browser_checkout_addresses_horizontal(browser, live_server, settings):
     wait_until_condition(browser, lambda x: x.find_by_name("shipping-country").has_class("disabled"))
     billing_country = browser.find_by_name("billing-country").first
     shipping_country = browser.find_by_name("shipping-country").first
+    wait_until_appeared(browser, "select[name='billing-region_code']")
+    wait_until_appeared(browser, "select[name='shipping-region_code']")
     billing_region_code = browser.find_by_name("billing-region_code").first
     shipping_region_code = browser.find_by_name("shipping-region_code").first
     assert billing_country.value == shipping_country.value
@@ -135,8 +137,10 @@ def test_browser_checkout_addresses_horizontal(browser, live_server, settings):
 
     # all values must be there with correct saved values
     billing_country = browser.find_by_name("billing-country").first
+    wait_until_appeared(browser, "select[name='billing-region_code']")
     billing_region_code = browser.find_by_name("billing-region_code").first
     shipping_country = browser.find_by_name("shipping-country").first
+    wait_until_appeared(browser, "select[name='shipping-region_code']")
     shipping_region_code = browser.find_by_name("shipping-region_code").first
     assert billing_country.value == customer_country1
     assert billing_region_code.value == customer_region1
@@ -261,8 +265,10 @@ def test_browser_checkout_addresses_vertical(browser, live_server, settings):
 
         # all values must be there with correct saved values
         billing_country = browser.find_by_name("billing-country").first
+        wait_until_appeared(browser, "select[name='billing-region_code']")
         billing_region_code = browser.find_by_name("billing-region_code").first
         shipping_country = browser.find_by_name("shipping-country").first
+        wait_until_appeared(browser, "select[name='shipping-region_code']")
         shipping_region_code = browser.find_by_name("shipping-region_code").first
         assert billing_country.value == customer_country1
         assert billing_region_code.value == customer_region1

--- a/shuup_tests/browser/front/test_xtheme_edit.py
+++ b/shuup_tests/browser/front/test_xtheme_edit.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+import pytest
+import selenium
+
+from django.core.urlresolvers import reverse
+
+from shuup.core.models import get_person_contact
+from shuup.testing import factories
+from shuup.testing.browser_utils import (
+    click_element, wait_until_condition
+)
+from shuup.testing.utils import (
+    initialize_admin_browser_test
+)
+
+
+pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
+
+
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_xtheme_edit_front(admin_user, browser, live_server, settings):
+    browser = initialize_admin_browser_test(browser, live_server, settings)  # Login to admin as admin user
+    browser.visit(live_server + "/")
+    wait_until_condition(browser, lambda x: x.is_text_present("Welcome to Default!"))
+
+    # Start edit
+    click_element(browser, ".xt-edit-toggle button[type='submit']")
+
+    # Add some content only visible for person contacts
+    person_contact_text_content = "This text is shown for person contacts only!"
+    _edit_layout(
+        browser, "front_content", "#xt-ph-front_content-xtheme-person-contact-layout", person_contact_text_content)
+    
+    browser.find_by_css("#admin-tools-menu li.dropdown").click()
+    browser.find_by_css("a[href='/force-anonymous-contact/']").first.click()
+
+    ## Add some content only visible for anonymous contacts
+    anonymous_contact_text_content = "This text is shown for guests only!"
+    _edit_layout(
+        browser, "front_content", "#xt-ph-front_content-xtheme-anonymous-contact-layout", anonymous_contact_text_content)
+
+    browser.find_by_css("#admin-tools-menu li.dropdown").click()
+    browser.find_by_css("a[href='/force-company-contact/']").first.click()
+
+    ### Add some content only visible for company contacts
+    company_contact_text_content = "This text is shown for company contacts only!"
+    _edit_layout(
+        browser, "front_content", "#xt-ph-front_content-xtheme-company-contact-layout", company_contact_text_content)
+    
+    # Close edit
+    click_element(browser, ".xt-edit-toggle button[type='submit']")
+
+    # Logout
+    click_element(browser, "div.top-nav i.menu-icon.fa.fa-user")
+    click_element(browser, "a[href='/logout/']")
+
+    # Go to home and check content for anonymous contacts
+    browser.visit(live_server + "/")
+    wait_until_condition(browser, lambda x: x.is_text_present("Welcome to Default!"))
+    wait_until_condition(browser, lambda x: x.is_text_present(anonymous_contact_text_content))
+    wait_until_condition(browser, lambda x: not x.is_text_present(person_contact_text_content))
+    wait_until_condition(browser, lambda x: not x.is_text_present(company_contact_text_content))
+
+    # Create user login and got check the content for person contact
+    user = factories.create_random_user()
+    password = "timo123"
+    user.set_password(password)
+    user.save()
+
+    click_element(browser, "#login-dropdown")
+    browser.fill("username", user.username)
+    browser.fill("password", password)
+    browser.find_by_css("ul.login button[type='submit']").click()
+
+    wait_until_condition(browser, lambda x: x.is_text_present("Welcome to Default!"))
+    wait_until_condition(browser, lambda x: x.is_text_present(person_contact_text_content))
+    wait_until_condition(browser, lambda x: not x.is_text_present(anonymous_contact_text_content))
+    wait_until_condition(browser, lambda x: not x.is_text_present(company_contact_text_content))
+
+    # Logout
+    click_element(browser, "div.top-nav i.menu-icon.fa.fa-user")
+    click_element(browser, "a[href='/logout/']")
+
+    # Create person contact to company and re-login and check the content for companies
+    company = factories.create_random_company()
+    company.members.add(get_person_contact(user))
+
+    click_element(browser, "#login-dropdown")
+    browser.fill("username", user.username)
+    browser.fill("password", password)
+    browser.find_by_css("ul.login button[type='submit']").click()
+
+    wait_until_condition(browser, lambda x: x.is_text_present("Welcome to Default!"))
+    wait_until_condition(browser, lambda x: x.is_text_present(company_contact_text_content))
+    wait_until_condition(browser, lambda x: not x.is_text_present(anonymous_contact_text_content))
+    wait_until_condition(browser, lambda x: not x.is_text_present(person_contact_text_content))
+
+
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_xtheme_edit_product(admin_user, browser, live_server, settings):
+    browser = initialize_admin_browser_test(browser, live_server, settings)  # Login to admin as admin user
+
+    shop = factories.get_default_shop()
+    supplier = factories.get_default_supplier()
+    products = []
+    for x in range(3):
+        products.append(factories.create_product("test%s" % x, shop=shop, supplier=supplier, default_price=10))
+
+    browser.visit(live_server + "/")
+    wait_until_condition(browser, lambda x: x.is_text_present("Welcome to Default!"))
+
+    # Start edit
+    click_element(browser, ".xt-edit-toggle button[type='submit']")
+
+    # Visit first product and edit the layout with custom text
+    first_product = products.pop()
+    first_product_url = "%s%s" % (
+        live_server, reverse("shuup:product", kwargs={"pk": first_product.pk, "slug": first_product.slug})
+    )
+    browser.visit(first_product_url)
+
+    first_product_text_content = "This text is only visible for product %s." % first_product.name
+    _edit_layout(
+        browser,
+        "product_extra_1",
+        "#xt-ph-product_extra_1-xtheme-product-layout-%s" % first_product.pk,
+        first_product_text_content
+    )
+
+    # Visit second product and edit the layout with custom text 
+    second_product = products.pop()
+    second_product_url = "%s%s" % (
+        live_server, reverse("shuup:product", kwargs={"pk": second_product.pk, "slug": second_product.slug})
+    )
+    browser.visit(second_product_url)
+
+    second_product_text_content = "This text is only visible for product %s." % second_product.name
+    _edit_layout(
+        browser,
+        "product_extra_1",
+        "#xt-ph-product_extra_1-xtheme-product-layout-%s" % second_product.pk,
+        second_product_text_content
+    )
+
+    # Visit third product and edit common layout with text
+    third_product = products.pop()
+    third_product_url = "%s%s" % (
+        live_server, reverse("shuup:product", kwargs={"pk": third_product.pk, "slug": third_product.slug})
+    )
+    browser.visit(third_product_url)
+
+    common_text_content = "This text is visible for all products."
+    _edit_layout(
+        browser, "product_extra_1", "#xt-ph-product_extra_1", common_text_content)
+
+    # Close edit
+    click_element(browser, ".xt-edit-toggle button[type='submit']")
+
+    # Logout
+    click_element(browser, "div.top-nav i.menu-icon.fa.fa-user")
+    click_element(browser, "a[href='/logout/']")
+
+    # Let's revisit the product details as anonymous and check the placeholder content
+    browser.visit(first_product_url)
+    wait_until_condition(browser, lambda x: x.is_text_present(common_text_content))
+    wait_until_condition(browser, lambda x: x.is_text_present(first_product_text_content))
+    wait_until_condition(browser, lambda x: not x.is_text_present(second_product_text_content))
+    
+    browser.visit(second_product_url)
+    wait_until_condition(browser, lambda x: x.is_text_present(common_text_content))
+    wait_until_condition(browser, lambda x: not x.is_text_present(first_product_text_content))
+    wait_until_condition(browser, lambda x: x.is_text_present(second_product_text_content))
+
+    browser.visit(third_product_url)
+    wait_until_condition(browser, lambda x: x.is_text_present(common_text_content))
+    wait_until_condition(browser, lambda x: not x.is_text_present(first_product_text_content))
+    wait_until_condition(browser, lambda x: not x.is_text_present(second_product_text_content))
+
+
+def _edit_layout(browser, placeholder_name, layout_selector, text_content):
+    wait_until_condition(browser, lambda x: x.is_element_present_by_css(layout_selector))
+    click_element(browser, layout_selector)
+    with browser.get_iframe("xt-edit-sidebar-iframe") as iframe:
+        wait_until_condition(iframe, lambda x: x.is_text_present("Edit Placeholder: %s" % placeholder_name))
+        wait_until_condition(iframe, lambda x: x.is_element_present_by_css("button.layout-add-row-btn"))
+        click_element(iframe, "button.layout-add-row-btn")
+
+        # Well the second click here makes it so that the next
+        # timeout exception doesn't happen (often). For some reason
+        # the button wasn't clickable when present. This is also
+        # weird since outside the brwoser tests there is no reason
+        # to expect that 'add row' is slower than other requests.
+        click_element(iframe, "button.layout-add-row-btn")
+
+        try:
+            wait_until_condition(iframe, lambda x: x.is_element_present_by_css("div.layout-cell"))
+        except selenium.common.exceptions.TimeoutException as e:  # Give the "Add new row" second chance
+            click_element(iframe, "button.layout-add-row-btn")
+            wait_until_condition(iframe, lambda x: x.is_element_present_by_css("div.layout-cell"))
+
+        click_element(iframe, "div.layout-cell")
+
+        wait_until_condition(iframe, lambda x: x.is_element_present_by_css("select[name='general-plugin']"))
+        iframe.select("general-plugin", "text")
+
+        wait_until_condition(iframe, lambda x: x.is_element_present_by_css("div.note-editable"))
+        wait_until_condition(iframe, lambda x: x.is_element_present_by_css("#id_plugin-text_en-editor-wrap"))
+        iframe.execute_script(
+            "$('#id_plugin-text_en-editor-wrap .summernote-editor').summernote('editor.insertText', '%s');" % text_content
+        )
+        click_element(iframe, "button.submit-form-btn")
+        click_element(iframe, "button.publish-btn")
+
+        alert = iframe.get_alert()
+        alert.accept()
+
+    wait_until_condition(browser, lambda x: not x.is_element_present_by_css("#xt-edit-sidebar-iframe"))

--- a/shuup_tests/core/test_utils_users.py
+++ b/shuup_tests/core/test_utils_users.py
@@ -1,0 +1,125 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from shuup.core.models import (
+    CompanyContact, get_company_contact, get_company_contact_for_shop_staff,
+    get_person_contact, PersonContact
+)
+from shuup.core.utils.users import (
+    force_anonymous_contact_for_user, force_person_contact_for_user,
+    is_user_all_seeing, toggle_all_seeing_for_user
+)
+from shuup.testing import factories
+
+
+@pytest.mark.django_db
+def test_is_user_all_seeing(rf, admin_user):
+    assert not is_user_all_seeing(admin_user)
+    toggle_all_seeing_for_user(admin_user)
+    assert is_user_all_seeing(admin_user)
+    toggle_all_seeing_for_user(admin_user)
+    assert not is_user_all_seeing(admin_user)
+
+
+@pytest.mark.django_db
+def test_forcing_to_anonymous_contact(rf, admin_user):
+    person_contact = get_person_contact(admin_user)
+    assert person_contact is not None
+    assert not get_person_contact(admin_user).is_anonymous
+
+    company_contact = get_company_contact(admin_user)
+    assert company_contact is None
+
+    force_anonymous_contact_for_user(admin_user)
+    assert get_person_contact(admin_user).is_anonymous
+
+    force_anonymous_contact_for_user(admin_user, False)
+    assert not get_person_contact(admin_user).is_anonymous
+    assert get_person_contact(admin_user).user.id == admin_user.id
+
+
+@pytest.mark.django_db
+def test_company_contact_for_shop_staff(rf, admin_user):
+    company_contact = get_company_contact(admin_user)
+    assert company_contact is None
+
+    shop = factories.get_default_shop()
+    # Let's create shop for the shop staff
+    company_contact = get_company_contact_for_shop_staff(shop, admin_user)
+
+    company_contact = get_company_contact_for_shop_staff(shop, admin_user)
+    assert company_contact is not None
+
+    # Let's create second staff member to make sure all good with
+    # creating company contact for shop staff.
+    new_staff_user = factories.create_random_user()
+    with pytest.raises(AssertionError):
+        get_company_contact_for_shop_staff(shop, new_staff_user)
+
+    new_staff_user.is_staff = True
+    new_staff_user.save()
+    
+    with pytest.raises(AssertionError):
+        # Since the new staff is not in shop members. The admin user
+        # passed since he is also superuser.
+        get_company_contact_for_shop_staff(shop, new_staff_user)
+
+    shop.staff_members.add(new_staff_user)
+    assert company_contact == get_company_contact_for_shop_staff(shop, new_staff_user)
+
+    # Make sure both user has person contact linked to the company contact
+    company_members = company_contact.members.all()
+    assert get_person_contact(admin_user) in company_members
+    assert get_person_contact(new_staff_user) in company_members
+
+
+@pytest.mark.django_db
+def test_forcing_to_person_contact(rf, admin_user):
+    company_contact = get_company_contact(admin_user)
+    assert company_contact is None
+    shop = factories.get_default_shop()
+    company_contact = get_company_contact_for_shop_staff(shop, admin_user)
+    assert isinstance(company_contact, CompanyContact)
+    assert company_contact == get_company_contact(admin_user)
+    
+    person_contact = get_person_contact(admin_user)
+    assert person_contact is not None
+
+    force_person_contact_for_user(admin_user)
+    assert get_company_contact(admin_user) is None
+
+    force_person_contact_for_user(admin_user, False)
+    assert company_contact == get_company_contact(admin_user)
+
+
+@pytest.mark.django_db
+def test_forcing_to_person_and_anonymous_contact(rf, admin_user):
+    company_contact = get_company_contact(admin_user)
+    assert company_contact is None
+    shop = factories.get_default_shop()
+    company_contact = get_company_contact_for_shop_staff(shop, admin_user)
+    assert isinstance(company_contact, CompanyContact)
+    assert company_contact == get_company_contact(admin_user)
+
+    person_contact = get_person_contact(admin_user)
+    assert person_contact is not None
+    assert not person_contact.is_anonymous
+
+    force_person_contact_for_user(admin_user)
+    assert get_company_contact(admin_user) is None
+
+    force_anonymous_contact_for_user(admin_user)
+    assert get_person_contact(admin_user).is_anonymous
+
+    force_person_contact_for_user(admin_user, False)
+    assert get_company_contact(admin_user) is None  # Since the person contact is still anonymous
+    assert get_person_contact(admin_user).is_anonymous
+
+    force_anonymous_contact_for_user(admin_user, False)
+    assert company_contact == get_company_contact(admin_user)
+    assert not get_person_contact(admin_user).is_anonymous

--- a/shuup_tests/front/test_all_seeing.py
+++ b/shuup_tests/front/test_all_seeing.py
@@ -33,11 +33,11 @@ def do_request_and_asserts(rf, contact, maintenance=False, expect_all_seeing=Fal
         texts.append(elem.text.strip())
 
     if contact.user.is_superuser:
-        text = "Show only visible products and categories" if expect_all_seeing else "Show all products and categories"
-        assert text in texts
+        text = "show only visible products and categories" if expect_all_seeing else "show all products and categories"
+        assert_text_in_texts(texts, text, True)
     else:
-        assert "Show only visible products and categories" not in texts
-        assert "Show all products and categories" not in texts
+        assert_text_in_texts(texts, "show only visible products and categories", False)
+        assert_text_in_texts(texts, "show all products and categories", False)
 
 
 @pytest.mark.django_db
@@ -74,3 +74,7 @@ def test_regular_user_is_blind(rf, regular_user):
 
     # Contact might be all-seeing in database but toolbar requires superuser
     do_request_and_asserts(rf, contact, maintenance=False, expect_all_seeing=False, expect_toolbar=False)
+
+
+def assert_text_in_texts(texts, expected_text, expected_outcome):
+    return any([text for text in texts if expected_text in text]) == expected_outcome

--- a/shuup_tests/front/test_contact_forcing_views.py
+++ b/shuup_tests/front/test_contact_forcing_views.py
@@ -1,0 +1,104 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from shuup.core.models import get_company_contact, get_person_contact
+from shuup.front.views.misc import (
+    force_anonymous_contact, force_company_contact, force_person_contact
+)
+from shuup.testing import factories
+from shuup.testing.utils import apply_request_middleware
+
+
+@pytest.mark.django_db
+def test_force_contact_views(rf):
+    shop = factories.get_default_shop()
+    user = factories.create_random_user(is_staff=True)
+    shop.staff_members.add(user)
+    person_contact = get_person_contact(user)
+    request = apply_request_middleware(rf.get("/"), user=user)
+    assert request.customer == person_contact
+
+    # Force contact to anonymous contact
+    _call_force_view(request, force_anonymous_contact)
+
+    # Re-process middlewares so we check the force contact
+    request = apply_request_middleware(rf.get("/"), user=user)
+    assert request.customer.is_anonymous
+    assert get_person_contact(user).is_anonymous
+    assert_all_good_with_random_user()
+
+    # Force contact to person contact
+    _call_force_view(request, force_person_contact)
+
+    request = apply_request_middleware(rf.get("/"), user=user)
+    assert request.customer == person_contact
+    assert get_person_contact(user) == person_contact
+    assert_all_good_with_random_user()
+
+    # Force contact to company contact. This also ensures
+    # company contact for staff user if does not exists.
+    _call_force_view(request, force_company_contact)
+
+    request = apply_request_middleware(rf.get("/"), user=user)
+    assert get_company_contact(user) == request.customer
+    assert person_contact in request.customer.members.all()
+    assert request.person == person_contact
+    assert_all_good_with_random_user()
+
+    # Finally force back to person contact. Now without
+    # forcing the request would have company contact
+    # since company contact for shop staff was created
+    # while forcing company.
+    _call_force_view(request, force_person_contact)
+
+    request = apply_request_middleware(rf.get("/"), user=user)
+    assert request.customer == person_contact
+    assert get_person_contact(user) == person_contact
+    assert get_company_contact(user) is None
+    assert_all_good_with_random_user()
+
+
+@pytest.mark.django_db
+def test_force_views_only_for_staff(rf):
+    shop = factories.get_default_shop()
+    user = factories.create_random_user(is_staff=True)
+    person_contact = get_person_contact(user)
+
+    # Start forcing. There shouldn't be any changes to
+    # request customer due calling the force functions since
+    # those just do the redirect in case the current is user
+    # is not shop staff.
+    request = apply_request_middleware(rf.get("/"), user=user)
+    assert request.customer == person_contact
+
+    _call_force_view(request, force_anonymous_contact)
+
+    request = apply_request_middleware(rf.get("/"), user=user)
+    assert request.customer == person_contact
+
+    _call_force_view(request, force_person_contact)
+
+    request = apply_request_middleware(rf.get("/"), user=user)
+    assert request.customer == person_contact
+
+    _call_force_view(request, force_company_contact)
+
+    request = apply_request_middleware(rf.get("/"), user=user)
+    assert request.customer == person_contact
+
+    assert get_company_contact(user) is None
+
+
+def _call_force_view(request, view):
+    request.META["HTTP_REFERER"] = "/"
+    response = view(request)
+    assert response.status_code == 302  # redirect
+
+
+def assert_all_good_with_random_user():
+    assert not get_person_contact(factories.create_random_user()).is_anonymous

--- a/shuup_tests/simple_cms/test_xtheme_layout.py
+++ b/shuup_tests/simple_cms/test_xtheme_layout.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import datetime
+
+import pytest
+from django.conf import settings
+from django.core.urlresolvers import reverse
+
+from shuup.simple_cms.layout import PageLayout
+from shuup.testing import factories
+from shuup.xtheme import get_current_theme
+from shuup.xtheme.layout.utils import get_layout_data_key
+from shuup.xtheme.view_config import ViewConfig
+from shuup_tests.utils import printable_gibberish, SmartClient
+
+from .utils import create_page
+
+
+@pytest.mark.django_db
+def test_page_layout():
+    if "shuup.xtheme" not in settings.INSTALLED_APPS:
+        pytest.skip("Need shuup.xtheme in INSTALLED_APPS")
+
+    shop = factories.get_default_shop()
+    theme = get_current_theme(shop)
+    view_config = ViewConfig(theme=theme, shop=shop, view_name="PageView", draft=True)
+    page1_content = printable_gibberish()
+    page1 = create_page(available_from=datetime.date(1917, 12, 6), content=page1_content, shop=shop, url="test1")
+    page2_content = printable_gibberish()
+    page2 = create_page(available_from=datetime.date(1917, 12, 6), content=page2_content, shop=shop, url="test2")
+
+    placeholder_name = "cms_page"
+    context = {"page": page1}
+    layout = view_config.get_placeholder_layout(PageLayout, placeholder_name, context=context)
+    assert isinstance(layout, PageLayout)
+    assert layout.get_help_text({}) == ""  # Invalid context for help text
+    assert page1.title in layout.get_help_text(context)
+
+    # Make sure layout is empty
+    serialized = layout.serialize()
+    assert len(serialized["rows"]) == 0
+    assert serialized["name"] == placeholder_name
+
+    # Add custom plugin to page
+    layout.begin_column({"md": 8})
+    plugin_text = printable_gibberish()
+    layout.add_plugin("text", {"text": plugin_text})
+    view_config.save_placeholder_layout(get_layout_data_key(placeholder_name, layout, context), layout)
+    view_config.publish()
+
+    c = SmartClient()
+    soup = c.soup(reverse("shuup:cms_page", kwargs={"url": page1.url}))
+    page_content = soup.find("div", {"class": "page-content"})
+    assert page1_content in page_content.text
+    assert plugin_text in page_content.text
+
+    c = SmartClient()
+    soup = c.soup(reverse("shuup:cms_page", kwargs={"url": page2.url}))
+    page_content = soup.find("div", {"class": "page-content"})
+    assert page2_content in page_content.text
+    assert plugin_text not in page_content.text

--- a/shuup_tests/xtheme/test_custom_layouts.py
+++ b/shuup_tests/xtheme/test_custom_layouts.py
@@ -1,0 +1,361 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from django.core.urlresolvers import reverse
+
+from shuup.apps.provides import override_provides
+from shuup.testing import factories
+from shuup.xtheme import get_current_theme
+from shuup.xtheme.layout import (
+    AnonymousContactLayout, ContactLayout, PersonContactLayout,
+    CompanyContactLayout, CategoryLayout, ProductLayout, Layout
+)
+from shuup.xtheme.layout.utils import get_layout_data_key
+from shuup.xtheme.view_config import ViewConfig
+from shuup_tests.utils import printable_gibberish, SmartClient
+from shuup_tests.xtheme.utils import get_request
+
+
+@pytest.mark.django_db
+def test_get_placeholder_layouts():
+    vc = _get_basic_view_config()
+    product = factories.create_product("test", name="Test product name")
+    category = factories.get_default_category()
+
+    placeholder_name = "hermit"
+    context = {"request": get_request(), "product": product, "category": category}
+
+    provides = []
+    with override_provides("xtheme_layout", provides):
+        assert len(vc.get_placeholder_layouts(context, placeholder_name)) == 1  # Default layout
+
+    provides.append("shuup.xtheme.layout.ProductLayout")
+    with override_provides("xtheme_layout", provides):
+        assert len(vc.get_placeholder_layouts(context, placeholder_name)) == 2
+
+    provides.append("shuup.xtheme.layout.CategoryLayout")
+    with override_provides("xtheme_layout", provides):
+        assert len(vc.get_placeholder_layouts(context, placeholder_name)) == 3
+
+    provides.append("shuup.xtheme.layout.AnonymousContactLayout")
+    with override_provides("xtheme_layout", provides):
+        assert len(vc.get_placeholder_layouts(context, placeholder_name)) == 4
+
+
+@pytest.mark.django_db
+def test_default_layout():
+    vc = _get_basic_view_config()
+    product = factories.create_product("test", name="Test product name")
+    category = factories.get_default_category()
+
+    placeholder_name = "wildhorse"
+    context = {"request": get_request(), "product": product, "category": category}
+    layout = vc.get_placeholder_layout(Layout, placeholder_name)
+    assert isinstance(layout, Layout)
+    assert layout.get_help_text({}) == layout.get_help_text(context)
+
+    _add_plugin_and_test_save(vc, layout, placeholder_name, context)
+
+
+@pytest.mark.django_db
+def test_product_layout():
+    vc = _get_basic_view_config()
+    product = factories.create_product("test", shop=factories.get_default_shop(), name="Test product name")
+
+    placeholder_name = "wow"
+    # Context doesn't validate with the product layout
+    assert vc.get_placeholder_layout(ProductLayout, placeholder_name) is None
+
+    context = {"product": product}
+    layout = vc.get_placeholder_layout(ProductLayout, placeholder_name, context=context)
+    assert isinstance(layout, ProductLayout)
+    assert layout.get_help_text({}) == ""  # Invalid context for help text
+    assert product.name in layout.get_help_text(context)
+    _assert_empty_layout(layout, placeholder_name)
+
+    _add_plugin_and_test_save(vc, layout, placeholder_name, context)
+    
+    # Make sure layout only available for this one product
+    new_product = factories.create_product("new_test")
+    context = {"product": new_product}
+    layout = vc.get_placeholder_layout(ProductLayout, placeholder_name, context=context)
+    _assert_empty_layout(layout, placeholder_name)
+
+
+@pytest.mark.django_db
+def test_product_detail_view():
+    vc = _get_basic_view_config(view_name="ProductDetailView")
+    product = factories.create_product("test", shop=factories.get_default_shop(), name="Test product name")
+    product2 = factories.create_product("test2", shop=factories.get_default_shop(), name="Test product name 2")
+    placeholder_name = "product_extra_1"
+    context = {"product": product}
+    layout = vc.get_placeholder_layout(ProductLayout, placeholder_name, context=context)
+    plugin_text = printable_gibberish()
+    _add_plugin_and_test_save(vc, layout, placeholder_name, context, plugin_text)
+
+    # Also let's confirm that the plugin visibility works with smart client
+    c = SmartClient()
+    soup = c.soup(reverse("shuup:product", kwargs={"pk": product.id, "slug": product.slug}))
+    product_details = soup.find("div", {"class": "product-basic-details"})
+    assert plugin_text in product_details.text
+
+    c = SmartClient()
+    soup = c.soup(reverse("shuup:product", kwargs={"pk": product2.id, "slug": product2.slug}))
+    product_details = soup.find("div", {"class": "product-basic-details"})
+    assert plugin_text not in product_details.text
+
+
+@pytest.mark.django_db
+def test_category_layout():
+    vc = _get_basic_view_config()
+    category = factories.get_default_category()
+
+    placeholder_name = "japanese"
+    context = {"category": category}
+    layout = vc.get_placeholder_layout(CategoryLayout, placeholder_name, context=context)
+    assert isinstance(layout, CategoryLayout)
+    assert layout.get_help_text({}) == ""  # Invalid context for help text
+    assert category.name in layout.get_help_text(context)
+    _assert_empty_layout(layout, placeholder_name)
+
+    _add_plugin_and_test_save(vc, layout, placeholder_name, context)
+
+
+@pytest.mark.django_db
+def test_anon_layout():
+    vc = _get_basic_view_config()
+
+    placeholder_name = "hip hop"
+    context = {"request": get_request()}  # By default user is anonymous
+    layout = vc.get_placeholder_layout(AnonymousContactLayout, placeholder_name, context=context)
+    assert isinstance(layout, AnonymousContactLayout)
+    help_text = layout.get_help_text({})  # Same help text with or without the context
+    assert layout.get_help_text(context) == help_text
+
+    # Invalid contexts for rest of the contact group layouts
+    assert vc.get_placeholder_layout(ContactLayout, placeholder_name, context=context) is None
+    assert vc.get_placeholder_layout(PersonContactLayout, placeholder_name, context=context) is None
+    assert vc.get_placeholder_layout(CompanyContactLayout, placeholder_name, context=context) is None
+
+    _add_plugin_and_test_save(vc, layout, placeholder_name, context)
+
+
+@pytest.mark.django_db
+def test_contact_layout():
+    vc = _get_basic_view_config()
+    person = factories.create_random_person()
+
+    placeholder_name = "country"
+    request = get_request()
+    request.customer = person
+    context = {"request": request}
+    layout = vc.get_placeholder_layout(ContactLayout, placeholder_name, context=context)
+    assert isinstance(layout, ContactLayout)
+    help_text = layout.get_help_text({})  # Same help text with or without the context
+    assert layout.get_help_text(context) == help_text
+
+    # Invalid context for anon and company layouts
+    assert vc.get_placeholder_layout(AnonymousContactLayout, placeholder_name, context=context) is None
+    assert vc.get_placeholder_layout(CompanyContactLayout, placeholder_name, context=context) is None
+
+    # Valid contexts for anon and person contact layout
+    assert vc.get_placeholder_layout(PersonContactLayout, placeholder_name, context=context) is not None
+
+    _add_plugin_and_test_save(vc, layout, placeholder_name, context)
+
+    # Ok here we want to check that the plugin doesn't end up to the
+    # person contact placeholders
+    person_layout = vc.get_placeholder_layout(PersonContactLayout, placeholder_name, context=context)
+    _assert_empty_layout(person_layout, placeholder_name)
+
+
+@pytest.mark.django_db
+def test_person_contact_layout():
+    vc = _get_basic_view_config()
+    person = factories.create_random_person()
+
+    placeholder_name = "kissa"
+    request = get_request()
+    request.customer = person
+    context = {"request": request}
+    layout = vc.get_placeholder_layout(PersonContactLayout, placeholder_name, context=context)
+    assert isinstance(layout, PersonContactLayout)
+    help_text = layout.get_help_text({})  # Same help text with or without the context
+    assert layout.get_help_text(context) == help_text
+
+    # Invalid contexts for anon and company layouts
+    assert vc.get_placeholder_layout(AnonymousContactLayout, placeholder_name, context=context) is None
+    assert vc.get_placeholder_layout(CompanyContactLayout, placeholder_name, context=context) is None
+
+    # Valid contexts for contact layout
+    assert vc.get_placeholder_layout(ContactLayout, placeholder_name, context=context) is not None
+
+    _add_plugin_and_test_save(vc, layout, placeholder_name, context)
+
+    # Ok here we want to check that the plugin doesn't end up to the
+    # contact placeholders
+    contact_layout = vc.get_placeholder_layout(ContactLayout, placeholder_name, context=context)
+    _assert_empty_layout(contact_layout, placeholder_name)
+
+
+@pytest.mark.django_db
+def test_company_contact_layout():
+    vc = _get_basic_view_config()
+    company = factories.create_random_company()
+
+    placeholder_name = "kissa"
+    request = get_request()
+    request.customer = company
+    context = {"request": request}
+    layout = vc.get_placeholder_layout(CompanyContactLayout, placeholder_name, context=context)
+    assert isinstance(layout, CompanyContactLayout)
+    help_text = layout.get_help_text({})  # Same help text with or without the context
+    assert layout.get_help_text(context) == help_text
+
+    # Invalid contexts for anon and person contact layouts
+    assert vc.get_placeholder_layout(AnonymousContactLayout, placeholder_name, context=context) is None
+    assert vc.get_placeholder_layout(PersonContactLayout, placeholder_name, context=context) is None
+
+    # Valid contexts for contact layout
+    assert vc.get_placeholder_layout(ContactLayout, placeholder_name, context=context) is not None
+
+    _add_plugin_and_test_save(vc, layout, placeholder_name, context)
+
+    # Ok here we want to check that the plugin doesn't end up to the
+    # contact placeholders
+    contact_layout = vc.get_placeholder_layout(ContactLayout, placeholder_name, context=context)
+    _assert_empty_layout(contact_layout, placeholder_name)
+
+
+@pytest.mark.django_db
+def test_index_view_with_contact_limitatons():
+    shop = factories.get_default_shop()
+    password = "kissa123"
+
+    # Person 1 to test contact and person contact layouts
+    person1 = factories.create_random_person(shop=shop)
+    person1.user = factories.create_random_user()
+    person1.user.set_password(password)
+    person1.user.save()
+    person1.save()
+
+    # Person 2 to test company layout
+    person2 = factories.create_random_person(shop=shop)
+    person2.user = factories.create_random_user()
+    person2.user.set_password(password)
+    person2.user.save()
+    person2.save()
+    company = factories.create_random_company(shop=shop)
+    company.members.add(person2)
+
+    placeholder_name = "front_content"
+    request = get_request()
+    context = {"request": request}
+
+    # Add plugin for anons
+    vc = _get_basic_view_config(view_name="IndexView")
+    anon_plugin_text = "This content is only for guests"
+    layout = vc.get_placeholder_layout(AnonymousContactLayout, placeholder_name, context=context)
+    _add_plugin_and_test_save(vc, layout, placeholder_name, context, anon_plugin_text)
+
+    # Add plugin for contact
+    vc = _get_basic_view_config(view_name="IndexView")
+    context["request"].customer = person1
+    contact_plugin_text = "This content is only for users logged in"
+    layout = vc.get_placeholder_layout(ContactLayout, placeholder_name, context=context)
+    _add_plugin_and_test_save(vc, layout, placeholder_name, context, contact_plugin_text)
+
+    # Add plugin for person contacts
+    vc = _get_basic_view_config(view_name="IndexView")
+    person_contact_plugin_text = "This content is only for person contacts"
+    layout = vc.get_placeholder_layout(PersonContactLayout, placeholder_name, context=context)
+    _add_plugin_and_test_save(vc, layout, placeholder_name, context, person_contact_plugin_text)
+
+    # Add plugin for companies
+    vc = _get_basic_view_config(view_name="IndexView")
+    context["request"].customer = company
+    company_plugin_text = "This content is only for companies"
+    layout = vc.get_placeholder_layout(CompanyContactLayout, placeholder_name, context=context)
+    _add_plugin_and_test_save(vc, layout, placeholder_name, context, company_plugin_text)
+
+    c = SmartClient()  # By default there is no user logged in
+    soup = c.soup(reverse("shuup:index"))
+    page_content = soup.find("div", {"class": "page-content"})
+    page_content_text = page_content.text
+    assert anon_plugin_text in page_content_text
+    assert contact_plugin_text not in page_content_text
+    assert person_contact_plugin_text not in page_content_text
+    assert company_plugin_text not in page_content_text
+
+    # Login as person1 user
+    c = SmartClient()
+    c.login(username=person1.user.username, password=password)
+    soup = c.soup(reverse("shuup:index"))
+    page_content = soup.find("div", {"class": "page-content"})
+    page_content_text = page_content.text
+    assert anon_plugin_text not in page_content_text
+    assert contact_plugin_text in page_content_text
+    assert person_contact_plugin_text in page_content_text
+    assert company_plugin_text not in page_content_text
+
+    # Login as person2 user which is linked to company
+    c = SmartClient()
+    c.login(username=person2.user.username, password=password)
+    soup = c.soup(reverse("shuup:index"))
+    page_content = soup.find("div", {"class": "page-content"})
+    page_content_text = page_content.text
+    assert anon_plugin_text not in page_content_text
+    assert contact_plugin_text in page_content_text
+    assert person_contact_plugin_text not in page_content_text
+    assert company_plugin_text in page_content_text
+
+
+def _get_basic_view_config(view_name="pow"):
+    shop = factories.get_default_shop()
+    theme = get_current_theme(shop)
+    return ViewConfig(theme=theme, shop=shop, view_name=view_name, draft=True)
+
+
+def _add_plugin_and_test_save(view_config, layout, placeholder_name, context, plugin_text=None):
+    if not plugin_text:
+        plugin_text = printable_gibberish()
+    _add_basic_plugin(layout, plugin_text)
+    view_config.save_placeholder_layout(get_layout_data_key(placeholder_name, layout, context), layout)
+    view_config.publish()
+
+    # Now refetching the layout we should get the plugin
+    layout = view_config.get_placeholder_layout(layout.__class__, placeholder_name, context=context)
+    assert isinstance(layout, layout.__class__)
+    _assert_layout_content_for_basic_plugin(layout, placeholder_name, plugin_text)
+
+
+def _add_basic_plugin(layout, plugin_text):
+    layout.begin_column({"md": 8})
+    layout.add_plugin("text", {"text": plugin_text})
+
+
+def _assert_layout_content_for_basic_plugin(layout, placeholder_name, plugin_text):
+    serialized = layout.serialize()
+    expected = {
+        'name': placeholder_name,
+        'rows': [
+            {
+                'cells': [
+                    {'config': {'text': plugin_text}, 'plugin': 'text', 'sizes': {"md": 8}}
+                ]
+            }
+        ]
+    }
+    assert bool(serialized == expected)
+
+
+def _assert_empty_layout(layout, placeholder_name):
+    serialized = layout.serialize()
+    assert len(serialized["rows"]) == 0
+    assert serialized["name"] == placeholder_name

--- a/shuup_tests/xtheme/test_layout.py
+++ b/shuup_tests/xtheme/test_layout.py
@@ -14,7 +14,7 @@ from shuup.xtheme.testing import override_current_theme_class
 from shuup_tests.utils import printable_gibberish
 from shuup_tests.xtheme.utils import (
     close_enough, FauxTheme, get_jinja2_engine, get_request,
-    get_test_template_bits, plugin_override
+    get_test_template_bits, layout_override, plugin_override
 )
 
 
@@ -43,17 +43,18 @@ def test_layout_rendering(rf):
     request = get_request(edit=False)
     with override_current_theme_class(None):
         with plugin_override():
-            (template, layout, gibberish, ctx) = get_test_template_bits(request)
+            with layout_override():
+                (template, layout, gibberish, ctx) = get_test_template_bits(request)
+                result = six.text_type(render_placeholder(ctx, "test", layout, "test"))
+                expect = """
+                <div class="xt-ph" id="xt-ph-test">
+                <div class="row xt-ph-row">
+                <div class="col-md-12 hidden-xs xt-ph-cell"><p>%s</p></div>
+                </div>
+                </div>
+                """ % gibberish
 
-            result = six.text_type(render_placeholder(ctx, "test", layout, "test"))
-            expect = """
-            <div class="xt-ph" id="xt-ph-test">
-            <div class="row xt-ph-row">
-            <div class="col-md-12 hidden-xs xt-ph-cell"><p>%s</p></div>
-            </div>
-            </div>
-            """ % gibberish
-            assert close_enough(result, expect)
+                assert close_enough(result, expect)
 
 
 def test_layout_rendering_with_global_type(rf):

--- a/shuup_tests/xtheme/test_load_save.py
+++ b/shuup_tests/xtheme/test_load_save.py
@@ -9,6 +9,7 @@ import pytest
 
 from shuup.testing.factories import get_default_shop
 from shuup.xtheme import Theme, XTHEME_GLOBAL_VIEW_NAME
+from shuup.xtheme.layout import Layout
 from shuup.xtheme.models import ThemeSettings
 from shuup.xtheme.view_config import ViewConfig
 from shuup_tests.utils import printable_gibberish
@@ -47,6 +48,7 @@ def test_load_save_publish():
     placeholder_name = "test_ph"
     data = {"dummy": True}
     vc.save_placeholder_layout(placeholder_name, data)
+    assert not ViewConfig(theme=theme, shop=shop, view_name=view_name, draft=False).save_default_placeholder_layout(placeholder_name, data)
     assert not ViewConfig(theme=theme, shop=shop, view_name=view_name, draft=False).saved_view_config.get_layout_data(placeholder_name)
     vc.publish()
     with pytest.raises(ValueError):  # Republishment is bad
@@ -100,7 +102,7 @@ def test_unthemebound_view_config_cant_do_much():
         vc.revert()
     with pytest.raises(ValueError):
         vc.save_placeholder_layout("hurr", {"foo": True})
-    l = vc.get_placeholder_layout("hurr")  # loading should work, but . . .
+    l = vc.get_placeholder_layout(Layout, "hurr")  # loading should work, but . . .
     assert not len(l.rows)  # . . . there shouldn't be much in there
 
 

--- a/shuup_tests/xtheme/test_rendering.py
+++ b/shuup_tests/xtheme/test_rendering.py
@@ -32,12 +32,16 @@ def test_rendering(edit, injectable, theme_class, global_type):
             output = template.render(context={
                 "view": view,
             }, request=request)
-            assert "wider column" in output
-            assert "less wide column" in output
+
+            # From now on we render placholders in views that
+            # actually can be edited.
+            if injectable and theme_class:
+                assert "wider column" in output
+                assert "less wide column" in output
+
             if edit and injectable and theme_class:
                 assert "xt-ph-edit" in output
                 assert "data-xt-placeholder-name" in output
                 assert "data-xt-row" in output
                 assert "data-xt-cell" in output
                 assert "XthemeEditorConfig" in output
-            # TODO: Should this test be better? No one knows.

--- a/shuup_tests/xtheme/test_resources.py
+++ b/shuup_tests/xtheme/test_resources.py
@@ -38,25 +38,6 @@ class ResourceInjectorPlugin(Plugin):
         return self.message
 
 
-def test_resources():
-    request = get_request(edit=False)
-    with override_current_theme_class(None):
-        with plugin_override():
-            jeng = get_jinja2_engine()
-            template = jeng.get_template("resinject.jinja")
-            output = template.render(request=request)
-            head, body = output.split("</head>", 1)
-            assert "alert('xss')" in body  # the inline script
-            assert '"bars": [1, 2, 3]' in head  # the script vars
-            assert '(unknown resource type:' in body  # the png
-            assert 'href="://example.com/css.css"' in head  # the css
-            assert 'src="://example.com/js.js"' in body  # the js
-            assert head.count(ResourceInjectorPlugin.meta_markup) == 1  # the duplicate meta
-            assert ResourceInjectorPlugin.message in output  # the actual message
-            assert output[:5] == "START"
-            assert output[-3:] == "END"
-
-
 def test_injecting_into_weird_places():
     request = get_request()
     (template, layout, gibberish, ctx) = get_test_template_bits(request, **{

--- a/shuup_tests/xtheme/utils.py
+++ b/shuup_tests/xtheme/utils.py
@@ -117,3 +117,7 @@ def plugin_override():
         "shuup.xtheme.plugins.text:TextPlugin",
         "shuup_tests.xtheme.test_resources:ResourceInjectorPlugin"
     ])
+
+
+def layout_override():
+    return override_provides("xtheme_layout", [])


### PR DESCRIPTION
* [x] Add option to do per object placeholders.
* [x] Add tests to prove this works
* [x] Add documenation to all new things
* [x] Add changelog
* [x] Document the new provide
* [x] Add option to pretend anonymous, person or company contact as a shop staff member while editing with xtheme.
* [x] Add browser test for the xtheme editing
* [x] Fix issue with deleting last cell
* [x] Add tests around admin tools
* [ ] Move admin tools styles outside the front styles so updating those would require re-releasing all existing themes.
* [ ] Add some help texts around the visibility limits.

Here we decided to add the visibility limitation to placeholders since that should make it easier for merchant to understand and preview. Also the logic behind "what should be shown for one placeholder" is easier.

Basically now the placeholder can have multiple layouts inside and these different layouts can be provided from apps. Then based on current context the right layouts is shown for each placeholder.

Editing the placeholders is pretty much untouched.

Refs #1220