### PR TITLE
Re-enable cache for unit tests

### DIFF
--- a/shuup/front/template_helpers/general.py
+++ b/shuup/front/template_helpers/general.py
@@ -22,9 +22,9 @@ from shuup.front.utils.product_statistics import get_best_selling_product_info
 from shuup.front.utils.translation import get_language_choices
 from shuup.front.utils.user import is_admin_user
 from shuup.front.utils.views import cache_product_things
+from shuup.utils.importing import cached_load
 from shuup.utils.mptt import get_cached_trees
 from shuup.utils.translation import cache_translations_for_tree
-from shuup.utils.importing import cached_load
 
 
 def get_login_form(request):
@@ -248,7 +248,8 @@ def get_random_products(context, n_products=6, orderable_only=True, sale_items_o
     request = context["request"]
     key, product_ids = context_cache.get_cached_value(
         identifier="random_products", item=None, context=request,
-        n_products=n_products, orderable_only=orderable_only
+        n_products=n_products, orderable_only=orderable_only,
+        sale_items_only=sale_items_only
     )
     if product_ids is not None and _can_use_cache(product_ids, request.shop, request.customer):
         return Product.objects.filter(id__in=product_ids)

--- a/shuup_tests/conftest.py
+++ b/shuup_tests/conftest.py
@@ -12,7 +12,6 @@ from django.core.signals import setting_changed
 from shuup.apps.provides import clear_provides_cache
 from shuup.testing.factories import get_default_shop
 from shuup.utils.importing import clear_load_cache
-from shuup.xtheme import set_current_theme
 from shuup.xtheme.testing import override_current_theme_class
 
 
@@ -53,6 +52,11 @@ def splinter_make_screenshot_on_failure():
 def enable_db_access(db):
     from django.utils.translation import activate
     activate("en")
+
+    # make sure the default cache is also cleared
+    # it is used by third party apps like parler
+    from django.core.cache import cache
+    cache.clear()
 
     from shuup.core import cache
     cache.init_cache()

--- a/shuup_tests/front/test_general_template_helpers.py
+++ b/shuup_tests/front/test_general_template_helpers.py
@@ -6,6 +6,7 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+from shuup.core import cache
 from shuup.core.models import AnonymousContact, Product, ShopProductVisibility, StockBehavior
 from shuup.testing.factories import (
     create_order_with_product, create_product, get_default_shop,
@@ -24,8 +25,8 @@ def test_get_login_form(rf):
     request = apply_request_middleware(rf.get("/"),shop=get_default_shop())
     form = general.get_login_form(request=request)
     assert isinstance(form, EmailAuthenticationForm)
-    
-    
+
+
 @pytest.mark.django_db
 def test_get_root_categories():
     populate_if_required()
@@ -52,19 +53,28 @@ def test_get_listed_products_orderable_only():
 
     from shuup.front.template_helpers import general
 
-    assert len(general.get_listed_products(context, n_products, orderable_only=True)) == 0
-    assert len(general.get_listed_products(context, n_products, orderable_only=False)) == 1
+    for cache_test in range(2):
+        assert len(general.get_listed_products(context, n_products, orderable_only=True)) == 0
+
+    for cache_test in range(2):
+        assert len(general.get_listed_products(context, n_products, orderable_only=False)) == 1
 
     # Increase stock on product
     quantity = product.get_shop_instance(shop).minimum_purchase_quantity
     simple_supplier.adjust_stock(product.id, quantity)
-    assert len(general.get_listed_products(context, n_products, orderable_only=True)) == 1
-    assert len(general.get_listed_products(context, n_products, orderable_only=False)) == 1
+    for cache_test in range(2):
+        assert len(general.get_listed_products(context, n_products, orderable_only=True)) == 1
+
+    for cache_test in range(2):
+        assert len(general.get_listed_products(context, n_products, orderable_only=False)) == 1
 
     # Decrease stock on product
     simple_supplier.adjust_stock(product.id, -quantity)
-    assert len(general.get_listed_products(context, n_products, orderable_only=True)) == 0
-    assert len(general.get_listed_products(context, n_products, orderable_only=False)) == 1
+    for cache_test in range(2):
+        assert len(general.get_listed_products(context, n_products, orderable_only=True)) == 0
+
+    for cache_test in range(2):
+        assert len(general.get_listed_products(context, n_products, orderable_only=False)) == 1
 
 
 @pytest.mark.django_db
@@ -83,7 +93,8 @@ def test_get_listed_products_sale_only():
     )
 
     from shuup.front.template_helpers import general
-    assert general.get_listed_products(context, n_products, orderable_only=False, sale_items_only=True) == []
+    for cache_test in range(2):
+        assert general.get_listed_products(context, n_products, orderable_only=False, sale_items_only=True) == []
 
     from shuup.customer_group_pricing.models import CgpDiscount
     CgpDiscount.objects.create(
@@ -92,7 +103,8 @@ def test_get_listed_products_sale_only():
         group=AnonymousContact.get_default_group(),
         discount_amount_value=5
     )
-    assert product in general.get_listed_products(context, n_products, orderable_only=False, sale_items_only=True)
+    for cache_test in range(2):
+        assert product in general.get_listed_products(context, n_products, orderable_only=False, sale_items_only=True)
 
     # create a package product
     package_product = create_product("package", shop, supplier, default_price=30)
@@ -102,7 +114,8 @@ def test_get_listed_products_sale_only():
     package_product.save()
 
     # package product is not returned as it has not discount
-    assert len(general.get_listed_products(context, n_products, orderable_only=False, sale_items_only=True)) == 1
+    for cache_test in range(2):
+        assert len(general.get_listed_products(context, n_products, orderable_only=False, sale_items_only=True)) == 1
 
     CgpDiscount.objects.create(
         shop=shop,
@@ -110,9 +123,10 @@ def test_get_listed_products_sale_only():
         group=AnonymousContact.get_default_group(),
         discount_amount_value=3
     )
-    products = general.get_listed_products(context, n_products, orderable_only=False, sale_items_only=True)
-    assert len(products) == 2
-    assert package_product in products
+    for cache_test in range(2):
+        products = general.get_listed_products(context, n_products, orderable_only=False, sale_items_only=True)
+        assert len(products) == 2
+        assert package_product in products
 
     # create a variation parent product
     parent = create_product("parent", shop, supplier, default_price=40)
@@ -121,8 +135,9 @@ def test_get_listed_products_sale_only():
         var_child.link_to_parent(parent, {"option": var_child.sku})
 
     # still the same, as there is no discount for variation
-    products = general.get_listed_products(context, n_products, orderable_only=False, sale_items_only=True)
-    assert len(products) == 2
+    for cache_test in range(2):
+        products = general.get_listed_products(context, n_products, orderable_only=False, sale_items_only=True)
+        assert len(products) == 2
 
     # add discount for just a variation child
     CgpDiscount.objects.create(
@@ -132,9 +147,10 @@ def test_get_listed_products_sale_only():
         discount_amount_value=0.1
     )
 
-    products = general.get_listed_products(context, n_products, orderable_only=False, sale_items_only=True)
-    assert len(products) == 3
-    assert parent in products
+    for cache_test in range(2):
+        products = general.get_listed_products(context, n_products, orderable_only=False, sale_items_only=True)
+        assert len(products) == 3
+        assert parent in products
 
 
 @pytest.mark.django_db
@@ -156,13 +172,15 @@ def test_get_listed_products_filter():
 
     from shuup.front.template_helpers import general
     filter_dict = {"id": product_1.id}
-    product_list = general.get_listed_products(context, n_products=2, filter_dict=filter_dict)
-    assert product_1 in product_list
-    assert product_2 not in product_list
+    for cache_test in range(2):
+        product_list = general.get_listed_products(context, n_products=2, filter_dict=filter_dict)
+        assert product_1 in product_list
+        assert product_2 not in product_list
 
-    product_list = general.get_listed_products(context, n_products=2, filter_dict=filter_dict, orderable_only=False)
-    assert product_1 in product_list
-    assert product_2 not in product_list
+    for cache_test in range(2):
+        product_list = general.get_listed_products(context, n_products=2, filter_dict=filter_dict, orderable_only=False)
+        assert product_1 in product_list
+        assert product_2 not in product_list
 
 
 @pytest.mark.django_db
@@ -180,8 +198,9 @@ def test_get_best_selling_products():
     create_order_with_product(product1, supplier, quantity=1, taxless_base_unit_price=10, shop=shop)
     create_order_with_product(product2, supplier, quantity=2, taxless_base_unit_price=20, shop=shop)
 
+    cache.clear()
     # Two products sold
-    for time in range(2):
+    for cache_test in range(2):
         best_selling_products = list(general.get_best_selling_products(context, n_products=3))
         assert len(best_selling_products) == 2
         assert product1 in best_selling_products
@@ -192,7 +211,8 @@ def test_get_best_selling_products():
     shop_product.visibility = ShopProductVisibility.NOT_VISIBLE
     shop_product.save()
 
-    for time in range(2):
+    cache.clear()
+    for cache_test in range(2):
         best_selling_products = list(general.get_best_selling_products(context, n_products=3))
         assert len(best_selling_products) == 1
         assert product1 not in best_selling_products
@@ -211,7 +231,11 @@ def test_get_best_selling_products():
         group=AnonymousContact.get_default_group(),
         discount_amount_value=5
     )
