### PR TITLE
Admin: fix picotable abstract view for mobile devices

### DIFF
--- a/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-02 16:19+0000\n"
+"POT-Creation-Date: 2018-10-02 18:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -716,6 +716,9 @@ msgid "Filter by %s"
 msgstr ""
 
 msgid "Filters"
+msgstr ""
+
+msgid "Show filters"
 msgstr ""
 
 msgid "Select Action"

--- a/shuup/admin/modules/categories/views/list.py
+++ b/shuup/admin/modules/categories/views/list.py
@@ -55,7 +55,7 @@ class CategoryListView(PicotableListView):
 
     def get_object_abstract(self, instance, item):
         return [
-            {"text": "%s" % instance, "class": "header"},
+            {"text": "%s" % instance.name, "class": "header"},
             {"title": _(u"Status"), "text": item.get("status")},
         ]
 

--- a/shuup/admin/modules/products/views/list.py
+++ b/shuup/admin/modules/products/views/list.py
@@ -72,7 +72,7 @@ class ProductListView(PicotableListView):
         Column(
             "primary_category",
             _("Primary Category"),
-            display="primary_category",
+            display=(lambda instance: instance.primary_category.name if instance.primary_category else None),
             filter_config=TextFilter(
                 filter_field="primary_category__translations__name",
                 placeholder=_("Filter by category name...")

--- a/shuup/admin/static_src/base/scss/shuup/picotable.scss
+++ b/shuup/admin/static_src/base/scss/shuup/picotable.scss
@@ -341,7 +341,7 @@
             margin-bottom: 15px;
             display: block;
 
-            a.inner {
+            .inner {
                 background-color: $white;
                 width: 100%;
                 display: block;

--- a/shuup/admin/static_src/picotable/picotable.js
+++ b/shuup/admin/static_src/picotable/picotable.js
@@ -664,8 +664,8 @@ const Picotable = (function(m, storage) {
                         (line.title ? "with-title" : "") +
                         (line.class ? "." + line.class : "");
                     return m(rowClass, [
-                        (line.title ? m("div.col-6.title", line.title) : null),
-                        m("div.col-6.value", line.text)
+                        (line.title ? m(".col.title", line.title) : null),
+                        m(".col.value", line.text)
                     ]);
                 });
                 if (!Util.any(content, function(v) {
@@ -680,8 +680,8 @@ const Picotable = (function(m, storage) {
                     var colContent = item[col.id] || "";
                     if (col.raw) colContent = m.trust(colContent);
                     return m("div.mobile-row.row.with-title", [
-                        m("div.col-6.title", col.title),
-                        m("div.col-6.text-right", colContent)
+                        m(".col.title", col.title),
+                        m(".col.text-right", colContent)
                     ]);
                 });
             }
@@ -695,14 +695,14 @@ const Picotable = (function(m, storage) {
         });
         return m("div.mobile", [
             m("div.mobile-header.row", [
-                m("div.col-sm-6", [
+                m("div.col", [
                     m("button.btn.btn-info.btn-block.toggle-btn",
                         {
                             onclick: function() {
                                 ctrl.vm.showMobileFilterSettings(true);
                             }
                         },
-                        [m("i.fa.fa-filter")], "Show filters"
+                        [m("i.fa.fa-filter")], gettext("Show filters")
                     )
                 ]),
                 m("div.col-sm-6", [

--- a/shuup/simple_supplier/admin_module/views.py
+++ b/shuup/simple_supplier/admin_module/views.py
@@ -53,7 +53,7 @@ class StocksListView(PicotableListView):
         self.columns = self.default_columns
 
     def get_object_abstract(self, instance, item):
-        item.update({"_linked_in_mobile": False, "_url": self.get_object_url(instance.product)})
+        item.update({"_linked_in_mobile": False, "_url": ""})
         return [
             {"text": item.get("name"), "class": "header"},
             {"title": "", "text": item.get("sku")},

--- a/shuup/simple_supplier/templates/shuup/simple_supplier/admin/base_picotable.jinja
+++ b/shuup/simple_supplier/templates/shuup/simple_supplier/admin/base_picotable.jinja
@@ -2,6 +2,5 @@
 
 {% block extra_js %}
     <script src="{{ static("shuup_admin/js/picotable.js") }}"></script>
-    <script>var picotable = new Picotable(document.getElementById("picotable"), window.location.pathname);</script>
     <script src="{{ static("simple_supplier/js/extra.js") }}"></script>
 {% endblock %}

--- a/shuup_tests/api/conftest.py
+++ b/shuup_tests/api/conftest.py
@@ -8,5 +8,14 @@
 from django.conf import settings
 
 
+ORIGINAL_SETTINGS = []
+
+
 def pytest_runtest_setup(item):
+    global ORIGINAL_SETTINGS
+    ORIGINAL_SETTINGS = [item for item in settings.INSTALLED_APPS]
     settings.INSTALLED_APPS = [app for app in settings.INSTALLED_APPS if "shuup.front" not in app]
+
+
+def pytest_runtest_teardown(item):
+    settings.INSTALLED_APPS = [item for item in ORIGINAL_SETTINGS]


### PR DESCRIPTION
- Make the column expand when possible and take advantage of free space.
- Do not add link to stock management rows
- Add box style to the abstract view when there is no link
- Show category name instead of the hierarchy in picotable columns 

Refs POS-2593
Replaces https://github.com/shuup/shuup/pull/1578