### PR TITLE
Core: improve to_aware function to consider DST cases

### DIFF
--- a/shuup/core/utils/product_statistics.py
+++ b/shuup/core/utils/product_statistics.py
@@ -14,6 +14,7 @@ from django.utils.translation import get_language
 
 from shuup.core import cache
 from shuup.core.models import OrderLine, OrderLineType, Product
+from shuup.utils.dates import to_aware
 
 
 def get_best_selling_product_info(shop_ids, cutoff_days=30):
@@ -26,7 +27,7 @@ def get_best_selling_product_info(shop_ids, cutoff_days=30):
             OrderLine.objects
             .filter(
                 order__shop_id__in=shop_ids,
-                order__order_date__gte=cutoff_date,
+                order__order_date__gte=to_aware(cutoff_date),
                 type=OrderLineType.PRODUCT
             )
             .values("product")

--- a/shuup_tests/utils/test_dates.py
+++ b/shuup_tests/utils/test_dates.py
@@ -5,12 +5,13 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+import pytz
 
 from datetime import date, datetime, time
 
 from shuup.utils.dates import (
     parse_date, parse_datetime, try_parse_date, try_parse_datetime,
-    try_parse_time
+    try_parse_time, to_aware
 )
 
 
@@ -69,3 +70,19 @@ def test_try_parse_datetime():
     assert try_parse_datetime(date_fmt2) == datetime(2018, 12, 31, 15, 40)
     assert try_parse_datetime(date_fmt3) == datetime(2016, 12, 31)
     assert try_parse_datetime("abc") is None
+
+
+def test_dst_safe_aware():
+    random_date = date(2018, 11, 4)
+
+    # with dst
+    sao_paulo = to_aware(random_date, tz=pytz.timezone("America/Sao_Paulo"))
+    assert sao_paulo.hour == 0
+    assert sao_paulo.minute == 0
+    assert sao_paulo.tzinfo._dst.seconds == 3600  # 1hr
+
+    # without dst
+    madrid = to_aware(random_date, tz=pytz.timezone("Europe/Madrid"))
+    assert madrid.hour == 0
+    assert madrid.minute == 0
+    assert madrid.tzinfo._dst.seconds == 0


### PR DESCRIPTION
When converting from date to datetime the time component will be
always 00:00 and in some cases, after applying the timezone information,
pytz will raise exception because the time can not exists at all.
This will occur when the date is a date which the timezone changes to DST,
adding 1 hour to time at 00:00 o'clock of the previous date.

To fix the issue, we first try making the datetime aware without DST mode,
if pytz raises NonExistentTimeError is because that time doesn't exist,
this way we try again but now informing that DST should be used instead.

No Refs