### PR TITLE
Add PyPI badge to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
     :target: https://travis-ci.org/shuup/shuup
 .. image:: https://coveralls.io/repos/github/shuup/shuup/badge.svg?branch=master
    :target: https://coveralls.io/github/shuup/shuup?branch=master
+.. image:: https://img.shields.io/pypi/v/shuup.svg
+   :alt: PyPI
+   :target: https://github.com/shuup/shuup
 
 Shuup
 =====


### PR DESCRIPTION
Should be useful to indicate that Shuup is available at PyPI. 
[![PyPI](https://img.shields.io/pypi/v/shuup.svg)](https://github.com/shuup/shuup)
