### PR TITLE
Admin: fix tour styles

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,4 +29,4 @@ diff=True
 
 [coverage:run]
 branch = True
-omit = */migrations/*
+omit = */migrations/*,*/testing/browser_utils*

--- a/shuup/admin/modules/categories/views/edit.py
+++ b/shuup/admin/modules/categories/views/edit.py
@@ -34,7 +34,7 @@ class CategoryEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateVie
     def get_context_data(self, **kwargs):
         context = super(CategoryEditView, self).get_context_data(**kwargs)
         context["tour_key"] = "category"
-        context["tour_complete"] = is_tour_complete(get_shop(self.request), "category")
+        context["tour_complete"] = is_tour_complete(get_shop(self.request), "category", user=self.request.user)
         if self.object.pk:
             context["title"] = self.object.name
 

--- a/shuup/admin/modules/products/views/edit.py
+++ b/shuup/admin/modules/products/views/edit.py
@@ -236,7 +236,7 @@ class ProductEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView
         context["orderability_errors"] = orderability_errors
         context["product_sections"] = []
         context["tour_key"] = "product"
-        context["tour_complete"] = is_tour_complete(get_shop(self.request), "product")
+        context["tour_complete"] = is_tour_complete(get_shop(self.request), "product", user=self.request.user)
 
         product_sections_provides = sorted(get_provide_objects("admin_product_section"), key=lambda x: x.order)
         for admin_product_section in product_sections_provides:

