### PR TITLE
Xtheme: add option to show only sale items in highlight plugin

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,11 @@ Unrealeased
   When releasing next version, the "Unreleased" header will be replaced
   with appropriate version header and this help text will be removed.
 
+Core
+~~~~
+
+- Add method to initialize cache variables
+
 Front
 ~~~~~
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,16 @@ Unrealeased
   When releasing next version, the "Unreleased" header will be replaced
   with appropriate version header and this help text will be removed.
 
+Front
+~~~~~
+
+- Add parameter to general template tags to filter only products on sale
+
+Xtheme
+~~~~~~
+
+- Add option to show only sale items in highlight plugin
+
 Admin
 ~~~~~
 

--- a/shuup/core/cache/__init__.py
+++ b/shuup/core/cache/__init__.py
@@ -31,8 +31,20 @@ __all__ = [
     "VersionedCache",
 ]
 
-_default_cache = VersionedCache(using="default")
-get = _default_cache.get
-set = _default_cache.set
-bump_version = _default_cache.bump_version
-clear = _default_cache.clear
+_default_cache = None
+get = None
+set = None
+bump_version = None
+clear = None
+
+
+def init_cache():
+    global _default_cache, get, set, bump_version, clear
+    _default_cache = VersionedCache(using="default")
+    get = _default_cache.get
+    set = _default_cache.set
+    bump_version = _default_cache.bump_version
+    clear = _default_cache.clear
+
+
+init_cache()

--- a/shuup/core/models/_categories.py
+++ b/shuup/core/models/_categories.py
@@ -160,7 +160,7 @@ class Category(MPTTModel, TranslatableModel):
         order_insertion_by = ["ordering"]
 
     def __str__(self):
-        return self.safe_translation_getter("name", any_language=True)
+        return self.safe_translation_getter("name", any_language=True) or self.identifier
 
     def is_visible(self, customer):
         if customer and customer.is_all_seeing:

--- a/shuup/xtheme/locale/en/LC_MESSAGES/django.po
+++ b/shuup/xtheme/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-19 17:40+0000\n"
+"POT-Creation-Date: 2018-07-04 18:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -140,6 +140,15 @@ msgstr ""
 msgid "Height (px)"
 msgstr ""
 
+msgid "Newest"
+msgstr ""
+
+msgid "Best Selling"
+msgstr ""
+
+msgid "Random"
+msgstr ""
+
 msgid "Product Highlights"
 msgstr ""
 
@@ -147,6 +156,12 @@ msgid "Type"
 msgstr ""
 
 msgid "Count"
+msgstr ""
+
+msgid "Only show sale items"
+msgstr ""
+
+msgid "Show only products that have discounts"
 msgstr ""
 
 msgid "Only show in-stock and orderable items"

--- a/shuup_tests/api/test_front_users_api.py
+++ b/shuup_tests/api/test_front_users_api.py
@@ -52,6 +52,7 @@ def test_register_api():
 @pytest.mark.django_db
 def test_register_email_api():
     get_default_shop()
+    configuration.set(None, "api_permission_FrontUserViewSet", PermissionLevel.PUBLIC_WRITE)
     client = _get_client()
     register_data = {
         "email": "myemail@email.com",
@@ -94,6 +95,7 @@ def test_register_email_api():
 @pytest.mark.django_db
 def test_register_bad_data():
     get_default_shop()
+    configuration.set(None, "api_permission_FrontUserViewSet", PermissionLevel.PUBLIC_WRITE)
     client = _get_client()
     # no username or email
     register_data = {

--- a/shuup_tests/conftest.py
+++ b/shuup_tests/conftest.py
@@ -48,10 +48,14 @@ def splinter_make_screenshot_on_failure():
 
 # use django_db on every test
 # activate the EN language by default
+# initialize a new cache
 @pytest.fixture(autouse=True)
 def enable_db_access(db):
     from django.utils.translation import activate
     activate("en")
+
+    from shuup.core import cache
+    cache.init_cache()
 
 
 # always make ShopProduct id different from Product id

--- a/shuup_tests/core/test_configurations.py
+++ b/shuup_tests/core/test_configurations.py
@@ -6,6 +6,7 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+from django.test.utils import override_settings
 
 from shuup import configuration
 from shuup.core import cache
@@ -15,120 +16,173 @@ from shuup.testing.factories import get_default_shop
 
 @pytest.mark.django_db
 def test_simple_set_and_get_with_shop():
-    shop = get_default_shop()
-    configuration.set(shop, "answer", 42)
-    assert configuration.get(shop, "answer") == 42
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_simple_set_and_get_with_shop',
+        }
+    }):
+        cache.init_cache()
+        shop = get_default_shop()
+        configuration.set(shop, "answer", 42)
+        assert configuration.get(shop, "answer") == 42
 