-    assert general.get_best_selling_products(context, n_products=5, sale_items_only=True) == [product3]
+    cache.clear()
+    for cache_test in range(2):
+        best_selling = general.get_best_selling_products(context, n_products=5, sale_items_only=True)
+        assert len(best_selling) == 1
+        product3 in best_selling
 
 
 @pytest.mark.django_db
@@ -230,30 +254,38 @@ def test_best_selling_products_with_multiple_orders():
     create_order_with_product(product_2, supplier, quantity=1, taxless_base_unit_price=price, shop=shop)
 
     # Two initial products sold
-    assert product_1 in general.get_best_selling_products(context, n_products=n_products)
-    assert product_2 in general.get_best_selling_products(context, n_products=n_products)
+    for cache_test in range(2):
+        assert product_1 in general.get_best_selling_products(context, n_products=n_products)
+        assert product_2 in general.get_best_selling_products(context, n_products=n_products)
 
     product_3 = create_product("test-sku-3", supplier=supplier, shop=shop, default_price=price)
     create_order_with_product(product_3, supplier, quantity=2, taxless_base_unit_price=price, shop=shop)
 
     # Third product sold in greater quantity
+    cache.clear()
     assert product_3 in general.get_best_selling_products(context, n_products=n_products)
 
     create_order_with_product(product_1, supplier, quantity=4, taxless_base_unit_price=price, shop=shop)
     create_order_with_product(product_2, supplier, quantity=4, taxless_base_unit_price=price, shop=shop)
