### PR TITLE
Admin: fix picotable abstract view for mobile devices

### DIFF
--- a/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-02 16:19+0000\n"
+"POT-Creation-Date: 2018-10-02 18:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -716,6 +716,9 @@ msgid "Filter by %s"
 msgstr ""
 
 msgid "Filters"
+msgstr ""
+
+msgid "Show filters"
 msgstr ""
 
 msgid "Select Action"

--- a/shuup/admin/modules/categories/views/list.py
+++ b/shuup/admin/modules/categories/views/list.py
@@ -55,7 +55,7 @@ class CategoryListView(PicotableListView):
 
     def get_object_abstract(self, instance, item):
         return [
-            {"text": "%s" % instance, "class": "header"},
+            {"text": "%s" % instance.name, "class": "header"},
             {"title": _(u"Status"), "text": item.get("status")},
         ]
 

--- a/shuup/admin/modules/products/views/list.py
+++ b/shuup/admin/modules/products/views/list.py
@@ -72,7 +72,7 @@ class ProductListView(PicotableListView):
         Column(
             "primary_category",
             _("Primary Category"),
-            display="primary_category",
+            display=(lambda instance: instance.primary_category.name if instance.primary_category else None),
             filter_config=TextFilter(
                 filter_field="primary_category__translations__name",
                 placeholder=_("Filter by category name...")

--- a/shuup/admin/static_src/base/scss/shuup/picotable.scss
+++ b/shuup/admin/static_src/base/scss/shuup/picotable.scss
@@ -341,7 +341,7 @@
             margin-bottom: 15px;
             display: block;
 
-            a.inner {
+            .inner {
                 background-color: $white;
                 width: 100%;
                 display: block;

--- a/shuup/admin/static_src/picotable/picotable.js
+++ b/shuup/admin/static_src/picotable/picotable.js
@@ -664,8 +664,8 @@ const Picotable = (function(m, storage) {
                         (line.title ? "with-title" : "") +
                         (line.class ? "." + line.class : "");
                     return m(rowClass, [
-                        (line.title ? m("div.col-6.title", line.title) : null),
-                        m("div.col-6.value", line.text)
+                        (line.title ? m(".col.title", line.title) : null),
+                        m(".col.value", line.text)
                     ]);
                 });
                 if (!Util.any(content, function(v) {
@@ -680,8 +680,8 @@ const Picotable = (function(m, storage) {
                     var colContent = item[col.id] || "";
                     if (col.raw) colContent = m.trust(colContent);
                     return m("div.mobile-row.row.with-title", [
-                        m("div.col-6.title", col.title),
-                        m("div.col-6.text-right", colContent)
+                        m(".col.title", col.title),
+                        m(".col.text-right", colContent)
                     ]);
                 });
             }
@@ -695,14 +695,14 @@ const Picotable = (function(m, storage) {
         });
         return m("div.mobile", [
             m("div.mobile-header.row", [
-                m("div.col-sm-6", [
+                m("div.col", [
                     m("button.btn.btn-info.btn-block.toggle-btn",
                         {
                             onclick: function() {
                                 ctrl.vm.showMobileFilterSettings(true);
                             }
                         },
-                        [m("i.fa.fa-filter")], "Show filters"
+                        [m("i.fa.fa-filter")], gettext("Show filters")
                     )
                 ]),
                 m("div.col-sm-6", [

--- a/shuup/simple_supplier/admin_module/views.py
+++ b/shuup/simple_supplier/admin_module/views.py
@@ -53,7 +53,7 @@ class StocksListView(PicotableListView):
         self.columns = self.default_columns
 
     def get_object_abstract(self, instance, item):
-        item.update({"_linked_in_mobile": False, "_url": self.get_object_url(instance.product)})
+        item.update({"_linked_in_mobile": False, "_url": ""})
         return [
             {"text": item.get("name"), "class": "header"},
             {"title": "", "text": item.get("sku")},

--- a/shuup/simple_supplier/templates/shuup/simple_supplier/admin/base_picotable.jinja
+++ b/shuup/simple_supplier/templates/shuup/simple_supplier/admin/base_picotable.jinja
@@ -2,6 +2,5 @@
 
 {% block extra_js %}
     <script src="{{ static("shuup_admin/js/picotable.js") }}"></script>
-    <script>var picotable = new Picotable(document.getElementById("picotable"), window.location.pathname);</script>
     <script src="{{ static("simple_supplier/js/extra.js") }}"></script>
 {% endblock %}

--- a/shuup_tests/admin/test_category_list_view.py
+++ b/shuup_tests/admin/test_category_list_view.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import json
+
+import pytest
+
+from shuup.testing import factories
+
+from shuup.testing.utils import apply_request_middleware
+from shuup.utils.importing import load
+
+
+@pytest.mark.django_db
+def test_list_view(rf, admin_user):
+    shop = factories.get_default_shop()
+
+    parent_category = factories.CategoryFactory()
+    parent_category.shops.add(shop)
+
+    child_category = factories.CategoryFactory()
+    child_category.parent = parent_category
+    child_category.save()
+    child_category.shops.add(shop)
+
+    view = load("shuup.admin.modules.categories.views:CategoryListView").as_view()
+    request = apply_request_middleware(rf.get("/", {
+        "jq": json.dumps({"perPage": 100, "page": 1})
+    }), user=admin_user)
+    response = view(request)
+    assert 200 <= response.status_code < 300
+
+    data = json.loads(response.content)
+    parent_data = _get_item_data(data, parent_category)
+    assert _get_abstract_header(parent_data) == parent_category.name
+
+    child_data = _get_item_data(data, child_category)
+    assert _get_abstract_header(child_data) == child_category.name
+
+
+def _get_item_data(data, item):
+    return [item_data for item_data in data["items"] if item_data["_id"] == item.pk][0]
+
+
+def _get_abstract_header(item_data):
+    print(item_data)
+    return [item for item in item_data["_abstract"] if item.get("class", "") == "header"][0]["text"]

--- a/shuup_tests/admin/test_product_list_view.py
+++ b/shuup_tests/admin/test_product_list_view.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import json
+
+import pytest
+
+from shuup.testing import factories
+
+from shuup.testing.utils import apply_request_middleware
+from shuup.utils.importing import load
+
+
+@pytest.mark.django_db
+def test_list_view(rf, admin_user):
+    shop = factories.get_default_shop()
+    product = factories.create_product(sku="test", shop=shop)
+    shop_product = product.get_shop_instance(shop)
+    shop_product.primary_category = factories.get_default_category()
+    shop_product.save()
+    shop_product.categories.add(shop_product.primary_category)
+
+    view = load("shuup.admin.modules.products.views:ProductListView").as_view()
+    request = apply_request_middleware(rf.get("/", {
+        "jq": json.dumps({"perPage": 100, "page": 1})
+    }), user=admin_user)
+    response = view(request)
+    assert 200 <= response.status_code < 300
+
+    data = json.loads(response.content)
+    product_data = [item for item in data["items"] if item["_id"] == shop_product.pk][0]
+    assert product_data["primary_category"] == factories.get_default_category().name
+    assert product_data["categories"] == factories.get_default_category().name

--- a/shuup_tests/api/conftest.py
+++ b/shuup_tests/api/conftest.py
@@ -8,5 +8,14 @@
 from django.conf import settings
 
 
+ORIGINAL_SETTINGS = []
+
+
 def pytest_runtest_setup(item):
+    global ORIGINAL_SETTINGS
+    ORIGINAL_SETTINGS = [item for item in settings.INSTALLED_APPS]
     settings.INSTALLED_APPS = [app for app in settings.INSTALLED_APPS if "shuup.front" not in app]
+
+
+def pytest_runtest_teardown(item):
+    settings.INSTALLED_APPS = [item for item in ORIGINAL_SETTINGS]

--- a/shuup_tests/simple_supplier/test_list_view.py
+++ b/shuup_tests/simple_supplier/test_list_view.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import json
+
+import pytest
+
+from shuup.core.models import StockBehavior
+from shuup.testing import factories
+from shuup.testing.utils import apply_request_middleware
+from shuup.utils.importing import load
+from shuup_tests.simple_supplier.utils import get_simple_supplier
+
+
+@pytest.mark.django_db
+def test_list_view(rf, admin_user):
+    shop = factories.get_default_shop()
+    supplier = get_simple_supplier()
+
+    product = factories.create_product(sku="test", shop=shop, supplier=supplier)
+    product.stock_behavior = StockBehavior.STOCKED
+    product.save()
+    shop_product = product.get_shop_instance(shop)
+    shop_product.primary_category = factories.get_default_category()
+    shop_product.save()
+    shop_product.categories.add(shop_product.primary_category)
+
+    view = load("shuup.simple_supplier.admin_module.views:StocksListView").as_view()
+    request = apply_request_middleware(rf.get("/", {
+        "jq": json.dumps({"perPage": 100, "page": 1})
+    }), user=admin_user)
+    response = view(request)
+    assert 200 <= response.status_code < 300
+
+    data = json.loads(response.content)
+    for item in data["items"]:
+        assert item["_url"] == ""


### PR DESCRIPTION
- Make the column expand when possible and take advantage of free space.
- Do not add link to stock management rows
- Add box style to the abstract view when there is no link
- Show category name instead of the hierarchy in picotable columns 

Refs POS-2593