### PR TITLE
Cache improvements

### DIFF
--- a/shuup/core/models/_categories.py
+++ b/shuup/core/models/_categories.py
@@ -165,7 +165,7 @@ class Category(MPTTModel, TranslatableModel):
     def get_hierarchy(self, reverse=True):
         return " / ".join([
             ancestor.safe_translation_getter("name", any_language=True) or ancestor.identifier
-            for ancestor in self.get_ancestors(ascending=reverse, include_self=True)
+            for ancestor in self.get_ancestors(ascending=reverse, include_self=True).prefetch_related("translations")
         ])
 
     def is_visible(self, customer):

--- a/shuup/front/signal_handlers.py
+++ b/shuup/front/signal_handlers.py
@@ -7,8 +7,10 @@
 # LICENSE file in the root directory of this source tree.
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from filer.models import Image
 
-from shuup.core.models import Manufacturer, Shop, ShopProduct
+from shuup.core import cache
+from shuup.core.models import Manufacturer, ProductMedia, Shop, ShopProduct
 from shuup.core.signals import context_cache_item_bumped  # noqa
 from shuup.core.utils import context_cache
 from shuup.front.utils import cache as cache_utils
@@ -41,4 +43,11 @@ def handle_manufacturer_post_save(sender, instance, **kwargs):
             context_cache.bump_cache_for_item(cache_utils.get_all_manufacturers_cache_item(shop))
 
 
+def bump_instance_thumbnail_cache(sender, instance, **kwargs):
+    cache_namespace = "thumbnail_{}_{}".format(instance.pk, instance.__class__.__name__)
+    cache.bump_version(cache_namespace)
+
+
+post_save.connect(bump_instance_thumbnail_cache, sender=ProductMedia)
+post_save.connect(bump_instance_thumbnail_cache, sender=Image)
 post_save.connect(handle_manufacturer_post_save, sender=Manufacturer)

--- a/shuup/xtheme/plugins/products.py
+++ b/shuup/xtheme/plugins/products.py
@@ -174,10 +174,14 @@ class ProductsFromCategoryPlugin(TemplatedPlugin):
         orderable_only = self.config.get("orderable_only", True)
         sale_items_only = self.config.get("sale_items_only", False)
 
-        category = Category.objects.filter(id=category_id).first() if category_id else None
-        if category:
+        if category_id:
             products = get_products_for_categories(
-                context, [category], n_products=count, orderable_only=orderable_only, sale_items_only=sale_items_only)
+                context,
+                [category_id],
+                n_products=count,
+                orderable_only=orderable_only,
+                sale_items_only=sale_items_only
+            )
         return {
             "request": context["request"],
             "title": self.get_translated_value("title"),

--- a/shuup_tests/browser/admin/test_tour.py
+++ b/shuup_tests/browser/admin/test_tour.py
@@ -138,6 +138,7 @@ def test_product_tour(browser, admin_user, live_server, settings):
         wait_until_condition(browser, lambda x: x.is_text_present("Welcome!"))
         browser.visit(live_server + "/sa/products/%d/" % shop_product.pk)
 
+        wait_until_condition(browser, lambda x: x.is_text_present(shop_product.product.name))
         wait_until_condition(browser, lambda x: x.is_text_present("You are adding a product."))
         wait_until_condition(browser, lambda x: x.is_element_present_by_css(".shepherd-button.btn-primary"))
         click_element(browser, ".shepherd-button.btn-primary")

--- a/shuup_tests/core/test_context_cache.py
+++ b/shuup_tests/core/test_context_cache.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+import mock
+
+from shuup.core import cache
+from shuup.core.utils import context_cache
+from shuup.core.utils.context_cache import _get_items_from_context
+from shuup.testing import factories
+
+
+class Context(object):
+    pass
+
+
+def test_get_items_from_dict_context():
+    customer = factories.create_random_person()
+    new_customer = factories.create_random_person()
+    contact_group = factories.create_random_contact_group()
+    contact_group.members.add(customer)
+
+    context = {
+        "customer": customer
+    }
+    items = _get_items_from_context(context)
+    groups = context_cache._get_val(customer.groups.all())
+    assert items["customer_groups"] == groups
+    assert "customer" not in items
+    # check whether items were cached
+    assert cache.get("_ctx_cache:customer_%d" % customer.pk) == groups
+
+    get_val_mock = mock.Mock(wraps=context_cache._get_val)
+    with mock.patch.object(context_cache, "_get_val", new=get_val_mock):
+        # get items again from the context, it shouldn't invoke _gel_val again for the customer
+        get_val_mock.assert_not_called()
+        items = _get_items_from_context(context)
+        get_val_mock.assert_not_called()
+
+    # check whether cache is bumped after changing contact
+    get_val_mock = mock.Mock(wraps=context_cache._get_val)
+    with mock.patch.object(context_cache, "_get_val", new=get_val_mock):
+        customer.save()
+        items = _get_items_from_context(context)
+        get_val_mock.assert_called()
+
+    # check whether cache is bumped after changing members of contact group
+    get_val_mock = mock.Mock(wraps=context_cache._get_val)
+    with mock.patch.object(context_cache, "_get_val", new=get_val_mock):
+        items = _get_items_from_context(context)
+        get_val_mock.assert_not_called()
+
+        contact_group.members.add(new_customer)
+
+        items = _get_items_from_context(context)
+        get_val_mock.assert_called()
+
+
+def test_get_items_from_obj_context():
+    shop = factories.get_default_shop()
+    customer = factories.create_random_person()
+    contact_group = factories.create_random_contact_group()
+    contact_group.members.add(customer)
+
+    context = Context()
+    context.customer = customer
+
+    items = _get_items_from_context(context)
+    groups = context_cache._get_val(customer.groups.all())
+
+    # check whether items were cached
+    assert cache.get("_ctx_cache:customer_%d" % customer.pk) == groups
+    assert context._ctx_cache_customer == groups
+
+    assert items["customer_groups"] == groups
+    assert "customer" not in items
+
+    get_val_mock = mock.Mock(wraps=context_cache._get_val)
+    with mock.patch.object(context_cache, "_get_val", new=get_val_mock):
+        # get items again from the context, it shouldn't invoke _gel_val again for the customer
+        get_val_mock.assert_not_called()
+        items = _get_items_from_context(context)
+        get_val_mock.assert_not_called()
+        assert items["customer_groups"] == groups
+        assert "customer" not in items


### PR DESCRIPTION
### Core: fix context cache when key is customer

Make sure to change the key to customer_groups when creating the cache key

### Front: cache thumbnail images when using template tags

Cache thumbnail images to prevent excessive thumbnails queries between requests

### Front: improve template helper by preventing unnecessary db query

Refs ENT-2729