### PR TITLE
Xtheme:  make the initially selected language be the active one in form tabs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,8 @@ matrix:
     - {python: 3.6, env: TOXENV=py36-django19-nomigrations}
     - {python: 2.7, env: TOXENV=py27-django111-nomigrations}
     - {python: 3.5, env: TOXENV=py35-django111-nomigrations}
-    - {python: 3.5, env: TOXENV=py35-django111-nomigrations}
     - {python: 3.6, env: TOXENV=py36-django111}
+    - {python: 3.6, env: TOXENV=py36-django111-nomigrations}
     - python: 3.6
       env: TOXENV=py36-django111-nomigrations-nocoverage-browser-travis-admin
       before_install:

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -22,6 +22,7 @@ Bug fixes
 - Fix order printouts template by checking whether the addresses are valid
   before calling methods.
 - Fix front manufacturer modified filter to consider only visible shop products
+- Make Xtheme TextPlugin fallback to empty string when there is no translation for the current language.
 
 Front
 ~~~~~

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -45,6 +45,7 @@ Simple CMS
 Xtheme
 ~~~~~~
 
+- Make the Parler default language be the first language in plugin multi-language form
 - Add option to render extra templates in theme configuration.
 - Add option for per object placeholders
 - Fix bug deleting last row from placeholder

--- a/shuup/admin/template_helpers/shuup_admin.py
+++ b/shuup/admin/template_helpers/shuup_admin.py
@@ -181,3 +181,9 @@ def get_admin_shop(context):
 @contextfunction
 def is_multishop_enabled(context):
     return settings.SHUUP_ENABLE_MULTIPLE_SHOPS is True
+
+
+@contextfunction
+def get_current_language(context):
+    from django.utils.translation import get_language
+    return get_language()

--- a/shuup/admin/templates/shuup/admin/macros/multilanguage.jinja
+++ b/shuup/admin/templates/shuup/admin/macros/multilanguage.jinja
@@ -15,7 +15,7 @@ When using multiple language_dependent_content_tabs in a single page, do remembe
         <div class="col-sm-8 col-sm-push-4 col-lg-6 col-lg-push-3">
             <ul class="nav nav-tabs">
                 {% for language in form.languages %}
-                <li role="presentation" {% if loop.first %}class="active"{% endif %} data-lang="{{ language }}">
+                <li role="presentation" {% if language == shuup_admin.get_current_language() %}class="active"{% endif %} data-lang="{{ language }}">
                     <a href="#{{ tab_id_prefix }}-{{ language }}" role="tab" data-toggle="tab">{{ form.language_names[language] }}</a>
                 </li>
                 {% endfor %}
@@ -25,7 +25,7 @@ When using multiple language_dependent_content_tabs in a single page, do remembe
     {% endif %}
     <div class="tab-content">
         {% for language in form.languages %}
-            <div class="tab-pane fade {% if loop.first %}in active{% endif %}" id="{{ tab_id_prefix }}-{{ language }}" data-lang="{{ language }}">
+            <div class="tab-pane fade {% if language == shuup_admin.get_current_language() %}in active{% endif %}" id="{{ tab_id_prefix }}-{{ language }}" data-lang="{{ language }}">
                 {% set map = form.trans_name_map[language] %}
                 {% if caller %}
                     {{ caller(form, language, map) }}

--- a/shuup/testing/browser_utils.py
+++ b/shuup/testing/browser_utils.py
@@ -121,3 +121,14 @@ def click_element(browser, css_selector, timeout=10, frequency=1.0, header_heigh
         timeout=timeout,
         frequency=frequency)
     browser.find_by_css(css_selector).click()
+
+
+def page_has_loaded(browser):
+    """
+    Returns whether the page has loaded
+
+    :param browser:
+    :type browser: splinter.browser.Browser
+    :rtype bool
+    """
+    return browser.evaluate_script("document.readyState") == "complete"

--- a/shuup/testing/utils.py
+++ b/shuup/testing/utils.py
@@ -111,7 +111,7 @@ def initialize_front_browser_test(browser, live_server):
 
 
 def initialize_admin_browser_test(
-        browser, live_server, settings, username="admin", password="password", onboarding=False):
+        browser, live_server, settings, username="admin", password="password", onboarding=False, language="en"):
     if not onboarding:
         settings.SHUUP_SETUP_WIZARD_PANE_SPEC = []
     activate("en")
