### PR TITLE
Xtheme: Add Extra CSS/Style class to cells

### DIFF
--- a/shuup/xtheme/layout/_base.py
+++ b/shuup/xtheme/layout/_base.py
@@ -19,7 +19,7 @@ class LayoutCell(object):
     A single cell in a layout. Maps to Bootstrap's `col-XX-XX` classes.
     """
 
-    def __init__(self, theme, plugin_identifier, config=None, sizes=None, align=""):
+    def __init__(self, theme, plugin_identifier, config=None, sizes=None, align="", extra_classes=""):
         """
         Initialize a layout cell with a given plugin, config and sizing configuration.
 
@@ -37,6 +37,7 @@ class LayoutCell(object):
         self.plugin_identifier = plugin_identifier
         self.config = config or {}
         self.align = align
+        self.extra_classes = extra_classes
 
     @property
     def plugin_class(self):
@@ -105,7 +106,8 @@ class LayoutCell(object):
             plugin_identifier=data.get("plugin"),
             config=data.get("config"),
             sizes=data.get("sizes"),
-            align=data.get("align", "")
+            align=data.get("align", ""),
+            extra_classes=data.get("extra_classes", "")
         )
 
     def serialize(self):
@@ -119,7 +121,8 @@ class LayoutCell(object):
             ("plugin", self.plugin_identifier),
             ("config", self.config),
             ("sizes", self.sizes),
-            ("align", self.align)
+            ("align", self.align),
+            ("extra_classes", self.extra_classes),
         ) if k and v)
 
 

--- a/shuup/xtheme/locale/en/LC_MESSAGES/django.po
+++ b/shuup/xtheme/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-03 19:29+0000\n"
+"POT-Creation-Date: 2018-09-07 02:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -469,6 +469,9 @@ msgid "Cell width"
 msgstr ""
 
 msgid "Cell align"
+msgstr ""
+
+msgid "Cell extra class"
 msgstr ""
 
 msgid "No Plugin"

--- a/shuup/xtheme/rendering.py
+++ b/shuup/xtheme/rendering.py
@@ -213,6 +213,8 @@ class PlaceholderRenderer(object):
                 classes.append(layout.cell_class_template % {"breakpoint": breakpoint, "width": width})
 
         classes.append(cell.align)
+        if cell.extra_classes:
+            classes.append(cell.extra_classes)
 
         cell_attrs = {
             "class": classes

--- a/shuup/xtheme/views/forms.py
+++ b/shuup/xtheme/views/forms.py
@@ -52,6 +52,10 @@ class LayoutCellGeneralInfoForm(forms.Form):
             self.fields["cell_align"] = forms.ChoiceField(
                 label=_("Cell align"), choices=self.CELL_ALIGN_CHOICES, initial=initial_cell_align)
 
+            initial_cell_style = self.layout_cell.extra_classes or ""
+            self.fields["cell_extra_classes"] = forms.CharField(
+                label=_("Cell extra class"), initial=initial_cell_style, required=False)
+
         if self.theme:
             plugin_choices = self.theme.get_all_plugin_choices(empty_label=_("No Plugin"))
             plugin_field = self.fields["plugin"]
@@ -73,6 +77,7 @@ class LayoutCellGeneralInfoForm(forms.Form):
             self.layout_cell.sizes[size] = int(data["cell_width"])
 
         self.layout_cell.align = data["cell_align"]
+        self.layout_cell.extra_classes = data["cell_extra_classes"].strip()
 
 
 class LayoutCellFormGroup(FormGroup):

--- a/shuup_tests/xtheme/test_editor_forms.py
+++ b/shuup_tests/xtheme/test_editor_forms.py
@@ -41,7 +41,8 @@ def test_formless_plugin_in_lcfg(rf):
             lcfg = LayoutCellFormGroup(
                 data={
                     "general-cell_width": "%d" % two_thirds,
-                    "general-cell_align": "pull-right"
+                    "general-cell_align": "pull-right",
+                    "general-cell_extra_classes" : "newClass",
                 },
                 layout_cell=cell,
                 theme=theme,
@@ -51,6 +52,7 @@ def test_formless_plugin_in_lcfg(rf):
             assert "plugin" not in lcfg.forms
             assert lcfg.is_valid()
             lcfg.save()
+            assert cell.extra_classes == "newClass"
             assert cell.sizes["md"] == two_thirds  # Something got saved even if the plugin doesn't need config
 
 
@@ -70,6 +72,7 @@ def test_lcfg(rf):
                 data={
                     "general-cell_width": "%d" % two_thirds,
                     "general-cell_align": " ",
+                    "general-cell_extra_classes" : "newClass",
                     "plugin-text_*": "Hello, world!"
                 },
                 layout_cell=cell,
@@ -79,4 +82,5 @@ def test_lcfg(rf):
             assert lcfg.is_valid()  # Let's see now!
             lcfg.save()
             assert cell.sizes["md"] == two_thirds
+            assert cell.extra_classes == "newClass"
             assert cell.config["text"] == {FALLBACK_LANGUAGE_CODE: "Hello, world!"}


### PR DESCRIPTION
Added "Cell extra class" or "style_class" to cells. This is to be used
by merchants for custom cell CSS.

Fixes #1475