### PR TITLE
Xtheme: fix snippet injection url

### DIFF
--- a/shuup/xtheme/editing.py
+++ b/shuup/xtheme/editing.py
@@ -96,7 +96,7 @@ def add_edit_resources(context):
     try:
         command_url = reverse("shuup:xtheme")
         edit_url = reverse("shuup:xtheme_editor")
-        inject_snipper = reverse("shuup:xtheme_editor")
+        inject_snipper = reverse("shuup_admin:xtheme_snippet.new")
     except NoReverseMatch:  # No URLs no resources
         return
 


### PR DESCRIPTION
Something happened to the correct url in some rebase, probably

No Refs