### PR TITLE
Core: fix basket to check whether the method exists before returning it

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,7 @@ Unrealeased
 Bug fixes
 ~~~~~~~~~
 
+- Fix basket to check whether the payment or shipping method exists before returning it.
 - Fix order printouts template by checking whether the addresses are valid
   before calling methods.
 - Fix front manufacturer modified filter to consider only visible shop products

--- a/shuup/core/basket/objects.py
+++ b/shuup/core/basket/objects.py
@@ -287,7 +287,7 @@ class BaseBasket(OrderSource):
             self.shipping_method_id = self._get_value_from_data("shipping_method_id")
 
         if self.shipping_method_id:
-            return ShippingMethod.objects.get(pk=self.shipping_method_id)
+            return ShippingMethod.objects.filter(pk=self.shipping_method_id).first()
 
     @shipping_method.setter
     def shipping_method(self, shipping_method):
@@ -300,7 +300,7 @@ class BaseBasket(OrderSource):
             self.payment_method_id = self._get_value_from_data("payment_method_id")
 
         if self.payment_method_id:
-            return PaymentMethod.objects.get(pk=self.payment_method_id)
+            return PaymentMethod.objects.filter(pk=self.payment_method_id).first()
 
     @payment_method.setter
     def payment_method(self, payment_method):

--- a/shuup/front/checkout/methods.py
+++ b/shuup/front/checkout/methods.py
@@ -118,8 +118,14 @@ class MethodsPhase(CheckoutPhaseViewMixin, FormView):
         return self.storage.has_any(["shipping_method_id", "payment_method_id"])
 
     def process(self):
-        self.basket.shipping_method_id = self.storage["shipping_method_id"]
-        self.basket.payment_method_id = self.storage["payment_method_id"]
+        shipping_method_id = self.storage["shipping_method_id"]
+        payment_method_id = self.storage["payment_method_id"]
+
+        shipping_method = ShippingMethod.objects.filter(pk=shipping_method_id).first()
+        payment_method = PaymentMethod.objects.filter(pk=payment_method_id).first()
+
+        self.basket.shipping_method_id = shipping_method.pk if shipping_method else None
+        self.basket.payment_method_id = shipping_method.pk if payment_method else None
 
     def get_form_kwargs(self):
         kwargs = super(MethodsPhase, self).get_form_kwargs()

--- a/shuup_tests/browser/front/test_checkout.py
+++ b/shuup_tests/browser/front/test_checkout.py
@@ -6,22 +6,22 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import os
-import pytest
 
-from django.conf import settings
+import pytest
+from django.core.urlresolvers import reverse
 from django.test import override_settings
 
 from shuup.core.models import OrderStatus, OrderStatusRole
 from shuup.testing.browser_utils import (
-    click_element, move_to_element, wait_until_appeared,
-    wait_until_disappeared,
-    wait_until_condition)
+    click_element, wait_until_appeared, wait_until_condition,
+    wait_until_disappeared
+)
 from shuup.testing.factories import (
     create_product, get_default_payment_method, get_default_shipping_method,
-    get_default_shop, get_default_supplier
+    get_default_shop, get_default_supplier, get_payment_method,
+    get_shipping_method
 )
 from shuup.testing.utils import initialize_front_browser_test
-from shuup.utils.importing import clear_load_cache
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 
@@ -124,7 +124,7 @@ def test_browser_checkout_horizontal(browser, live_server, settings):
 @pytest.mark.urls('shuup.testing.single_page_checkout_test_urls')
 @pytest.mark.browser
 @pytest.mark.djangodb
-def test_browser_checkout_vertical(browser, live_server, settings): 
+def test_browser_checkout_vertical(browser, live_server, settings):
     with override_settings(SHUUP_CHECKOUT_VIEW_SPEC=("shuup.front.views.checkout:SinglePageCheckoutView")):
         # initialize
         product_name = "Test Product"
@@ -210,3 +210,103 @@ def test_browser_checkout_vertical(browser, live_server, settings):
         click_element(browser, ".btn.btn-primary.btn-lg")  # click "place order"
 
         wait_until_condition(browser, lambda x: x.is_text_present("Thank you for your order!"))  # order succeeded