-    assert configuration.get(shop, "non-existing") is None
-    configuration.set(shop, "non-existing", "hello")
-    assert configuration.get(shop, "non-existing") == "hello"
+        assert configuration.get(shop, "non-existing") is None
+        configuration.set(shop, "non-existing", "hello")
+        assert configuration.get(shop, "non-existing") == "hello"
 
 
 @pytest.mark.django_db
 def test_simple_set_and_get_without_shop():
-    configuration.set(None, "answer", 42)
-    assert configuration.get(None, "answer") == 42
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_simple_set_and_get_without_shop',
+        }
+    }):
+        cache.init_cache()
+        configuration.set(None, "answer", 42)
+        assert configuration.get(None, "answer") == 42
 
-    assert configuration.get(None, "non-existing") is None
-    configuration.set(None, "non-existing", "hello")
-    assert configuration.get(None, "non-existing") == "hello"
+        assert configuration.get(None, "non-existing") is None
+        configuration.set(None, "non-existing", "hello")
+        assert configuration.get(None, "non-existing") == "hello"
 
 
 @pytest.mark.django_db
 def test_simple_set_and_get_cascading():
-    shop = get_default_shop()
-    configuration.set(None, "answer", 42)
-    assert configuration.get(None, "answer") == 42
-    assert configuration.get(shop, "answer", 42)
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_simple_set_and_get_cascading',
+        }
+    }):
+        cache.init_cache()
+        shop = get_default_shop()
+        configuration.set(None, "answer", 42)
+        assert configuration.get(None, "answer") == 42
+        assert configuration.get(shop, "answer", 42)
 
-    assert configuration.get(None, "non-existing") is None
-    assert configuration.get(shop, "non-existing") is None
-    configuration.set(shop, "non-existing", "hello")
-    assert configuration.get(None, "non-existing") is None
-    assert configuration.get(shop, "non-existing") == "hello"
+        assert configuration.get(None, "non-existing") is None
+        assert configuration.get(shop, "non-existing") is None
+        configuration.set(shop, "non-existing", "hello")
+        assert configuration.get(None, "non-existing") is None
+        assert configuration.get(shop, "non-existing") == "hello"
 
-    assert configuration.get(None, "foo") is None
-    assert configuration.get(shop, "foo") is None
-    configuration.set(None, "foo", "bar")
-    configuration.set(shop, "foo", "baz")
-    assert configuration.get(None, "foo") == "bar"
-    assert configuration.get(shop, "foo") == "baz"
+        assert configuration.get(None, "foo") is None
+        assert configuration.get(shop, "foo") is None
+        configuration.set(None, "foo", "bar")
+        configuration.set(shop, "foo", "baz")
+        assert configuration.get(None, "foo") == "bar"
+        assert configuration.get(shop, "foo") == "baz"
 
 
 @pytest.mark.django_db
 def test_configuration_gets_saved():
