### PR TITLE
WIP: Make the menu retractable & add babel-polyfill

### DIFF
--- a/shuup/admin/npm-shrinkwrap.json
+++ b/shuup/admin/npm-shrinkwrap.json
@@ -46,6 +46,15 @@
         }
       }
     },
+    "@babel/polyfill": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
+      "integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
+      "requires": {
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.11.1"
+      }
+    },
     "@compone/class": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@compone/class/-/class-1.1.1.tgz",
@@ -2809,8 +2818,7 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-      "dev": true
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -10410,8 +10418,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/shuup/admin/package.json
+++ b/shuup/admin/package.json
@@ -14,6 +14,7 @@
   "license": "OSL-3.0",
   "private": true,
   "dependencies": {
+    "@babel/polyfill": "^7.0.0",
     "bootstrap": "^4.1.2",
     "bootstrap-datetime-picker": "^2.4.4",
     "chart.js": "^2.7.2",

--- a/shuup/admin/static_src/base/js/main-menu.js
+++ b/shuup/admin/static_src/base/js/main-menu.js
@@ -58,15 +58,16 @@ const handleMainMenu = () => {
       mainMenu.classList.remove('open');
     });
   }
-
+  // media query change
+  if ($(window).width() >= 1024) {
+    $("body").toggleClass("menu-open");
+    $('.main-menu').addClass('open');
+  }
   if (toggleBtn) {
     toggleBtn.addEventListener('click', () => {
-      if (mainMenu.classList.contains('open')) {
-        mainMenu.classList.remove('open');
-      } else {
-        mainMenu.classList.add('open');
-        hideMainMenu();
-      }
+      $("body").toggleClass("menu-open");
+      $('.main-menu').toggleClass('open');
+
     });
   }
 }

--- a/shuup/admin/static_src/base/scss/shuup/base.scss
+++ b/shuup/admin/static_src/base/scss/shuup/base.scss
@@ -23,10 +23,27 @@ body {
         overflow: hidden;
     }
 
+
     &.menu-open {
+
         @include media-breakpoint-down(sm) {
             overflow: hidden;
         }
+
+        #top-header {
+            left: $main-menu-width;
+            width: calc(100% - #{$main-menu-width});
+        }
+        @include media-breakpoint-up(lg) {
+            .support-nav-wrap {
+                padding-left: $main-menu-width + 30px;
+            }
+
+            #main-content {
+                margin-left: $main-menu-width;
+            }
+        }
+
     }
 }
 
@@ -56,7 +73,7 @@ img {
 #main-content {
     margin-top: 0 !important;
     padding-top: 15px;
-    margin-left: $main-menu-width;
+    margin-left: 0px;
     padding: 1.2em;
 
     @include media-breakpoint-down(md) {
@@ -104,6 +121,8 @@ canvas {
     max-height: 100%;
     height: auto !important;
     width: auto !important;
+
+
 }
 
 .tooltip {

--- a/shuup/admin/static_src/base/scss/shuup/main-menu.scss
+++ b/shuup/admin/static_src/base/scss/shuup/main-menu.scss
@@ -9,6 +9,7 @@
     box-shadow: $shadow-lg;
     transition: transform 0.15s ease-in-out;
     -webkit-overflow-scrolling: touch;
+    display: none;
 
     @include media-breakpoint-down(md) {
         transform: translate3d(-100%,0,0);

--- a/shuup/admin/static_src/base/scss/shuup/navigation.scss
+++ b/shuup/admin/static_src/base/scss/shuup/navigation.scss
@@ -1,12 +1,12 @@
 #top-header {
     background: $nav-bg;
     height: $top-header-height;
-    width: calc(100% - #{$main-menu-width});
     position: fixed;
     top: 0;
     border-bottom: 1px solid $border-color;
-    left: $main-menu-width;
     z-index: 1000;
+    left: 0px;
+    width: 100%;
 
     @include media-breakpoint-down(md) {
         left: 0;
@@ -149,9 +149,6 @@
             }
         }
 
-        body.menu-open & {
-            background: $nav-bg-hover;
-        }
 
         .toggler {
             display: block;
@@ -160,6 +157,7 @@
             height: 60px;
             width: 60px;
             border-right: 1px solid $border-color;
+            background-color: transparent;
 
             span, span:before, span:after {
                 background: $text-color;
@@ -197,12 +195,12 @@
             }
 
             &:before {
-                background: $primary;
+                background: black;
                 @include rotate(-45deg);
             }
 
             &:after {
-                background: $primary;
+                background: black;
                 @include rotate(45deg);
             }
         }

--- a/shuup/admin/static_src/base/scss/shuup/support-navigation.scss
+++ b/shuup/admin/static_src/base/scss/shuup/support-navigation.scss
@@ -1,10 +1,9 @@
 .support-nav-wrap {
     z-index: 2;
     width: 100%;
-    padding-left: $main-menu-width + 30px;
+    padding-left: 30px;
     padding-right: 30px;
     padding-top: 10px;
-
     @include media-breakpoint-down(md) {
         padding-left: 15px;
     }

--- a/shuup/admin/static_src/vendor/vendor.js
+++ b/shuup/admin/static_src/vendor/vendor.js
@@ -7,6 +7,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import "@babel/polyfill";
+
 //-- jQuery
 var jquery = require("jquery");
 window.$ = window.jQuery = jquery;

--- a/shuup/admin/templates/shuup/admin/base/_main_menu.jinja
+++ b/shuup/admin/templates/shuup/admin/base/_main_menu.jinja
@@ -7,7 +7,7 @@
     <div class="scroll-inner-content">
         <div class="logo-wrap d-flex align-items-center justify-content-between">
             <a class="logo" href="{{ url("shuup_admin:dashboard") }}" data-toggle="tooltip" data-placement="bottom" title="{% trans %}Dashboard{% endtrans %}">Shuup</a>
-            <div class="d-block d-lg-none">
+            <div class="d-block d-md-none">
                 <a id="js-menu-close" class="mobile-menu-close d-inline-block" href="#">
                     <i class="fa fa-times"></i>
                 </a>

--- a/shuup/admin/templates/shuup/admin/base/_navigation.jinja
+++ b/shuup/admin/templates/shuup/admin/base/_navigation.jinja
@@ -1,4 +1,4 @@
-<button id="menu-button" class="nav-menu-button d-flex d-lg-none" data-toggle="tooltip" data-placement="bottom" title="{% trans %}Menu{% endtrans %}">
+<button id="menu-button" class="nav-menu-button d-flex" data-toggle="tooltip" data-placement="bottom" title="{% trans %}Menu{% endtrans %}">
     <span class="toggler">
         <span></span>
     </span>


### PR DESCRIPTION
Menu is now retractable on all devices.
`Array.from` in our javascript was breaking the menu completely for older
browsers, adding babel polyfill fixes that.
Fixes #1501

![screenshot from 2018-09-24 20-34-38](https://user-images.githubusercontent.com/40273438/46034820-dc4d9480-c101-11e8-9c2e-50ab1454cdbd.png)

![screenshot from 2018-09-24 20-34-48](https://user-images.githubusercontent.com/40273438/46034799-d2c42c80-c101-11e8-8ca7-7e78c094d66c.png)

