### PR TITLE
Front: ensure the request has the correct language code

### DIFF
--- a/shuup/front/middleware.py
+++ b/shuup/front/middleware.py
@@ -163,6 +163,7 @@ class ShuupFrontMiddleware(object):
         available_languages = [code for (code, name, local_name) in get_language_choices(request.shop)]
         if current_language not in available_languages:
             translation.activate(available_languages[0])
+            request.LANGUAGE_CODE = translation.get_language()
 
     def _get_maintenance_response(self, request, view_func):
         if settings.DEBUG:

--- a/shuup/front/urls.py
+++ b/shuup/front/urls.py
@@ -16,7 +16,6 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.i18n import set_language
 
 from shuup.apps.provides import get_provide_objects
-from shuup.utils.i18n import javascript_catalog_all
 
 from .views.basket import BasketView
 from .views.category import CategoryView
@@ -38,12 +37,19 @@ def _not_here_yet(request, *args, **kwargs):
         status=410)
 
 
+# Use a different js catalog function in front urlpatterns to prevent forcing
+# the shop language settings in admin js catalog.
+def front_javascript_catalog_all(request, domain='djangojs'):
+    from shuup.utils.i18n import javascript_catalog_all
+    return javascript_catalog_all(request, domain)
+
+
 checkout_view = get_checkout_view()
 
 
 urlpatterns = [
     url(r'^set-language/$', csrf_exempt(set_language), name="set-language"),
-    url(r'^i18n.js$', javascript_catalog_all, name='js-catalog'),
+    url(r'^i18n.js$', front_javascript_catalog_all, name='js-catalog'),
     url(r'^checkout/$', checkout_view, name='checkout'),
     url(r'^checkout/(?P<phase>.+)/$', checkout_view, name='checkout'),
     url(r'^basket/$', csrf_exempt(BasketView.as_view()), name='basket'),


### PR DESCRIPTION
The same approach is done by Django `LocaleMiddleware` middleware.

Use a different js catalog function in front urlpatterns to prevent forcing the shop language settings in admin js catalog.

Refs POS-2495