### PR TITLE
Admin: add button to edit selected instances on select inputs

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -43,6 +43,7 @@ Admin
 ~~~~~
 
 - Add `HexColorWidget` to pick hexadecimal colors on input fields
+- Add button to edit selected instances on select inputs
 
 General
 ~~~~~~~

--- a/shuup/admin/forms/widgets.py
+++ b/shuup/admin/forms/widgets.py
@@ -12,8 +12,9 @@ import json
 import django
 import six
 from django.core.urlresolvers import reverse_lazy
+from django.forms import HiddenInput, Textarea, TextInput
 from django.forms import TimeInput as DjangoTimeInput
-from django.forms import HiddenInput, Textarea, TextInput, Widget
+from django.forms import Widget
 from django.utils.encoding import force_text
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
@@ -236,6 +237,23 @@ class QuickAddCategorySelect(QuickAddRelatedObjectSelect):
 
 class QuickAddProductTypeSelect(QuickAddRelatedObjectSelect):
     url = reverse_lazy("shuup_admin:product_type.new")
+
+
+class QuickAddTaxGroupSelect(QuickAddRelatedObjectSelect):
+    url = reverse_lazy("shuup_admin:customer_tax_group.new")
+    model = "shuup.CustomerTaxGroup"
+
+
+class QuickAddTaxClassSelect(QuickAddRelatedObjectSelect):
+    url = reverse_lazy("shuup_admin:tax_class.new")
+
+
+class QuickAddSalesUnitSelect(QuickAddRelatedObjectSelect):
+    url = reverse_lazy("shuup_admin:sales_unit.new")
+
+
+class QuickAddDisplayUnitSelect(QuickAddRelatedObjectSelect):
+    url = reverse_lazy("shuup_admin:display_unit.new")
 
 
 class QuickAddManufacturerSelect(QuickAddRelatedObjectSelect):

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-02 18:17+0000\n"
+"POT-Creation-Date: 2018-07-05 20:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -3021,6 +3021,9 @@ msgid ""
 "try again later."
 msgstr ""
 
+msgid "Edit the selected object"
+msgstr ""
+
 msgid "Welcome to Shuup!"
 msgstr ""
 
@@ -3616,14 +3619,6 @@ msgid "Are you sure you wish to delete %s?"
 msgstr ""
 
 #, python-format
-msgid "Required. %s"
-msgstr ""
-
-#, python-format
-msgid "Optional. %s"
-msgstr ""
-
-#, python-format
 msgid "Showing %(per_page)s of %(n_items)s %(verbose_name_plural)s"
 msgstr ""
 
@@ -3680,6 +3675,15 @@ msgid "Only one %(model)s permitted."
 msgstr ""
 
 msgid "Mass Edit"
+msgstr ""
+
+msgid "Invalid object."
+msgstr ""
+
+msgid "Invalid model."
+msgstr ""
+
+msgid "Object not found"
 msgstr ""
 
 msgid "Storefront"

--- a/shuup/admin/modules/categories/forms.py
+++ b/shuup/admin/modules/categories/forms.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from shuup.admin.forms import ShuupAdminForm
 from shuup.admin.forms.fields import Select2MultipleField
