### PR TITLE
Admin: add option to prevent highlighting a picotable column

### DIFF
--- a/shuup/admin/modules/categories/views/list.py
+++ b/shuup/admin/modules/categories/views/list.py
@@ -20,7 +20,7 @@ class CategoryListView(PicotableListView):
     default_columns = [
         Column("image", _("Image"), sortable=False, linked=True, raw=True),
         Column(
-            "name", _(u"Name"), sortable=False, display="format_name", linked=True,
+            "name", _(u"Name"), sortable=False, display="format_name", linked=True, allow_highlight=False,
             filter_config=MPTTFilter(
                 choices="get_name_filter_choices",
                 filter_field="id"

--- a/shuup/admin/static_src/picotable/picotable.js
+++ b/shuup/admin/static_src/picotable/picotable.js
@@ -370,13 +370,9 @@ const Picotable = (function (m, storage) {
 
     // Check to see if it's any of the types of filters that
     // we want to highlight by placing it at the top of the table
+    // FIXME: remove fixed col names from here and bring from col definition
     function isLiftFilter(col) {
-        return (
-            col.id === "name"
-            || col.id === "customer"
-            || col.id === "title"
-            || col.id === "code"
-        );
+        return (col.allowHighlight && ["name", "customer", "title", "code"].includes(col.id));
     }
 
     function buildNameFilter(ctrl) {
@@ -808,7 +804,7 @@ const Picotable = (function (m, storage) {
         const columnFilterCells = (
             data.columns.filter(col => col.filter) ?
                 data.columns.map(col => {
-                    if (col.sortable && !isLiftFilter(col)) {
+                    if (!isLiftFilter(col)) {
                         return buildColumnFilterCell(ctrl, col);
                     }
                 }) : null

--- a/shuup/admin/utils/picotable.py
+++ b/shuup/admin/utils/picotable.py
@@ -274,6 +274,7 @@ class Column(object):
         self.ordering = kwargs.pop("ordering", 9999)
         self.context = None  # will be set after initializing
         self.sort_field = kwargs.pop("sort_field", None)
+        self.allow_highlight = kwargs.pop("allow_highlight", True)
 
         if kwargs and type(self) is Column:  # If we're not derived, validate that client code doesn't fail
             raise NameError("Unexpected kwarg(s): %s" % kwargs.keys())
@@ -286,6 +287,7 @@ class Column(object):
             "filter": self.filter_config.to_json(context=context) if self.filter_config else None,
             "sortable": bool(self.sortable),
             "linked": bool(self.linked),
+            "allowHighlight": bool(self.allow_highlight),
             "raw": bool(self.raw),
         }
         return dict((key, value) for (key, value) in six.iteritems(out) if value is not None)


### PR DESCRIPTION
This fixes a bug in Category List View which was breaking when filling the name input

No Refs