### PR TITLE
Admin: Remove duplicate fields in CGP & Fix API Docs 

### DIFF
--- a/shuup/api/docs.py
+++ b/shuup/api/docs.py
@@ -144,10 +144,15 @@ class ShuupAPISchemaGenerator(SchemaGenerator):
         return fields
 
 
+class JSONOpenAPIRenderer(renderers.OpenAPIRenderer):
+    media_type = 'application/json'
+
+
 class SwaggerSchemaView(APIView):
     renderer_classes = [
         renderers.OpenAPIRenderer,
-        renderers.SwaggerUIRenderer
+        renderers.SwaggerUIRenderer,
+        JSONOpenAPIRenderer
     ]
 
     def get(self, request):

--- a/shuup/core/api/front_passwords.py
+++ b/shuup/core/api/front_passwords.py
@@ -72,6 +72,8 @@ class SetAuthenticatedUserPasswordSerializer(serializers.Serializer):
 
 
 class PasswordResetViewSet(GenericViewSet):
+    serializer_class = serializers.BaseSerializer
+
     def create(self, request):
         form = RecoverPasswordForm(request.data)
         if form.is_valid():
@@ -82,6 +84,8 @@ class PasswordResetViewSet(GenericViewSet):
 
 
 class SetPasswordViewSet(GenericViewSet):
+    serializer_class = serializers.BaseSerializer
+
     def create(self, request):
         if not request.user.is_anonymous():
             serializer = SetAuthenticatedUserPasswordSerializer(data=request.data, context={'request': request})

--- a/shuup/customer_group_pricing/admin_form_part.py
+++ b/shuup/customer_group_pricing/admin_form_part.py
@@ -33,9 +33,9 @@ class CustomerGroupPricingForm(forms.Form):
             Q(price_display_options__show_pricing=True) |
             Q(
                 id__in=CgpPrice.objects.filter(product=self.product)
-                .values_list("group_id", flat=True).distinct()
+                .values_list("group_id", flat=True)
             )
-        ))
+        ).distinct())
         prices_by_shop_and_group = dict(
             ((shop_id or 0, group_id or 0), price)
             for (shop_id, group_id, price)
@@ -114,9 +114,9 @@ class CustomerGroupDiscountForm(forms.Form):
             Q(price_display_options__show_pricing=True) |
             Q(
                 id__in=CgpDiscount.objects.filter(product=self.product)
-                .values_list("group_id", flat=True).distinct()
+                .values_list("group_id", flat=True)
             )
-        ))
+        ).distinct())
         discounts_by_shop_and_group = dict(
             ((shop_id or 0, group_id or 0), discount_amount)
             for (shop_id, group_id, discount_amount)


### PR DESCRIPTION
- Admin: Remove duplicate fields in Contact Group Pricing & Discount forms
Contact group pricing & discounts for products were showing duplicate fields.

- API: Fix docs view bugs
Accessing /api/docs would throw a django assertion error, SetPasswordViewSet & PasswordResetViewSet were missing
serializer_class. Defined the base serializer for them.

Clicking "Try it out" on docs in api/docs would throw a 406 error.
Fixes #1602 