### PR TITLE
Admin: picotable general fixes

### DIFF
--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-12 13:08+0000\n"
+"POT-Creation-Date: 2018-10-12 20:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -3129,11 +3129,11 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-msgid "This action effects on all products."
+msgid "This action effects on all items."
 msgstr ""
 
 #, python-format
-msgid "This action effects %(item_count)s products."
+msgid "This action affects %(item_count)s item(s)."
 msgstr ""
 
 msgid "Upload"

--- a/shuup/admin/static_src/base/js/drag-n-drop.js
+++ b/shuup/admin/static_src/base/js/drag-n-drop.js
@@ -35,10 +35,15 @@ function addToActive(e) {
 
     var label = $(this).data("label");
     var name = $(this).data("name");
-
+    var sourceItem = $(this).closest("li");
     const $source = $("#source-placeholder li");
     const html = $source.html().replace(/NAME/g, name).replace(/LABEL/g, label);
-    window.targetElement.append($("<li>").html(html));
+
+    const item = document.createElement("li");
+    item.setAttribute("class", sourceItem.prop("class"));
+    item.innerHTML = html;
+
+    window.targetElement.append($(item));
     $(this).closest("li").remove();
     updateOrdering();
 }
@@ -50,7 +55,7 @@ window.activateSortable = function(targetElement, sourceElement) {
     window.sourceElement = $source;
 
     var el = document.getElementById(targetElement);
-    var sortable = window.Sortable.create(el, {
+    window.Sortable.create(el, {
         handle: ".sorting-handle",
         onEnd: function (/**Event*/evt) {
             updateOrdering();

--- a/shuup/admin/static_src/picotable/picotable.js
+++ b/shuup/admin/static_src/picotable/picotable.js
@@ -323,8 +323,10 @@ const Picotable = (function (m, storage) {
             key: "min",
             value: Util.stringValue(value.min),
             placeholder: lang.RANGE_FROM,
-            onchange: function () {
-                setFilterValueFromInput.call(this, "min");
+            onchange: function (e) {
+                if (value.min !== e.target.value) {
+                    setFilterValueFromInput.call(this, "min");
+                }
             },
             config: useDatepicker ? ctrl.datePicker() : debounceChangeConfig(500)
         }));
@@ -333,8 +335,10 @@ const Picotable = (function (m, storage) {
             key: "max",
             value: Util.stringValue(value.max),
             placeholder: lang.RANGE_TO,
-            onchange: function () {
-                setFilterValueFromInput.call(this, "max");
+            onchange: function (e) {
+                if (value.max !== e.target.value) {
+                    setFilterValueFromInput.call(this, "max");
+                }
             },
             config: useDatepicker ? ctrl.datePicker() : debounceChangeConfig(500)
         }));

--- a/shuup/admin/templates/shuup/admin/edit_settings.jinja
+++ b/shuup/admin/templates/shuup/admin/edit_settings.jinja
@@ -68,7 +68,7 @@
                            name="NAME"
                            type="checkbox"> <label for="id_NAME">LABEL</label>
                     </div>
-                    <button class="btn btn-xs btn-red btn-remove-sortable" data-name="NAME" data-label="LABEL">{% trans %}Remove{% endtrans %}</button>
+                    <button class="btn btn-xs btn-red btn-remove-sortable ml-auto" data-name="NAME" data-label="LABEL">{% trans %}Remove{% endtrans %}</button>
                 </li>
             </ul>
         </div>

--- a/shuup/admin/templates/shuup/admin/mass_action/mass_edit.jinja
+++ b/shuup/admin/templates/shuup/admin/mass_action/mass_edit.jinja
@@ -16,15 +16,17 @@
 {% call content_block() %}
     <h3 class="text-center">
     {% if is_all_selected %}
-        {% trans%}This action effects on all products.{% endtrans %}
+        {% trans%}This action effects on all items.{% endtrans %}
     {% else %}
-        {% trans item_count=item_count %}This action effects {{ item_count }} products.{% endtrans %}
+        {% trans item_count=item_count %}This action affects {{ item_count }} item(s).{% endtrans %}
     {% endif %}
     </h3>
 
     <form method="post" id="mass_edit">
         {% csrf_token %}
-        {{ bs3.form(form) }}
+        {% for field in form %}
+            {{ bs3.field(field) }}
+        {% endfor %}
     </form>
 {% endcall %}
 {% endblock %}

--- a/shuup/admin/utils/picotable.py
+++ b/shuup/admin/utils/picotable.py
@@ -24,7 +24,7 @@ from filer.models import Image
 from shuup.admin.utils.urls import get_model_url, NoModelUrl
 from shuup.apps.provides import get_provide_objects
 from shuup.core.models import ProductMedia
-from shuup.utils.dates import try_parse_date
+from shuup.utils.dates import try_parse_datetime
 from shuup.utils.i18n import format_money, get_locally_formatted_datetime
 from shuup.utils.importing import load
 from shuup.utils.money import Money
@@ -193,8 +193,8 @@ class DateRangeFilter(RangeFilter):
     def filter_queryset(self, queryset, column, value, context):
         if value:
             value = {
-                "min": try_parse_date(value.get("min")),
-                "max": try_parse_date(value.get("max")),
+                "min": try_parse_datetime(value.get("min")),
+                "max": try_parse_datetime(value.get("max"))
             }
         return super(DateRangeFilter, self).filter_queryset(queryset, column, value, context)
 

--- a/shuup/utils/dates.py
+++ b/shuup/utils/dates.py
@@ -8,6 +8,7 @@
 from __future__ import unicode_literals
 
 import datetime
+import itertools
 import time
 
 import six
@@ -15,7 +16,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
 
-__all__ = ("parse_date", "parse_time", "try_parse_date", "try_parse_time")
+__all__ = ("parse_date", "parse_time", "try_parse_date", "try_parse_time", "try_parse_datetime")
 
 _date_formats = (
     "%Y-%m-%d",
@@ -31,6 +32,11 @@ _time_formats = (
     "%H:%M:%S",
     "%H:%M",
 )
+
+_datetime_formats = list(itertools.chain.from_iterable([
+    ["{} %H:%M:%S".format(fmt) for fmt in _date_formats],
+    ["{} %H:%M".format(fmt) for fmt in _date_formats]
+]))
 
 locale_year_and_month_formats = {
     # Sourced from the Unicode CLDR, version 27.1.
@@ -86,7 +92,7 @@ def _parse_date_str(value):
 
 def _parse_datetime_str(value):
     value = value.strip()
-    for fmt in _date_formats:
+    for fmt in itertools.chain.from_iterable((_datetime_formats, _date_formats)):
         try:
             return datetime.datetime.strptime(value, fmt)
         except:
@@ -164,10 +170,10 @@ def parse_time(value):
     if isinstance(value, datetime.datetime):
         return value.time()
     if isinstance(value, six.string_types):
-        time = _parse_time_str(value)
-        if not time:
+        parsed_time = _parse_time_str(value)
+        if not parsed_time:
             raise ValueError("Unable to parse %s as date." % value)
-        return time
+        return parsed_time
     raise ValueError("Unable to parse %s as date (unknown type)." % value)
 
 

--- a/shuup_tests/utils/test_dates.py
+++ b/shuup_tests/utils/test_dates.py
@@ -6,9 +6,12 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 
-from datetime import date, datetime
+from datetime import date, datetime, time
 
-from shuup.utils.dates import parse_date, parse_datetime
+from shuup.utils.dates import (
+    parse_date, parse_datetime, try_parse_date, try_parse_datetime,
+    try_parse_time
+)
 
 
 def test_parse_date():
@@ -25,6 +28,8 @@ def test_parse_date():
     assert parse_date(date_fmt1) == expected_date
     assert parse_date(date_fmt2) == expected_date
     assert parse_date(date_fmt3) == expected_date
+    assert try_parse_date(1) is None
+
 
 
 def test_parse_datetime():
@@ -40,3 +45,27 @@ def test_parse_datetime():
     assert parse_datetime(date_fmt1) == datetime(2016, 12, 31)
     assert parse_datetime(date_fmt2) == datetime(2016, 12, 31, 15, 40, 34, 404540)
     assert parse_datetime(date_fmt3) == datetime(2016, 12, 31)
+
+
+def test_parse_time():
+    now = datetime.now()
+
+    time_fmt1 = "10:20"
+    time_fmt2 = "12:32:21"
+
+    assert try_parse_time(now) == now.time()
+    assert try_parse_time(now.time()) == now.time()
+    assert try_parse_time(time_fmt1) == time(10, 20)
+    assert try_parse_time(time_fmt2) == time(12, 32, 21)
+    assert try_parse_time("12341") is None
+
+
+def test_try_parse_datetime():
+    date_fmt1 = "2016-12-31 15:40:34"
+    date_fmt2 = "2018-12-31 15:40"
+    date_fmt3 = "12/31/2016"
+
+    assert try_parse_datetime(date_fmt1) == datetime(2016, 12, 31, 15, 40, 34)
+    assert try_parse_datetime(date_fmt2) == datetime(2018, 12, 31, 15, 40)
+    assert try_parse_datetime(date_fmt3) == datetime(2016, 12, 31)
+    assert try_parse_datetime("abc") is None


### PR DESCRIPTION
### Fix mass edit to not fail when all items are selected

### Fix datetime parse utils to consider datetime formats
Some picotable filters use time and it was not expected when parsing the values

### Improve mass edit form
Render fields separately through bs3.field method making form apply standard styles
Improve selected items count message

### Fix picotable settings view styles
Add more styles to the item template when adding a field to picotable

### Prevent double query on change event of picotable range filter
Check whether the field value has changed before making a new request

Refs ENT-2551