### PR TITLE
Fix parler cache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,6 @@ REQUIRES = [
     'django-filter>=1.0,<1.2',
     'django-jinja>=1.4,<3',
     'django-mptt>=0.8.0,<0.10',  # Django-filer doesn't officially support 0.9.0
-    'django-parler>=1.5,<2',
     'django-parler-rest>=1.3a1,<2',
     'django-polymorphic>=0.8,<2.1.0',  # For Django 1.8 and 1.9 use version lower 1
     'django-registration-redux>=1.5,<1.9',
@@ -117,8 +116,12 @@ REQUIRES = [
     'secretstorage==2.3.1',
     'six>=1.9,<2',
     'unicodecsv==0.14.1',
-    'xlrd>=1'
+    'xlrd>=1',
+
+    # FIXME: Use this commit until Django Parler v1.9.3 is released and publishe in PyPI
+    'django-parler @ https://github.com/django-parler/django-parler/tarball/10479b0'
 ]
+
 
 REQUIRES_FOR_PYTHON2_ONLY = [
     'pillow>=3.4.2,<4'
@@ -167,5 +170,5 @@ if __name__ == '__main__':
         extras_require=EXTRAS_REQUIRE,
         packages=utils.find_packages(exclude=EXCLUDED_PACKAGES),
         include_package_data=True,
-        cmdclass=utils.COMMANDS,
+        cmdclass=utils.COMMANDS
     )

--- a/shuup/core/models/_products.py
+++ b/shuup/core/models/_products.py
@@ -368,17 +368,18 @@ class Product(TaxableItem, AttributableMixin, TranslatableModel):
         :rtype: shuup.core.models.ShopProduct
         """
 
-        # FIXME: Temporary removed the cache to prevent parler issues
-        # Uncomment this as soon as https://github.com/shuup/shuup/issues/1323 is fixed
-        # and Django Parler version is bumped with the fix
+        from shuup.core.utils import context_cache
+        key, val = context_cache.get_cached_value(
+            identifier="shop_product",
+            item=self,
+            context={"shop": shop},
+            allow_cache=allow_cache
+        )
+        if val is not None:
+            return val
 
-        # from shuup.core.utils import context_cache
-        # key, val = context_cache.get_cached_value(
-        #     identifier="shop_product", item=self, context={"shop": shop}, allow_cache=allow_cache)
-        # if val is not None:
-        #     return val
         shop_inst = self.shop_products.get(shop_id=shop.id)
-        # context_cache.set_cached_value(key, shop_inst)
+        context_cache.set_cached_value(key, shop_inst)
         return shop_inst
 
     def get_priced_children(self, context, quantity=1):

--- a/shuup/core/shop_provider.py
+++ b/shuup/core/shop_provider.py
@@ -12,7 +12,9 @@ from shuup.utils.importing import cached_load
 class DefaultShopProvider(object):
     @classmethod
     def get_shop(cls, request, **kwargs):
-        shop = None
+        shop = getattr(request, "_cached_default_shop_provider_shop", None)
+        if shop:
+            return shop
 
         host = request.META.get("HTTP_HOST")
         if host:
@@ -21,6 +23,8 @@ class DefaultShopProvider(object):
         if not shop:
             shop = Shop.objects.first()
 
+        # cache shop as we already calculated it
+        setattr(request, "_cached_default_shop_provider_shop", shop)
         return shop
 
 

--- a/shuup/core/utils/context_cache.py
+++ b/shuup/core/utils/context_cache.py
@@ -190,7 +190,14 @@ def _get_items_from_context(context):
         for k, v in six.iteritems(context):
             if k in HASHABLE_KEYS:
                 if k == "customer" and hasattr(v, "groups"):
-                    v = v.groups.all()
+                    # cache groups in the instance to prevent creating a new queryset everytime
+                    if hasattr(v, "_cached_groups"):
+                        v = v._cached_groups
+                    else:
+                        groups_value = _get_val(v.groups.all())
+                        v._cached_groups = groups_value
+                        v = groups_value
+
                     k = "customer_groups"
                 items[k] = _get_val(v)
     else:

--- a/shuup/front/apps/saved_carts/templates/shuup/saved_carts/cart_detail.jinja
+++ b/shuup/front/apps/saved_carts/templates/shuup/saved_carts/cart_detail.jinja
@@ -32,7 +32,7 @@
                 <tbody>
                 {% for line in lines %}
                     {% set product = line.product %}
-                    {% set unit = line.product.get_shop_instance(request.shop).unit -%}
+                    {% set unit = line.product.get_shop_instance(request.shop, allow_cache=True).unit -%}
                     {% set image = product.primary_image %}
                     {% if not image and product.variation_parent %}
                         {% set image = product.variation_parent.primary_image %}

--- a/shuup/front/template_helpers/general.py
+++ b/shuup/front/template_helpers/general.py
@@ -125,20 +125,6 @@ def get_listed_products(context, n_products, ordering=None, filter_dict=None,
     return products_qs[:n_products]
 
 
-def _can_use_cache(products, shop, customer):
-    """
-    Check whether the cached products can be still used
-
-    If any of the products is no more orderable refetch the products
-    """
-    product_ids = [prod.pk for prod in products]
-    for supplier in Supplier.objects.filter(shops__in=[shop]):
-        for sp in ShopProduct.objects.filter(product__id__in=product_ids, shop=shop):
-            if not sp.is_orderable(supplier, customer=customer, quantity=sp.minimum_purchase_quantity):
-                return False
-    return True
-
-
 @contextfunction
 def get_best_selling_products(context, n_products=12, cutoff_days=30, orderable_only=True, sale_items_only=False):
     request = context["request"]
@@ -151,7 +137,7 @@ def get_best_selling_products(context, n_products=12, cutoff_days=30, orderable_
         orderable_only=orderable_only, sale_items_only=sale_items_only
     )
 
-    if products is not None and _can_use_cache(products, request.shop, request.customer):
+    if products is not None:
         return products
 
     products = _get_best_selling_products(cutoff_days, n_products, orderable_only, request, sale_items_only)
@@ -229,7 +215,7 @@ def get_newest_products(context, n_products=6, orderable_only=True, sale_items_o
         context=request,
         n_products=n_products, orderable_only=orderable_only, sale_items_only=sale_items_only
     )
-    if products is not None and _can_use_cache(products, request.shop, request.customer):
+    if products is not None:
         return products
 
     products = get_listed_products(
@@ -257,7 +243,7 @@ def get_random_products(context, n_products=6, orderable_only=True, sale_items_o
         n_products=n_products, orderable_only=orderable_only,
         sale_items_only=sale_items_only
     )
-    if products is not None and _can_use_cache(products, request.shop, request.customer):
+    if products is not None:
         return products
 
     products = get_listed_products(
@@ -287,7 +273,7 @@ def get_products_for_categories(context, categories, n_products=6, orderable_onl
         orderable_only=orderable_only,
         sale_items_only=sale_items_only
     )
-    if products is not None and _can_use_cache(products, request.shop, request.customer):
+    if products is not None:
         return products
 
     products = get_listed_products(

--- a/shuup/front/templates/shuup/front/macros/order.jinja
+++ b/shuup/front/templates/shuup/front/macros/order.jinja
@@ -148,7 +148,7 @@
     {% set quantity_map = product.get_package_child_to_quantity_map() %}
     <ul class="package-children">
         {% for child in package_children %}
-            {%- set unit = child.get_shop_instance(request.shop).unit -%}
+            {%- set unit = child.get_shop_instance(request.shop, allow_cache=True).unit -%}
             <li><small><em>
                 {{- unit.render_quantity(quantity_map[child]) }}
                 &times; {{ child -}}

--- a/shuup/front/templates/shuup/front/macros/product.jinja
+++ b/shuup/front/templates/shuup/front/macros/product.jinja
@@ -53,7 +53,7 @@ Inheritance order for product macors:
 
 {% macro render_product_price(product, show_units=True) %}
     {% if show_prices() and not xtheme.get("hide_prices") %}
-        {%- set unit = product.get_shop_instance(request.shop).unit -%}
+        {%- set unit = product.get_shop_instance(request.shop, allow_cache=True).unit -%}
         {%- set (per_qty, per_text) = unit.get_per_values(show_units) -%}
         <div class="price-line">
             <span class="lead">

--- a/shuup/front/templates/shuup/front/macros/product_information.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_information.jinja
@@ -138,7 +138,7 @@
 
 {% macro product_line(product, quantity) %}
     {% set u = url("shuup:product", pk=product.pk, slug=product.slug) %}
-    {% set unit = product.get_shop_instance(request.shop).unit %}
+    {% set unit = product.get_shop_instance(request.shop, allow_cache=True).unit %}
     {{ unit.render_quantity(quantity) }} &times;
     <a href="{{ u }}">{{ product.name }}</a>
 {% endmacro %}

--- a/shuup/front/templates/shuup/front/macros/product_ordering.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_ordering.jinja
@@ -2,7 +2,7 @@
 
 
 {% macro render_product_order_section(product, variation_variables, variation_children, unorderability_reason, orderable_variation_children) %}
-    {%- set shop_product = product.get_shop_instance(request.shop, allow_cache=False) -%}
+    {%- set shop_product = product.get_shop_instance(request.shop, allow_cache=True) -%}
     {% if not quantity %}
         {%- set quantity = shop_product.rounded_minimum_purchase_quantity -%}
     {% endif %}

--- a/shuup/front/utils/cache.py
+++ b/shuup/front/utils/cache.py
@@ -6,11 +6,11 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 
-BEST_SELLING_PRODUCTS_CACHE_ITEM_FMT = "best_selling_products-{shop_id}"
-NEWEST_PRODUCTS_CACHE_ITEM_FMT = "newest_products-{shop_id}"
-RANDOM_PRODUCTS_CACHE_ITEM_FMT = "random_products-{shop_id}"
-PRODUCTS_FOR_CATEGORY_CACHE_ITEM_FMT = "products_for_category-{shop_id}"
-ALL_MANUFACTURERS_CACHE_ITEM_FMT = "all_manufacturers-{shop_id}"
+BEST_SELLING_PRODUCTS_CACHE_ITEM_FMT = "best_selling_products_objs-{shop_id}"
+NEWEST_PRODUCTS_CACHE_ITEM_FMT = "newest_products_objs-{shop_id}"
+RANDOM_PRODUCTS_CACHE_ITEM_FMT = "random_products_objs-{shop_id}"
+PRODUCTS_FOR_CATEGORY_CACHE_ITEM_FMT = "products_for_category_objs-{shop_id}"
+ALL_MANUFACTURERS_CACHE_ITEM_FMT = "all_manufacturers_objs-{shop_id}"
 
 
 def get_best_selling_products_cache_item(shop):

--- a/shuup/simple_cms/plugins.py
+++ b/shuup/simple_cms/plugins.py
@@ -79,7 +79,7 @@ class PageLinksPlugin(TemplatedPlugin):
         show_all_pages = self.config.get("show_all_pages", True)
         hide_expired = self.config.get("hide_expired", False)
 
-        pages_qs = Page.objects.filter()
+        pages_qs = Page.objects.prefetch_related("translations")
         if hide_expired:
             pages_qs = pages_qs.visible(context["request"].shop)
 

--- a/shuup/xtheme/plugins/category_links.py
+++ b/shuup/xtheme/plugins/category_links.py
@@ -73,7 +73,7 @@ class CategoryLinksPlugin(TemplatedPlugin):
         categories = Category.objects.all_visible(
             customer=getattr(request, "customer"),
             shop=getattr(request, "shop")
-        )
+        ).prefetch_related("translations")
         if not show_all_categories:
             categories = categories.filter(id__in=selected_categories)
         return {

--- a/shuup_tests/front/test_general_template_helpers.py
+++ b/shuup_tests/front/test_general_template_helpers.py
@@ -264,9 +264,13 @@ def test_get_best_selling_products_cache_bump():
     cache.clear()
     from shuup.front.template_helpers import general
     context = get_jinja_context()
-    set_cached_value_mock = mock.Mock(wraps=context_cache.set_cached_value)
 
-    with mock.patch.object(context_cache, "set_cached_value", new=set_cached_value_mock):
+    set_cached_value_mock = mock.Mock(wraps=context_cache.set_cached_value)
+    def set_cache_value(key, value, timeout=None):
+        if "best_selling_products" in key:
+            return set_cached_value_mock(key, value, timeout)
+
+    with mock.patch.object(context_cache, "set_cached_value", new=set_cache_value):
         assert set_cached_value_mock.call_count == 0
 
         assert general.get_best_selling_products(context, 2, orderable_only=False)
@@ -432,8 +436,11 @@ def test_get_newest_products_cache_bump():
     context = get_jinja_context()
     cache.clear()
     set_cached_value_mock = mock.Mock(wraps=context_cache.set_cached_value)
+    def set_cache_value(key, value, timeout=None):
+        if "newest_products" in key:
+            return set_cached_value_mock(key, value, timeout)
 
-    with mock.patch.object(context_cache, "set_cached_value", new=set_cached_value_mock):
+    with mock.patch.object(context_cache, "set_cached_value", new=set_cache_value):
         assert set_cached_value_mock.call_count == 0
 
         assert general.get_newest_products(context, 2, orderable_only=False)
@@ -518,8 +525,11 @@ def test_get_random_products_cache_bump():
     context = get_jinja_context()
     cache.clear()
     set_cached_value_mock = mock.Mock(wraps=context_cache.set_cached_value)
+    def set_cache_value(key, value, timeout=None):
+        if "random_products" in key:
+            return set_cached_value_mock(key, value, timeout)
 
-    with mock.patch.object(context_cache, "set_cached_value", new=set_cached_value_mock):
+    with mock.patch.object(context_cache, "set_cached_value", new=set_cache_value):
         assert set_cached_value_mock.call_count == 0
 
         assert general.get_random_products(context, n_products=10)
@@ -581,7 +591,11 @@ def test_products_for_category_cache_bump():
 
     cache.clear()
     set_cached_value_mock = mock.Mock(wraps=context_cache.set_cached_value)
-    with mock.patch.object(context_cache, "set_cached_value", new=set_cached_value_mock):
+    def set_cache_value(key, value, timeout=None):
+        if "products_for_category" in key:
+            return set_cached_value_mock(key, value, timeout)
+
+    with mock.patch.object(context_cache, "set_cached_value", new=set_cache_value):
         assert set_cached_value_mock.call_count == 0
 
         assert general.get_products_for_categories(context, [category])
@@ -618,7 +632,11 @@ def test_get_all_manufacturers():
     products[2].manufacturer = manuf3; products[2].save()
 
     set_cached_value_mock = mock.Mock(wraps=context_cache.set_cached_value)
-    with mock.patch.object(context_cache, "set_cached_value", new=set_cached_value_mock):
+    def set_cache_value(key, value, timeout=None):
+        if "all_manufacturers" in key:
+            return set_cached_value_mock(key, value, timeout)
+
+    with mock.patch.object(context_cache, "set_cached_value", new=set_cache_value):
         assert set_cached_value_mock.call_count == 0
 
         # manufacturers are cached


### PR DESCRIPTION
### Front: cache instances instead of ids in template helpers

IDs were used because of a bug of Django Parler which was fixed in django-parler/django-parler#228
As the fix was not release in PyPi, use the last commit of GitHub repository available.

Fixes #1323
Refs ENT-2729

### Core: improve context cache by preventing new queries

Context cache was creating new user group queries everytime for the same context object.
Cache the groups inside the instance so we can reuse that for the same request

Refs ENT-2729

### General: improve caches and optimize queries
- Use shop product cache in templates
- Prefetch and select related objects in several queries to prevent a lot of db queries

Refs ENT-2729