### PR TITLE
Admin: fix wizard skip button alignment

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,6 +20,7 @@ Bug fixes
 - Fix Xtheme editor menu for mobile devices
 - Fix filter fields in order status, simple cms and tasks type admin modules
 - Fix GDPR user information serializer to consider the correct document consent structure
+- Fix admin wizard skip button alignment
 
 Admin
 ~~~~~

--- a/shuup/admin/static_src/wizard/js/wizard.js
+++ b/shuup/admin/static_src/wizard/js/wizard.js
@@ -44,11 +44,11 @@
                     '<div class="clearfix">' +
                         getButton(gettext("Previous"), "previous", disablePrevious, "btn-primary pull-left " + (config.hidePrevious? "hidden":"")) +
                         getButton(isLastPane() ? gettext("Finish") : gettext("Next"), "next", disableNext, "btn-primary pull-right") +
+                        (
+                            ($activeWizardPane.data("can_skip") === "True" || config.skip) ?
+                            getButton(gettext("Skip"), "skip", false, "btn-default pull-right btn-wizard-skip", config.skipTooltip) : ''
+                        ) +
                     '</div>' +
-                    ($activeWizardPane.data("can_skip") === "True" || config.skip?
-                    '<div class="clearfix">' +
-                        getButton(gettext("Skip"), "skip", false, "btn-default pull-right", config.skipTooltip) +
-                    '</div>': '') +
                 '</div>'
             );
             $activeWizardPane.find('[data-toggle="tooltip"]').tooltip();

--- a/shuup/admin/static_src/wizard/less/wizard.less
+++ b/shuup/admin/static_src/wizard/less/wizard.less
@@ -128,6 +128,11 @@
         .wizard-pane {
             display: none;
 
+            .btn-wizard-skip {
+                margin-left: 20px;
+                margin-right: 20px;
+            }
+
             &.active {
                 display: block;
             }


### PR DESCRIPTION
Make the button align horizontally with Next/Finish button

No Refs

**Before**
![image](https://user-images.githubusercontent.com/8770370/45096629-57212200-b0f7-11e8-83bf-91a88b823826.png)


**After**
![image](https://user-images.githubusercontent.com/8770370/45096578-3bb61700-b0f7-11e8-9838-cdcb3dbd43a7.png)