-    configuration.set(None, "x", 1)
-    assert configuration.get(None, "x") == 1
-    configuration.set(None, "x", 2)
-    assert configuration.get(None, "x") == 2
-    configuration.set(None, "x", 3)
-    assert configuration.get(None, "x") == 3
-    conf_item = ConfigurationItem.objects.get(shop=None, key="x")
-    assert conf_item.value == 3
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_configuration_gets_saved',
+        }
+    }):
+        cache.init_cache()
+        configuration.set(None, "x", 1)
+        assert configuration.get(None, "x") == 1
+        configuration.set(None, "x", 2)
+        assert configuration.get(None, "x") == 2
+        configuration.set(None, "x", 3)
+        assert configuration.get(None, "x") == 3
+        conf_item = ConfigurationItem.objects.get(shop=None, key="x")
+        assert conf_item.value == 3
 
 
 @pytest.mark.django_db
 def test_configuration_set_and_get():
-    cache.clear()
-    shop = get_default_shop()
-    test_conf_data = {"data": "test"}
-    configuration.set(shop, "key", test_conf_data)
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_configuration_set_and_get',
+        }
+    }):
+        cache.init_cache()
+        shop = get_default_shop()
+        test_conf_data = {"data": "test"}
+        configuration.set(shop, "key", test_conf_data)
 
-    # Get the configuration via configuration API
-    assert configuration.get(shop, "key") == test_conf_data
-    # Check that configuration is saved to database
-    assert ConfigurationItem.objects.get(shop=shop, key="key").value == test_conf_data
+        # Get the configuration via configuration API
+        assert configuration.get(shop, "key") == test_conf_data
+        # Check that configuration is saved to database
+        assert ConfigurationItem.objects.get(shop=shop, key="key").value == test_conf_data
 
 
 @pytest.mark.django_db
 def test_configuration_update():
-    cache.clear()
-    shop = get_default_shop()
-    configuration.set(shop, "key1", {"data": "test1"})
-    configuration.set(shop, "key2", {"data": "test2"})
-    configuration.set(shop, "key3", {"data": "test3"})
-    assert configuration.get(shop, "key1").get("data") == "test1"
-    assert configuration.get(shop, "key3").get("data") == "test3"
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_configuration_update',
+        }
+    }):
+        cache.init_cache()
+        shop = get_default_shop()
+        configuration.set(shop, "key1", {"data": "test1"})
+        configuration.set(shop, "key2", {"data": "test2"})
+        configuration.set(shop, "key3", {"data": "test3"})
+        assert configuration.get(shop, "key1").get("data") == "test1"
+        assert configuration.get(shop, "key3").get("data") == "test3"
 
-    # Update configuration
-    configuration.set(shop, "key3", {"data": "test_bump"})
-    assert configuration.get(shop, "key3").get("data") == "test_bump"
+        # Update configuration
+        configuration.set(shop, "key3", {"data": "test_bump"})
+        assert configuration.get(shop, "key3").get("data") == "test_bump"
 
 
 @pytest.mark.django_db
 def test_global_configurations():
-    cache.clear()
-    shop = get_default_shop()
-    configuration.set(None, "key1", {"data": "test1"})
-    configuration.set(shop, "key2", {"data": "test2"})
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_global_configurations',
+        }
+    }):
+        cache.init_cache()
+        shop = get_default_shop()
+        configuration.set(None, "key1", {"data": "test1"})
+        configuration.set(shop, "key2", {"data": "test2"})
 
-    # key1 from shop should come from global configuration
-    assert configuration.get(shop, "key1").get("data") == "test1"
-    # key2 shouldn't be in global configurations
-    assert configuration.get(None, "key2") is None
+        # key1 from shop should come from global configuration
+        assert configuration.get(shop, "key1").get("data") == "test1"
+        # key2 shouldn't be in global configurations
+        assert configuration.get(None, "key2") is None
 
-    # Update global configuration
-    configuration.set(None, "key1", {"data": "test_bump"})
-    assert configuration.get(shop, "key1").get("data") == "test_bump"
+        # Update global configuration
+        configuration.set(None, "key1", {"data": "test_bump"})
+        assert configuration.get(shop, "key1").get("data") == "test_bump"
 
-    # Override shop data for global key1
-    configuration.set(shop, "key1", "test_data")
-    assert configuration.get(shop, "key1") == "test_data"
+        # Override shop data for global key1
+        configuration.set(shop, "key1", "test_data")
+        assert configuration.get(shop, "key1") == "test_data"
 
