### PR TITLE
Front: fix manufacturer modified filter to consider only visible shop products

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,11 @@ Unrealeased
   When releasing next version, the "Unreleased" header will be replaced
   with appropriate version header and this help text will be removed.
 
+Front
+~~~~~
+
+- Fixed manufacturer modified filter to consider only visible shop products
+
 Classic Gray Theme
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
**Issue:** some manufacturers were available for filtering and when applied, no product was returned. The queryset was not considering invisible shop products that had the manufacturer linked.
Excluding invisible shop products fixes the issue.

The current shop was also added to the manufacturer and shop product queryset to avoid considering other shops.

Refs POS-2497