### PR TITLE
Simple Search: add default setting for search limit

### DIFF
--- a/shuup/front/apps/simple_search/settings.py
+++ b/shuup/front/apps/simple_search/settings.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+
+#: The limit number of products to be returned by the search
+#:
+SHUUP_SIMPLE_SEARCH_LIMIT = 150


### PR DESCRIPTION
As there is no default setting, the app will break when trying to use this setting

No Refs