### PR TITLE
Front: fix reordering from order history

### DIFF
--- a/shuup/front/apps/personal_order_history/views.py
+++ b/shuup/front/apps/personal_order_history/views.py
@@ -9,7 +9,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.views.generic import View
 
-from shuup.core.models import Order, ProductMode, Supplier
+from shuup.core.models import Order, ProductMode
 from shuup.front.views.dashboard import DashboardViewMixin
 
 
@@ -38,17 +38,15 @@ class OrderDetailView(DashboardViewMixin, OrderViewMixin, django.views.generic.D
 
 
 class ReorderView(View):
-
     def get(self, request, *args, **kwargs):
         try:
             order = Order.objects.get(customer=request.customer, pk=kwargs["pk"])
         except Order.DoesNotExist:
             return HttpResponseRedirect(reverse("shuup:show-order", kwargs=kwargs))
 
-        supplier = Supplier.objects.first()
         for line in _get_reorderable_lines(order):
             request.basket.add_product(
-                supplier=supplier,
+                supplier=line.supplier,
                 shop=request.shop,
                 product=line.product,
                 quantity=line.quantity

--- a/shuup/testing/factories.py
+++ b/shuup/testing/factories.py
@@ -794,7 +794,7 @@ def create_random_company(shop=None):
     return contact
 
 
-def create_random_order(customer=None, products=(), completion_probability=0, shop=None):
+def create_random_order(customer=None, products=(), completion_probability=0, shop=None, random_products=True):
     if not customer:
         customer = Contact.objects.all().order_by("?").first()
 
@@ -823,8 +823,17 @@ def create_random_order(customer=None, products=(), completion_probability=0, sh
     if not products:
         products = list(Product.objects.listed(source.shop, customer).order_by("?")[:40])
 
-    for i in range(random.randint(3, 10)):
-        product = random.choice(products)
+    if random_products:
+        quantity = random.randint(3, 10)
+    else:
+        quantity = len(products)
+
+    for i in range(quantity):
+        if random_products:
+            product = random.choice(products)
+        else:
+            product = products[i]
+
         quantity = random.randint(1, 5)
         price_info = product.get_price_info(pricing_context, quantity=quantity)
         shop_product = product.get_shop_instance(source.shop)
@@ -840,6 +849,7 @@ def create_random_order(customer=None, products=(), completion_probability=0, sh
             text=product.safe_translation_getter("name", any_language=True)
         )
         assert line.price == price_info.price
+
     with atomic():
         oc = OrderCreator()
         order = oc.create_order(source)

--- a/shuup_tests/front/test_reorder.py
+++ b/shuup_tests/front/test_reorder.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2018, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+from django.core.urlresolvers import reverse
+from django.test.client import Client
+from shuup.simple_supplier.module import SimpleSupplierModule
+
+from shuup.testing import factories
+from shuup.core.models import ShippingMode
+
+
+@pytest.mark.django_db
+def test_reorder_view():
+    shop = factories.get_default_shop()
+    factories.get_default_shipping_method()
+    factories.get_default_payment_method()
+
+    supplier1 = factories.get_supplier(SimpleSupplierModule.identifier, shop=shop)
+    supplier2 = factories.get_supplier(SimpleSupplierModule.identifier, shop=shop)
+    assert supplier1.pk != supplier2.pk
+
+    product_supplier1 = factories.create_product(
+        "product_supplier1",
+        shop=shop,
+        supplier=supplier1,
+        default_price=10,
+        shipping_mode=ShippingMode.NOT_SHIPPED
+    )
+    product_supplier2 = factories.create_product(
+        "product_supplier2",
+        shop=shop,
+        supplier=supplier2,
+        default_price=20,
+        shipping_mode=ShippingMode.NOT_SHIPPED
+    )
+
+    user = factories.create_random_user("en")
+    user.set_password("user")
+    user.save()
+
+    customer = factories.create_random_person("en")
+    customer.user = user
+    customer.save()
+
+    order = factories.create_random_order(
+        customer=customer,
+        shop=shop,
+        products=[product_supplier1, product_supplier2],
+        completion_probability=0,
+        random_products=False
+    )
+    suppliers = [line.supplier for line in order.lines.products()]
+    assert supplier1 in suppliers
+    assert supplier2 in suppliers
+
+    client = Client()
+    client.login(username=user.username, password="user")
+
+    # list orders
+    response = client.get(reverse("shuup:personal-orders"))
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "<td>%d</td>" % order.id in content
+    assert "<td>Received</td>" in content
+
+    # go to order detail
+    response = client.get(reverse("shuup:show-order", kwargs=dict(pk=order.pk)))
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert "Add all products to cart" in content
+    reorder_url = reverse("shuup:reorder-order", kwargs=dict(pk=order.pk))
+    assert reorder_url in content
+
+    # reorder products
+    response = client.get(reorder_url)
+    assert response.status_code == 302
+    assert response.url == reverse("shuup:basket")
+
+    # go to basket
+    response = client.get(response.url)
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+
+    # ensure the basket contain those products and suppliers
+    basket_key = client.session["basket_basket_key"]["key"]
+    from shuup.front.models import StoredBasket
+    basket = StoredBasket.objects.get(key=basket_key)
+    lines = basket.data["lines"]
+    product_supplier = [(line["product_id"], line["supplier_id"]) for line in lines]
+    assert (product_supplier1.pk, supplier1.pk) in product_supplier
+    assert (product_supplier2.pk, supplier2.pk) in product_supplier
+
+    assert product_supplier1.name in content
+    assert product_supplier2.name in content
+    assert "You are unable to proceed to checkout!" not in content


### PR DESCRIPTION
Do not use the first available supplier to add items to the basket when reordering.
Use the own order line supplier instead.

Refs ENT-2744