### PR TITLE
Front: Do not continue product reload without ajax div

### DIFF
--- a/shuup/front/static_src/js/category.js
+++ b/shuup/front/static_src/js/category.js
@@ -68,6 +68,9 @@ function getFilterString(state) {
 
 function reloadProducts(filterString) {
     const $cont = $("#ajax_content");
+    if ($cont.length === 0) {
+        return;
+    }
     const $prods = $(".products-wrap");
     const $adminMenu = $("#admin-tools-menu");
     const adminMenuHeight = ($adminMenu.length > 0) ? $adminMenu.height() : 0;


### PR DESCRIPTION
Things like for example Wishlist plugin might call this reload on wrong times like frontpage for example.