### PR TITLE
Front: Fix Windows phone & iOS issues (POS-2513)

### DIFF
--- a/shuup/gdpr/static_src/js/index.js
+++ b/shuup/gdpr/static_src/js/index.js
@@ -8,6 +8,14 @@
  */
 
 (() => {
+
+    $(document).ready(function() {
+        if(navigator.userAgent.match(/Windows Phone/i)){
+            $(".gdpr-consent-warn-content").addClass("windows-phone");
+        }
+
+    });
+
     $("#privacy-preferences-btn").click(() => {
         $(".gdpr-consent-preferences").addClass("visible");
         $("body").addClass("body-noscroll");

--- a/shuup/gdpr/static_src/less/index.less
+++ b/shuup/gdpr/static_src/less/index.less
@@ -24,6 +24,12 @@
         justify-content: space-between;
         align-items: center;
 
+        &.windows-phone {
+            display: block;
+        }
+        div.consent-content {
+            flex: 1;
+        }
         #privacy-preferences-btn {
             white-space: nowrap;
             color: white !important;
@@ -31,7 +37,6 @@
         #agree-btn {
             padding: 0.5em 1em;
         }
-
         @media (max-width: 768px) {
             flex-direction: column;
 
@@ -97,7 +102,7 @@
             }
 
             .consent-view {
-                width: 100%;
+                width: 80%;
                 display: flex;
                 flex-direction: column;
                 max-height: 300px;

--- a/shuup/gdpr/templates/shuup/gdpr/gdpr_consent.jinja
+++ b/shuup/gdpr/templates/shuup/gdpr/gdpr_consent.jinja
@@ -7,7 +7,7 @@
 
 <div class="gdpr-consent-warn-bar">
     <div class="gdpr-consent-warn-content">
-        <p>{{ gdpr_settings.cookie_banner_content|safe }}</p>
+        <div class="consent-content">{{ gdpr_settings.cookie_banner_content|safe }}</div>
         <a href="#" id="privacy-preferences-btn">{{ _("Privacy Preferences") }}</a>
         <button class="btn btn-info" id="agree-btn">
             <i class="fa fa-check"></i>


### PR DESCRIPTION
Fixed gdpr-privacy bar issues with iOS & Windows phone (On Win Phone the text would go over the screen, on iOS the 'accept' button wasn't visible when rotated horizontally) 
Also fixed the privacy-preference box issue, the text was showing up outside of the box on mobile devices.

Tickets for some of the issues here don't exist. 