### PR TITLE
Fixed is_maintenance_mode badge. Live was showing in maintenance mode…

### DIFF
--- a/shuup/front/templates/shuup/front/macros/general.jinja
+++ b/shuup/front/templates/shuup/front/macros/general.jinja
@@ -220,9 +220,9 @@
                     <h2>{% trans %}Tools{% endtrans %}</h2>
                     <div class="admin-tools-info">
                     {% if is_maintenance_mode %}
-                        <span class="badge badge-success">{% trans %}Live{% endtrans %}</span>
-                    {% else %}
                         <span class="badge badge-warning">{% trans %}Maintenance{% endtrans %}</span>
+                    {% else %}
+                        <span class="badge badge-success">{% trans %}Live{% endtrans %}</span>
                     {% endif %}
                     </div>
                     <div class="admin-tools-info">


### PR DESCRIPTION
Live badge was showing when in Maintenance Mode and the Maintenance badge was showing when Live.