### PR TITLE
GDPR: Turn consent-form into an ajax form

### DIFF
--- a/shuup/gdpr/static_src/gdpr.js
+++ b/shuup/gdpr/static_src/gdpr.js
@@ -35,7 +35,17 @@
     });
 
     function saveConsent() {
-        $("#consent-form").submit();
+        data = $("#consent-form").serialize();
+        var request = $.ajax({
+            url: $("#consent-form").attr("action"),
+            type: 'POST',
+            data: data,
+            success: function() {
+                $(".gdpr-consent-warn-bar").remove();
+                $(".gdpr-consent-preferences").remove(); // Remove GDPR divs and their content upon successful completion
+                $("body").removeClass("body-noscroll");
+            }
+        });
     }
 
     $("#btn-save-preferences").click(() => {

--- a/shuup/gdpr/templates/shuup/gdpr/gdpr_consent.jinja
+++ b/shuup/gdpr/templates/shuup/gdpr/gdpr_consent.jinja
@@ -28,7 +28,7 @@
                 </div>
             </div>
             <div class="panel-body">
-                <form id="consent-form" action="{{ url("shuup:gdpr_consent") }}" method="POST">
+                <form id="consent-form" action="{{ url("shuup:gdpr_consent") }}">
                     {% csrf_token %}
                     <div class="consent-body">
                         <div class="list-group">

--- a/shuup_tests/browser/front/test_gdpr_consent.py
+++ b/shuup_tests/browser/front/test_gdpr_consent.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+
+import pytest
+from django.core.urlresolvers import reverse
+
+from shuup.gdpr.models import GDPRSettings
+from shuup.testing.browser_utils import (
+    click_element, wait_until_appeared
+)
+from shuup.testing.factories import get_default_shop
+from shuup.testing.utils import initialize_front_browser_test
+
+pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
+
+@pytest.mark.browser
+def test_gdpr_consent(browser, live_server, settings):
+    browser = initialize_front_browser_test(browser, live_server)
+
+    shop = get_default_shop()
+    index_url = reverse("shuup:index")
+
+    # create a GDPR setting for the shop
+    shop_gdpr = GDPRSettings.get_for_shop(shop)
+    shop_gdpr.cookie_banner_content = "my cookie banner content"
+    shop_gdpr.cookie_privacy_excerpt = "my cookie privacyexcerpt"
+    shop_gdpr.enabled = True
+    shop_gdpr.save() # Enable GDPR
+
+    browser.visit("%s%s" % (live_server, index_url))
+    wait_until_appeared(browser, ".gdpr-consent-warn-bar")
+    assert (len(browser.find_by_css(".gdpr-consent-preferences")) == 1)
+    click_element(browser, "#agree-btn")
+
+    assert len(browser.find_by_css(".gdpr-consent-warn-bar")) == 0
+    assert len(browser.find_by_css(".gdpr-consent-preferences")) == 0


### PR DESCRIPTION
Consent-bar form is now purely ajax POST form.
GDPR divs are removed upon successful completion of AJAX.

Possible issues:
Missing tests?

https://github.com/shuup/shuup/issues/1425