### PR TITLE
Admin: Add option to filter product with categories

### DIFF
--- a/shuup/admin/modules/products/views/list.py
+++ b/shuup/admin/modules/products/views/list.py
@@ -33,42 +33,60 @@ class ProductListView(PicotableListView):
     picotable_class = ProductPicotable
 
     default_columns = [
-        Column("primary_image",
-               _(u"Primary Image"),
-               display="get_primary_image",
-               class_name="text-center",
-               raw=True,
-               ordering=1,
-               sortable=False),
-        Column("name",
-               _(u"Name"),
-               sort_field="product__translations__name",
-               display="product__name",
-               filter_config=TextFilter(filter_field="product__translations__name",
-                                        placeholder=_("Filter by name...")),
-               ordering=2),
-        Column("shop",
-               _("Shop"),
-               ordering=2),
-        Column("sku",
-               _(u"SKU"),
-               display="product__sku",
-               filter_config=RangeFilter(filter_field="product__sku"),
-               ordering=3),
-        Column("barcode",
-               _(u"Barcode"),
-               display="product__barcode",
-               filter_config=TextFilter(placeholder=_("Filter by barcode...")),
-               ordering=4),
-        Column("type",
-               _(u"Type"),
-               display="product__type",
-               ordering=5),
-        Column("mode",
-               _(u"Mode"),
-               display="product__mode",
-               filter_config=ChoicesFilter(ProductMode.choices),
-               ordering=6),
+        Column(
+            "primary_image",
+            _(u"Primary Image"),
+            display="get_primary_image",
+            class_name="text-center",
+            raw=True,
+            ordering=1,
+            sortable=False),
+        Column(
+            "name",
+            _(u"Name"),
+            sort_field="product__translations__name",
+            display="product__name",
+            filter_config=TextFilter(
+                filter_field="product__translations__name",
+                placeholder=_("Filter by name...")
+            ),
+            ordering=2),
+        Column(
+            "sku",
+            _(u"SKU"),
+            display="product__sku",
+            filter_config=RangeFilter(filter_field="product__sku"),
+            ordering=3),
+        Column(
+            "barcode",
+            _(u"Barcode"),
+            display="product__barcode",
+            filter_config=TextFilter(placeholder=_("Filter by barcode...")),
+            ordering=4),
+        Column(
+            "mode",
+            _(u"Mode"),
+            display="product__mode",
+            filter_config=ChoicesFilter(ProductMode.choices),
+            ordering=5),
+        Column(
+            "primary_category",
+            _("Primary Category"),
+            display="primary_category",
+            filter_config=TextFilter(
+                filter_field="primary_category__translations__name",
+                placeholder=_("Filter by category name...")
+            ),
+            ordering=6),
+        Column(
+            "categories",
+            _("Categories"),
+            display="categories",
+            filter_config=TextFilter(
+                filter_field="categories__translations__name",
+                placeholder=_("Filter by category name...")
+            ),
+            ordering=7)
     ]
 
     related_objects = [

--- a/shuup_tests/browser/admin/test_picotable.py
+++ b/shuup_tests/browser/admin/test_picotable.py
@@ -46,8 +46,8 @@ list_view_settings = {
     },
     "shop_product": {
         "page_header": "Shop Products",
-        "default_column_count": 6,
-        "addable_fields": [(13, "Gtin"), (6, "Default Price")],
+        "default_column_count": 7,
+        "addable_fields": [(12, "Gtin"), (5, "Default Price")],
         "creator": create_products,
         "test_pagination": False
     },


### PR DESCRIPTION
Well there is certain limitations with our Picotable filters since for example filtering with categories would require to use current shop  to filter the filter options. The name filter here looks pretty handy. When we have the admin design update done maybe we then introduce more options for related filters.

Since pretty much only option to add filters to the columns is define column as default column I removed few to add the categories. Shop shouldn't be needed since the products are already filtered by currently active shop. Also product type shouldn't have too much importance in basic installation.