### PR TITLE
Admin: Fix tour cancel button & update shepherd

### DIFF
--- a/shuup/admin/npm-shrinkwrap.json
+++ b/shuup/admin/npm-shrinkwrap.json
@@ -10732,13 +10732,20 @@
       }
     },
     "shepherd.js": {
-      "version": "2.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/shepherd.js/-/shepherd.js-2.0.0-beta.18.tgz",
-      "integrity": "sha512-emi0WfQBQYf/qfZmm7yzvVCrjPCIYVudvbhN0eaTwLmNdrtnZvZFRSc+7aA1BoOVgUpgU0UF7WjyqNG9Da0kow==",
+      "version": "2.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/shepherd.js/-/shepherd.js-2.0.0-beta.27.tgz",
+      "integrity": "sha512-z4AbyF5hQsF8LJc9LWHfYtx2/cNQWuSW404CwODEeqXexCsm3UrOe1h0TZaUzZdOPW/vuG0wnKR/MDtcnbFwrA==",
       "requires": {
         "element-matches": "^0.1.2",
-        "lodash": "^4.17.10",
+        "lodash-es": "^4.17.10",
         "popper.js": "^1.14.3"
+      },
+      "dependencies": {
+        "lodash-es": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
+          "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
+        }
       }
     },
     "shuup-static-build-tools": {

--- a/shuup/admin/package.json
+++ b/shuup/admin/package.json
@@ -47,7 +47,7 @@
     "redux-persist": "^3.5.0",
     "select2": "^4.0.6-rc.1",
     "select2-bootstrap-css": "^1.4.6",
-    "shepherd.js": "^2.0.0-beta.18",
+    "shepherd.js": "^2.0.0-beta.27",
     "shuup-static-build-tools": "file:../../lib/shuup_static_build_tools",
     "sortablejs": "^1.7.0",
     "summernote": "^0.8.10",

--- a/shuup/admin/static_src/base/js/tour.js
+++ b/shuup/admin/static_src/base/js/tour.js
@@ -174,7 +174,7 @@
             return;
         }
         let tour = new Shepherd.Tour({
-            defaults: {
+            defaultStepOptions: {
                 classes: "shepherd-theme-arrows",
                 scrollTo: true,
                 showCancelLink: true

--- a/shuup/admin/static_src/base/js/tour.js
+++ b/shuup/admin/static_src/base/js/tour.js
@@ -6,13 +6,13 @@
  * This source code is licensed under the OSL-3.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-(function($) {
+((($) => {
     function getAppChromeSteps(key) {
         if(key !== "home" && typeof(key) !== "undefined") {
             return [];
         }
 
-        let menu = $("#main-menu");
+        const menu = $("#main-menu");
         if (menu && menu.position() && menu.position().left !== 0) {
             // don't show chrome tour on mobile
             return [];
@@ -20,12 +20,12 @@
         const popperOptions = {
             modifiers: {
                 preventOverflow: {
-                    boundariesElement: 'offsetParent'
+                    boundariesElement: "offsetParent"
                 }
             }
         };
 
-        let steps = [];
+        const steps = [];
         if (!$("body").hasClass("desktop-menu-closed")) {
             if ($("li a[data-target-id='quicklinks']").length > 0) {
                 steps.push({
@@ -76,7 +76,6 @@
                     title: gettext("Campaigns"),
                     text: [gettext("Great loyalty tool for creating marketing, campaigns, special offers and coupons to entice your shoppers!"), gettext("Set offers based on their previous purchase behavior to up- and cross sale your inventory.")],
                     attachTo: "li a[data-target-id='category-5'] right",
-                    scrollTo: false,
                     popperOptions
                 });
             }
@@ -104,7 +103,6 @@
                     title: gettext("Shops"),
                     text: [gettext("Place for your Shop specific settings. You can customize taxes, currencies, customer groups, and many other things in this menu.")],
                     attachTo: "li a[data-target-id='category-6'] right",
-                    scrollTo: true,
                     popperOptions
                 });
             }
@@ -114,8 +112,15 @@
                     title: gettext("Addons"),
                     text: [gettext("This is your connection interface. Addons and other systems you use can be attached to your store through powerful data connections."), gettext("Supercharge your site and gather crazy amounts of data with integrations to CRMs and ERPs, POS’s and PIM’s, or any other acronym you can think of.")],
                     attachTo: "li a[data-target-id='category-7'] right",
-                    scrollTo: true,
-                    popperOptions
+                    popperOptions,
+                    when: {
+                        show() {
+                            $("ul.menu-list").addClass("pb-5");
+                        },
+                        hide() {
+                            $("ul.menu-list").removeClass("pb-5");
+                        }
+                    }
                 });
             }
 
@@ -127,11 +132,18 @@
                     ],
                     attachTo: "li a[data-target-id='category-8'] right",
                     scrollTo: true,
-                    popperOptions
+                    popperOptions,
+                    when: {
+                        show() {
+                            $("ul.menu-list").addClass("pb-5");
+                        },
+                        hide() {
+                            $("ul.menu-list").removeClass("pb-5");
+                        }
+                    }
                 });
             }
         }
-
 
         if ($("#site-search").length > 0 && $("#site-search").is(":visible")) {
             steps.push({
@@ -163,17 +175,17 @@
     }
 
     $(".show-tour").on("click", function(e) {
-        e.stopImmediatePropagation()
+        e.stopImmediatePropagation();
         e.preventDefault();
         $.tour();
     });
 
-    $.tour = function(config={}, params) {
+    $.tour = (config={}, params) => {
         if(config === "setPageSteps") {
             this.pageSteps = params;
             return;
         }
-        let tour = new Shepherd.Tour({
+        const tour = new window.Shepherd.Tour({
             defaultStepOptions: {
                 classes: "shepherd-theme-arrows",
                 scrollTo: true,
@@ -231,7 +243,7 @@
 
         function getTextLines(text) {
             let content = "";
-            for(let i = 0; i < text.length; i++) {
+            for(let i = 0; i < text.length; i+=1) {
                 content += "<p class='lead'>" + text[i] + "</p>";
             }
             return content;
@@ -252,7 +264,7 @@
 
         }
         function getTourButtons(type) {
-            let buttons = [];
+            const buttons = [];
             if(type !== "first" && type !== "last") {
                 buttons.push({
                     text: "Previous",
@@ -286,4 +298,4 @@
         tour.start();
         return tour;
     };
-}(jQuery));
+})(jQuery));

--- a/shuup/admin/static_src/base/scss/shuup/tour.scss
+++ b/shuup/admin/static_src/base/scss/shuup/tour.scss
@@ -117,6 +117,10 @@ body.shepherd-active > .shepherd-step {
     border-radius: 4px;
 }
 
+.shepherd-element {
+    width: auto;
+}
+
 .shepherd-element.shepherd-theme-arrows .shepherd-content .shepherd-text p.lead {
     font-size: 16px;
     line-height: inherit;


### PR DESCRIPTION
Updated shepherd to 2.0.0-beta.27,
Product and Category tours can now be cancelled by "X".
Issue now is that product's first step style differs from other steps.

![screenshot from 2018-10-03 03-23-49](https://user-images.githubusercontent.com/40273438/46385299-c456b180-c6bb-11e8-92e7-2cc2e65a7623.png)

Fixes #1560 