### PR TITLE
Xtheme: fix publish on save routine

### DIFF
--- a/shuup/xtheme/static_src/editor/editor.js
+++ b/shuup/xtheme/static_src/editor/editor.js
@@ -87,7 +87,7 @@ domready(() => {
         }
         post({command: "revert"});
     });
-    $("input, select, textarea").on("change,input", function() {
+    $("input, select, textarea").on("change input", function() {
         if (this.id === "id_general-plugin") {
             return;
         }


### PR DESCRIPTION
Fix jQuery event selector by replacing comma with space.

JQuery documentation says it is a string keys that represent one or more space-separated event types

Refs ENT-2565