### PR TITLE
Fix MPTT version to max 0.9.0 for Django <= 1.9

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,10 @@ deps =
     # Django
     django18: django>=1.8,<1.9
     django18: django-polymorphic>=0.8.0,<0.10
+    django18: django-mptt>=0.8.0,<=0.9.0
     django19: django>=1.9,<1.10
     django19: django-polymorphic>=0.8.0,<0.10
+    django19: django-mptt>=0.8.0,<=0.9.0
     django111: django>=1.11,<2
     # Do not remove the following BEGIN/END comments. setup.py uses them
     # BEGIN testing deps


### PR DESCRIPTION
MPTT 0.9.1 dropped support for old Django versions

https://github.com/django-mptt/django-mptt/commit/b18933b24a8ab25e91916e4fc3104a867eadcf88