### PR TITLE
Core: Fix product price range sorting

### DIFF
--- a/shuup/core/models/_products.py
+++ b/shuup/core/models/_products.py
@@ -494,7 +494,11 @@ class Product(TaxableItem, AttributableMixin, TranslatableModel):
         :type context: shuup.core.pricing.PricingContextable
         :rtype: shuup.core.pricing.Price
         """
-        return self.get_price_info(context, quantity).price
+        # Check if product has variations (children) if yes, return cheapest variation price
+        if self.is_variation_parent():
+            return self.get_cheapest_child_price_info(context, quantity).price
+        else:
+            return self.get_price_info(context, quantity).price
 
     def get_base_price(self, context, quantity=1):
         """

--- a/shuup_tests/browser/front/test_search_view.py
+++ b/shuup_tests/browser/front/test_search_view.py
@@ -77,7 +77,7 @@ def test_search_product_list(browser, live_server, settings):
     wait_until_condition(browser, lambda x: len(x.find_by_css(".product-card")) == 9)
 
     check_default_ordering(browser)
-    # basic_sorting_test(browser)
+    basic_sorting_test(browser)
     second_test_query(browser, live_server, url)
 
 


### PR DESCRIPTION
`get_price_info` alone would return 0 for products who have range variations. This adds a check for that which if positive returns the cheapest product variation's price.
Also enabled tests for basic sorting.



