### PR TITLE
Admin: Fix adding stock products to the order

### DIFF
--- a/shuup/admin/modules/orders/static_src/create/utils/numbers.js
+++ b/shuup/admin/modules/orders/static_src/create/utils/numbers.js
@@ -17,7 +17,7 @@ function ensureNumericValue(value, defaultValue = 0, asInteger = false) {
     if (Number.isInteger(value) || asInteger) {
         return parseInt(value, 10);
     }
-    return parseFloat(value).toFixed(2);
+    return parseFloat(value);
 }
 
 export default ensureNumericValue;


### PR DESCRIPTION
toFixed in ensureNumericValue was returning a string instead of an int or a float,
that's what was breaking the addition of stock products to the order in admin.

Refs #1431