+
+    cache.clear()
     # Third product outsold by first two products
-    assert product_3 not in general.get_best_selling_products(context, n_products=n_products)
+    for cache_test in range(2):
+        assert product_3 not in general.get_best_selling_products(context, n_products=n_products)
 
     children = [create_product("SimpleVarChild-%d" % x, supplier=supplier, shop=shop) for x in range(5)]
     for child in children:
         child.link_to_parent(product_3)
         create_order_with_product(child, supplier, quantity=1, taxless_base_unit_price=price, shop=shop)
 
+    cache.clear()
     # Third product now sold in greatest quantity
-    assert product_3 == general.get_best_selling_products(context, n_products=n_products)[0]
+    for cache_test in range(2):
+        assert product_3 == general.get_best_selling_products(context, n_products=n_products)[0]
 
     # return only products with discounts
-    assert len(general.get_best_selling_products(context, n_products=n_products, sale_items_only=True)) == 0
+    for cache_test in range(2):
+        assert len(general.get_best_selling_products(context, n_products=n_products, sale_items_only=True)) == 0
 
     # add a new product with discounted amount
     product_4 = create_product("test-sku-4", supplier=supplier, shop=shop, default_price=price)
@@ -265,7 +297,11 @@ def test_best_selling_products_with_multiple_orders():
         group=AnonymousContact.get_default_group(),
         discount_amount_value=(price * 0.1)
     )