--- a/shuup/admin/static_src/base/js/tour.js
+++ b/shuup/admin/static_src/base/js/tour.js
@@ -8,7 +8,7 @@
  */
 ((($) => {
     function getAppChromeSteps(key) {
-        if(key !== "home" && typeof(key) !== "undefined") {
+        if (key !== "home" && typeof (key) !== "undefined") {
             return [];
         }
 
@@ -174,15 +174,19 @@
         return steps;
     }
 
-    $(".show-tour").on("click", function(e) {
+    $(".show-tour").on("click", (e) => {
         e.stopImmediatePropagation();
         e.preventDefault();
         $.tour();
     });
 
-    $.tour = (config={}, params) => {
-        if(config === "setPageSteps") {
-            this.pageSteps = params;
+    $.tour = (config = {}) => {
+        if (config.method === "setPageSteps") {
+            this.pageSteps = config.steps;
+
+            if (config.mode) {
+                this.mode = config.mode;
+            }
             return;
         }
         const tour = new window.Shepherd.Tour({
@@ -193,37 +197,38 @@
             }
         });
 
-        var steps = [];
-        if (this.pageSteps && this.pageSteps.length > 1) {
+        let steps = [];
+        if (this.pageSteps) {
             steps = this.pageSteps;
-        }
-        else {
-            steps = (this.pageSteps || []).concat(getAppChromeSteps(config.tourKey));
+
+            if (this.mode === "homeTour") {
+                steps = steps.concat(getAppChromeSteps(config.tourKey));
+            }
+        } else {
+            steps = getAppChromeSteps(config.tourKey);
         }
 
         $.each(steps, (idx, step) => {
             var buttonType = null;
-            if(idx === 0) {
+            if (idx === 0) {
                 buttonType = "first";
             }
-            if(idx === steps.length - 1) {
+            if (idx === steps.length - 1) {
                 buttonType = "last";
             }
-            step = $.extend({}, step, {buttons: getTourButtons(buttonType)});
+            step = $.extend({}, step, { buttons: getTourButtons(buttonType) });
             let content = "";
-            if(step.icon) {
-                content += "<div class='clearfix'>";
-                content += "<div class='pull-left'>";
+            if (step.icon) {
+                content += "<div class='d-flex flex-row justify-content-between align-items-center'>";
                 content += "<div class='icon'>";
                 content += "<img src='" + step.icon + "' />";
                 content += "</div>";
-                content += "</div>";
-                content += "<div class='step-with-icon'>";
+                content += "<div class='step-with-icon flex-fill'>";
                 content += getTextLines(step.text);
                 content += getHelpButton(step.helpPage);
                 content += "</div>";
                 content += "</div>";
-            } else if(step.banner){
+            } else if (step.banner) {
                 content += "<div>";
                 content += "<div class='banner'>";
                 content += "<img src='" + step.banner + "' />";
@@ -243,15 +248,15 @@
 
         function getTextLines(text) {
             let content = "";
-            for(let i = 0; i < text.length; i+=1) {
-                content += "<p class='lead'>" + text[i] + "</p>";
+            for (let i = 0; i < text.length; i += 1) {
+                content += "<p>" + text[i] + "</p>";
             }
             return content;
         }
 
         function getHelpButton(page) {
             let content = "";
-            if(page) {
+            if (page) {
                 const helpUrl = window.ShuupAdminConfig.docsPage + page;
                 content += "<br>";
                 content += "<p class='text-center'>";
@@ -265,7 +270,7 @@
         }
         function getTourButtons(type) {
             const buttons = [];
-            if(type !== "first" && type !== "last") {
+            if (type !== "first" && type !== "last") {
                 buttons.push({
                     text: "Previous",
                     classes: "btn btn-primary",
@@ -273,7 +278,7 @@
                 });
             }
 
-            if(type === "last") {
+            if (type === "last") {
                 buttons.push({
                     text: "OK",
                     classes: "btn btn-primary",
@@ -290,9 +295,9 @@
             return buttons;
         }
 
-        if(config.tourKey) {
+        if (config.tourKey) {
             tour.on("cancel", () => {
-                $.post(config.url, {"csrfmiddlewaretoken": window.ShuupAdminConfig.csrf, "tourKey": config.tourKey});
+                $.post(config.url, { "csrfmiddlewaretoken": window.ShuupAdminConfig.csrf, "tourKey": config.tourKey });
             });
         }
         tour.start();

--- a/shuup/admin/static_src/base/scss/shuup/tour.scss
+++ b/shuup/admin/static_src/base/scss/shuup/tour.scss
@@ -49,7 +49,7 @@ body.shepherd-active {
 
 }
 
-body.shepherd-active > .shepherd-step {
+body.shepherd-active > .shepherd-element {
     z-index: 10001;
     pointer-events: auto;
 
@@ -79,11 +79,6 @@ body.shepherd-active > .shepherd-step {
         height: 200px;
     }
 
-    .step-with-icon {
-        margin-left: 220px;
-        max-width: 400px;
-    }
-
     .step-with-banner {
         padding: 1em;
     }
@@ -101,14 +96,10 @@ body.shepherd-active > .shepherd-step {
                 margin: 0 auto;
             }
         }
-
-        .step-with-icon {
-            margin-left: 0;
-        }
     }
 }
 
-.shepherd-element.shepherd-theme-arrows .shepherd-content footer .shepherd-buttons li .shepherd-button {
+.shepherd-element .shepherd-content footer .shepherd-buttons li .shepherd-button {
     text-transform: none;
     letter-spacing: 0;
     font-size: 0.9rem;
@@ -121,7 +112,7 @@ body.shepherd-active > .shepherd-step {
     width: auto;
 }
 
-.shepherd-element.shepherd-theme-arrows .shepherd-content .shepherd-text p.lead {
+.shepherd-element .shepherd-content .shepherd-text p.lead {
     font-size: 16px;
     line-height: inherit;
 

--- a/shuup/admin/templates/shuup/admin/base.jinja
+++ b/shuup/admin/templates/shuup/admin/base.jinja
@@ -78,12 +78,12 @@
             }());
         </script>
         {% endif %}
-        {% if tour_complete is defined and not tour_complete %}
+        {% if tour_complete == False %}
         <script>
             $(document).ready(function() {
                 // 991px - 15px = Table breakpoint
                 if ($(window).width() > 976) {
-                    $.tour({tourKey: "{{ tour_key }}", url: ShuupAdminConfig.browserUrls.tour});
+                    $.tour({ tourKey: "{{ tour_key }}", url: ShuupAdminConfig.browserUrls.tour });
                 }
             });
         </script>

--- a/shuup/admin/templates/shuup/admin/categories/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/categories/edit.jinja
@@ -36,16 +36,18 @@
                 }
             });
         }
-
         (function() {
-            $.tour("setPageSteps", [{
-                title: "{% trans %}Add a new product category{% endtrans %}",
-                icon: "{{ static('shuup_admin/img/category.png') }}",
-                text: [
-                    "{% trans %}You are adding a new product category. When people search your store, they can find your product under the category you choose for it, like the aisle signs at the supermarket.{% endtrans %}",
-                    "{% trans %}You can add a name, description, picture or anything you want to make it stand out.{% endtrans %}"
-                ]
-            }]);
+            $.tour({
+                method: "setPageSteps",
+                steps: [{
+                    title: "{% trans %}Add a new product category{% endtrans %}",
+                    icon: "{{ static('shuup_admin/img/category.png') }}",
+                    text: [
+                        "{% trans %}You are adding a new product category. When people search your store, they can find your product under the category you choose for it, like the aisle signs at the supermarket.{% endtrans %}",
+                        "{% trans %}You can add a name, description, picture or anything you want to make it stand out.{% endtrans %}"
+                    ]
+                }]
+            });
         })();
     </script>
 {% endblock %}

--- a/shuup/admin/templates/shuup/admin/dashboard/dashboard.jinja
+++ b/shuup/admin/templates/shuup/admin/dashboard/dashboard.jinja
@@ -113,13 +113,17 @@
     <script src="{{ static("shuup_admin/js/dashboard.js") }}"></script>
     <script>
         (function(){
-            $.tour("setPageSteps", [{
-                text: [
-                    "{% trans %}This is the dashboard for your store. It’s like the flight deck for your ecommerce spaceship. You can control everything from here.{% endtrans %}",
-                    "{% trans %}Check out your shoppers’ info, add more products or categories, setup marketing campaigns, see orders and sales stats, and track the money you’ve made.{% endtrans %}",
-                    "{% trans %}Every setting you could possibly need is in here.{% endtrans %}"
-                ]
-            }]);
+            $.tour({
+                method: "setPageSteps",
+                steps: [{
+                    title: "{{ _('Dashboard') }}",
+                    text: [
+                        "{% trans %}This is the dashboard for your store. It’s like the flight deck for your ecommerce spaceship. You can control everything from here.{% endtrans %}",
+                        "{% trans %}Check out your shoppers’ info, add more products or categories, setup marketing campaigns, see orders and sales stats, and track the money you’ve made.{% endtrans %}",
+                        "{% trans %}Every setting you could possibly need is in here.{% endtrans %}"
+                    ]
+                }]
+            });
         })();
     </script>
 {% endblock %}

--- a/shuup/admin/templates/shuup/admin/home/home.jinja
+++ b/shuup/admin/templates/shuup/admin/home/home.jinja
@@ -31,16 +31,20 @@
 {% block extra_js %}
     <script>
         (function(){
-            $.tour("setPageSteps", [{
-                banner: "{{ static("shuup_admin/img/welcome_banner.png") }}",
-                showCancelLink: false,
-                classes: "shepherd-theme-arrows has-banner",
-                text: [
-                    "{% trans %}Hi, new shop owner!{% endtrans %}",
-                    "{% trans %}Welcome to your store admin!{% endtrans %}",
-                    "{% trans %}Let’s go through some of the things you can do here. Click next to begin.{% endtrans %}"
-                ]
-            }]);
+            $.tour({
+                method: "setPageSteps",
+                mode: "homeTour",
+                steps: [{
+                    banner: "{{ static('shuup_admin/img/welcome_banner.png') }}",
+                    showCancelLink: false,
+                    classes: "shepherd-theme-arrows has-banner",
+                    text: [
+                        "{% trans %}Hi, new shop owner!{% endtrans %}",
+                        "{% trans %}Welcome to your store admin!{% endtrans %}",
+                        "{% trans %}Let’s go through some of the things you can do here. Click next to begin.{% endtrans %}"
+                    ]
+                }]
+            });
         })();
     </script>
 {% endblock %}

--- a/shuup/admin/templates/shuup/admin/products/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/products/edit.jinja
@@ -96,7 +96,7 @@
                     scrollTo: false,
                 });
             }
-            if ($("a[href='#contact-group-media-section']").length > 0) {
+            if ($("a[href='#product-media-section']").length > 0) {
                 steps.push({
                     title: "{% trans %}Product Files{% endtrans %}",
                     text: ["{% trans %}You can attach files such as manual to the merchandise(s) here.{% endtrans %}"],
@@ -104,7 +104,7 @@
                     scrollTo: false,
                 });
             }
-            if ($("a[href='#contact-group-images-section']").length > 0) {
+            if ($("a[href='#product-images-section']").length > 0) {
                 steps.push({
                     title: "{% trans %}Images{% endtrans %}",
                     text: ["{% trans %}Showcase your merchandise here.{% endtrans %}"],
@@ -129,7 +129,7 @@
                     scrollTo: false,
                 });
             }
-            $.tour("setPageSteps", steps);
+            $.tour({ method: "setPageSteps", steps: steps });
         });
     </script>
     {% for product_section in product_sections %}

--- a/shuup/admin/utils/tour.py
+++ b/shuup/admin/utils/tour.py
@@ -8,7 +8,7 @@
 from shuup import configuration
 
 
-def is_tour_complete(shop, tour_key):
+def is_tour_complete(shop, tour_key, user=None):
     """
     Check if the tour is complete
 
@@ -17,4 +17,10 @@ def is_tour_complete(shop, tour_key):
     :return: whether tour is complete
     :rtype: Boolean
     """
-    return configuration.get(shop, "shuup_%s_tour_complete" % tour_key, False)
+    user_id = user.pk if user else "-"
+    return configuration.get(shop, "shuup_%s_%s_tour_complete" % (tour_key, user_id), False)
+
+
+def set_tour_complete(shop, tour_key, complete=True, user=None):
+    user_id = user.pk if user else "-"
+    return configuration.set(shop, "shuup_%s_%s_tour_complete" % (tour_key, user_id), complete)

--- a/shuup/admin/views/dashboard.py
+++ b/shuup/admin/views/dashboard.py
@@ -33,7 +33,7 @@ class DashboardView(TemplateView):
                 blocks.extend(module.get_dashboard_blocks(request=self.request))
         context["activity"] = get_activity(request=self.request)
         context["tour_key"] = "dashboard"
-        context["tour_complete"] = is_tour_complete(get_shop(self.request), "dashboard")
+        context["tour_complete"] = is_tour_complete(get_shop(self.request), "dashboard", user=self.request.user)
         return context
 
     def get(self, request, *args, **kwargs):

--- a/shuup/admin/views/home.py
+++ b/shuup/admin/views/home.py
@@ -67,7 +67,7 @@ class HomeView(TemplateView):
         context = super(HomeView, self).get_context_data(**kwargs)
         context["blocks"] = blocks = []
         context["tour_key"] = "home"
-        context["tour_complete"] = is_tour_complete(get_shop(self.request), "home")
+        context["tour_complete"] = is_tour_complete(get_shop(self.request), "home", user=self.request.user)
         wizard_complete = setup_wizard_complete(self.request)
 
         wizard_url = reverse("shuup_admin:wizard")

--- a/shuup/admin/views/tour.py
+++ b/shuup/admin/views/tour.py
@@ -9,11 +9,12 @@
 from django.http.response import JsonResponse
 from django.views.generic import View
 
-from shuup import configuration
+from shuup.admin.shop_provider import get_shop
+from shuup.admin.utils.tour import set_tour_complete
 
 
 class TourView(View):
     def post(self, request, *args, **kwargs):
         tour_key = request.POST.get("tourKey", "")
-        configuration.set(None, "shuup_%s_tour_complete" % tour_key, True)
+        set_tour_complete(get_shop(request), tour_key, True, request.user)
         return JsonResponse({"success": True})

--- a/shuup/testing/utils.py
+++ b/shuup/testing/utils.py
@@ -14,9 +14,6 @@ from django.utils.module_loading import import_string
 from django.utils.translation import activate, get_language
 
 from shuup.admin.shop_provider import set_shop
-from shuup.admin.utils.tour import set_tour_complete
-from shuup.core import cache
-from shuup.testing.factories import get_default_shop
 
 
 def apply_request_middleware(request, **attrs):
@@ -108,45 +105,3 @@ def apply_all_middleware(request, **attrs):
     for key, value in attrs.items():
         setattr(request, key, value)
     return request
-
-
-def initialize_front_browser_test(browser, live_server):
-    activate("en")
-    get_default_shop()
-    url = live_server + "/"
-    browser.visit(url)
-    # set shop language to eng
-    browser.find_by_id("language-changer").click()
-    browser.find_by_xpath('//a[@class="language"]').first.click()
-    return browser
-
-
-def initialize_admin_browser_test(browser, live_server, settings, username="admin", password="password",
-                                  onboarding=False, language="en", shop=None, tour_complete=True):
-    if not onboarding:
-        settings.SHUUP_SETUP_WIZARD_PANE_SPEC = []
-    activate("en")
-    cache.clear()
-
-    shop = shop or get_default_shop()
-
-    if tour_complete:
-        from django.contrib.auth import get_user_model
-        user = get_user_model().objects.get(username=username)
-        set_tour_complete(shop, "dashboard", True, user)
-        set_tour_complete(shop, "home", True, user)
-        set_tour_complete(shop, "product", True, user)
-        set_tour_complete(shop, "category", True, user)
-
-    url = live_server + "/sa"
-    browser.visit(url)
-    browser.fill('username', username)
-    browser.fill('password', password)
-    browser.find_by_css(".btn.btn-primary.btn-lg.btn-block").first.click()
-
-    if not onboarding:
-        # set shop language to eng
-        browser.find_by_id("dropdownMenu").click()
-        browser.find_by_xpath('//a[@data-value="%s"]' % language).first.click()
-
-    return browser

--- a/shuup_tests/admin/test_views.py
+++ b/shuup_tests/admin/test_views.py
@@ -14,6 +14,7 @@ from django.utils.encoding import force_text
 from django.utils.translation import activate
 
 from shuup.admin.modules.products.views import ProductEditView
+from shuup.admin.utils.tour import is_tour_complete
 from shuup.core.models import Product
 from shuup.core.models import Shop
 from shuup.core.models import ShopProduct
@@ -275,3 +276,12 @@ def test_menu_view(rf, admin_user):
         response.render()
     assert response.status_code == 200
     assert request.session["menu_open"]  # Menu open
+
+
+def test_tour_view(rf, admin_user):
+    shop = get_default_shop()
+    assert is_tour_complete(shop, "home", admin_user) is False
+    view = load("shuup.admin.views.tour:TourView").as_view()
+    request = apply_request_middleware(rf.post("/", data={"tourKey": "home"}), user=admin_user)
+    view(request)
+    assert is_tour_complete(shop, "home", admin_user)

--- a/shuup_tests/browser/admin/test_dev_onboarding.py
+++ b/shuup_tests/browser/admin/test_dev_onboarding.py
@@ -29,7 +29,6 @@ def test_dev_onboarding(browser, admin_user, live_server, settings):
     shop = Shop.objects.first()
     assert shop.maintenance_mode
     initialize_admin_browser_test(browser, live_server, settings, onboarding=True)
-    configuration.set(shop, "shuup_home_tour_complete", True)  # Make home view tour complete
 
     browser.fill("address-first_name", "Matti")
     browser.fill("address-last_name", "Teppo")
@@ -68,7 +67,7 @@ def test_dev_onboarding(browser, admin_user, live_server, settings):
     click_element(browser, "button[name='next']")
 
     wait_until_condition(browser, lambda x: x.is_text_present("Welcome to Shuup!"))
-    
+
     click_element(browser, "input[value='Publish shop']")
 
     shop.refresh_from_db()

--- a/shuup_tests/browser/admin/test_dev_onboarding.py
+++ b/shuup_tests/browser/admin/test_dev_onboarding.py
@@ -11,12 +11,11 @@ import pytest
 
 from django.core.management import call_command
 
-from shuup import configuration
 from shuup.core.models import AnonymousContact, Product, Shop, Supplier
 from shuup.testing.browser_utils import (
     click_element, wait_until_appeared, wait_until_condition
 )
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/admin/test_editor.py
+++ b/shuup_tests/browser/admin/test_editor.py
@@ -16,7 +16,7 @@ from shuup.testing.browser_utils import (
     click_element, move_to_element, wait_until_appeared,
     wait_until_condition
 )
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/admin/test_editor.py
+++ b/shuup_tests/browser/admin/test_editor.py
@@ -11,7 +11,6 @@ import pytest
 from django.core.urlresolvers import reverse
 from django.utils.translation import activate
 
-from shuup import configuration
 from shuup.testing import factories
 from shuup.testing.browser_utils import (
     click_element, move_to_element, wait_until_appeared,
@@ -32,7 +31,6 @@ def test_summernote_editor_picture(browser, admin_user, live_server, settings):
     factories.get_default_sales_unit()
     factories.get_default_tax_class()
     filer_image = factories.get_random_filer_image()
-    configuration.set(None, "shuup_product_tour_complete", True)
 
     initialize_admin_browser_test(browser, live_server, settings)
     browser.driver.set_window_size(1920, 1080)

--- a/shuup_tests/browser/admin/test_menu.py
+++ b/shuup_tests/browser/admin/test_menu.py
@@ -14,7 +14,7 @@ from django.core.urlresolvers import reverse
 
 from shuup.testing.browser_utils import wait_until_condition, wait_until_appeared
 from shuup.testing.factories import get_default_shop
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/admin/test_order_creator.py
+++ b/shuup_tests/browser/admin/test_order_creator.py
@@ -23,7 +23,7 @@ from shuup.testing.factories import (
     get_default_shipping_method, get_default_shop, get_default_supplier,
     get_initial_order_status
 )
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 OBJECT_CREATED_LOG_IDENTIFIER = "object_created_signal_handled"

--- a/shuup_tests/browser/admin/test_order_detail.py
+++ b/shuup_tests/browser/admin/test_order_detail.py
@@ -17,7 +17,7 @@ from shuup.testing.browser_utils import (
     click_element, wait_until_appeared, wait_until_condition
 )
 from shuup.testing.factories import create_empty_order, get_default_shop
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/admin/test_order_list.py
+++ b/shuup_tests/browser/admin/test_order_list.py
@@ -15,7 +15,7 @@ from shuup.testing.browser_utils import (
     click_element, wait_until_appeared, wait_until_condition
 )
 from shuup.testing.factories import create_empty_order, get_default_shop
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/admin/test_picotable.py
+++ b/shuup_tests/browser/admin/test_picotable.py
@@ -19,7 +19,7 @@ from shuup.testing.factories import (
     create_product, create_random_person, get_default_shop,
     get_default_supplier
 )
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/admin/test_product_create.py
+++ b/shuup_tests/browser/admin/test_product_create.py
@@ -14,7 +14,6 @@ import time
 from django.core.urlresolvers import reverse
 from django.utils.translation import activate
 
-from shuup import configuration
 from shuup.admin.signals import object_created
 from shuup.core.models import Category, Product
 from shuup.testing.browser_utils import (
@@ -39,7 +38,6 @@ def test_product_create(browser, admin_user, live_server, settings):
     get_default_product_type()
     get_default_sales_unit()
     get_default_tax_class()
-    configuration.set(None, "shuup_product_tour_complete", True)
     object_created.connect(_add_custom_product_created_message, sender=Product, dispatch_uid="object_created_signal_test")
     initialize_admin_browser_test(browser, live_server, settings)
 
@@ -57,7 +55,6 @@ def test_product_create(browser, admin_user, live_server, settings):
     browser.fill("base-short_description__en", short_description)
     browser.fill("shop%s-default_price_value" % shop.pk, price_value)
 
-    configuration.set(None, "shuup_category_tour_complete", True)
     _add_primary_category(browser, shop)
     _add_additional_category(browser, shop)
 

--- a/shuup_tests/browser/admin/test_product_create.py
+++ b/shuup_tests/browser/admin/test_product_create.py
@@ -24,7 +24,7 @@ from shuup.testing.factories import (
     get_default_product_type, get_default_sales_unit,
     get_default_shop, get_default_tax_class
 )
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 OBJECT_CREATED_LOG_IDENTIFIER = "object_created_signal_handled"

--- a/shuup_tests/browser/admin/test_product_detail.py
+++ b/shuup_tests/browser/admin/test_product_detail.py
@@ -14,7 +14,7 @@ from shuup.testing.browser_utils import (
     click_element, wait_until_condition, wait_until_appeared
 )
 from shuup.testing.factories import create_product, get_default_shop
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/admin/test_product_detail.py
+++ b/shuup_tests/browser/admin/test_product_detail.py
@@ -10,7 +10,6 @@ import os
 import pytest
 from django.core.urlresolvers import reverse
 
-from shuup import configuration
 from shuup.testing.browser_utils import (
     click_element, wait_until_condition, wait_until_appeared
 )
@@ -25,7 +24,6 @@ pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1
 def test_product_detail(browser, admin_user, live_server, settings):
     shop = get_default_shop()
     product = create_product("test_sku", shop, default_price=10)
-    configuration.set(None, "shuup_product_tour_complete", True)
     initialize_admin_browser_test(browser, live_server, settings)
 
     url = reverse("shuup_admin:shop_product.edit", kwargs={"pk": product.get_shop_instance(shop).pk})

--- a/shuup_tests/browser/admin/test_quick_add_edit_button.py
+++ b/shuup_tests/browser/admin/test_quick_add_edit_button.py
@@ -24,7 +24,7 @@ from shuup.testing.factories import (
     create_random_user, get_default_product_type, get_default_sales_unit,
     get_default_shop, get_default_tax_class
 )
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/admin/test_quick_add_edit_button.py
+++ b/shuup_tests/browser/admin/test_quick_add_edit_button.py
@@ -12,7 +12,6 @@ import pytest
 from django.contrib.auth.models import Group, Permission
 from django.core.urlresolvers import reverse
 
-from shuup import configuration
 from shuup.admin.module_registry import get_modules
 from shuup.admin.utils.permissions import (
     get_default_model_permissions, get_permission_object_from_string
@@ -37,7 +36,6 @@ def test_quick_add(browser, admin_user, live_server, settings):
     get_default_product_type()
     get_default_sales_unit()
     get_default_tax_class()
-    configuration.set(None, "shuup_product_tour_complete", True)
     initialize_admin_browser_test(browser, live_server, settings)
 
     url = reverse("shuup_admin:shop_product.new")
@@ -51,8 +49,6 @@ def test_quick_add(browser, admin_user, live_server, settings):
     browser.fill("base-name__en", name)
     browser.fill("base-short_description__en", short_description)
     browser.fill("shop%s-default_price_value" % shop.pk, price_value)
-
-    configuration.set(None, "shuup_category_tour_complete", True)
 
     wait_until_appeared(browser, "#id_shop%d-primary_category ~ .quick-add-btn a.btn" % shop.id)
     click_element(browser, "#id_shop%d-primary_category ~ .quick-add-btn a.btn" % shop.id)
@@ -109,7 +105,6 @@ def test_edit_button_no_permission(browser, admin_user, live_server, settings):
     get_default_product_type()
     get_default_sales_unit()
     get_default_tax_class()
-    configuration.set(None, "shuup_product_tour_complete", True)
     initialize_admin_browser_test(browser, live_server, settings, username=manager.username)
 
     url = reverse("shuup_admin:shop_product.new")
@@ -124,8 +119,6 @@ def test_edit_button_no_permission(browser, admin_user, live_server, settings):
     browser.fill("base-name__en", name)
     browser.fill("base-short_description__en", short_description)
     browser.fill("shop%s-default_price_value" % shop.pk, price_value)
-
-    configuration.set(None, "shuup_category_tour_complete", True)
 
     wait_until_appeared(browser, "#id_shop%d-primary_category ~ .quick-add-btn a.btn" % shop.id)
     click_element(browser, "#id_shop%d-primary_category ~ .quick-add-btn a.btn" % shop.id)

--- a/shuup_tests/browser/admin/test_refunds.py
+++ b/shuup_tests/browser/admin/test_refunds.py
@@ -20,7 +20,7 @@ from shuup.testing.factories import (
     create_order_with_product, get_default_product, get_default_shop,
     get_default_supplier
 )
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 from shuup.utils.i18n import format_money
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")

--- a/shuup_tests/browser/admin/test_snippet_injection.py
+++ b/shuup_tests/browser/admin/test_snippet_injection.py
@@ -14,7 +14,7 @@ from shuup.testing import factories
 from shuup.testing.browser_utils import (
     click_element, wait_until_appeared, wait_until_condition
 )
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 from shuup.core import cache
 from shuup.xtheme import get_current_theme
 from shuup.xtheme.models import Snippet

--- a/shuup_tests/browser/admin/test_tour.py
+++ b/shuup_tests/browser/admin/test_tour.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+
+import pytest
+
+from shuup.admin.utils.tour import is_tour_complete
+from shuup.testing import factories
+from shuup.testing.browser_utils import (
+    click_element, move_to_element, wait_until_condition
+)
+from shuup.testing.utils import initialize_admin_browser_test
+
+pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
+
+
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_dashbord_tour(browser, admin_user, live_server, settings):
+    shop = factories.get_default_shop()
+    shop2 = factories.get_shop(identifier="shop2")
+    admin_user_2 = factories.create_random_user(is_staff=True, is_superuser=True)
+    admin_user_2.set_password("password")
+    admin_user_2.save()
+
+    shop.staff_members.add(admin_user)
+    shop.staff_members.add(admin_user_2)
+
+    # test with admin_user 1
+    initialize_admin_browser_test(browser, live_server, settings, shop=shop, tour_complete=False)
+    wait_until_condition(browser, lambda x: x.is_text_present("Welcome!"))
+    wait_until_condition(browser, lambda x: x.is_text_present("Quicklinks"))
+    wait_until_condition(browser, lambda x: x.is_element_present_by_css("#menu-button"))
+    wait_until_condition(browser, lambda x: x.is_text_present("This is the dashboard for your store."))
+    wait_until_condition(browser, lambda x: x.is_element_present_by_css(".shepherd-button.btn-primary"))
+    click_element(browser, ".shepherd-button.btn-primary")
+    wait_until_condition(browser, lambda x: not x.is_element_present_by_css(".shepherd-button"))
+    wait_until_condition(browser, lambda x: is_tour_complete(shop, "dashboard", admin_user))
+
+    browser.visit(live_server + "/logout")
+    browser.visit(live_server + "/sa")
+
+    # test with admin_user 2
+    initialize_admin_browser_test(browser, live_server, settings, shop=shop, tour_complete=False, username=admin_user_2.username)
+    wait_until_condition(browser, lambda x: x.is_text_present("Welcome!"))
+    wait_until_condition(browser, lambda x: x.is_element_present_by_css("#menu-button"))
+    wait_until_condition(browser, lambda x: x.is_text_present("This is the dashboard for your store."))
+    wait_until_condition(browser, lambda x: x.is_element_present_by_css(".shepherd-button.btn-primary"))
+    click_element(browser, ".shepherd-button.btn-primary")
+    wait_until_condition(browser, lambda x: not x.is_element_present_by_css(".shepherd-button"))
+    wait_until_condition(browser, lambda x: is_tour_complete(shop, "dashboard", admin_user_2))
+
+    # check whether the tour is shown again
+    browser.visit(live_server + "/sa")
+    wait_until_condition(browser, lambda x: not x.is_text_present("This is the dashboard for your store."))
+
+    assert is_tour_complete(shop2, "dashboard", admin_user) is False
+    assert is_tour_complete(shop2, "dashboard", admin_user_2) is False
+
+
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_home_tour(browser, admin_user, live_server, settings):
+    shop = factories.get_default_shop()
+    shop2 = factories.get_shop(identifier="shop2")
+    admin_user_2 = factories.create_random_user(is_staff=True, is_superuser=True)
+    admin_user_2.set_password("password")
+    admin_user_2.save()
+
+    shop.staff_members.add(admin_user)
+    shop.staff_members.add(admin_user_2)
+
+    for user in [admin_user, admin_user_2]:
+        initialize_admin_browser_test(browser, live_server, settings, username=user.username, tour_complete=False)
+        wait_until_condition(browser, lambda x: x.is_text_present("Welcome!"))
+        browser.visit(live_server + "/sa/home")
+
+        wait_until_condition(browser, lambda x: x.is_text_present("Hi, new shop owner!"))
+        wait_until_condition(browser, lambda x: x.is_element_present_by_css(".shepherd-button.btn-primary"))
+        click_element(browser, ".shepherd-button.btn-primary")
+
+        category_targets = [
+            ".shepherd-enabled[data-target-id='category-1'",
+            ".shepherd-enabled[data-target-id='category-2'",
+            ".shepherd-enabled[data-target-id='category-3'",
+            ".shepherd-enabled[data-target-id='category-5'",
+            ".shepherd-enabled[data-target-id='category-9'",
+            ".shepherd-enabled[data-target-id='category-4'",
+            ".shepherd-enabled[data-target-id='category-6'",
+            ".shepherd-enabled[data-target-id='category-7'",
+            ".shepherd-enabled[data-target-id='category-8'",
+            ".shepherd-enabled#site-search",
+            ".shepherd-enabled.shop-btn.visit-store",
+        ]
+        for target in category_targets:
+            wait_until_condition(browser, lambda x: x.is_element_present_by_css(target))
+            move_to_element(browser, ".shepherd-button.btn-primary")
+            browser.find_by_css(".shepherd-button.btn-primary").last.click()
+
+        wait_until_condition(browser, lambda x: x.is_text_present("We're done!"))
+        move_to_element(browser, ".shepherd-button.btn-primary")
+        browser.find_by_css(".shepherd-button.btn-primary").last.click()
+        wait_until_condition(browser, lambda x: is_tour_complete(shop, "home", user))
+
+        # check whether the tour is shown again
+        browser.visit(live_server + "/sa/home")
+        wait_until_condition(browser, lambda x: not x.is_text_present("Hi, new shop owner!"))
+
+        browser.visit(live_server + "/logout")
+        browser.visit(live_server + "/sa")
+
+        wait_until_condition(browser, lambda x: not x.is_text_present("Hi, new shop owner!"))
+
+        assert is_tour_complete(shop2, "home", user) is False
+
+
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_product_tour(browser, admin_user, live_server, settings):
+    shop = factories.get_default_shop()
+    shop2 = factories.get_shop(identifier="shop2")
+    admin_user_2 = factories.create_random_user(is_staff=True, is_superuser=True)
+    admin_user_2.set_password("password")
+    admin_user_2.save()
+    product = factories.get_default_product()
+    shop_product = product.get_shop_instance(shop)
+
+    shop.staff_members.add(admin_user)
+    shop.staff_members.add(admin_user_2)
+
+    for user in [admin_user, admin_user_2]:
+        initialize_admin_browser_test(browser, live_server, settings, username=user.username, tour_complete=False)
+        wait_until_condition(browser, lambda x: x.is_text_present("Welcome!"))
+        browser.visit(live_server + "/sa/products/%d/" % shop_product.pk)
+
+        wait_until_condition(browser, lambda x: x.is_text_present("You are adding a product."))
+        wait_until_condition(browser, lambda x: x.is_element_present_by_css(".shepherd-button.btn-primary"))
+        click_element(browser, ".shepherd-button.btn-primary")
+
+        category_targets = [
+            "a.shepherd-enabled[href='#basic-information-section']",
+            "a.shepherd-enabled[href='#additional-details-section']",
+            "a.shepherd-enabled[href='#manufacturer-section']",
+            "a.shepherd-enabled[href*='-additional-section']",
+            "a.shepherd-enabled[href='#product-media-section']",
+            "a.shepherd-enabled[href='#product-images-section']",
+            "a.shepherd-enabled[href='#contact-group-pricing-section']",
+            "a.shepherd-enabled[href='#contact-group-discount-section']"
+        ]
+        for target in category_targets:
+            wait_until_condition(browser, lambda x: x.is_element_present_by_css(target))
+            move_to_element(browser, ".shepherd-button.btn-primary")
+            browser.find_by_css(".shepherd-button.btn-primary").last.click()
+        wait_until_condition(browser, lambda x: is_tour_complete(shop, "product", user))
+
+        # check whether the tour is shown again
+        browser.visit(live_server + "/sa/products/%d/" % shop_product.pk)
+        wait_until_condition(browser, lambda x: not x.is_text_present("You are adding a product."))
+
+        assert is_tour_complete(shop2, "product", user) is False
+
+        browser.visit(live_server + "/logout")
+        browser.visit(live_server + "/sa")
+
+
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_category_tour(browser, admin_user, live_server, settings):
+    shop = factories.get_default_shop()
+    shop2 = factories.get_shop(identifier="shop2")
+    admin_user_2 = factories.create_random_user(is_staff=True, is_superuser=True)
+    admin_user_2.set_password("password")
+    admin_user_2.save()
+
+    shop.staff_members.add(admin_user)
+    shop.staff_members.add(admin_user_2)
+
+    for user in [admin_user, admin_user_2]:
+        initialize_admin_browser_test(browser, live_server, settings, username=user.username, tour_complete=False)
+        wait_until_condition(browser, lambda x: x.is_text_present("Welcome!"))
+        browser.visit(live_server + "/sa/categories/new")
+
+        wait_until_condition(browser, lambda x: x.is_text_present("Add a new product category"))
+        wait_until_condition(browser, lambda x: x.is_element_present_by_css(".shepherd-button.btn-primary"))
+        click_element(browser, ".shepherd-button.btn-primary")
+        wait_until_condition(browser, lambda x: not x.is_element_present_by_css(".shepherd-button"))
+        wait_until_condition(browser, lambda x: is_tour_complete(shop, "category", user))
+
+        # check whether the tour is shown again
+        browser.visit(live_server + "/sa/categories/new")
+        wait_until_condition(browser, lambda x: not x.is_text_present("Add a new product category"))
+
+        browser.visit(live_server + "/logout")
+        browser.visit(live_server + "/sa")
+
+        assert is_tour_complete(shop2, "category", user) is False

--- a/shuup_tests/browser/admin/test_tour.py
+++ b/shuup_tests/browser/admin/test_tour.py
@@ -14,7 +14,7 @@ from shuup.testing import factories
 from shuup.testing.browser_utils import (
     click_element, move_to_element, wait_until_condition
 )
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/front/test_category_view.py
+++ b/shuup_tests/browser/front/test_category_view.py
@@ -25,7 +25,7 @@ from shuup.testing.browser_utils import click_element, wait_until_condition
 from shuup.testing.factories import (
     create_product, get_default_shop, get_default_supplier
 )
-from shuup.testing.utils import initialize_front_browser_test
+from shuup.testing.browser_utils import initialize_front_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/front/test_checkout.py
+++ b/shuup_tests/browser/front/test_checkout.py
@@ -21,7 +21,7 @@ from shuup.testing.factories import (
     get_default_shop, get_default_supplier, get_payment_method,
     get_shipping_method
 )
-from shuup.testing.utils import initialize_front_browser_test
+from shuup.testing.browser_utils import initialize_front_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/front/test_checkout_addresses.py
+++ b/shuup_tests/browser/front/test_checkout_addresses.py
@@ -20,7 +20,7 @@ from shuup.testing.factories import (
     create_product, get_default_payment_method, get_default_shipping_method,
     get_default_shop, get_default_supplier
 )
-from shuup.testing.utils import initialize_front_browser_test
+from shuup.testing.browser_utils import initialize_front_browser_test
 from shuup.utils.importing import clear_load_cache
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")

--- a/shuup_tests/browser/front/test_checkout_with_login_and_register.py
+++ b/shuup_tests/browser/front/test_checkout_with_login_and_register.py
@@ -23,7 +23,7 @@ from shuup.testing.factories import (
     create_product, get_default_payment_method, get_default_shipping_method,
     get_default_shop, get_default_supplier
 )
-from shuup.testing.utils import initialize_front_browser_test
+from shuup.testing.browser_utils import initialize_front_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/front/test_coupon.py
+++ b/shuup_tests/browser/front/test_coupon.py
@@ -29,7 +29,7 @@ from shuup.testing.factories import (
     create_product, get_default_payment_method, get_default_shipping_method,
     get_default_shop, get_default_supplier
 )
-from shuup.testing.utils import initialize_front_browser_test
+from shuup.testing.browser_utils import initialize_front_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/front/test_gdpr_consent.py
+++ b/shuup_tests/browser/front/test_gdpr_consent.py
@@ -15,7 +15,7 @@ from shuup.testing.browser_utils import (
     click_element, wait_until_appeared, wait_until_condition
 )
 from shuup.testing.factories import get_default_shop
-from shuup.testing.utils import initialize_front_browser_test
+from shuup.testing.browser_utils import initialize_front_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/front/test_product_view.py
+++ b/shuup_tests/browser/front/test_product_view.py
@@ -18,7 +18,7 @@ from shuup.testing.factories import (
     create_product, get_default_category, get_default_shop,
     get_default_supplier
 )
-from shuup.testing.utils import initialize_front_browser_test
+from shuup.testing.browser_utils import initialize_front_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/front/test_recently_viewed_products.py
+++ b/shuup_tests/browser/front/test_recently_viewed_products.py
@@ -8,7 +8,7 @@ import os
 import pytest
 from django.core.urlresolvers import reverse
 
-from shuup.testing.utils import initialize_front_browser_test
+from shuup.testing.browser_utils import initialize_front_browser_test
 from shuup.testing.factories import (
     create_product, get_default_category, get_default_shop
 )

--- a/shuup_tests/browser/front/test_search_view.py
+++ b/shuup_tests/browser/front/test_search_view.py
@@ -28,7 +28,7 @@ from shuup.testing.factories import (
     create_product, get_default_category, get_default_shop,
     get_default_supplier
 )
-from shuup.testing.utils import initialize_front_browser_test
+from shuup.testing.browser_utils import initialize_front_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/front/test_xtheme_edit.py
+++ b/shuup_tests/browser/front/test_xtheme_edit.py
@@ -17,7 +17,7 @@ from shuup.testing import factories
 from shuup.testing.browser_utils import (
     click_element, wait_until_condition
 )
-from shuup.testing.utils import (
+from shuup.testing.browser_utils import (
     initialize_admin_browser_test
 )
 from shuup.testing.browser_utils import page_has_loaded

--- a/shuup_tests/browser/front/test_xtheme_plugin_form.py
+++ b/shuup_tests/browser/front/test_xtheme_plugin_form.py
@@ -16,7 +16,7 @@ from shuup.testing import factories
 from shuup.testing.browser_utils import (
     click_element, page_has_loaded, wait_until_appeared, wait_until_condition
 )
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/notify/test_script_template.py
+++ b/shuup_tests/browser/notify/test_script_template.py
@@ -28,7 +28,7 @@ from shuup.testing.browser_utils import (
     click_element, move_to_element, wait_until_condition
 )
 from shuup.testing.notify_script_templates import DummyScriptTemplate
-from shuup.testing.utils import initialize_admin_browser_test
+from shuup.testing.browser_utils import initialize_admin_browser_test
 
 pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
 

--- a/shuup_tests/browser/notify/test_script_template.py
+++ b/shuup_tests/browser/notify/test_script_template.py
@@ -45,7 +45,6 @@ def post_initialize():
     DB seems to be randomly locked and we want to wait
     until we perform these post procedures.
     """
-    configuration.set(None, "shuup_product_tour_complete", True)
     Script.objects.all().delete()
 
 


### PR DESCRIPTION
After upgrading Shepherd to latest version, some styling fixing was necessary

- Fix the product tour which were not showing media and images steps correctly.
- Make tour be saved based on shop and user
- Create unit tests for all tours

As the tour key was changed, the tour will be visible for all users again.

Fixes #1560