### PR TITLE
Test Results Management for Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ lib/
 lib64/
 local_settings.py
 nosetests.xml
+testresults.xml
 parts/
 pip-delete-this-directory.txt
 pip-log.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,8 +89,15 @@ install:
   - pip install tox
   - pip install coveralls
   - pip install codecov
+  - mkdir -p $HOME/bin
+  - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+  - testspace config url $TS_ORG.testspace.com
 script:
   - tox
+after_script:
+  - if [[ "${TOXENV}" =~ ^py ]] ; then
+      testspace [${TOXENV/-/\/}]testresults.xml{.} --link=coveralls;
+    fi
 after_success:
   - coveralls
   - codecov

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ usedevelop = {env:USE_DEVELOP:True}
 commands =
     browser: pip install .
     py.test \
-     -ra --doctest-modules \
+     -ra --doctest-modules --junit-xml=testresults.xml \
      {env:COV_ARGS:--cov shuup --cov-config=.coveragerc} \
      {posargs:{env:TEST_ARGS:shuup_tests shuup}}
 


### PR DESCRIPTION

We’ve made a few minor changes to demonstrate how [Testspace.com](https://www.testspace.com/) can be used by your team to better manage your **test results**. Note that there is **no** impact on the workflow and the product is **completely free** for open source.

YOUR TEST RESULTS from `our fork` at https://open.testspace.com/projects/TryTestspace:shuup.

Testspace Badge:

[![Space Health](https://open.testspace.com/spaces/122275/badge?token=4406405800b7219da76bcf53d519eb689ef4291c)](https://open.testspace.com/spaces/122275?utm_campaign=badge&utm_medium=referral&utm_source=test "Test Cases")

**FYI** we noticed some instability in the test results. Take a look here: https://open.testspace.com/spaces/122275/result_sets. There seems to be some random failures once in a while.

----

We use Testspace for our own development along with `GitHub` and `Circle CI`. To see how Testspace really works, check out our demo.

**LIVE DEMO**: https://demo.testspace.com. 

#### Setup is Easy

1. Create a free [Open Source Account](https://signup.testspace.com/?plan_id=open.2)
2. Create a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on name selected in step 1
