### PR TITLE
Admin: fix translatable string format

### DIFF
--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-05 20:19+0000\n"
+"POT-Creation-Date: 2018-07-13 19:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -3024,6 +3024,14 @@ msgstr ""
 msgid "Edit the selected object"
 msgstr ""
 
+#, python-brace-format
+msgid "Required. {field_help}"
+msgstr ""
+
+#, python-brace-format
+msgid "Optional. {field_help}"
+msgstr ""
+
 msgid "Welcome to Shuup!"
 msgstr ""
 
@@ -3681,6 +3689,13 @@ msgid "Invalid object."
 msgstr ""
 
 msgid "Invalid model."
+msgstr ""
+
+#, python-format
+msgid "You do not have the required permission(s): %s"
+msgstr ""
+
+msgid "Unauthorized"
 msgstr ""
 
 msgid "Object not found"

--- a/shuup/admin/templates/shuup/admin/forms/widgets/help_text.jinja
+++ b/shuup/admin/templates/shuup/admin/forms/widgets/help_text.jinja
@@ -1,8 +1,8 @@
 {% if field.field_help %}
     {% if field.field.required %}
-        {% set help_text = _("Required. %(field_help)s" % {"field_help": field.field_help}) %}
+        {% set help_text = _("Required. {field_help}").format(field_help=field.field_help) %}
     {% else %}
-    {% set help_text = _("Optional. %(field_help)s" % {"field_help": field.field_help}) %}
+        {% set help_text = _("Optional. {field_help}").format(field_help=field.field_help) %}
     {% endif %}
     <span class="help-popover-btn">
     {# tabindex is required for popover to function but we don't actually want to be able to tab to it #}


### PR DESCRIPTION
The translation was getting formatted before the actual string translation
This ensures the translation is formatted after the correct string is being returned

No Refs