### PR TITLE
Importer: do not change the current shop for existing shop products

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -15,6 +15,11 @@ General
 - Changed the way static resources are built.
   Parcel is used to build all apps and `generated_resources.txt` is auto-generated.
 
+Importer
+~~~~~~~~
+
+- Removed shop field from importer form and using the current admin shop
+
 Shuup 1.6.9
 -----------
 

--- a/shuup/admin/template_helpers/shuup_admin.py
+++ b/shuup/admin/template_helpers/shuup_admin.py
@@ -20,6 +20,7 @@ from jinja2.utils import contextfunction
 from shuup import configuration
 from shuup.admin import menu
 from shuup.admin.breadcrumbs import Breadcrumbs
+from shuup.admin.shop_provider import get_shop
 from shuup.admin.utils.urls import manipulate_query_string, NoModelUrl
 from shuup.apps.provides import get_provide_objects
 from shuup.core.models import Shop
@@ -150,7 +151,7 @@ def model_url(context, model, kind="detail", default=None, **kwargs):
     user = context.get("user")
     try:
         request = context.get("request")
-        shop = request.shop if request else None
+        shop = get_shop(request) if request else None
         admin_model_url_resolvers = get_provide_objects("admin_model_url_resolver")
 
         for resolver in admin_model_url_resolvers:

--- a/shuup/default_importer/importers/product.py
+++ b/shuup/default_importer/importers/product.py
@@ -171,15 +171,7 @@ class ProductMetaBase(ImportMetaBase):
 
     def postsave_hook(self, sess):
         # get all the special values
-
-        try:
-            shop_product = ShopProduct.objects.get(product=sess.instance)
-        except:
-            shop_product = ShopProduct()
-
-        shop_product.shop = sess.shop
-        shop_product.product = sess.instance
-        shop_product.save()
+        shop_product = ShopProduct.objects.get_or_create(product=sess.instance, shop=sess.shop)[0]
 
         matched_fields = []
         for k, v in six.iteritems(sess.importer.extra_matches):

--- a/shuup/importer/admin_module/forms.py
+++ b/shuup/importer/admin_module/forms.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from enumfields import EnumField
 
-from shuup.core.models import Shop
 from shuup.importer.utils import get_importer_choices
 from shuup.importer.utils.importer import ImportMode
 
@@ -23,7 +22,6 @@ class ImportForm(forms.Form):
     language = forms.ChoiceField(label=_("Importing language"), choices=settings.LANGUAGES, help_text=_(
         "The language of the data you would like to import."
     ))
-    shop = forms.ChoiceField(label=_("Shop"), help_text=_("Select a shop you want import into"))
     importer = forms.ChoiceField(label=_("Importer"), help_text=_(
         "Select a importer type matching the data you would like to import"))
     file = forms.FileField(label=_("File"))
@@ -31,7 +29,4 @@ class ImportForm(forms.Form):
     def __init__(self, **kwargs):
         self.request = kwargs.pop("request")
         super(ImportForm, self).__init__(**kwargs)
-        self.fields["shop"].choices = [
-            (shop.pk, shop.name) for shop in Shop.objects.filter(staff_members=self.request.user)
-        ]
         self.fields["importer"].choices = get_importer_choices()

--- a/shuup/importer/admin_module/import_views.py
+++ b/shuup/importer/admin_module/import_views.py
@@ -18,7 +18,7 @@ from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import FormView, TemplateView, View
 
-from shuup.core.models import Shop
+from shuup.admin.shop_provider import get_shop
 from shuup.importer.admin_module.forms import ImportForm, ImportSettingsForm
 from shuup.importer.transforms import transform_file
 from shuup.importer.utils import (
@@ -36,7 +36,6 @@ class ImportProcessView(TemplateView):
     def dispatch(self, request, *args, **kwargs):
         self.importer_cls = get_importer(request.GET.get("importer"))
         self.model_str = request.GET.get("importer")
-        self.shop = Shop.objects.get(pk=request.GET.get("shop"), staff_members=request.user)
         self.lang = request.GET.get("lang")
         return super(ImportProcessView, self).dispatch(request, *args, **kwargs)
 
@@ -62,7 +61,7 @@ class ImportProcessView(TemplateView):
         if self.data is None:
             return False
 
-        self.importer = self.importer_cls(self.data, self.shop, self.lang)
+        self.importer = self.importer_cls(self.data, get_shop(self.request), self.lang)
         self.importer.process_data()
 
         if self.request.method == "POST":
@@ -129,9 +128,8 @@ class ImportView(FormView):
 
         next_url = request.POST.get("next")
         importer = request.POST.get("importer")
-        shop_id = request.POST.get("shop")
         lang = request.POST.get("language")
-        return redirect("%s?n=%s&importer=%s&shop=%s&lang=%s" % (next_url, import_name, importer, shop_id, lang))
+        return redirect("%s?n=%s&importer=%s&lang=%s" % (next_url, import_name, importer, lang))
 
     def get_form_kwargs(self):
         kwargs = super(ImportView, self).get_form_kwargs()


### PR DESCRIPTION
- Create a new shop product for the current shop when importing products. The importer was changing the shop of existing shop products to the current importer one
- Removed shop field from importer form and using the current admin shop

Refs POS-2538