### PR TITLE
Admin: hotfix summernote editor scroll

### DIFF
--- a/shuup/admin/static_src/base/scss/shuup/summernote.scss
+++ b/shuup/admin/static_src/base/scss/shuup/summernote.scss
@@ -1,0 +1,4 @@
+.note-toolbar.card-header {
+    position: relative !important;
+    width: 100% !important;
+}

--- a/shuup/admin/static_src/base/scss/style.scss
+++ b/shuup/admin/static_src/base/scss/style.scss
@@ -29,3 +29,4 @@
 @import "shuup/list-settings";
 @import "shuup/quick-add";
 @import "shuup/loader";
+@import "shuup/summernote";


### PR DESCRIPTION
It seems on scroll some Summernote JS sets it's header width to 20px while making it's position fixed while scrolling close to top. Couldn't find any unwanted side effects from this fix either.

Separated .scss since easier to spot and throw out once this re-fixed in some future release.

Fixes https://github.com/shuup/shuup/issues/1521