### PR TITLE
Front: add edit object link to admin toolbar

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,6 +18,7 @@ Front
 ~~~~~
 
 - Bump template helpers caches when shop products and manufacturers are saved
+- Add edit in admin button to toolbar to enable editing the current object in admin page
 
 General
 ~~~~~~~

--- a/shuup/admin/template_helpers/shuup_admin.py
+++ b/shuup/admin/template_helpers/shuup_admin.py
@@ -158,7 +158,6 @@ def model_url(context, model, kind="detail", default=None, **kwargs):
             url = resolver(model, kind=kind, user=user, shop=shop, **kwargs)
             if url:
                 return url
-
     except NoModelUrl:
         return default
 

--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-19 20:39+0000\n"
+"POT-Creation-Date: 2018-08-16 22:09+0000\n"
 "PO-Revision-Date: 2016-08-04 10:51-0700\n"
 "Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
@@ -819,9 +819,6 @@ msgstr ""
 msgid "Change customer mode to guest"
 msgstr ""
 
-msgid "Toggle navigation"
-msgstr ""
-
 msgid "Tools"
 msgstr ""
 
@@ -841,6 +838,17 @@ msgid "COMPANY CONTACT"
 msgstr ""
 
 msgid "PERSON CONTACT"
+msgstr ""
+
+msgid "Toggle navigation"
+msgstr ""
+
+#, python-brace-format
+msgid "Edit '{object_title}' in administration page"
+msgstr ""
+
+#, python-brace-format
+msgid "Edit {object_name} in Admin"
 msgstr ""
 
 msgid "Shop Administration"

--- a/shuup/front/static_src/less/front/navigation.less
+++ b/shuup/front/static_src/less/front/navigation.less
@@ -334,4 +334,26 @@
             }
         }
     }
+
+    #admin-tools-menu {
+        li.nav-button {
+            padding: .9rem 1rem;
+
+            a {
+                display: inline-block;
+                appearance: none;
+                border: 0;
+                background: @brand-primary !important;
+                color: #fff !important;
+                font-size: 14px !important;
+                padding: 6px 12px;
+                border-radius: 4px;
+                font-weight: bold;
+                transition: background 0.1s;
+                &:hover, &:focus {
+                    background: darken(@brand-primary, 5%) !important;
+                }
+            }
+        }
+    }
 }

--- a/shuup/front/template_helpers/general.py
+++ b/shuup/front/template_helpers/general.py
@@ -422,3 +422,14 @@ def can_toggle_all_seeing(context):
         # 'is all seeing' is purely person contact feature.
         return False
     return getattr(request.user, "is_superuser", False)
+
+
+@contextfunction
+def get_admin_edit_url(context, intance_or_model):
+    from shuup.admin.template_helpers.shuup_admin import model_url
+    url = model_url(context, intance_or_model)
+    if url:
+        return dict(
+            url=url,
+            name=intance_or_model._meta.verbose_name.title(),
+        )

--- a/shuup/front/templates/shuup/front/macros/general.jinja
+++ b/shuup/front/templates/shuup/front/macros/general.jinja
@@ -216,16 +216,6 @@
     <nav class="navbar navbar-default navbar-admin-tools navbar-fixed-top">
         <div class="container-fluid">
             <div class="navbar-header">
-                <button type="button"
-                        class="navbar-toggle collapsed"
-                        data-toggle="collapse"
-                        data-target="#admin-tools-menu"
-                        aria-expanded="false">
-                    <span class="sr-only">{% trans %}Toggle navigation{% endtrans %}</span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </button>
                 <div class="navbar-brand">
                     <h2>{% trans %}Tools{% endtrans %}</h2>
                     <div class="admin-tools-info">
@@ -254,9 +244,33 @@
                         </div>
                     {% endif %}
                 </div>
+                <button type="button"
+                    class="navbar-toggle collapsed"
+                    data-toggle="collapse"
+                    data-target="#admin-tools-menu"
+                    aria-expanded="false">
+                <span class="sr-only">{% trans %}Toggle navigation{% endtrans %}</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
             </div>
             <div class="collapse navbar-collapse" id="admin-tools-menu">
                 <ul class="nav navbar-nav navbar-right">
+                {% if object %}
+                    {% set edit_object_url = shuup.general.get_admin_edit_url(object) %}
+                    {% if edit_object_url %}
+                        <li class="nav-button">
+                            <a
+                                href="{{ edit_object_url.url }}"
+                                target="_blank"
+                                title="{{ _("Edit '{object_title}' in administration page").format(object_title=object) }}"
+                            >
+                                {{ _("Edit {object_name} in Admin").format(object_name=edit_object_url.name) }}
+                            </a>
+                        </li>
+                    {% endif %}
+                {% endif %}
                     <li>
                         <a href="{{ url("shuup_admin:dashboard") }}" target="_blank">{% trans %}Shop Administration{% endtrans %}</a>
                     </li>

--- a/shuup_tests/front/test_edit_in_admin_toolbar.py
+++ b/shuup_tests/front/test_edit_in_admin_toolbar.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from bs4 import BeautifulSoup
+
+from shuup.testing.factories import (
+    get_default_category, get_default_product, get_default_shop)
+from shuup.front.views.product import ProductDetailView
+from shuup.testing.utils import apply_request_middleware
+from shuup.front.views.category import CategoryView
+from shuup.simple_cms.views import PageView
+from shuup_tests.simple_cms.utils import create_page
+from shuup.admin.utils.urls import get_model_url
+
+
+@pytest.mark.parametrize("view, function", [
+    (ProductDetailView, get_default_product),
+    (CategoryView, get_default_category),
+])
+@pytest.mark.django_db
+def test_edit_in_admin_url(rf, view, function, admin_user):
+    shop = get_default_shop()  # obvious prerequisite
+    shop.staff_members.add(admin_user)
+    model = function() # call the function get_default_model
+    view_func = view.as_view()
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
+    response = view_func(request, pk=model.pk)
+    response.render()
+    content = (response.content)
+    soup = BeautifulSoup(content)
+    check_url(soup, model)
+
+
+@pytest.mark.django_db
+def test_edit_page_in_admin_toolbar(rf, admin_user):
+    shop = get_default_shop()  # test 
+    shop.staff_members.add(admin_user)
+    model = create_page(shop=shop)
+    view = PageView.as_view()
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
+    response = view(request, url=model.url)
+    response.render()
+    content = (response.content)
+    soup = BeautifulSoup(content)
+    check_url(soup, model)
+
+
+def check_url(soup, model):
+    ul = soup.find('ul', class_="nav navbar-nav navbar-right")
+    a = ul.find_all('li')[0].find('a')
+    assert a.get('href') == get_model_url(model)


### PR DESCRIPTION
Add edit in admin button to toolbar to enable editing the current object in admin page

Refs POS-2487

![image](https://user-images.githubusercontent.com/8770370/44238025-441ad200-a189-11e8-83f3-caf33c15e509.png)
![image](https://user-images.githubusercontent.com/8770370/44238035-4c730d00-a189-11e8-8c0d-bcc2fba548cd.png)