+
+
+
+@pytest.mark.parametrize("delete_method", ["shipping", "payment"])
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_browser_checkout_disable_methods(browser, live_server, settings, delete_method):
+    # initialize
+    product_name = "Test Product"
+    shop = get_default_shop()
+
+    payment_method = get_default_payment_method()
+    shipping_method = get_default_shipping_method()
+
+    product = create_orderable_product(product_name, "test-123", price=100)
+    OrderStatus.objects.create(
+        identifier="initial",
+        role=OrderStatusRole.INITIAL,
+        name="initial",
+        default=True
+    )
+
+    # initialize test and go to front page
+    browser = initialize_front_browser_test(browser, live_server)
+
+    # check that front page actually loaded
+    wait_until_condition(browser, lambda x: x.is_text_present("Welcome to Default!"))
+    wait_until_condition(browser, lambda x: x.is_text_present("Newest Products"))
+    wait_until_condition(browser, lambda x: x.is_text_present(product_name))
+
+    click_element(browser, "#product-%s" % product.pk)  # open product from product list
+    click_element(browser, "#add-to-cart-button-%s" % product.pk)  # add product to basket
+
+    wait_until_appeared(browser, ".cover-wrap")
+    wait_until_disappeared(browser, ".cover-wrap")
+
+    click_element(browser, "#navigation-basket-partial")  # open upper basket navigation menu
+    click_element(browser, "a[href='/basket/']")  # click the link to basket in dropdown
+    wait_until_condition(browser, lambda x: x.is_text_present("Shopping cart"))  # we are in basket page
+    wait_until_condition(browser, lambda x: x.is_text_present(product_name))  # product is in basket
+
+    click_element(browser, "a[href='/checkout/']") # click link that leads to checkout
+
+    customer_name = "Test Tester"
+    customer_street = "Test Street"
+    customer_city = "Test City"
+    customer_region = "CA"
+    customer_country = "US"
+
+    # Fill all necessary information
+    browser.fill("billing-name", customer_name)
+    browser.fill("billing-street", customer_street)
+    browser.fill("billing-city", customer_city)
+    browser.select("billing-country", customer_country)
+    wait_until_appeared(browser, "select[name='billing-region_code']")
+    browser.select("billing-region_code", customer_region)
+
+    browser.fill("billing-name", customer_name)
+    browser.fill("billing-street", customer_street)
+    browser.fill("billing-city", customer_city)
+    browser.select("billing-country", customer_country)
+    wait_until_appeared(browser, "select[name='billing-region_code']")
+    browser.select("billing-region_code", customer_region)
+
+    click_element(browser, "#addresses button[type='submit']")  # This shouldn't submit since missing required fields
+
+    # Fill rest of the fields
+    browser.fill("shipping-name", customer_name)
+    browser.fill("shipping-street", customer_street)
+    browser.fill("shipping-city", customer_city)
+    browser.select("shipping-country", customer_country)
+
+    click_element(browser, "#addresses button[type='submit']")
+    wait_until_condition(browser, lambda x: x.is_text_present("Checkout: Shipping & Payment"))
+    wait_until_condition(browser, lambda x: x.is_text_present(payment_method.name))
+    wait_until_condition(browser, lambda x: x.is_text_present(shipping_method.name))
+
+    browser.find_by_css("input[name='shipping_method'][value='%d']" % shipping_method.pk).first.click()
+    browser.find_by_css("input[name='payment_method'][value='%d']" % payment_method.pk).first.click()
+
+    click_element(browser, ".btn.btn-primary.btn-lg.pull-right")  # click "continue" on methods page
+    wait_until_condition(browser, lambda x: x.is_text_present("Checkout: Confirmation"))  # we are indeed in confirmation page
+
+    if delete_method == "payment":
+        payment_method.delete()
+    else:
+        shipping_method.delete()
+
+    click_element(browser, "a[href='/checkout/methods/']")
+
+    wait_until_condition(browser, lambda x: x.is_text_present("Checkout: Shipping & Payment"))
+
+    if delete_method == "payment":
+        wait_until_condition(browser, lambda x: x.is_text_present("No method is available."))
+        wait_until_condition(browser, lambda x: not x.is_text_present(payment_method.name))
+        wait_until_condition(browser, lambda x: x.is_text_present(shipping_method.name))
+    else:
+        wait_until_condition(browser, lambda x: x.is_text_present("No method is available."))
+        wait_until_condition(browser, lambda x: x.is_text_present(payment_method.name))
+        wait_until_condition(browser, lambda x: not x.is_text_present(shipping_method.name))


### PR DESCRIPTION
There is some cases where the payment or shipping method can be deleted and basket could contain invalid PKs. This prevents errors from being raised.

Refs POS-2504