### PR TITLE
 Admin: fix order creator form

### DIFF
--- a/shuup/admin/modules/contacts/views/list.py
+++ b/shuup/admin/modules/contacts/views/list.py
@@ -118,7 +118,7 @@ class ContactListView(PicotableListView):
         :type instance: shuup.core.models.Contact
         """
         bits = filter(None, [
-            item.get("type"),
+            self.get_type_display(instance),
             _("Active") if instance.is_active else _("Inactive"),
             _("Email: %s") % (instance.email or "\u2014"),
             _("Phone: %s") % (instance.phone or "\u2014"),

--- a/shuup/admin/modules/orders/static_src/create/view/customers.js
+++ b/shuup/admin/modules/orders/static_src/create/view/customers.js
@@ -66,14 +66,17 @@ function renderAddress(store, shop, customer, address, addressType) {
         if (field.key === "tax_number" || field.key === "email") {
             onchange = function () {
                 store.dispatch(setAddressProperty(addressType, field.key, this.value));
-                get("customer_exists", {
-                    "field": field.key, "value": this.value
-                }).then((data) => {
-                    removeWarningBlocks(this.parentElement);
-                    if (data.id && data.id !== customer.id) {
-                        buildWarningBlock(store, this.parentElement, field.label.toLowerCase(), data.name, data.id);
-                    }
-                });
+
+                if (this.value) {
+                    get("customer_exists", {
+                        "field": field.key, "value": this.value
+                    }).then((data) => {
+                        removeWarningBlocks(this.parentElement);
+                        if (data.id && data.id !== customer.id) {
+                            buildWarningBlock(store, this.parentElement, field.label.toLowerCase(), data.name, data.id);
+                        }
+                    });
+                }
             };
         }
         if (window.REGIONS) {

--- a/shuup/admin/modules/orders/static_src/create/view/customers.js
+++ b/shuup/admin/modules/orders/static_src/create/view/customers.js
@@ -6,16 +6,18 @@
  * This source code is licensed under the OSL-3.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import {get} from "../api";
-import {clearExistingCustomer, retrieveCustomerData, setAddressProperty,
-    setAddressSavingOption, setShipToBillingAddress, setIsCompany, showCustomerModal, retrieveCustomerDetails} from "../actions";
-import {ADDRESS_FIELDS, selectBox, contentBlock, infoRow, table, modal, Select2, HelpPopover} from "./utils";
+import { get } from "../api";
+import {
+    clearExistingCustomer, retrieveCustomerData, setAddressProperty,
+    setAddressSavingOption, setShipToBillingAddress, setIsCompany, showCustomerModal, retrieveCustomerDetails
+} from "../actions";
+import { ADDRESS_FIELDS, selectBox, contentBlock, infoRow, table, modal, Select2, HelpPopover } from "./utils";
 const BrowseAPI = window.BrowseAPI;
 
-function removeWarningBlocks(parentElement){
+function removeWarningBlocks(parentElement) {
     var previousWarnings = parentElement.getElementsByClassName("duplicate-warning");
 
-    while(previousWarnings[0]){
+    while (previousWarnings[0]) {
         previousWarnings[0].parentNode.removeChild(previousWarnings[0]);
     }
 }
@@ -30,8 +32,8 @@ function buildWarningBlock(store, parentElement, fieldName, customerName, custom
 
     var link = document.createElement("a");
     link.href = "#";
-    link.onclick = function() {
-        store.dispatch(retrieveCustomerData({id: customerId}));
+    link.onclick = function () {
+        store.dispatch(retrieveCustomerData({ id: customerId }));
         removeWarningBlocks(document);
     };
     link.innerHTML = interpolate(gettext("Click to select user %s."), [customerName]);
@@ -61,8 +63,8 @@ function renderAddress(store, shop, customer, address, addressType) {
         var onchange = function () {
             store.dispatch(setAddressProperty(addressType, field.key, this.value));
         };
-        if (field.key === "tax_number" || field.key === "email"){
-            onchange = function() {
+        if (field.key === "tax_number" || field.key === "email") {
+            onchange = function () {
                 store.dispatch(setAddressProperty(addressType, field.key, this.value));
                 get("customer_exists", {
                     "field": field.key, "value": this.value
@@ -84,7 +86,7 @@ function renderAddress(store, shop, customer, address, addressType) {
                         m("div.form-input-group.d-flex", [
                             selectBox(
                                 _.get(address, field.key, ""), onchange, regionsData,
-                                "code", "name", addressType + "-" + field.key, {code: "", name: "---------"}),
+                                "code", "name", addressType + "-" + field.key, { code: "", name: "---------" }),
                             m.component(HelpPopover, {
                                 title: field.label,
                                 content: helpText
@@ -137,7 +139,7 @@ function renderCustomerAddressView(store, shop, customer) {
                         name: "save-address",
                         type: "checkbox",
                         checked: customer.saveAddress,
-                        onchange: function() {
+                        onchange: function () {
                             store.dispatch(setAddressSavingOption(this.checked));
                         }
                     }),
@@ -153,7 +155,7 @@ function renderCustomerAddressView(store, shop, customer) {
                         name: "ship-to-billing-address",
                         type: "checkbox",
                         checked: customer.shipToBillingAddress,
-                        onchange: function() {
+                        onchange: function () {
                             store.dispatch(setShipToBillingAddress(this.checked));
                         }
                     }),
@@ -169,7 +171,7 @@ function renderCustomerAddressView(store, shop, customer) {
                         name: "order-for-company",
                         type: "checkbox",
                         checked: customer.isCompany,
-                        onchange: function() {
+                        onchange: function () {
                             store.dispatch(setIsCompany(this.checked));
                         }
                     }),
@@ -230,8 +232,8 @@ function customerDetailView(customerInfo) {
 
 function orderSummaryView(orderSummary) {
     const columns = [
-        {key: "year", label: gettext("Year")},
-        {key: "total", label: gettext("Total Sales")}
+        { key: "year", label: gettext("Year") },
+        { key: "total", label: gettext("Total Sales") }
     ];
 
     return m("div.table-responsive",
@@ -245,11 +247,11 @@ function orderSummaryView(orderSummary) {
 
 function recentOrderView(recentOrders) {
     const columns = [
-        {key: "order_date", label: gettext("Date")},
-        {key: "shipment_status", label: gettext("Shipment Status")},
-        {key: "payment_status", label: gettext("Payment Status")},
-        {key: "status", label: gettext("Order Status")},
-        {key: "total", label: gettext("Total")}
+        { key: "order_date", label: gettext("Date") },
+        { key: "shipment_status", label: gettext("Shipment Status") },
+        { key: "payment_status", label: gettext("Payment Status") },
+        { key: "status", label: gettext("Order Status") },
+        { key: "total", label: gettext("Total") }
     ];
 
     return m("div.table-responsive",
@@ -264,13 +266,13 @@ function recentOrderView(recentOrders) {
 function renderCustomerSelectionView(store, customer) {
     return [
         m("div.row", [
-            m("div.col-lg-6.col-md-12", {id: "customer-search"}, [
+            m("div.col-lg-6.col-md-12", { id: "customer-search" }, [
                 m.component(Select2, {
                     name: "customer-search",
                     model: "shuup.contact",
                     onchange: (obj) => {
-                        if(obj.length > 0) {
-                            store.dispatch(retrieveCustomerData({id: obj[0].id}));
+                        if (obj.length > 0) {
+                            store.dispatch(retrieveCustomerData({ id: obj[0].id }));
                         }
                     },
                     clear: true,
@@ -285,12 +287,12 @@ function renderCustomerSelectionView(store, customer) {
                             kind: "contact",
                             clearable: true,
                             onSelect: (obj) => {
-                                store.dispatch(retrieveCustomerData({id: obj.id}));
+                                store.dispatch(retrieveCustomerData({ id: obj.id }));
                             }
                         });
                     }
                 }, m("i.fa.fa-search")),
-                m("button.btn.text-success" + (!customer.id ? ".disabled": ""), {
+                m("button.btn.text-success" + (!customer.id ? ".disabled" : ""), {
                     id: "clear-customer",
                     disabled: !customer.id,
                     onclick: () => {
@@ -304,19 +306,19 @@ function renderCustomerSelectionView(store, customer) {
             ])
         ]),
         m("div.row", [
-            m("div.col-lg-6.col-md-12.mt-1", {id: "customer-description"}, [
-                (customer.id?
-                m("p.view-details-link", [
-                    m("div", gettext("Customer") + ": " + customer.name),
-                    m("a[href='#customer-detail-view']", {
-                        onclick: (e) => {
-                            e.preventDefault();
-                            store.dispatch(retrieveCustomerDetails({id: customer.id})).then(() => {
-                                store.dispatch(showCustomerModal(true));
-                            });
-                        }
-                    }, gettext("View Details"))
-                ]) : m("p", gettext("A new customer will be created based on billing address.")))
+            m("div.col-lg-6.col-md-12.mt-1", { id: "customer-description" }, [
+                (customer.id ?
+                    m("p.view-details-link", [
+                        m("div", gettext("Customer") + ": " + customer.name),
+                        m("a[href='#customer-detail-view']", {
+                            onclick: (e) => {
+                                e.preventDefault();
+                                store.dispatch(retrieveCustomerDetails({ id: customer.id })).then(() => {
+                                    store.dispatch(showCustomerModal(true));
+                                });
+                            }
+                        }, gettext("View Details"))
+                    ]) : m("p", gettext("A new customer will be created based on billing address.")))
             ])
         ]),
         m("br")
@@ -324,7 +326,7 @@ function renderCustomerSelectionView(store, customer) {
 }
 
 export function renderCustomerDetailModal(store) {
-    const {customerDetails} = store.getState();
+    const { customerDetails } = store.getState();
 
     const customerInfo = customerDetails.customerInfo || {};
     const orderSummary = customerDetails.orderSummary || [];
@@ -349,7 +351,7 @@ export function renderCustomerDetailModal(store) {
 }
 
 export function customerSelectView(store) {
-    const {customer, order, shop} = store.getState();
+    const { customer, order, shop } = store.getState();
     return m("div", [
         ((!customer.id && order.id !== null) ? m("p.text-danger", gettext("Warning: No customer account is currently associated with this order.")) : null),
         renderCustomerSelectionView(store, customer),

--- a/shuup/admin/modules/orders/static_src/create/view/index.js
+++ b/shuup/admin/modules/orders/static_src/create/view/index.js
@@ -26,7 +26,7 @@ export default function view() {
         viewObj = m("div.container-fluid",
             confirmView(source),
             m("div", [
-                m("button.btn.btn-danger.btn-lg" + (creating ? ".disabled" : ""), {
+                m("button.btn.btn-outline-danger.btn-lg" + (creating ? ".disabled" : ""), {
                     disabled: creating,
                     onclick: () => {
                         store.dispatch(clearOrderSourceData());

--- a/shuup/admin/static_src/base/js/components.js
+++ b/shuup/admin/static_src/base/js/components.js
@@ -13,13 +13,16 @@ const ScrollToTopButton = {
         };
         $(window).on("scroll", () => {
             const scrolled = (window.scrollY > 50);
-            ctrl.visible(scrolled);
-            if (scrolled) {
-                $("body").addClass("scrolled");
-            } else {
-                $("body").removeClass("scrolled");
+            const changed = (ctrl.visible() !== scrolled);
+            if (changed) {
+                ctrl.visible(scrolled);
+                if (scrolled) {
+                    $("body").addClass("scrolled");
+                } else {
+                    $("body").removeClass("scrolled");
+                }
+                m.redraw();
             }
-            m.redraw();
         });
         return ctrl;
     },

--- a/shuup/admin/static_src/base/scss/shuup/base.scss
+++ b/shuup/admin/static_src/base/scss/shuup/base.scss
@@ -150,12 +150,15 @@ img {
     left: 0;
     right: 0;
     bottom: 0;
+    z-index: 99999;
+    pointer-events: none;
 
     display: flex;
     flex-direction: row;
     justify-content: center;
 
     .scroll-to-top-button {
+        pointer-events: all;
         cursor: pointer;
         width: 2.5rem;
         height: 2.5rem;
@@ -163,7 +166,6 @@ img {
         box-shadow: 0 0px 10px 1px rgba(0, 0, 0, 0.15);
         border-radius: 50%;
         background-color: lighten($primary, 50%);
-        z-index: 999999;
 
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
### Admin: fix contacts select2 search and picotable
- Allow superuser selecting any contact without shop filtering
- Show the contact type correctly on contact list view when mobile device

### Admin: format customers.js file

### Admin: fix order creator form
- Make scroll to top only render when current value has really changed, preventing calling thousands of redraws with no
  reason
- Make buttons below scroll to top button container clickable
- Make order creator Back button style outline

Refs POS-2626