-    assert general.get_best_selling_products(context, n_products=n_products, sale_items_only=True) == [product_4]
+    cache.clear()
+    for cache_test in range(2):
+        best_selling = general.get_best_selling_products(context, n_products=n_products, sale_items_only=True)
+        assert len(best_selling) == 1
+        assert product_4 in best_selling
 
 
 @pytest.mark.django_db
@@ -282,7 +318,8 @@ def test_get_newest_products():
 
     context = get_jinja_context()
 
-    newest_products = list(general.get_newest_products(context, n_products=10))
+    for cache_test in range(2):
+        newest_products = list(general.get_newest_products(context, n_products=10))
     # only 2 products exist
     assert len(newest_products) == 2
     assert products[0] in newest_products
@@ -291,7 +328,8 @@ def test_get_newest_products():
     # Delete one product
     products[0].soft_delete()
 
-    newest_products = list(general.get_newest_products(context, n_products=10))
+    for cache_test in range(2):
+        newest_products = list(general.get_newest_products(context, n_products=10))
     # only 2 products exist
     assert len(newest_products) == 1
     assert products[0] not in newest_products
@@ -307,8 +345,10 @@ def test_get_newest_products_sale_only():
     product = create_product("sku-1", supplier=supplier, shop=shop, default_price=10)
     context = get_jinja_context()
 
-    assert len(general.get_newest_products(context, n_products=10)) == 1
-    assert len(general.get_newest_products(context, n_products=10, sale_items_only=True)) == 0
+    cache.clear()
+    for cache_test in range(2):
+        assert len(general.get_newest_products(context, n_products=10)) == 1
+        assert len(general.get_newest_products(context, n_products=10, sale_items_only=True)) == 0
 
     # add a catalog campaign discount for the product
     from shuup.campaigns.models import CatalogCampaign
@@ -320,8 +360,10 @@ def test_get_newest_products_sale_only():
     campaign.filters.add(product_filter)
     ProductDiscountAmount.objects.create(campaign=campaign, discount_amount=0.1)
 
-    assert len(general.get_newest_products(context, n_products=10, sale_items_only=True)) == 1
-    assert product in general.get_newest_products(context, n_products=10, sale_items_only=True)
+    cache.clear()
+    for cache_test in range(2):
+        assert len(general.get_newest_products(context, n_products=10, sale_items_only=True)) == 1
+        assert product in general.get_newest_products(context, n_products=10, sale_items_only=True)
 
 
 @pytest.mark.django_db
@@ -355,8 +397,10 @@ def test_get_random_products_sale_only():
     product = create_product("sku-1", supplier=supplier, shop=shop, default_price=10)
     context = get_jinja_context()
 
-    assert len(general.get_random_products(context, n_products=10)) == 1
-    assert len(general.get_random_products(context, n_products=10, sale_items_only=True)) == 0
+    cache.clear()
+    for cache_test in range(2):
+        assert len(general.get_random_products(context, n_products=10)) == 1
+        assert len(general.get_random_products(context, n_products=10, sale_items_only=True)) == 0
 
     # add a catalog campaign discount for the product
     from shuup.campaigns.models import CatalogCampaign
@@ -368,8 +412,10 @@ def test_get_random_products_sale_only():
     campaign.filters.add(product_filter)
     ProductDiscountAmount.objects.create(campaign=campaign, discount_amount=0.1)
 
-    assert len(general.get_random_products(context, n_products=10, sale_items_only=True)) == 1
-    assert product in general.get_random_products(context, n_products=10, sale_items_only=True)
+    cache.clear()
+    for cache_test in range(2):
+        assert len(general.get_random_products(context, n_products=10, sale_items_only=True)) == 1
+        assert product in general.get_random_products(context, n_products=10, sale_items_only=True)
 
 
 @pytest.mark.django_db

--- a/shuup_tests/xtheme/test_theme.py
+++ b/shuup_tests/xtheme/test_theme.py
@@ -6,7 +6,6 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
-from django.test import override_settings
 
 from shuup.apps.provides import override_provides
 from shuup.core import cache
