### PR TITLE
Fix ShopProduct & Category ManyToMany relation, Enable Contact Group Quick add for Contact edit page

### DIFF
--- a/shuup/admin/forms/widgets.py
+++ b/shuup/admin/forms/widgets.py
@@ -268,5 +268,9 @@ class QuickAddContactGroupSelect(QuickAddRelatedObjectSelect):
     url = reverse_lazy("shuup_admin:contact_group.new")
 
 
+class QuickAddContactGroupMultiSelect(QuickAddRelatedObjectMultiSelect):
+    url = reverse_lazy("shuup_admin:contact_group.new")
+
+
 class TimeInput(DjangoTimeInput):
     input_type = "time"

--- a/shuup/admin/modules/contacts/forms.py
+++ b/shuup/admin/modules/contacts/forms.py
@@ -14,7 +14,8 @@ from enumfields import EnumField
 
 from shuup.admin.forms.fields import Select2MultipleField
 from shuup.admin.forms.widgets import (
-    PersonContactChoiceWidget, QuickAddTaxGroupSelect
+    PersonContactChoiceWidget, QuickAddContactGroupMultiSelect,
+    QuickAddTaxGroupSelect
 )
 from shuup.admin.shop_provider import get_shop
 from shuup.core.fields import LanguageFormField
@@ -47,7 +48,7 @@ class ContactBaseFormMixin(object):
             queryset=ContactGroup.objects.all_except_defaults(),
             initial=(self.instance.groups.all_except_defaults() if self.instance.pk else ()),
             required=False,
-            widget=forms.SelectMultiple(),
+            widget=QuickAddContactGroupMultiSelect(attrs={"data-model": "shuup.ContactGroup"}),
             label=_("Contact Groups"),
             help_text=_(
                 "The contact groups this contact belongs to. Contact groups are defined in Contacts - Contact Groups "

--- a/shuup/admin/modules/products/signal_handlers.py
+++ b/shuup/admin/modules/products/signal_handlers.py
@@ -7,6 +7,8 @@
 # LICENSE file in the root directory of this source tree.
 from django.conf import settings
 
+from shuup.core.models import Category
+
 
 def update_categories_post_save(sender, instance, **kwargs):
     if not getattr(settings, "SHUUP_AUTO_SHOP_PRODUCT_CATEGORIES", False):
@@ -30,7 +32,15 @@ def update_categories_through(sender, instance, **kwargs):
 
     if not instance.pk:
         return
+    if isinstance(instance, Category):
+        shop_products = instance.shop_products.all()
+        for shop_product in shop_products:
+            set_shop_product_category(shop_product)
+    else:
+        set_shop_product_category(instance)
 
+
+def set_shop_product_category(instance):
     if not instance.categories.count():
         return
 

--- a/shuup_tests/core/test_product_caching_object.py
+++ b/shuup_tests/core/test_product_caching_object.py
@@ -10,7 +10,7 @@ import pytest
 
 from shuup.core.models import Product
 from shuup.core.utils.product_caching_object import ProductCachingObject
-from shuup.testing.factories import create_product, get_default_shop_product
+from shuup.testing.factories import create_product, get_default_shop_product, get_default_category
 
 
 def test_product_caching_object_nulling():
@@ -69,3 +69,14 @@ def test_product_caching_object():
     pco.product_id = product.pk
     assert pco.product == product
     assert pco.product_id == product.pk
+
+
+@pytest.mark.django_db
+def test_shopproduct_category_manytomany():
+    shop_product = get_default_shop_product()
+    category = get_default_category()
+    shop_product.categories = [category]
+    category.shop_products = [shop_product]
+    shop_product.save()
+    assert shop_product.categories.first() == category
+    assert category.shop_products.first() == shop_product


### PR DESCRIPTION
- Core: Fix ShopProduct & Category ManyToMany relation

A check needed to be done in `update_categories_through` to see if the
instance sent is a Category or a ShopProduct and then to proceed accordingly.
Test I wrote here will break without the mentioned check.

Fixes #1188

- Admin: Enable Contact Group Quick add for Contact edit page

Made a new widget -` QuickAddContactGroupMutliSelect` because if I changed
the QuickAdd`ContactGroupSelect` to inherit QuickAdd`RelatedObjectMultiSelect` it would
crash the discount module which supports only one group per discount. Perhaps that should be changed?

Fixes #1489