@@ -126,6 +126,6 @@ def initialize_admin_browser_test(
     if not onboarding:
         # set shop language to eng
         browser.find_by_id("dropdownMenu").click()
-        browser.find_by_xpath('//a[@data-value="en"]').first.click()
+        browser.find_by_xpath('//a[@data-value="%s"]' % language).first.click()
 
     return browser

--- a/shuup/xtheme/plugins/forms.py
+++ b/shuup/xtheme/plugins/forms.py
@@ -101,7 +101,13 @@ class PluginForm(forms.Form):
         return config
 
     def get_languages(self):
-        return [l[0] for l in settings.LANGUAGES] + [FALLBACK_LANGUAGE_CODE]
+        default_language = settings.PARLER_DEFAULT_LANGUAGE_CODE
+        languages = [l[0] for l in settings.LANGUAGES]
+
+        if default_language in languages:
+            languages.remove(default_language)
+
+        return [default_language] + languages + [FALLBACK_LANGUAGE_CODE]
 
 
 class GenericPluginForm(PluginForm):

--- a/shuup/xtheme/plugins/text.py
+++ b/shuup/xtheme/plugins/text.py
@@ -28,5 +28,5 @@ class TextPlugin(Plugin):
     ]
 
     def render(self, context):  # doccov: ignore
-        text = self.get_translated_value("text")
+        text = self.get_translated_value("text", default="")
         return mark_safe(text)

--- a/shuup/xtheme/templates/shuup/xtheme/_editor_cell.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/_editor_cell.jinja
@@ -1,6 +1,8 @@
-<button class="del-cell-btn"
-        data-x="{{ current_cell_coords[0] }}"
-        data-y="{{ current_cell_coords[1] }}">
+<button
+    class="del-cell-btn"
+    data-x="{{ current_cell_coords[0] }}"
+    data-y="{{ current_cell_coords[1] }}"
+>
     <i class="fa fa-trash"></i> {% trans %}Delete This Cell{% endtrans %}
 </button>
 
@@ -19,7 +21,7 @@
                 <div>
                     <ul class="editor-tabs nav nav-tabs">
                         {% for language_code in form.plugin.get_languages() %}
-                        <li role="presentation" {% if loop.first %}class="active"{% endif %}>
+                        <li role="presentation" {% if language_code == LANGUAGE_CODE %}class="active"{% endif %}>
                             {% if language_code == "*" %}
                                 <a href="#untranslated" data-toggle="tab">{% trans %}Untranslated{% endtrans %}</a>
                             {% else %}
@@ -30,7 +32,7 @@
                     </ul>
                     <div class="tab-content">
                         {% for language_code in form.plugin.get_languages() %}
-                            <div role="tabpanel" class="tab-pane {% if loop.first %}active{% endif %}"
+                            <div role="tabpanel" class="tab-pane {% if language_code == LANGUAGE_CODE %}active{% endif %}"
                                 {% if language_code == "*" %}
                                     id="untranslated"
                                 {% else %}

--- a/shuup/xtheme/templates/shuup/xtheme/editor.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/editor.jinja
@@ -20,7 +20,7 @@
 </div>
 {% include "shuup/xtheme/_editor_layout.jinja" %}
 {% if current_cell %}
-    {% include "shuup/xtheme/_editor_cell.jinja" %}
+    {% include "shuup/xtheme/_editor_cell.jinja" with context %}
 {% endif %}
 {% if changed %}
     <script>refreshPlaceholderInParent({{ layout.placeholder_name|json }});</script>

