### PR TITLE
Front: Do not open files to check whether SVG

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,6 +17,13 @@ Bug fixes
   before calling methods.
 - Fix front manufacturer modified filter to consider only visible shop products
 
+Front
+~~~~~
+
+- Change the way SVG files are detected in thumnailer. From now on the SVG
+  check is done purely based on filename instead of checking the file
+  content.
+
 Classic Gray Theme
 ~~~~~~~~~~~~~~~~~~
 

--- a/shuup/front/templatetags/thumbnails.py
+++ b/shuup/front/templatetags/thumbnails.py
@@ -7,6 +7,8 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 
+import os
+
 import six
 from django.conf import settings
 from django_jinja import library
@@ -39,7 +41,7 @@ def thumbnail(source, alias=None, generate=True, **kwargs):
     if not thumbnailer:
         return None
 
-    if _is_svg(thumbnailer.file):
+    if _is_svg(thumbnailer):
         return source.url if hasattr(source, 'url') else None
 
     if alias:
@@ -55,29 +57,11 @@ def thumbnail(source, alias=None, generate=True, **kwargs):
         return None
 
 
-def _is_svg(fileobj):
-    """
-    Detect if file object contains SVG data.
-
-    >>> from io import BytesIO as B
-    >>> assert _is_svg(B(b'<?xml><svg></svg>')) is True
-    >>> assert _is_svg(B(b'something else')) is False
-    >>> assert _is_svg(b'not a file') is None
-    """
-    try:
-        return _is_svg_inner(fileobj)
-    except (AttributeError, IOError):
-        return None
-
-
-def _is_svg_inner(fileobj):
-    pos = fileobj.tell()
-    try:
-        fileobj.seek(0)
-        content = fileobj.read(1024)
-    finally:
-        fileobj.seek(pos)
-    return (b'<svg' in content and b'>' in content)
+def _is_svg(thumbnailer):
+    file_name = getattr(thumbnailer, "name", None)
+    if not file_name:
+        return False
+    return bool(os.path.splitext(file_name)[1].lower() == ".svg")
 
 
 @library.filter

--- a/shuup_tests/front/test_thumbnails_templatetag.py
+++ b/shuup_tests/front/test_thumbnails_templatetag.py
@@ -64,7 +64,12 @@ def test_thumbnailing_nonseekable_svg_file():
 
     source = Thumbnailer(file=DummyFile(TEST_SVG), name='test.svg')
     source.url = '/media/test.svg'
-    assert thumbnail(source) is None
+
+    # Well if the merchant tries his luck with non seekable file
+    # and decides to name it as svg then he might not have working
+    # front. Also not worth thumbnail these anyways so might as well
+    # return the source url.
+    assert thumbnail(source) == source.url
 
 
 def do_thumbnailing(content, name, *args, **kwargs):


### PR DESCRIPTION
With external media like S3 this check makes it super slow since every single file is openeed and fetched from S3 just for this check on every single request.

And if some SVG files gets past this check then maybe the merchant just deserves the fail.