### PR TITLE
Xtheme: highlight the configure button of the active theme

### DIFF
--- a/shuup/xtheme/locale/en/LC_MESSAGES/django.po
+++ b/shuup/xtheme/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-04 18:50+0000\n"
+"POT-Creation-Date: 2018-07-10 18:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -285,6 +285,9 @@ msgstr ""
 msgid "Select theme"
 msgstr ""
 
+msgid "Active"
+msgstr ""
+
 msgid "Guide"
 msgstr ""
 
@@ -303,16 +306,19 @@ msgstr ""
 msgid "No guide"
 msgstr ""
 
-msgid "Currently active"
+msgid "Activate"
 msgstr ""
 
-msgid "Activate"
+msgid "Click here to configure the theme"
 msgstr ""
 
 msgid "Configure"
 msgstr ""
 
 msgid "Theme Name"
+msgstr ""
+
+msgid "Currently active"
 msgstr ""
 
 msgid "Revert Changes"

--- a/shuup/xtheme/templates/shuup/xtheme/admin/macros.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/admin/macros.jinja
@@ -1,7 +1,8 @@
 {% macro theme_table(theme_classes, current_theme, on_activate="", new_tab=False) %}
-    <table class="table table-striped table-bordered table-shuup theme-table">
+    <table class="table table-bordered table-shuup theme-table">
         <thead>
             <tr>
+                <th>{% trans %}Active{% endtrans %}</th>
                 <th>{% trans %}Theme{% endtrans %}</th>
                 <th>{% trans %}Guide{% endtrans %}</th>
                 <th colspan="2">{% trans %}Actions{% endtrans %}</th>
@@ -10,7 +11,10 @@
         <tbody>
         {% for theme in theme_classes %}
             {% set active_theme = current_theme and theme.identifier == current_theme.identifier %}
-            <tr {% if active_theme %} class="active-row" {% endif %}>
+            <tr {% if active_theme %} class="active-row active" {% endif %}>
+                <td class="text-center">
+                    {% if active_theme %}<i class="fa fa-check text-success"></i>{% endif %}
+                </td>
                 <td>
                     {% if current_theme and theme.identifier == current_theme.identifier %}
                         <strong class="title">{{ theme.name or theme.identifier }}</strong>
@@ -33,18 +37,21 @@
                     {% endif %}
                 </td>
                 <td>
-                    <span class="active {% if not active_theme %} hidden {% endif %}"><i class="fa fa-check text-success"></i> {% trans %}Currently active{% endtrans %}</span>
                     <button
                         name="activate"
                         value="{{ theme.identifier }}"
                         {% if on_activate != "" %} type="button" onclick="{{ on_activate }}" {% else %} type="submit" {% endif %}
-                        class="btn btn-sm btn-success {% if active_theme %} hidden {% endif %}">
+                        class="btn btn-sm btn-success {% if active_theme %} hidden{% endif %}">
                         <i class="fa fa-check-circle"></i> {% trans %}Activate{% endtrans %}
                     </button>
-                </td>
-
-                <td>
-                    <a {% if new_tab %} target="_blank" {% endif %} href="{{ url("shuup_admin:xtheme.config_detail", theme_identifier=theme.identifier) }}" class="btn btn-sm btn-gray">
+                    <a
+                        {% if new_tab %} target="_blank" {% endif %}
+                        href="{{ url("shuup_admin:xtheme.config_detail", theme_identifier=theme.identifier) }}"
+                        class="btn btn-sm btn-configure-theme {% if active_theme %}active btn-info{% else %}btn-gray{% endif %}"
+                        data-placement="bottom"
+                        data-trigger="manual"
+                        data-content="{{ _("Click here to configure the theme") }}"
+                    >
                         <i class="fa fa-cogs"></i> {% trans %}Configure{% endtrans %}
                     </a>
                 </td>
@@ -52,6 +59,17 @@
         {% endfor %}
         </tbody>
     </table>
+    <script>
+        (function() {
+            window.addEventListener("load", function() {
+                $(".btn-configure-theme.active").popover();
+                $(".btn-configure-theme.active").popover("show");
+                setTimeout(function (){
+                    $(".btn-configure-theme.active").popover("hide");
+                }, 3000);
+            });
+        })();
+    </script>
 {% endmacro %}
 
 {% macro wizard_theme_table(theme_classes, current_theme, shop, on_activate="", new_tab=False) %}
@@ -77,7 +95,7 @@
                     {% endif %}
                 </td>
                 <td>
-                    <span class="active {% if not active_theme %} hidden {% endif %}"><i class="fa fa-check text-success"></i> {% trans %}Currently active{% endtrans %}</span>
+                    <span class="active {% if not active_theme %} hidden{% endif %}"><i class="fa fa-check text-success"></i> {% trans %}Currently active{% endtrans %}</span>
                     <button
                         name="activate"
                         value="{{ theme.identifier }}"


### PR DESCRIPTION
Add a popover to help users to configure the theme. The popover is show when the page loads and it is hidden after 3 secs. 

Refs POS-2477

![image](https://user-images.githubusercontent.com/8770370/42522114-b676dfb2-8440-11e8-90d5-a0a903be8939.png)
