### PR TITLE
Classic Gray: add option to configure shop logo size styles

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,11 @@ Unrealeased
   When releasing next version, the "Unreleased" header will be replaced
   with appropriate version header and this help text will be removed.
 
+Xtheme
+~~~~~~
+
+- Add option to render extra templates in theme configuration.
+
 Shuup 1.6.6
 -----------
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,11 @@ Unrealeased
   When releasing next version, the "Unreleased" header will be replaced
   with appropriate version header and this help text will be removed.
 
+Classic Gray Theme
+~~~~~~~~~~~~~~~~~~
+
+- Add option to configure shop logo size styles
+
 Xtheme
 ~~~~~~
 

--- a/shuup/front/static_src/less/front/navigation.less
+++ b/shuup/front/static_src/less/front/navigation.less
@@ -150,6 +150,15 @@
                     background-repeat: no-repeat;
                     background-size: contain;
                     background-position: 0% 50%;
+                    &.left {
+                        background-position: 0% 50%;
+                    }
+                    &.right {
+                        background-position: 100% 50%;
+                    }
+                    &.center {
+                        background-position: 50% 50%;
+                    }
                 }
                 &.text {
                     transition: color 0.1s;

--- a/shuup/themes/classic_gray/locale/en/LC_MESSAGES/django.po
+++ b/shuup/themes/classic_gray/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-22 18:32+0000\n"
+"POT-Creation-Date: 2018-07-09 21:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+msgid "Calculate the best logo size"
+msgstr ""
+
+msgid "Reset shop logo values"
+msgstr ""
+
+msgid "Shop logo preview"
+msgstr ""
+
+#, python-brace-format
+msgid "Original image size: {width} x {height}"
+msgstr ""
 
 msgid "Classic Gray"
 msgstr ""
@@ -36,6 +49,15 @@ msgstr ""
 msgid "Products"
 msgstr ""
 
+msgid "Left"
+msgstr ""
+
+msgid "Right"
+msgstr ""
+
+msgid "Center"
+msgstr ""
+
 msgid "Show Frontpage Welcome Text"
 msgstr ""
 
@@ -43,6 +65,27 @@ msgid "Hide prices"
 msgstr ""
 
 msgid "Set shop in catalog mode"
+msgstr ""
+
+msgid "Shop logo width"
+msgstr ""
+
+msgid "This is the width of the image, in pixels."
+msgstr ""
+
+msgid "Shop logo height"
+msgstr ""
+
+msgid "This is the height of the image, in pixels."
+msgstr ""
+
+msgid "Shop logo alignment"
+msgstr ""
+
+msgid "Keep logo aspect ratio"
+msgstr ""
+
+msgid "Check this to keep the aspect ratio of the image."
 msgstr ""
 
 msgid "Default"

--- a/shuup/themes/classic_gray/templates/classic_gray/admin/extra_config.jinja
+++ b/shuup/themes/classic_gray/templates/classic_gray/admin/extra_config.jinja
@@ -1,0 +1,21 @@
+{% if shop and shop.logo %}
+<div class="text-center">
+    <button class="btn btn-info" type="button" id="calculate-best-size">
+        {{ _("Calculate the best logo size") }}
+    </button>
+    <button class="btn btn-primary" type="button" id="reset-shop-logo">
+        {{ _("Reset shop logo values") }}
+    </button>
+</div>
+<div class="shop-logo-preview-container">
+    <h3 class="text-center">{{ _("Shop logo preview") }}</h3>
+    <div class="shop-logo-preview-content">
+        <div class="shop-logo-preview" id="shop-logo-preview">
+            <div class="shop-logo image" style="background-image:url('{{ shop.logo.url }}')"></div>
+        </div>
+    </div>
+    <div class="text-center text-muted">
+        <small>{{ _("Original image size: {width} x {height}").format(width=shop.logo.width, height=shop.logo.height) }}</small>
+    </div>
+</div>
+{% endif %}

--- a/shuup/themes/classic_gray/templates/classic_gray/admin/extra_config_css.jinja
+++ b/shuup/themes/classic_gray/templates/classic_gray/admin/extra_config_css.jinja
@@ -1,0 +1,26 @@
+<style>
+    .shop-logo-preview-container {
+        margin: 1em;
+    }
+    .shop-logo-preview-content {
+        display: flex;
+        flex-direction: row;
+        justify-content: center;
+    }
+    .shop-logo {
+        width: 100%;
+        height: 100%;
+        background-repeat: no-repeat;
+        background-size: contain;
+        border: 1px dashed gray;
+    }
+    .shop-logo.left {
+        background-position: 0% 50%;
+    }
+    .shop-logo.right {
+        background-position: 100% 50%;
+    }
+    .shop-logo.center {
+        background-position: 50% 50%;
+    }
+</style>

--- a/shuup/themes/classic_gray/templates/classic_gray/admin/extra_config_js.jinja
+++ b/shuup/themes/classic_gray/templates/classic_gray/admin/extra_config_js.jinja
@@ -1,0 +1,101 @@
+<script>
+    (function() {
+        var bestMaxLogoHeight = 80;
+        var bestMaxLogoWidth = 200;
+
+        var originalWidth = {{ shop.logo.width if shop.logo else 0 }};
+        var originalHeight = {{ shop.logo.height if shop.logo else 0 }};
+
+        function setImageSize() {
+            var width = $("input[name='shop_logo_width']").val();
+            var height = $("input[name='shop_logo_height']").val();
+            var alignment = $(":input[name='shop_logo_alignment']").val();
+
+            $("#shop-logo-preview").css("height", height);
+            $("#shop-logo-preview").css("width", width);
+            $(".shop-logo").removeClass("left").removeClass("right").removeClass("center").addClass(alignment);
+        }
+
+        function changeSize(size = "width") {
+            var width = parseInt($("input[name='shop_logo_width']").val(), 10);
+            var maxWidth = parseInt($("input[name='shop_logo_width']").prop("max"), 10);
+            var height = parseInt($("input[name='shop_logo_height']").val(), 10);
+            var maxHeight = parseInt($("input[name='shop_logo_height']").prop("max"), 10);
+            var keepAspectRatio = $(":input[name='shop_logo_aspect_ratio']").prop("checked");
+
+            if (keepAspectRatio && originalHeight && originalWidth) {
+                if (size === "width") {
+                    height = Math.round((originalHeight / originalWidth) * width);
+                } else {
+                    width = Math.round((originalWidth / originalHeight) * height);
+                }
+            }
+
+            if (width > maxWidth) {
+                width = maxWidth;
+            }
+            if (height > maxHeight) {
+                height = maxHeight;
+            }
+
+            $("input[name='shop_logo_height']").val(height);
+            $("input[name='shop_logo_width']").val(width);
+
+            setImageSize();
+        }
+
+        function calculateBestSizes() {
+            $("input[name='shop_logo_aspect_ratio']").prop("checked", true);
+
+            // the image is squared, make it 80x80
+            if (Math.abs(originalHeight - originalWidth) <= 1) {
+                $("input[name='shop_logo_height']").val(bestMaxLogoHeight);
+                $("input[name='shop_logo_width']").val(bestMaxLogoHeight);
+                changeSize();
+
+            // logo is retangular, set the best height size so we don't explode the width
+            } else if (originalWidth > originalHeight) {
+                $("input[name='shop_logo_height']").val(bestMaxLogoHeight);
+                changeSize("height");
+
+            // logo is a portrait image (omg) - use the best width
+            } else {
+                $("input[name='shop_logo_width']").val(bestMaxLogoWidth);
+                changeSize();
+            }
+        }
+
+        // add listeners
+        $("input[name='shop_logo_width']").on("change", function (e){
+            changeSize();
+        });
+        $("input[name='shop_logo_height']").on("change", function (e){
+            changeSize("height");
+        });
+        $(":input[name='shop_logo_alignment']").on("change", function (){
+            changeSize();
+        });
+        $("#reset-shop-logo").click(function() {
+            $("input[name='shop_logo_width']").val(bestMaxLogoWidth);
+            $("input[name='shop_logo_height']").val(bestMaxLogoHeight);
+            $("input[name='shop_logo_aspect_ratio']").prop("checked", true);
+            changeSize();
+        });
+        $("#calculate-best-size").click(calculateBestSizes);
+        $("input[name='shop_logo_aspect_ratio']").on("change", function (e) {
+            if (e.target.checked) {
+                $("input[name='shop_logo_height']").prop("readonly", true);
+            } else {
+                $("input[name='shop_logo_height']").prop("readonly", false);
+            }
+        });
+
+        if (document.getElementById("shop-logo-preview")) {
+            setImageSize();
+            if ($(":input[name='shop_logo_aspect_ratio']").prop("checked")) {
+                $("input[name='shop_logo_height']").prop("readonly", true);
+                changeSize();
+            }
+        }
+    })();
+</script>

--- a/shuup/themes/classic_gray/templates/classic_gray/shuup/front/macros/theme/navigation.jinja
+++ b/shuup/themes/classic_gray/templates/classic_gray/shuup/front/macros/theme/navigation.jinja
@@ -1,3 +1,28 @@
+{% macro render_logo() %}
+    {% if request.shop.logo %}
+        {% set height_css = "height: {}px;".format(xtheme.get("shop_logo_height")) if xtheme.get("shop_logo_height") else "" %}
+        {% set width_css = "width: {}px;".format(xtheme.get("shop_logo_width")) if xtheme.get("shop_logo_width") else "" %}
+        {% if xtheme.get("shop_logo_height") and xtheme.get("shop_logo_width") %}
+            {% set cropped_logo = request.shop.logo|thumbnail(size=(xtheme.get("shop_logo_width"), xtheme.get("shop_logo_height"))) %}
+        {% else %}
+            {% set cropped_logo = request.shop.logo|thumbnail(size=(500, 500)) %}
+        {% endif %}
+    {% endif %}
+    <div
+        class="logo {% if not cropped_logo %}no-image{% endif %}"
+        style="{% if cropped_logo %}{{ height_css }}{{ width_css }}{% endif %}"
+    >
+        {% if cropped_logo %}
+            <a
+                href="/" class="image {% if cropped_logo %}{{ xtheme.get("shop_logo_alignment", "left") }}{% endif %}"
+                style="background-image:url('{{ cropped_logo }}');"
+            ></a>
+        {% else %}
+            <a href="/" class="text"><h4>{{ request.shop.public_name }}</h4></a>
+        {% endif %}
+    </div>
+{% endmacro %}
+
 {% macro render_menu_items() %}
     <button class="toggle-mobile-nav">
         <span class="sr-only">{% trans %}Menu{% endtrans %}</span>

--- a/shuup/themes/classic_gray/theme.py
+++ b/shuup/themes/classic_gray/theme.py
@@ -10,8 +10,20 @@ import django.conf
 from django import forms
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
+from enumfields import Enum
 
 from shuup.xtheme import Theme
+
+
+class ShopLogoAlignment(Enum):
+    LEFT = "left"
+    RIGHT = "right"
+    CENTER = "center"
+
+    class Labels:
+        LEFT = _("Left")
+        RIGHT = _("Right")
+        CENTER = _("Center")
 
 
 class ClassicGrayTheme(Theme):
@@ -24,9 +36,33 @@ class ClassicGrayTheme(Theme):
         ("show_welcome_text", forms.BooleanField(required=False, initial=True, label=_("Show Frontpage Welcome Text"))),
         ("hide_prices", forms.BooleanField(required=False, initial=False, label=_("Hide prices"))),
         ("catalog_mode", forms.BooleanField(required=False, initial=False, label=_("Set shop in catalog mode"))),
+        ("shop_logo_width", forms.IntegerField(
+            initial=200, max_value=960,
+            label=_("Shop logo width"),
+            help_text=_("This is the width of the image, in pixels.")
+        )),
+        ("shop_logo_height", forms.IntegerField(
+            initial=80, max_value=500,
+            label=_("Shop logo height"),
+            help_text=_("This is the height of the image, in pixels.")
+        )),
+        ("shop_logo_alignment", forms.ChoiceField(
+            required=False,
+            choices=ShopLogoAlignment.choices(),
+            initial=ShopLogoAlignment.LEFT.value,
+            label=_("Shop logo alignment")
+        )),
+        ("shop_logo_aspect_ratio", forms.BooleanField(
+            required=False, initial=True,
+            label=_("Keep logo aspect ratio"),
+            help_text=_("Check this to keep the aspect ratio of the image.")
+        ))
     ]
 
     guide_template = "classic_gray/admin/guide.jinja"