-    # Update shop configuration for global key1
-    configuration.set(shop, "key1", "test_data1")
-    assert configuration.get(shop, "key1") == "test_data1"
+        # Update shop configuration for global key1
+        configuration.set(shop, "key1", "test_data1")
+        assert configuration.get(shop, "key1") == "test_data1"
 
 
 @pytest.mark.django_db
 def test_configuration_cache():
-    cache.clear()
-    shop = get_default_shop()
-    configuration.set(None, "key1", "test1")
-    configuration.set(shop, "key2", "test2")
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_configuration_cache',
+        }
+    }):
+        cache.init_cache()
 
-    # Shop configurations cache should be bumped
-    assert cache.get(configuration._get_cache_key(shop)) is None
-    configuration.get(shop, "key1")
-    # Now shop configurations and key2 should found from cache
-    assert cache.get(configuration._get_cache_key(shop)).get("key2") == "test2"
+        shop = get_default_shop()
+        configuration.set(None, "key1", "test1")
+        configuration.set(shop, "key2", "test2")
+
+        # Shop configurations cache should be bumped
+        assert cache.get(configuration._get_cache_key(shop)) is None
+        configuration.get(shop, "key1")
+        # Now shop configurations and key2 should found from cache
+        assert cache.get(configuration._get_cache_key(shop)).get("key2") == "test2"

--- a/shuup_tests/core/test_products_in_shops.py
+++ b/shuup_tests/core/test_products_in_shops.py
@@ -327,18 +327,14 @@ def test_product_categories(settings):
 @pytest.mark.parametrize("key", ["name", "description", "short_description"])
 @pytest.mark.django_db
 def test_get_safe_strings(key):
-    activate("en")
     shop_product = get_default_shop_product()
     setattr(shop_product.product, key, "test")
     shop_product.product.save()
     shop_product.refresh_from_db()
 
     assert getattr(shop_product.product, key)
-    if key == "name":
-        with pytest.raises(TranslationDoesNotExist):
-            assert not getattr(shop_product, key)
-    else:
-        assert not getattr(shop_product, key)
+    with pytest.raises(TranslationDoesNotExist):
+        getattr(shop_product, key)
 
     func = getattr(shop_product, "get_" + key)
     assert getattr(shop_product.product, key) == func()  # returns value from product

--- a/shuup_tests/utils/test_cache.py
+++ b/shuup_tests/utils/test_cache.py
@@ -5,16 +5,25 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+from django.test import override_settings
 
 from shuup.core import cache
 
 
 def test_cache_api():
-    key = "test_prefix:123"
-    value = "456"
-    cache.set(key, value)
-    assert cache.get(key) == value
-    cache.bump_version(key)
-    assert cache.get(key, default="derp") == "derp"  # version was bumped, so no way this is there
-    cache.set(key, value)
-    assert cache.get(key) == value
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_configuration_cache',
+        }
+    }):
+        cache.init_cache()
+
+        key = "test_prefix:123"
+        value = "456"
+        cache.set(key, value)
+        assert cache.get(key) == value
+        cache.bump_version(key)
+        assert cache.get(key, default="derp") == "derp"  # version was bumped, so no way this is there
+        cache.set(key, value)
+        assert cache.get(key) == value

--- a/shuup_tests/xtheme/test_default_template_dir.py
+++ b/shuup_tests/xtheme/test_default_template_dir.py
@@ -7,7 +7,9 @@
 # LICENSE file in the root directory of this source tree.
 import pytest
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 
+from shuup.core import cache
 from shuup.testing.factories import get_default_shop
 from shuup.testing.themes import (
     ShuupTestingTheme, ShuupTestingThemeWithCustomBase
@@ -18,18 +20,33 @@ from shuup_tests.utils import SmartClient
 
 @pytest.mark.django_db
 def test_theme_without_default_template_dir():
-    with override_current_theme_class(ShuupTestingTheme, get_default_shop()):
-        c = SmartClient()
-        soup = c.soup(reverse("shuup:index"))
-        assert "Simple base for themes to use" not in soup
-        assert "Welcome to test Shuup!" in soup.find("div", {"class": "page-content"}).text
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_configuration_cache',
+        }
+    }):
+        cache.init_cache()
+
+        with override_current_theme_class(ShuupTestingTheme, get_default_shop()):
+            c = SmartClient()
+            soup = c.soup(reverse("shuup:index"))
+            assert "Simple base for themes to use" not in soup
+            assert "Welcome to test Shuup!" in soup.find("div", {"class": "page-content"}).text
 
 
 @pytest.mark.django_db
 def test_theme_with_default_template_dir():
