### PR TITLE
Xtheme: fix plugin form styles

### DIFF
--- a/shuup/xtheme/static_src/editor/editor.less
+++ b/shuup/xtheme/static_src/editor/editor.less
@@ -194,6 +194,13 @@ form {
     .helptext {
         font-size: 0.85em;
     }
+    table th {
+        width: 30%;
+        max-width: 50%;
+    }
+    table td {
+        min-width: 50%;
+    }
 }
 
 @import "variables.less";


### PR DESCRIPTION
Make the title column be max 50% of width.
Some cases where plugins have only checkboxes the title width was 100%.

No Refs