### PR TITLE
Front: Enable coupon removal in basket

### DIFF
--- a/shuup/campaigns/modules.py
+++ b/shuup/campaigns/modules.py
@@ -76,9 +76,10 @@ class BasketCampaignModule(OrderSourceModifierModule):
 
     def _get_campaign_line(self, campaign, highest_discount, order_source):
         text = campaign.public_name
-
+        value = ""
         if campaign.coupon:
             text += " (%s %s)" % (_("Coupon Code:"), campaign.coupon.code)
+            value = campaign.coupon.code
 
         return order_source.create_line(
             line_id="discount_%s" % str(random.randint(0, 0x7FFFFFFF)),
@@ -86,7 +87,8 @@ class BasketCampaignModule(OrderSourceModifierModule):
             quantity=1,
             discount_amount=campaign.shop.create_price(highest_discount),
             text=text,
-            line_source=LineSource.DISCOUNT_MODULE
+            line_source=LineSource.DISCOUNT_MODULE,
+            value=value
         )
 
     def can_use_code(self, order_source, code):

--- a/shuup/core/order_creator/_source.py
+++ b/shuup/core/order_creator/_source.py
@@ -659,6 +659,7 @@ class SourceLine(TaxableItem, Priceful, LineWithUnit):
         "quantity", "base_unit_price", "discount_amount",
         "sku", "text",
         "require_verification", "accounting_identifier",
+        "value"
     ]
     _FIELDSET = set(_FIELDS)
     _OBJECT_FIELDS = {
@@ -699,7 +700,7 @@ class SourceLine(TaxableItem, Priceful, LineWithUnit):
         self.text = kwargs.pop("text", "")
         self.require_verification = kwargs.pop("require_verification", False)
         self.accounting_identifier = kwargs.pop("accounting_identifier", "")
-
+        self.value = kwargs.pop("value", "")
         self.line_source = kwargs.pop("line_source", LineSource.CUSTOMER)
 
         self._taxes = None

--- a/shuup/front/templates/shuup/front/macros/basket.jinja
+++ b/shuup/front/templates/shuup/front/macros/basket.jinja
@@ -18,6 +18,7 @@
 {% macro _render_basket_line(line) %}
     {% set product = line.product %}
     {% set shop_product = line.shop_product %}
+    {% set value = line.value %}
     {% set show_supplier_info = xtheme.get("show_supplier_info") %}
     <div class="single-item">
         {% if product %}
@@ -91,10 +92,11 @@
             </div>
         {% endif %}
         <div class="delete">
-            {% if line.can_delete %}
+            {% if line.can_delete or line.value != "" %}
                 <button type="submit"
                         class="btn btn-sm"
                         name="delete_{{ line.line_id }}"
+                        value = "{{ value }}"
                         title="{% trans %}Remove product from basket{% endtrans %}">
                     <i class="fa fa-times"></i>
                 </button>
@@ -253,7 +255,7 @@
             };
 
             $.ajax({
-                url: "",
+                url: "{{ url("shuup:basket") }}",
                 method: "POST",
                 data: data,
                 success: function(response) {
@@ -270,6 +272,26 @@
             });
         }
     });
+    $("button[name^='delete_discount']").click(function() {
+        const coupon = $("button[name^='delete_discount']").val();
+        const data = {
+                "command": "remove_campaign_code",
+                "code": coupon
+            };
+             $.ajax({
+                url: "{{ url("shuup:basket") }}",
+                method: "POST",
+                data: data,
+                success: function(response) {
+                    if (response.ok) {
+                        location.reload();
+                    }
+                    else {
+                    }
+                }
+            });
+    });
+
 {% endmacro %}
 
 {% macro save_cart_js() %}

--- a/shuup_tests/browser/front/test_coupon.py
+++ b/shuup_tests/browser/front/test_coupon.py
@@ -65,7 +65,7 @@ def test_coupon(browser, live_server, settings):
     browser = initialize_front_browser_test(browser, live_server)
 
     _add_product_to_basket_from_category(live_server, browser, first_category, shop)
-    _activate_basket_campaign_through_coupon(browser, first_category, shop)
+    _test_coupon_activation_and_removal(browser, first_category, shop)
 
 
 def _populate_products_form_data(data, shop, category=None):
@@ -148,7 +148,7 @@ def _create_category_product_discount(category, shop, discount_amount):
     discount.shops = [shop]
 
 
-def _activate_basket_campaign_through_coupon(browser, category, shop):
+def _test_coupon_activation_and_removal(browser, category, shop):
     # We should already be at basket so let's verify the total
     wait_until_condition(browser, lambda x: "110.53" in x.find_by_css("div.total-price strong").first.text)
 
@@ -159,6 +159,11 @@ def _activate_basket_campaign_through_coupon(browser, category, shop):
     wait_until_condition(browser, lambda x: x.is_text_present(coupon_code))
     wait_until_condition(browser, lambda x: "-€22.11" in x.find_by_css("div.product-sum h4.price").last.text)
     wait_until_condition(browser, lambda x: "€88.42" in x.find_by_css("div.total-price strong").first.text)
+    wait_until_condition(browser, lambda x: "€88.42" in x.find_by_css("div.total-price strong").first.text)
+    wait_until_condition(browser, lambda x: x.is_element_present_by_value(coupon_code))
+    click_element(browser, "button[name^='delete_discount']")
+    wait_until_condition(browser, lambda x: not(x.is_text_present(coupon_code)))
+    wait_until_condition(browser, lambda x: "110.53" in x.find_by_css("div.total-price strong").first.text)
 
     # TODO: Should disabling catalog campaigns here change the line totals
 


### PR DESCRIPTION
Coupons can now be removed in basket. Added "value" field to basketline API so I could get coupon code in JS. (which I needed to send the AJAX request)

Refs #1653