### PR TITLE
Front: Fix product card image cropping & make product card bigger

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -17,6 +17,7 @@ Core
 Front
 ~~~~~
 
+- Tune product card and product list styles for better alignment
 - Bump template helpers caches when shop products and manufacturers are saved
 
 General

--- a/shuup/front/static_src/less/front/product-card.less
+++ b/shuup/front/static_src/less/front/product-card.less
@@ -85,6 +85,7 @@
         }
     }
     .price {
+        text-align: center;
         padding: 0px 15px;
         font-size: 1.6rem;
         font-weight: bold;
@@ -100,5 +101,11 @@
             font-size: 1.3rem;
             margin-left: 5px;
         }
+    }
+    .detail-wrap {
+        overflow: hidden;
+        height: 100px;
+        display: flex;
+        flex-direction: column;
     }
 }

--- a/shuup/front/static_src/less/front/product-list.less
+++ b/shuup/front/static_src/less/front/product-list.less
@@ -189,6 +189,16 @@
     }
 }
 
+.product-list {
+    .single-product {
+        @media (max-width: @screen-xs-max) {
+            display: flex;
+            flex-direction: row;
+            justify-content: center;
+        }
+    }
+}
+
 .product-list-view {
 
     .single-product {
@@ -248,13 +258,16 @@
                 .make-sm-column(8);
                 .make-lg-column(9);
                 display: flex;
-                flex-flow: column wrap;
+                flex-direction: column;
                 justify-content: center;
-                height: 100%;
+                height: 150px;
                 padding: 15px;
+
+                &.with-description {
+                    height: 200px;
+                }
             }
             .single-product {
-                width: 100%;
                 .product-card {
                     padding-bottom: 42px;
                     text-align: left;

--- a/shuup/front/templates/shuup/front/macros/product.jinja
+++ b/shuup/front/templates/shuup/front/macros/product.jinja
@@ -9,7 +9,7 @@ Inheritance order for product macors:
 #}
 {% extends "shuup/front/macros/product_image.jinja" %}
 
-{% macro product_box(product, show_image=True, show_description=True, class="product-box", thumbnail_size=(500,500)) %}
+{% macro product_box(product, show_image=True, show_description=True, class="product-box", thumbnail_size=(300, 300)) %}
     {% set u = url("shuup:product", pk=product.pk, slug=product.slug) %}
     <div class="product-card {{ class }}" id="product-{{ product.id }}">
         <a href="{{ u }}" rel="product-detail" title="{{ product.name }}">
@@ -27,17 +27,17 @@ Inheritance order for product macors:
                     <div class="image" style="background-image:url('{{ image_url }}')"></div>
                 </div>
             {% endif %}
-            <div class="detail-wrap">
-                <div class="name">{{ product.name }}</div>
+            <div class="detail-wrap {% if show_description %}with-description{% endif %}">
+                <div class="name">{{ product.name|truncate(60, True) }}</div>
                 {% if show_description and product.short_description %}
-                    <p class="description">{{ product.short_description|safe }}</p>
-                {% endif %}
-                {% if show_prices() and not xtheme.get("hide_prices") %}
-                    <div class="price">
-                        {{ render_product_price(product, show_units=False) }}
-                    </div>
+                    <p class="description">{{ product.short_description|safe|truncate(45, True) }}</p>
                 {% endif %}
             </div>
+            {% if show_prices() and not xtheme.get("hide_prices") %}
+                <div class="price">
+                    {{ render_product_price(product, show_units=False) }}
+                </div>
+            {% endif %}
         </a>
         <div class="actions clearfix">
             <button type="button"

--- a/shuup/xtheme/templates/shuup/xtheme/plugins/cross_sells_plugin.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/plugins/cross_sells_plugin.jinja
@@ -3,9 +3,9 @@
 {% if cross_sell_products %}
     <hr>
     {% if title %}<h3>{{ title }}</h3>{% endif %}
-    <div class="row">
+    <div class="row product-list">
         {% for product in cross_sell_products %}
-            <div class="col-md-3">
+            <div class="col-sm-4 col-md-3 single-product">
                 {{ product_box(product) }}
             </div>
         {% endfor %}

--- a/shuup/xtheme/templates/shuup/xtheme/plugins/highlight_plugin.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/plugins/highlight_plugin.jinja
@@ -1,7 +1,7 @@
 {%- from "shuup/front/macros/product.jinja" import product_box with context -%}
 <section class="product-highlight-plugin">
     {% if title %}<h2>{{ title }}</h2>{% endif %}
-    <div class="row">
+    <div class="row product-list">
     {% for product in products if shuup.product.is_visible(product) %}
         <div class="col-sm-4 col-md-3 single-product">
             {{ product_box(product) }}


### PR DESCRIPTION
Fixed product card image cropping by replacing 500x500 dimensions
with 420x420, enabled smart cropping in settings
Made product card's detail-wrap bigger so now a product with a long name
(up to three lines) doesn't cause the cards to differ.

Refs POS-2543

![image](https://user-images.githubusercontent.com/8770370/44268431-d2359d80-a207-11e8-8dd9-c847dddec6d7.png)
![image](https://user-images.githubusercontent.com/8770370/44268437-db266f00-a207-11e8-9d12-960a13987308.png)
![image](https://user-images.githubusercontent.com/8770370/44268459-e6799a80-a207-11e8-8378-96a25cf88ac7.png)
![image](https://user-images.githubusercontent.com/8770370/44268518-15900c00-a208-11e8-907b-f772d43d9603.png)
![image](https://user-images.githubusercontent.com/8770370/44268525-1b85ed00-a208-11e8-99ae-66309516036c.png)
![image](https://user-images.githubusercontent.com/8770370/44268538-23de2800-a208-11e8-9e7a-db06be76498c.png)