@@ -21,50 +20,36 @@ from shuup_tests.xtheme.utils import FauxTheme, FauxTheme2
 
 @pytest.mark.django_db
 def test_theme_activation():
-    with override_settings(CACHES={
-        'default': {
-            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-            'LOCATION': 'test_configuration_cache',
-        }
-    }):
-        cache.init_cache()
-        shop = get_default_shop()
+    cache.init_cache()
+    shop = get_default_shop()
 
-        with override_provides("xtheme", [
-            "shuup_tests.xtheme.utils:FauxTheme",
-            "shuup_tests.xtheme.utils:FauxTheme2"
-        ]):
-            theme = get_current_theme(shop)
-            assert theme is None
-            set_current_theme(FauxTheme.identifier, shop)
-            assert isinstance(get_current_theme(shop), FauxTheme)
-            set_current_theme(FauxTheme2.identifier, shop)
-            assert isinstance(get_current_theme(shop), FauxTheme2)
-            with pytest.raises(ValueError):
-                set_current_theme(printable_gibberish(), shop)
+    with override_provides("xtheme", [
+        "shuup_tests.xtheme.utils:FauxTheme",
+        "shuup_tests.xtheme.utils:FauxTheme2"
+    ]):
+        set_current_theme(FauxTheme.identifier, shop)
+        assert isinstance(get_current_theme(shop), FauxTheme)
+        set_current_theme(FauxTheme2.identifier, shop)
+        assert isinstance(get_current_theme(shop), FauxTheme2)
+        with pytest.raises(ValueError):
+            set_current_theme(printable_gibberish(), shop)
 
 
 @pytest.mark.django_db
 def test_theme_settings_api():
-    with override_settings(CACHES={
-        'default': {
-            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-            'LOCATION': 'test_configuration_cache',
+    cache.init_cache()
+    shop = get_default_shop()
+    with override_provides("xtheme", [
+        "shuup_tests.xtheme.utils:FauxTheme",
+        "shuup_tests.xtheme.utils:FauxTheme2"
+    ]):
+        ThemeSettings.objects.all().delete()
+        theme = get_theme_by_identifier(FauxTheme2.identifier, shop)
+        theme.set_setting("foo", "bar")
+        theme.set_settings(quux=[4, 8, 15, 16, 23, 42])
+        theme = get_theme_by_identifier(FauxTheme2.identifier, shop)
+        assert theme.get_setting("foo") == "bar"
+        assert theme.get_settings() == {
+            "foo": "bar",
+            "quux": [4, 8, 15, 16, 23, 42]
         }
-    }):
-        cache.init_cache()
-        shop = get_default_shop()
-        with override_provides("xtheme", [
-            "shuup_tests.xtheme.utils:FauxTheme",
-            "shuup_tests.xtheme.utils:FauxTheme2"
-        ]):
-            ThemeSettings.objects.all().delete()
-            theme = get_theme_by_identifier(FauxTheme2.identifier, shop)
-            theme.set_setting("foo", "bar")
-            theme.set_settings(quux=[4, 8, 15, 16, 23, 42])
-            theme = get_theme_by_identifier(FauxTheme2.identifier, shop)
-            assert theme.get_setting("foo") == "bar"
-            assert theme.get_settings() == {
-                "foo": "bar",
-                "quux": [4, 8, 15, 16, 23, 42]
-            }

--- a/shuup_workbench/test_settings.py
+++ b/shuup_workbench/test_settings.py
@@ -228,13 +228,6 @@ SHUUP_ERROR_PAGE_HANDLERS_SPEC = [
 
 SHUUP_SIMPLE_SEARCH_LIMIT = 150
 
-# Disable caches for tests
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-    }
-}
-
 
 if os.environ.get("SHUUP_WORKBENCH_DISABLE_MIGRATIONS") == "1":
     from .settings.utils import get_disabled_migrations


### PR DESCRIPTION
Enabling cache will simulate better the real world scenario when Shuup is deployed.

Refs #1375