+    extra_config_template = "classic_gray/admin/extra_config.jinja"
+    extra_config_extra_js = "classic_gray/admin/extra_config_js.jinja"
+    extra_config_extra_css = "classic_gray/admin/extra_config_css.jinja"
 
     stylesheets = [
         {

--- a/shuup/xtheme/_theme.py
+++ b/shuup/xtheme/_theme.py
@@ -110,6 +110,11 @@ class Theme(object):
     # Guide template location
     guide_template = None
 
+    # Extra configuration themes - it will be included after the configuration form
+    extra_config_template = None
+    extra_config_extra_css = None
+    extra_config_extra_js = None
+
     def __init__(self, theme_settings=None, shop=None):
         """
         Initialize this theme, with an optional `ThemeSettings` or `Shop` object. One should be passed.

--- a/shuup/xtheme/templates/shuup/xtheme/admin/config_detail.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/admin/config_detail.jinja
@@ -8,7 +8,7 @@
         <form method="post" id="theme_settings_form">
             {% csrf_token %}
             {% call content_block(_("Theme Configuration"), "fa-cog") %}
-                {% if form.fields %}
+                {% if form.fields or theme.extra_config_template %}
                     {% for field in form %}
                         {% if field.name == "stylesheet" and has_images %}
                             <div class="form-group required-field">
@@ -24,6 +24,9 @@
                             {{ bs3.field(field) }}
                         {% endif %}
                     {% endfor %}
+                    {% if theme.extra_config_template %}
+                        {% include theme.extra_config_template with context %}
+                    {% endif %}
                 {% else %}
                     <div class="alert alert-info">
                         {% trans %}There's nothing to configure in this theme.{% endtrans %}
@@ -64,7 +67,13 @@
 {% endblock %}
 {% block extra_css %}
     <link rel="stylesheet" href="{{ static("xtheme/admin/xtheme_admin.css") }}">
+    {% if theme.extra_config_extra_css %}
+        {% include theme.extra_config_extra_css %}
+    {% endif %}
 {% endblock %}
 {% block extra_js %}
     <script src="{{ static("xtheme/admin/admin.js") }}"></script>
+    {% if theme.extra_config_extra_js %}
+        {% include theme.extra_config_extra_js %}
+    {% endif %}
 {% endblock %}

--- a/shuup_tests/front/test_classic_gray_theme_settings.py
+++ b/shuup_tests/front/test_classic_gray_theme_settings.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from django.core.urlresolvers import reverse
+from django.test import override_settings
+from django.test.client import Client
+
+from shuup.apps.provides import override_provides
+from shuup.core import cache
+from shuup.testing.factories import get_default_shop
+from shuup.themes.classic_gray.theme import ClassicGrayTheme
+from shuup.xtheme._theme import _get_current_theme, set_current_theme
+from shuup.xtheme.models import ThemeSettings
+
+
+@pytest.mark.django_db
+def test_classic_gray_theme_settings(admin_user):
+    with override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test_configuration_cache',
+        }
+    }):
+        cache.init_cache()
+        shop = get_default_shop()
+
+        with override_provides("xtheme", ["shuup.themes.classic_gray.theme:ClassicGrayTheme"]):
+            set_current_theme(ClassicGrayTheme.identifier, shop)
+            theme = _get_current_theme(shop)
+            assert isinstance(theme, ClassicGrayTheme)
+            ThemeSettings.objects.all().delete()
+
+            client = Client()
+            admin_user.set_password("admin")
+            admin_user.save()
+            client.login(username=admin_user.username, password="admin")
+
+            theme_config_url = reverse("shuup_admin:xtheme.config_detail", kwargs=dict(theme_identifier=ClassicGrayTheme.identifier))
+            response = client.get(theme_config_url)
+            assert response.status_code == 200
+
+            assert theme.get_setting("shop_logo_width") is None
+            assert theme.get_setting("shop_logo_height") is None
+            assert theme.get_setting("shop_logo_alignment") is None
+            assert theme.get_setting("shop_logo_aspect_ratio") is None
+
+            settings = {
+                "stylesheet": "shuup/classic_gray/blue/style.css",
+                "shop_logo_width": 800,
+                "shop_logo_height": 400,
+                "shop_logo_alignment": "right",
+                "shop_logo_aspect_ratio": True
+            }
+            response = client.post(theme_config_url, data=settings)
+            assert response.status_code == 302
+
+            theme = _get_current_theme(shop)
+            for key, value in settings.items():
+                assert theme.get_setting(key) == value


### PR DESCRIPTION
Add Xtheme option to render extra templates in theme configuration. This enable template injection in the configuration page for more advanced visualization and options.

Refs POS-2476