### PR TITLE
Fix filter fields in order status, simple cms and tasks type admin modules

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,11 @@ Unrealeased
   When releasing next version, the "Unreleased" header will be replaced
   with appropriate version header and this help text will be removed.
 
+Bug fixes
+~~~~~~~~~
+
+- Fix filter fields in order status, simple cms and tasks type admin modules
+
 Core
 ~~~~
 

--- a/shuup/admin/modules/orders/views/status.py
+++ b/shuup/admin/modules/orders/views/status.py
@@ -66,8 +66,24 @@ class OrderStatusListView(PicotableListView):
     model = OrderStatus
     default_columns = [
         Column("identifier", _("Identifier"), linked=True, filter_config=TextFilter(operator="startswith")),
-        Column("name", _("Name"), linked=True, filter_config=TextFilter(operator="startswith")),
-        Column("public_name", _("Public Name"), linked=False, filter_config=TextFilter(operator="startswith")),
+        Column(
+            "name",
+            _("Name"),
+            linked=True,
+            filter_config=TextFilter(
+                operator="startswith",
+                filter_field="translations__name"
+            )
+        ),
+        Column(
+            "public_name",
+            _("Public Name"),
+            linked=False,
+            filter_config=TextFilter(
+                operator="startswith",
+                filter_field="translations__name"
+            )
+        ),
         Column("role", _("Role"), linked=False, filter_config=ChoicesFilter(choices=OrderStatusRole.choices)),
         Column(
             "default", _("Default"), linked=False, filter_config=ChoicesFilter([(False, _("yes")), (True, _("no"))])),

--- a/shuup/simple_cms/admin_module/views.py
+++ b/shuup/simple_cms/admin_module/views.py
@@ -186,8 +186,15 @@ class PageListView(PicotableListView):
     model = Page
     default_columns = [
         Column(
-            "title", _(u"Title"), sort_field="translations__title", display="title", linked=True,
-            filter_config=TextFilter(operator="startswith")
+            "title",
+            _(u"Title"),
+            sort_field="translations__title",
+            display="title",
+            linked=True,
+            filter_config=TextFilter(
+                operator="startswith",
+                filter_field="translations__title"
+            )
         ),
         Column("available_from", _(u"Available from")),
         Column("available_to", _(u"Available to")),

--- a/shuup/tasks/admin_module/views/list.py
+++ b/shuup/tasks/admin_module/views/list.py
@@ -67,7 +67,7 @@ class TaskTypeListView(PicotableListView):
             sort_field="name",
             display="name",
             filter_config=TextFilter(
-                filter_field="name",
+                filter_field="translations__name",
                 placeholder=_("Filter by name...")
             )
         )


### PR DESCRIPTION
All of them are translation fields and they need to filter by the related field name

Refs POS-2551