-from shuup.admin.forms.widgets import TextEditorWidget
+from shuup.admin.forms.widgets import QuickAddCategorySelect, TextEditorWidget
 from shuup.admin.shop_provider import get_shop
 from shuup.admin.utils.forms import filter_form_field_choices
 from shuup.core.models import (
@@ -40,7 +40,8 @@ class CategoryBaseForm(ShuupAdminForm):
         widgets = {
             "status": forms.RadioSelect,
             "visibility": forms.RadioSelect,
-            "description": TextEditorWidget()
+            "description": TextEditorWidget(),
+            "parent": QuickAddCategorySelect(editable_model="shuup.Category")
         }
 
     def __init__(self, request, **kwargs):

--- a/shuup/admin/modules/contacts/forms.py
+++ b/shuup/admin/modules/contacts/forms.py
@@ -13,7 +13,9 @@ from django_countries.fields import LazyTypedChoiceField
 from enumfields import EnumField
 
 from shuup.admin.forms.fields import Select2MultipleField
-from shuup.admin.forms.widgets import PersonContactChoiceWidget
+from shuup.admin.forms.widgets import (
+    PersonContactChoiceWidget, QuickAddTaxGroupSelect
+)
 from shuup.core.fields import LanguageFormField
 from shuup.core.models import (
     CompanyContact, Contact, ContactGroup, Gender, PersonContact, Shop
@@ -58,6 +60,13 @@ class ContactBaseFormMixin(object):
             shops_qs = Shop.objects.all()
         else:
             shops_qs = Shop.objects.filter(staff_members__in=[self.request.user])
+
+        if "tax_group" in self.fields:
+            self.fields["tax_group"].widget = QuickAddTaxGroupSelect(editable_model="shuup.CustomerTaxGroup")
+            if self.instance:
+                self.fields["tax_group"].widget.choices = [
+                    (self.instance.tax_group.id, self.instance.tax_group.name)
+                ]
 
         self.fields["shops"] = forms.ModelMultipleChoiceField(
             queryset=shops_qs,

--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -20,8 +20,10 @@ from filer.models import Image
 
 from shuup.admin.forms.widgets import (
     FileDnDUploaderWidget, QuickAddCategoryMultiSelect, QuickAddCategorySelect,
-    QuickAddManufacturerSelect, QuickAddPaymentMethodsSelect,
-    QuickAddProductTypeSelect, QuickAddShippingMethodsSelect, TextEditorWidget
+    QuickAddDisplayUnitSelect, QuickAddManufacturerSelect,
+    QuickAddPaymentMethodsSelect, QuickAddProductTypeSelect,
+    QuickAddSalesUnitSelect, QuickAddShippingMethodsSelect,
+    QuickAddTaxClassSelect, TextEditorWidget
 )
 from shuup.admin.signals import form_post_clean, form_pre_clean
 from shuup.core.models import (
@@ -73,8 +75,10 @@ class ProductBaseForm(MultiLanguageModelForm):
         )
         widgets = {
             "keywords": forms.TextInput(),
-            "type": QuickAddProductTypeSelect(),
-            "manufacturer": QuickAddManufacturerSelect(),
+            "sales_unit": QuickAddSalesUnitSelect(editable_model="shuup.SalesUnit"),
+            "tax_class": QuickAddTaxClassSelect(editable_model="shuup.TaxClass"),
+            "type": QuickAddProductTypeSelect(editable_model="shuup.ProductType"),
+            "manufacturer": QuickAddManufacturerSelect(editable_model="shuup.Manufacturer"),
             "description": TextEditorWidget(),
             "short_description": forms.TextInput(),
         }
@@ -149,7 +153,8 @@ class ShopProductForm(forms.ModelForm):
                                    "Set to blank for product to be purchasable without limits")
         }
         widgets = {
-            "primary_category": QuickAddCategorySelect(),
+            "display_unit": QuickAddDisplayUnitSelect(editable_model="shuup.DisplayUnit"),
+            "primary_category": QuickAddCategorySelect(editable_model="shuup.Category"),
             "categories": QuickAddCategoryMultiSelect(),
             "payment_methods": QuickAddPaymentMethodsSelect(),
             "shipping_methods": QuickAddShippingMethodsSelect(),

--- a/shuup/admin/static_src/base/less/shuup/custom-forms.less
+++ b/shuup/admin/static_src/base/less/shuup/custom-forms.less
@@ -106,17 +106,11 @@
             }
         }
 
-        .quick-add-btn + .help-popover-btn {
+        .quick-add-btn + .help-popover-btn,
+        .edit-object-btn + .help-popover-btn,
+        .quick-add-btn + .edit-object-btn {
             @media (min-width: @screen-lg-min) {
-                margin-left: -15px;
-            }
-
-            @media (max-width: @screen-md-max) {
-                .btn {
-                    position: absolute;
-                    top: 0px;
-                    right: -15px;
-                }
+                margin-left: -10px;
             }
         }
 

--- a/shuup/admin/static_src/base/less/shuup/quick-add.less
+++ b/shuup/admin/static_src/base/less/shuup/quick-add.less
@@ -69,7 +69,25 @@ div.container-fluid.support-nav-wrap {
                 .btn {
                     position: absolute;
                     top: 0px;
-                    right: 15px;
+                    right: 30px;
+                }
+            }
+        }
+
+        .edit-object-btn {
+            cursor: pointer;
+            float: left;
+            position: initial;
+
+            i.fa-plus:hover {
+                color: #000;
+            }
+
+            @media (max-width: @screen-xs-max) {
+                .btn {
+                    position: absolute;
+                    top: 0px;
+                    right: 75px;
                 }
             }
         }