-    get_default_shop()
-    with override_current_theme_class(ShuupTestingThemeWithCustomBase, get_default_shop()):
-        c = SmartClient()
-        soup = c.soup(reverse("shuup:index"))
-        assert "Simple base for themes to use" in soup.find("h1").text
-        assert "Welcome to test Shuup!" in soup.find("h1").text
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_configuration_cache',
+        }
+    }):
+        cache.init_cache()
+        get_default_shop()
+        with override_current_theme_class(ShuupTestingThemeWithCustomBase, get_default_shop()):
+            c = SmartClient()
+            soup = c.soup(reverse("shuup:index"))
+            assert "Simple base for themes to use" in soup.find("h1").text
+            assert "Welcome to test Shuup!" in soup.find("h1").text

--- a/shuup_tests/xtheme/test_extra_views.py
+++ b/shuup_tests/xtheme/test_extra_views.py
@@ -7,8 +7,10 @@
 # LICENSE file in the root directory of this source tree.
 import pytest
 from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
 from django.utils.encoding import force_text
 
+from shuup.core import cache
 from shuup.testing.factories import get_default_shop
 from shuup.xtheme.testing import override_current_theme_class
 from shuup.xtheme.views.extra import extra_view_dispatch
@@ -16,23 +18,37 @@ from shuup_tests.xtheme.utils import H2G2Theme
 
 
 def test_xtheme_extra_views(rf):
-    with override_current_theme_class(H2G2Theme, get_default_shop()):
-        request = rf.get("/", {"name": "Arthur Dent"})
-        request.shop = get_default_shop()
-        # Simulate /xtheme/greeting
-        response = extra_view_dispatch(request, "greeting")
-        assert force_text(response.content) == "So long, and thanks for all the fish, Arthur Dent"
-        # Try that again (to exercise the _VIEW_CACHE code path):
-        response = extra_view_dispatch(request, "greeting")
-        assert force_text(response.content) == "So long, and thanks for all the fish, Arthur Dent"
-        # Now test that CBVs work
-        assert not extra_view_dispatch(request, "faux").content
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_configuration_cache',
+        }
+    }):
+        cache.init_cache()
+        with override_current_theme_class(H2G2Theme, get_default_shop()):
+            request = rf.get("/", {"name": "Arthur Dent"})
+            request.shop = get_default_shop()
+            # Simulate /xtheme/greeting
+            response = extra_view_dispatch(request, "greeting")
+            assert force_text(response.content) == "So long, and thanks for all the fish, Arthur Dent"
+            # Try that again (to exercise the _VIEW_CACHE code path):
+            response = extra_view_dispatch(request, "greeting")
+            assert force_text(response.content) == "So long, and thanks for all the fish, Arthur Dent"
+            # Now test that CBVs work
+            assert not extra_view_dispatch(request, "faux").content
 
 
 def test_xtheme_extra_view_exceptions(rf):
-    with override_current_theme_class(H2G2Theme, get_default_shop()):
-        request = rf.get("/")
-        request.shop = get_default_shop()
-        assert extra_view_dispatch(request, "vogons").status_code == 404
-        with pytest.raises(ImproperlyConfigured):
-            assert extra_view_dispatch(request, "true")
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_configuration_cache',
+        }
+    }):
+        cache.init_cache()
+        with override_current_theme_class(H2G2Theme, get_default_shop()):
+            request = rf.get("/")
+            request.shop = get_default_shop()
+            assert extra_view_dispatch(request, "vogons").status_code == 404
+            with pytest.raises(ImproperlyConfigured):
+                assert extra_view_dispatch(request, "true")

