### PR TITLE
Owl Carousel plugin set to the newest version

### DIFF
--- a/shuup/front/bower.json
+++ b/shuup/front/bower.json
@@ -18,6 +18,6 @@
     "font-awesome": "4.4.0",
     "bootstrap-select": "1.6.5",
     "jquery.easing": "1.3.1",
-    "owl.carousel": "2.0.0-beta.3"
+    "owl.carousel": "2.3.4"
   }
 }

--- a/shuup/themes/classic_gray/bower.json
+++ b/shuup/themes/classic_gray/bower.json
@@ -14,6 +14,6 @@
     "tests"
   ],
   "dependencies": {
-    "owl.carousel": "2.0.0-beta.3"
+    "owl.carousel": "2.3.4"
   }
 }


### PR DESCRIPTION
This fixes the carousel bug that occurs on IE Mobile 11.

Ref: POS-2512