### PR TITLE
Xtheme: fix image plugin by rendering h2 only when necessary

### DIFF
--- a/shuup/xtheme/templates/shuup/xtheme/plugins/image.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/plugins/image.jinja
@@ -1,5 +1,5 @@
 <section class="xtheme-image-plugin">
-    <h2>{{ title }}</h2>
+    {% if title %}<h2>{{ title }}</h2>{% endif %}
     {% if image %}
         {% if url %}<a href="{{ url }}">{% endif %}
             <img src="{{ image.url }}"


### PR DESCRIPTION
This prevents adding an empty h2 tag which can add extra padding/margin to the placeholder