--- a/shuup_tests/browser/front/test_xtheme_plugin_form.py
+++ b/shuup_tests/browser/front/test_xtheme_plugin_form.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+
+import time
+import pytest
+from django.test.utils import override_settings
+
+from django.utils.translation import get_language, activate
+from shuup.testing.browser_utils import (
+    click_element, page_has_loaded, wait_until_appeared,
+    wait_until_condition
+)
+from shuup.testing.utils import initialize_admin_browser_test
+
+pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
+
+
+
+@pytest.mark.parametrize("default_language", ["it", "pt-br", "fi"])
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_xtheme_plugin_form_language_order(admin_user, browser, live_server, settings, default_language):
+    """
+    Test that the first language option is the Parler default
+
+    As you can see, we check for that the page has loaded and we use a sleep of 1 second.
+    This is necessary specially into iframes. On this test, when we click to add a new plugin row
+    or after a row selection, the iframe content is changed through a request,
+    like a internal link when user clicks on a anchor. We have to make sure the NEW content is loaded
+    before doing any element check, because it looks like the iframe won't find the correct elements
+    if you start checking that before the new content gets loaded.
+    """
+    with override_settings(PARLER_DEFAULT_LANGUAGE_CODE=default_language):
+        browser = initialize_admin_browser_test(browser, live_server, settings)
+        browser.visit(live_server + "/")
+
+        # Start edit
+        wait_until_condition(browser, lambda x: page_has_loaded(x), timeout=20)
+        wait_until_appeared(browser, ".xt-edit-toggle button[type='submit']")
+        click_element(browser, ".xt-edit-toggle button[type='submit']")
+
+        placeholder_selector = "#xt-ph-front_content-xtheme-person-contact-layout"
+        placeholder_name = "front_content"
+        wait_until_condition(browser, lambda x: x.is_element_present_by_css(placeholder_selector))
+        click_element(browser, placeholder_selector)
+
+        with browser.get_iframe("xt-edit-sidebar-iframe") as iframe:
+            # make sure all scripts are loaded
+            wait_until_condition(iframe, lambda x: page_has_loaded(x), timeout=20)
+
+            wait_until_condition(iframe, lambda x: x.is_text_present("Edit Placeholder: %s" % placeholder_name))
+            wait_until_appeared(iframe, "button.layout-add-row-btn")
+            time.sleep(1)
+            wait_until_condition(iframe, lambda x: page_has_loaded(x), timeout=20)
+
+            # click to add a new row
+            click_element(iframe, "button.layout-add-row-btn")
+            time.sleep(1)
+            wait_until_condition(iframe, lambda x: page_has_loaded(x), timeout=20)
+
+            # select the last row (the added one)
+            click_element(iframe, "button.layout-add-row-btn")
+            iframe.find_by_css("div.layout-cell").last.click()
+            time.sleep(1)
+            wait_until_condition(iframe, lambda x: page_has_loaded(x), timeout=20)
+
+            # select the TextPlugin
+            wait_until_appeared(iframe, "select[name='general-plugin']")
+            iframe.select("general-plugin", "text")
+            time.sleep(1)
+            wait_until_condition(iframe, lambda x: page_has_loaded(x), timeout=20)
+            wait_until_appeared(iframe, "ul.editor-tabs")
+
+            # check the languages order
+            languages = [el.text for el in iframe.find_by_css("ul.editor-tabs li a")]
+            assert languages[0] == default_language
+
+
+@pytest.mark.parametrize("language", ["it", "pt-br", "fi", "en"])
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_xtheme_plugin_form_selected_language_pane(admin_user, browser, live_server, settings, language):
+    """
+    Test that the current language is selected by default
+    """
+    browser = initialize_admin_browser_test(browser, live_server, settings, language=language)
+    browser.visit(live_server + "/")
+
+    # Start edit
+    wait_until_condition(browser, lambda x: page_has_loaded(x), timeout=20)
+    wait_until_appeared(browser, ".xt-edit-toggle button[type='submit']")
+    click_element(browser, ".xt-edit-toggle button[type='submit']")
+
+    placeholder_selector = "#xt-ph-front_content-xtheme-person-contact-layout"
+    wait_until_condition(browser, lambda x: x.is_element_present_by_css(placeholder_selector))
+    click_element(browser, placeholder_selector)
+
+    with browser.get_iframe("xt-edit-sidebar-iframe") as iframe:
+        # make sure all scripts are loaded
+        wait_until_condition(iframe, lambda x: page_has_loaded(x), timeout=20)
+
+        wait_until_condition(iframe, lambda x: x.is_text_present("front_content"))
+        wait_until_appeared(iframe, "button.layout-add-row-btn")
+        time.sleep(1)
+        wait_until_condition(iframe, lambda x: page_has_loaded(x), timeout=20)
+
+        # click to add a new row
+        click_element(iframe, "button.layout-add-row-btn")
+        time.sleep(1)
+        wait_until_condition(iframe, lambda x: page_has_loaded(x), timeout=20)
+
+        # select the last row (the added one)
+        click_element(iframe, "button.layout-add-row-btn")
+        iframe.find_by_css("div.layout-cell").last.click()
+        time.sleep(1)
+        wait_until_condition(iframe, lambda x: page_has_loaded(x), timeout=20)
+
+        # select the TextPlugin
+        wait_until_appeared(iframe, "select[name='general-plugin']")
+        iframe.select("general-plugin", "text")
+        time.sleep(1)
+        wait_until_condition(iframe, lambda x: page_has_loaded(x), timeout=20)
+        wait_until_appeared(iframe, "ul.editor-tabs")
+
+        # check the active language
+        assert language == iframe.find_by_css("ul.editor-tabs li.active a").first.text


### PR DESCRIPTION
Make the initial selected language be the current language in multi-language forms to save extra clicks from users.

Improve xtheme to make TextPlugin fallback to empty string instead of `None` and also make the Parler default language be the first one in multi-language forms.

Refs POS-2510