--- a/shuup_tests/xtheme/test_theme.py
+++ b/shuup_tests/xtheme/test_theme.py
@@ -6,31 +6,36 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+from django.test import override_settings
 
 from shuup.apps.provides import override_provides
+from shuup.core import cache
 from shuup.testing.factories import get_default_shop
 from shuup.xtheme import (
     get_current_theme, get_theme_by_identifier, set_current_theme
 )
 from shuup.xtheme.models import ThemeSettings
-from shuup.xtheme.testing import override_current_theme_class
 from shuup_tests.utils import printable_gibberish
 from shuup_tests.xtheme.utils import FauxTheme, FauxTheme2
 
 
 @pytest.mark.django_db
 def test_theme_activation():
-    shop = get_default_shop()
-    with override_current_theme_class():
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_configuration_cache',
+        }
+    }):
+        cache.init_cache()
+        shop = get_default_shop()
+
         with override_provides("xtheme", [
             "shuup_tests.xtheme.utils:FauxTheme",
             "shuup_tests.xtheme.utils:FauxTheme2"
         ]):
-            ThemeSettings.objects.all().delete()
-            # ThemeSettings will be created on the fly
             theme = get_current_theme(shop)
-            assert theme
-            assert theme.settings_obj
+            assert theme is None
             set_current_theme(FauxTheme.identifier, shop)
             assert isinstance(get_current_theme(shop), FauxTheme)
             set_current_theme(FauxTheme2.identifier, shop)
@@ -39,21 +44,27 @@ def test_theme_activation():
                 set_current_theme(printable_gibberish(), shop)
 
 
-
 @pytest.mark.django_db
 def test_theme_settings_api():
-    shop = get_default_shop()
-    with override_provides("xtheme", [
-        "shuup_tests.xtheme.utils:FauxTheme",
-        "shuup_tests.xtheme.utils:FauxTheme2"
-    ]):
-        ThemeSettings.objects.all().delete()
-        theme = get_theme_by_identifier(FauxTheme2.identifier, shop)
-        theme.set_setting("foo", "bar")
-        theme.set_settings(quux=[4, 8, 15, 16, 23, 42])
-        theme = get_theme_by_identifier(FauxTheme2.identifier, shop)
-        assert theme.get_setting("foo") == "bar"
-        assert theme.get_settings() == {
-            "foo": "bar",
-            "quux": [4, 8, 15, 16, 23, 42]
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_configuration_cache',
         }
+    }):
+        cache.init_cache()
+        shop = get_default_shop()
+        with override_provides("xtheme", [
+            "shuup_tests.xtheme.utils:FauxTheme",
+            "shuup_tests.xtheme.utils:FauxTheme2"
+        ]):
+            ThemeSettings.objects.all().delete()
+            theme = get_theme_by_identifier(FauxTheme2.identifier, shop)
+            theme.set_setting("foo", "bar")
+            theme.set_settings(quux=[4, 8, 15, 16, 23, 42])
+            theme = get_theme_by_identifier(FauxTheme2.identifier, shop)
+            assert theme.get_setting("foo") == "bar"
+            assert theme.get_settings() == {
+                "foo": "bar",
+                "quux": [4, 8, 15, 16, 23, 42]
+            }

--- a/shuup_workbench/test_settings.py
+++ b/shuup_workbench/test_settings.py
@@ -228,6 +228,13 @@ SHUUP_ERROR_PAGE_HANDLERS_SPEC = [
 
 SHUUP_SIMPLE_SEARCH_LIMIT = 150
 
+# Disable caches for tests
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}
+
 
 if os.environ.get("SHUUP_WORKBENCH_DISABLE_MIGRATIONS") == "1":
     from .settings.utils import get_disabled_migrations


### PR DESCRIPTION
- Add parameter to general template tags to filter only products on sale
- Add option to show only sale items in highlight plugin
- Translate Highlight option types

Refs POS-2484