### PR TITLE
Fix summernote codeview

### DIFF
--- a/shuup/admin/static_src/base/js/editor.js
+++ b/shuup/admin/static_src/base/js/editor.js
@@ -64,6 +64,11 @@ function activateEditor($editor, attrs = {}) {
     $editor.parent().find(".note-editable").on("drop", (event) => {
         cancelEvent(event);
     });
+
+    $editor.parent().find(".note-codable").on("blur", function () {
+        var textarea = $editor.parent().find("textarea");
+        textarea.val($editor.summernote("code"));
+    });
     return $summernote;
 }
 

--- a/shuup/xtheme/templates/shuup/xtheme/editor.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/editor.jinja
@@ -83,6 +83,11 @@
             $editor.parent().find(".note-editable").on("drop", function (event) {
                 cancelEvent(event);
             });
+
+            $editor.parent().find(".note-codable").on("blur", function () {
+                var textarea = $editor.parent().find("textarea");
+                textarea.val($editor.summernote("code"));
+            });
         })
     })();
 </script>


### PR DESCRIPTION
The issue is with summernote itself, this is a simple workaround. Summernote content can now be saved from codeview.

This fixes #1467