### PR TITLE
Admin: add scroll to top button

### DIFF
--- a/shuup/admin/static_src/base/js/base.js
+++ b/shuup/admin/static_src/base/js/base.js
@@ -27,6 +27,5 @@ import './timesince.js';
 import './tooltip.js';
 import './tour.js';
 import './select.js';
-import handleMainMenu from './main-menu.js';
-
-handleMainMenu();
+import './components.js';
+import './main-menu.js';

--- a/shuup/admin/static_src/base/js/components.js
+++ b/shuup/admin/static_src/base/js/components.js
@@ -1,0 +1,46 @@
+/**
+ * This file is part of Shuup.
+ *
+ * Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+ *
+ * This source code is licensed under the OSL-3.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const ScrollToTopButton = {
+    controller() {
+        const ctrl = {
+            visible: m.prop(false)
+        };
+        $(window).on("scroll", () => {
+            const scrolled = (window.scrollY > 50);
+            ctrl.visible(scrolled);
+            if (scrolled) {
+                $("body").addClass("scrolled");
+            } else {
+                $("body").removeClass("scrolled");
+            }
+            m.redraw();
+        });
+        return ctrl;
+    },
+    view(ctrl) {
+        if (!ctrl.visible()) {
+            return m(".");
+        }
+        return (
+            m(".scroll-to-top-button", {
+                onclick(e) {
+                    e.preventDefault();
+                    const body = $("html, body");
+                    body.stop().animate({ scrollTop:0 }, 200, "swing");
+                }
+            }, m("i.fa.fa-chevron-up"))
+        );
+    }
+};
+
+(() => {
+    if (document.getElementById("scroll-to-top")) {
+        m.mount(document.getElementById("scroll-to-top"), ScrollToTopButton);
+    }
+})();

--- a/shuup/admin/static_src/base/js/main-menu.js
+++ b/shuup/admin/static_src/base/js/main-menu.js
@@ -72,4 +72,5 @@ const handleMainMenu = () => {
   }
 };
 
+handleMainMenu();
 export default handleMainMenu;

--- a/shuup/admin/static_src/base/scss/shuup/base.scss
+++ b/shuup/admin/static_src/base/scss/shuup/base.scss
@@ -86,6 +86,13 @@ body {
         }
     }
 
+    // add extra bottom padding to the bottom so the scroll to top button doesn't endup over components and text
+    &.scrolled {
+        padding-bottom: 2rem !important;
+        @include media-breakpoint-down(sm) {
+            padding-bottom: 3rem !important;
+        }
+    }
 }
 
 *::selection {
@@ -135,6 +142,47 @@ img {
 
     body.popup & {
         padding: 5px;
+    }
+}
+
+#scroll-to-top {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+
+    .scroll-to-top-button {
+        cursor: pointer;
+        width: 2.5rem;
+        height: 2.5rem;
+        margin-bottom: 0.5rem;
+        box-shadow: 0 0px 10px 1px rgba(0, 0, 0, 0.15);
+        border-radius: 50%;
+        background-color: lighten($primary, 50%);
+        z-index: 999999;
+
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+
+        color: $primary;
+        transform: translateY(0);
+
+        &:hover {
+            color: lighten($primary, 20%);
+            animation-timing-function: ease-in-out;
+            animation: jump 0.1s linear forwards;
+        }
+    }
+}
+@keyframes jump {
+    to {
+        transform: translateY(-0.3rem);
     }
 }
 

--- a/shuup/admin/templates/shuup/admin/base.jinja
+++ b/shuup/admin/templates/shuup/admin/base.jinja
@@ -27,8 +27,6 @@
                 {% include "shuup/admin/base/_main_menu.jinja" %}
             {% endif %}
         {% endblock %}
-
-
         {% block support_content %}
             <div class="support-nav-wrap{% if iframe_mode %} iframe-mode{% endif %}">
                 {% if shuup_admin.is_multishop_enabled() %}
@@ -61,6 +59,7 @@
         <main id="main-content"{% if iframe_mode %}class="iframe-mode"{% endif %}>
             {% block content %}{% endblock %}
         </main>
+        {% block scroll_top_button %}<div id="scroll-to-top"></div>{% endblock %}
         {% endblock %}
         {% block post_content %}{% endblock %}
         {% endif %}

--- a/shuup/admin/templates/shuup/admin/dashboard/dashboard.jinja
+++ b/shuup/admin/templates/shuup/admin/dashboard/dashboard.jinja
@@ -80,7 +80,6 @@
 
 {% block content_wrap %}
     <main id="main-content" class="dashboard">
-
         {% block content %}
             <div id="dashboard-wrapper">
 
@@ -107,6 +106,7 @@
             </div>
         {% endblock %}
     </main>
+    {% block scroll_top_button %}<div id="scroll-to-top"></div>{% endblock %}
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
Add a button to the bottom center of the admin pages that will scroll to top when the page is scrolled.
This help users to back to the top when pages are too long.

Refs POS-2611

![image](https://user-images.githubusercontent.com/8770370/46216146-50ac5180-c315-11e8-85d6-e6fdeaedf1f8.png)