--- a/shuup/admin/template_helpers/shuup_admin.py
+++ b/shuup/admin/template_helpers/shuup_admin.py
@@ -71,6 +71,7 @@ def get_support_id(context):
 
 # TODO: Figure out a more extensible way to deal with this
 BROWSER_URL_NAMES = {
+    "edit": "shuup_admin:edit",
     "select": "shuup_admin:select",
     "media": "shuup_admin:media.browse",
     "product": "shuup_admin:shop_product.list",

--- a/shuup/admin/templates/shuup/admin/forms/widgets/edit_button.jinja
+++ b/shuup/admin/templates/shuup/admin/forms/widgets/edit_button.jinja
@@ -1,0 +1,17 @@
+{% set editable_model = (field.widget.editable_model or field.widget.attrs.get("data-edit-model")) %}
+{% if editable_model %}
+<span class="edit-object-btn">
+    <a
+        class="btn"
+        data-toggle="popover"
+        data-placement="bottom"
+        data-trigger="manual"
+        data-content="{{ _("Edit the selected object") }}"
+        data-edit-model="{{ editable_model }}"
+        data-edit-url="{{ url("shuup_admin:edit") }}"
+        data-target="{{ field.field.html_name }}"
+    >
+        <i class="fa fa-pencil text-primary"></i>
+    </a>
+</span>
+{% endif %}

--- a/shuup/admin/templates/shuup/admin/forms/widgets/help_text.jinja
+++ b/shuup/admin/templates/shuup/admin/forms/widgets/help_text.jinja
@@ -1,0 +1,31 @@
+{% if field.field_help %}
+    {% if field.field.required %}
+        {% set help_text = _("Required. %(field_help)s" % {"field_help": field.field_help}) %}
+    {% else %}
+    {% set help_text = _("Optional. %(field_help)s" % {"field_help": field.field_help}) %}
+    {% endif %}
+    <span class="help-popover-btn">
+    {# tabindex is required for popover to function but we don't actually want to be able to tab to it #}
+    {# so set a large tabindex #}
+        <a
+            class="btn"
+            data-toggle="popover"
+            data-placement="bottom"
+            role="button"
+            tabindex="50000"
+            data-html="true"
+            data-trigger="focus"
+            title="{{ field.field.label }}"
+            data-content="{{ help_text }}"
+        >
+            <i class="fa fa-question-circle"></i>
+        </a>
+    </span>
+{% endif %}
+{% if field.field_errors %}
+    <div class="help-block error-block">
+    {% for error in field.field_errors %}
+        {{ error }}<br>
+    {% endfor %}
+    </div>
+{% endif %}

--- a/shuup/admin/templates/shuup/admin/forms/widgets/quick_add_select.jinja
+++ b/shuup/admin/templates/shuup/admin/forms/widgets/quick_add_select.jinja
@@ -1,17 +1,19 @@
+{% if quick_add_url %}
 <select name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %} {% if quick_add_model %}data-model="{{ quick_add_model }}"{% endif %}>
     {% for group_name, group_choices, group_index in widget.optgroups %}{% if group_name %}
     <optgroup label="{{ group_name }}">{% endif %}{% for widget in group_choices %}
     {% include widget.template_name %}{% endfor %}{% if group_name %}
     </optgroup>{% endif %}{% endfor %}
-  </select>
-  <span class="quick-add-btn">
-    <a
-        class="btn"
-        data-url="{{ quick_add_url }}"
-        data-toggle="popover"
-        data-placement="bottom"
-        data-trigger="manual"
-        data-content="{{ quick_add_btn_title }}">
-            <i class="fa fa-plus text-primary"></i>
-    </a>
-  </span>
+</select>
+<span class="quick-add-btn">
+<a
+    class="btn"
+    data-url="{{ quick_add_url }}"
+    data-toggle="popover"
+    data-placement="bottom"
+    data-trigger="manual"
+    data-content="{{ quick_add_btn_title }}">
+        <i class="fa fa-plus text-primary"></i>
+</a>
+</span>
+{% endif %}

--- a/shuup/admin/urls.py
+++ b/shuup/admin/urls.py
@@ -20,6 +20,7 @@ from shuup.admin.forms import EmailAuthenticationForm
 from shuup.admin.module_registry import get_module_urls
 from shuup.admin.utils.urls import admin_url, AdminRegexURLPattern
 from shuup.admin.views.dashboard import DashboardView
+from shuup.admin.views.edit import EditObjectView
 from shuup.admin.views.home import HomeView
 from shuup.admin.views.menu import MenuView
 from shuup.admin.views.password import RequestPasswordView, ResetPasswordView
@@ -48,6 +49,7 @@ def get_urls():
         admin_url(r'^tour/$', TourView.as_view(), name='tour'),
         admin_url(r'^search/$', SearchView.as_view(), name='search'),
         admin_url(r'^select/$', MultiselectAjaxView.as_view(), name='select'),
+        admin_url(r'^edit/$', EditObjectView.as_view(), name='edit'),
         admin_url(r'^menu/$', MenuView.as_view(), name='menu'),
         admin_url(
             r'^login/$',

--- a/shuup/admin/utils/bs3_renderers.py
+++ b/shuup/admin/utils/bs3_renderers.py
@@ -10,7 +10,6 @@ from __future__ import unicode_literals
 from bootstrap3.renderers import FieldRenderer
 from bootstrap3.utils import add_css_class
 from django.forms import DateField, DateTimeField, ModelMultipleChoiceField
-from django.utils.translation import ugettext_lazy as _
 
 
 class AdminFieldRenderer(FieldRenderer):
@@ -61,22 +60,7 @@ class AdminFieldRenderer(FieldRenderer):
             self.field_help = ''
 
     def append_to_field(self, html):
-        if self.field_help:
-            if self.field.field.required:
-                self.field_help = _("Required. %s" % self.field_help)
-            else:
-                self.field_help = _("Optional. %s" % self.field_help)
-            html += "<span class='help-popover-btn'>"
-            # tabindex is required for popover to function but we don't actually want to be able to tab to it
-            # so set a large tabindex
-            html += "<a class=\"btn\" data-toggle=\"popover\" data-placement=\"bottom\" "
-            html += "role=\"button\" tabindex=\"50000\" "
-            html += "data-html=\"true\" data-trigger=\"focus\" title=\"{title}\" data-content=\"{help}\">".format(
-                title=self.field.label, help=self.field_help)
-            html += "<i class='fa fa-question-circle'></i>"
-            html += "</a>"
-            html += "</span>"
-        if self.field_errors:
-            errors = "<br>".join(self.field_errors)
-            html += '<div class="help-block error-block">{error}</div>'.format(error=errors)
-        return html
+        from django.template import loader as template_loader
+        edit_button = template_loader.render_to_string("shuup/admin/forms/widgets/edit_button.jinja", {"field": self})
+        help_text = template_loader.render_to_string("shuup/admin/forms/widgets/help_text.jinja", {"field": self})
+        return "".join([html, edit_button.strip(), help_text.strip()])

--- a/shuup/admin/views/edit.py
+++ b/shuup/admin/views/edit.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.apps import apps
+from django.http.response import (
+    Http404, HttpResponseBadRequest, HttpResponseRedirect
+)
+from django.utils.translation import ugettext_lazy as _
+from django.views.generic import View
+
+from shuup.admin.shop_provider import get_shop
+from shuup.admin.utils.permissions import get_missing_permissions
+from shuup.admin.utils.urls import get_model_url, NoModelUrl
+from shuup.utils.excs import Problem
+
+
+class EditObjectView(View):
+    def get(self, request):     # noqa (C901)
+        model_name = request.GET.get("model")
+        object_id = request.GET.get("pk", request.GET.get("id"))
+
+        if not model_name or not object_id:
+            return HttpResponseBadRequest(_("Invalid object."))
+
+        url = None
+
+        try:
+            model = apps.get_model(model_name)
+        except LookupError:
+            return HttpResponseBadRequest(_("Invalid model."))
+
+        instance = model.objects.filter(pk=object_id).first()
+        if instance:
+            required_permission = "%s.change_%s" % (instance._meta.app_label, instance._meta.model_name)
+            missing_permissions = get_missing_permissions(request.user, [required_permission])
+
+            if missing_permissions:
+                reason = _("You do not have the required permission(s): %s") % ", ".join(missing_permissions)
+                raise Problem(_("Can't view this page. %(reason)s") % {"reason": reason}, _("Unauthorized"))
+
+            # try edit first
+            try:
+                url = get_model_url(
+                    instance,
+                    kind="edit",
+                    user=request.user,
+                    shop=get_shop(request),
+                    required_permissions=[required_permission]
+                )
+            except NoModelUrl:
+                # try detail
+                try:
+                    url = get_model_url(
+                        instance,
+                        kind="detail",
+                        user=request.user,
+                        shop=get_shop(request),
+                        required_permissions=[required_permission]
+                    )
+                except NoModelUrl:
+                    pass
+
+            if url:
+                # forward the mode param
+                if request.GET.get("mode"):
+                    url = "{}?mode={}".format(url, request.GET["mode"])
+
+                return HttpResponseRedirect(url)
+
+        raise Http404(_("Object not found"))

--- a/shuup/campaigns/admin_module/forms/_basket.py
+++ b/shuup/campaigns/admin_module/forms/_basket.py
@@ -29,7 +29,7 @@ class BasketCampaignForm(BaseCampaignForm):
         field_kwargs = dict(choices=coupon_code_choices, required=False)
         field_kwargs["help_text"] = _("Define the required coupon for this campaign.")
         field_kwargs["label"] = _("Coupon")
-        field_kwargs["widget"] = QuickAddCouponSelect()
+        field_kwargs["widget"] = QuickAddCouponSelect(editable_model="campaigns.Coupon")
         if self.instance.pk and self.instance.coupon:
             field_kwargs["initial"] = self.instance.coupon.pk
 

--- a/shuup/core/models/_configurations.py
+++ b/shuup/core/models/_configurations.py
@@ -32,9 +32,9 @@ class ConfigurationItem(ShuupModel):
 
     def __str__(self):
         if self.shop:
-            return _("%(key)s for shop %(shop)s") % vars(self)
+            return _("%(key)s for shop %(shop)s") % dict(key=self.key, shop=self.shop)
         else:
-            return _("%(key)s (global)") % vars(self)
+            return _("%(key)s (global)") % dict(key=self.key)
 
     def __repr__(self):
         return '<%s "%s" for %r>' % (type(self).__name__, self.key, self.shop)

--- a/shuup/gdpr/admin_module/forms.py
+++ b/shuup/gdpr/admin_module/forms.py
@@ -6,11 +6,15 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.conf import settings
+from django.core.urlresolvers import reverse_lazy
 from django.forms import BaseModelFormSet
 from django.forms.formsets import DEFAULT_MAX_NUM, DEFAULT_MIN_NUM
 
 from shuup.admin.form_part import FormPart, TemplatedFormDef
-from shuup.admin.forms.widgets import TextEditorWidget
+from shuup.admin.forms.widgets import (
+    QuickAddRelatedObjectMultiSelect, QuickAddRelatedObjectSelect,
+    TextEditorWidget
+)
 from shuup.admin.shop_provider import get_shop
 from shuup.gdpr.models import GDPRCookieCategory, GDPRSettings
 from shuup.gdpr.utils import get_possible_consent_pages
@@ -19,13 +23,23 @@ from shuup.utils.multilanguage_model_form import (
 )
 
 
+class QuickAddPageSelect(QuickAddRelatedObjectSelect):
+    url = reverse_lazy("shuup_admin:simple_cms.page.new")
+
+
+class QuickAddPageMultiSelect(QuickAddRelatedObjectMultiSelect):
+    url = reverse_lazy("shuup_admin:simple_cms.page.new")
+
+
 class GDPRSettingsForm(MultiLanguageModelForm):
     class Meta:
         exclude = ("shop",)
         model = GDPRSettings
         widgets = {
             "cookie_banner_content": TextEditorWidget(),
-            "cookie_privacy_excerpt": TextEditorWidget()
+            "cookie_privacy_excerpt": TextEditorWidget(),
+            "privacy_policy_page": QuickAddPageSelect(editable_model="shuup_simple_cms.Page"),
+            "consent_pages": QuickAddPageMultiSelect()
         }
 
     def __init__(self, **kwargs):

--- a/shuup/tasks/admin_module/views/edit.py
+++ b/shuup/tasks/admin_module/views/edit.py
@@ -52,7 +52,7 @@ class TaskForm(ModelForm):
         model = Task
         exclude = ("shop", "created_on", "modified_on", "status", "completed_on", "completed_by", "creator")
         widgets = {
-            "type": QuickAddTaskTypeSelect()
+            "type": QuickAddTaskTypeSelect(editable_model="shuup_tasks.TaskType")
         }
 
     def __init__(self, *args, **kwargs):
@@ -63,6 +63,7 @@ class TaskForm(ModelForm):
         self.fields["assigned_to"].queryset = Contact.objects.filter(
             Q(shops=shop) | Q(id__in=shop.staff_members.values_list("id"))
         ).distinct()
+        self.fields["assigned_to"].widget.editable_model = "shuup.Contact"
 
     def save(self, **kwargs):
         is_new = (not self.instance.pk)

--- a/shuup_tests/admin/test_edit_object_view.py
+++ b/shuup_tests/admin/test_edit_object_view.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.core.urlresolvers import reverse
+from django.http.response import Http404
+
+from shuup.admin.shop_provider import SHOP_SESSION_KEY
+from shuup.admin.utils.urls import get_model_url
+from shuup.admin.views.edit import EditObjectView, NoModelUrl
+from shuup.testing import factories
+from shuup.testing.utils import apply_request_middleware
+from shuup.utils.excs import Problem
+
+
+def _get_edit_object_view(rf, view, model_name, object_id, user, shop, mode=None):
+    data = {
+        "model": model_name,
+        "id": object_id
+    }
+    if mode:
+        data["mode"] = mode
+    request = apply_request_middleware(rf.get(reverse("shuup_admin:edit"), data), user=user, shop=shop)
+    request.session = {SHOP_SESSION_KEY: shop.id}
+    return view(request)
+
+
+@pytest.mark.parametrize("creator_fn", [
+    lambda: factories.create_product("sku", factories.get_default_shop(), factories.get_default_supplier()),
+    lambda: factories.create_random_person(),
+    lambda: factories.create_random_company(),
+    lambda: factories.create_random_order(customer=factories.create_random_person(), products=[
+        factories.create_product("p", factories.get_default_shop(), factories.get_default_supplier())
+    ]),
+    lambda: factories.create_random_user(),
+])
+@pytest.mark.django_db
+def test_edit_object_view(rf, admin_user, creator_fn):
+    shop = factories.get_default_shop()
+    view = EditObjectView.as_view()
+    object_instance = creator_fn()
+    model = ".".join(ContentType.objects.get_for_model(object_instance).natural_key())
+
+    # correct shop
+    response = _get_edit_object_view(rf, view, model, object_instance.id, admin_user, shop)
+    assert response.status_code == 302
+
+    urls = []
+
+    try:
+        urls.append(get_model_url(object_instance, kind="edit", user=admin_user, shop=shop))
+    except NoModelUrl:
+        pass
+
+    try:
+        urls.append(get_model_url(object_instance, kind="detail", user=admin_user, shop=shop))
+    except NoModelUrl:
+        pass
+
+    assert response.url in urls
+
+    # pass the mode query parameter
+    response = _get_edit_object_view(rf, view, model, object_instance.id, admin_user, shop, mode="test")
+    assert response.status_code == 302
+    assert "mode=test" in response.url
+
+
+@pytest.mark.django_db
+def test_edit_object_view_no_permissions(rf):
+    user = factories.create_random_user("en", is_staff=True)
+    shop = factories.get_default_shop()
+    shop.staff_members.add(user)
+
+    view = EditObjectView.as_view()
+    product = factories.create_product("p1", shop, factories.get_default_supplier())
+    model = ".".join(ContentType.objects.get_for_model(product).natural_key())
+
+    # no permission
+    with pytest.raises(Problem) as error:
+        _get_edit_object_view(rf, view, model, product.id, user, shop)
+    assert "You do not have the required permission" in str(error)
+
+
+@pytest.mark.django_db
+def test_edit_object_view_errors(rf, admin_user):
+    shop = factories.get_default_shop()
+    view = EditObjectView.as_view()
+
+    # missing params
+    response = view(apply_request_middleware(rf.get(reverse("shuup_admin:edit")), user=admin_user, shop=shop))
+    assert response.status_code == 400
+    assert "Invalid object" in response.content.decode("utf-8")
+
+    # invalid model
+    response = _get_edit_object_view(rf, view, ".", None, admin_user, shop)
+    assert response.status_code == 400
+    assert "Invalid model" in response.content.decode("utf-8")
+
+    # invalid object ID
+    product = factories.create_product("p1", shop, factories.get_default_supplier())
+    model = ".".join(ContentType.objects.get_for_model(product).natural_key())
+    with pytest.raises(Http404) as error:
+        _get_edit_object_view(rf, view, model, product.id + 10, admin_user, shop)
+    assert "Object not found" in str(error)
+
+    # object has no admin url
+    from shuup.core.models import ConfigurationItem
+    config = ConfigurationItem.objects.create(shop=shop, key="test", value={"value": 123})
+    model = ".".join(ContentType.objects.get_for_model(config).natural_key())
+    with pytest.raises(Http404) as error:
+        _get_edit_object_view(rf, view, model, config.id, admin_user, shop)
+    assert "Object not found" in str(error)

--- a/shuup_tests/browser/admin/test_quick_add_edit_button.py
+++ b/shuup_tests/browser/admin/test_quick_add_edit_button.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+import time
+
+import pytest
+from django.contrib.auth.models import Group, Permission
+from django.core.urlresolvers import reverse
+
+from shuup import configuration
+from shuup.admin.module_registry import get_modules
+from shuup.admin.utils.permissions import (
+    get_default_model_permissions, get_permission_object_from_string
+)
+from shuup.core.models import Category, Product, Shop, ShopProduct
+from shuup.testing.browser_utils import (
+    click_element, wait_until_appeared, wait_until_condition, wait_until_disappeared
+)
+from shuup.testing.factories import (
+    create_random_user, get_default_product_type, get_default_sales_unit,
+    get_default_shop, get_default_tax_class
+)
+from shuup.testing.utils import initialize_admin_browser_test
+
+pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
+
+
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_quick_add(browser, admin_user, live_server, settings):
+    shop = get_default_shop()
+    get_default_product_type()
+    get_default_sales_unit()
+    get_default_tax_class()
+    configuration.set(None, "shuup_product_tour_complete", True)
+    initialize_admin_browser_test(browser, live_server, settings)
+
+    url = reverse("shuup_admin:shop_product.new")
+    browser.visit("%s%s" % (live_server, url))
+    sku = "testsku"
+    name = "Some product name"
+    price_value = 10
+    short_description = "short but gold"
+
+    browser.fill("base-sku", sku)
+    browser.fill("base-name__en", name)
+    browser.fill("base-short_description__en", short_description)
+    browser.fill("shop%s-default_price_value" % shop.pk, price_value)
+
+    configuration.set(None, "shuup_category_tour_complete", True)
+
+    wait_until_appeared(browser, "#id_shop%d-primary_category ~ .quick-add-btn a.btn" % shop.id)
+    click_element(browser, "#id_shop%d-primary_category ~ .quick-add-btn a.btn" % shop.id)
+    wait_until_appeared(browser, "#create-object-iframe")
+
+    with browser.get_iframe('create-object-iframe') as iframe:
+        assert Category.objects.count() == 0
+        wait_until_appeared(iframe, "input[name='base-name__en']")
+        iframe.fill("base-name__en", "Test Category")
+        time.sleep(3)  # Let's just wait here to the iFrame to open fully (for Chrome and headless)
+        wait_until_appeared(iframe, "button[form='category_form']")
+        click_element(browser, "button[form='category_form']")
+        wait_until_condition(browser, condition=lambda x: Category.objects.count() == 1, timeout=20)
+
+    assert Category.objects.first().name == "Test Category"
+
+    # click to edit the button
+    click_element(browser, "#id_shop%d-primary_category ~ .edit-object-btn a.btn" % shop.id)
+
+    with browser.get_iframe('create-object-iframe') as iframe:
+        wait_until_appeared(iframe, "input[name='base-name__en']")
+        new_cat_name = "Changed Name"
+        iframe.fill("base-name__en", new_cat_name)
+        time.sleep(3)  # Let's just wait here to the iFrame to open fully (for Chrome and headless)
+        wait_until_appeared(iframe, "button[form='category_form']")
+        click_element(iframe, "button[form='category_form']")
+
+    wait_until_condition(browser, condition=lambda x: Category.objects.first().name == new_cat_name, timeout=20)
+
+    click_element(browser, "button[form='product_form']")
+    wait_until_appeared(browser, "div[class='message success']")
+
+
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_edit_button_no_permission(browser, admin_user, live_server, settings):
+    shop = get_default_shop()
+
+    manager_group = Group.objects.create(name="Managers")
+
+    manager = create_random_user("en", is_staff=True)
+    manager.username = "manager"
+    manager.set_password("password")
+    manager.save()
+    manager.groups.add(manager_group)
+    shop.staff_members.add(manager)
+
+    # add permissions for Product
+    permission_models = [Shop, Product, ShopProduct]
+    for model in permission_models:
+        for permission in get_default_model_permissions(model):
+            manager_group.permissions.add(get_permission_object_from_string(permission))
+
+    get_default_product_type()
+    get_default_sales_unit()
+    get_default_tax_class()
+    configuration.set(None, "shuup_product_tour_complete", True)
+    initialize_admin_browser_test(browser, live_server, settings, username=manager.username)
+
+    url = reverse("shuup_admin:shop_product.new")
+    browser.visit("%s%s" % (live_server, url))
+
+    sku = "testsku"
+    name = "Some product name"
+    price_value = 10
+    short_description = "short but gold"
+
+    browser.fill("base-sku", sku)
+    browser.fill("base-name__en", name)
+    browser.fill("base-short_description__en", short_description)
+    browser.fill("shop%s-default_price_value" % shop.pk, price_value)
+
+    configuration.set(None, "shuup_category_tour_complete", True)
+
+    wait_until_appeared(browser, "#id_shop%d-primary_category ~ .quick-add-btn a.btn" % shop.id)
+    click_element(browser, "#id_shop%d-primary_category ~ .quick-add-btn a.btn" % shop.id)
+    wait_until_appeared(browser, "#create-object-iframe")
+
+    # no permission to add category
+    with browser.get_iframe('create-object-iframe') as iframe:
+        error = "Can't view this page. You do not have the required permissions: %s" % ", ".join(get_default_model_permissions(Category))
+        wait_until_condition(iframe, condition=lambda x: x.is_text_present(error))
+
+    # close iframe
+    click_element(browser, "#create-object-overlay a.close-btn")
+
+    # add permission to add category
+    for permission in get_default_model_permissions(Category):
+        manager_group.permissions.add(get_permission_object_from_string(permission))
+
+    # click to add category again
+    click_element(browser, "#id_shop%d-primary_category ~ .quick-add-btn a.btn" % shop.id)
+    wait_until_appeared(browser, "#create-object-iframe")
+
+    # add the category
+    with browser.get_iframe('create-object-iframe') as iframe:
+        assert Category.objects.count() == 0
+        wait_until_appeared(iframe, "input[name='base-name__en']")
+        iframe.fill("base-name__en", "Test Category")
+        time.sleep(3)  # Let's just wait here to the iFrame to open fully (for Chrome and headless)
+        wait_until_appeared(iframe, "button[form='category_form']")
+        click_element(browser, "button[form='category_form']")
+        wait_until_condition(browser, condition=lambda x: Category.objects.count() == 1, timeout=20)
+
+    assert Category.objects.first().name == "Test Category"
+
+    # remove the edit category permissions
+    # add permission to add category
+    for permission in get_default_model_permissions(Category):
+        manager_group.permissions.remove(get_permission_object_from_string(permission))
+
+    # click to edit the button
+    click_element(browser, "#id_shop%d-primary_category ~ .edit-object-btn a.btn" % shop.id)
+
+    # no permission to edit category
+    with browser.get_iframe('create-object-iframe') as iframe:
+        error = "Can't view this page. You do not have the required permission(s): shuup.change_category"
+        wait_until_condition(iframe, condition=lambda x: x.is_text_present(error))
+
+    # close iframe
+    click_element(browser, "#create-object-overlay a.close-btn")
+
+    for permission in get_default_model_permissions(Category):
+        manager_group.permissions.add(get_permission_object_from_string(permission))
+
+    click_element(browser, "#id_shop%d-primary_category ~ .edit-object-btn a.btn" % shop.id)
+    wait_until_appeared(browser, "#create-object-iframe")
+
+    new_cat_name = "Changed Name"
+    with browser.get_iframe('create-object-iframe') as iframe:
+        wait_until_appeared(iframe, "input[name='base-name__en']")
+        iframe.fill("base-name__en", new_cat_name)
+        time.sleep(3)  # Let's just wait here to the iFrame to open fully (for Chrome and headless)
+        wait_until_appeared(iframe, "button[form='category_form']")
+        click_element(browser, "button[form='category_form']")
+
+    wait_until_condition(browser, condition=lambda x: Category.objects.first().name == new_cat_name, timeout=20)


### PR DESCRIPTION
Now one can open edit page for related objects right on the object selector.
![image](https://user-images.githubusercontent.com/8770370/42349113-fa9749ba-8081-11e8-9ffc-0cac283b8e25.png)
This makes it handy to open the related object page and make some changes.
Also, more quick add widgets were added in admin.

Refs POS-2486