### PR TITLE
Front: do not raise exception in Front model url resolver

### DIFF
--- a/doc/ref/provides.rst
+++ b/doc/ref/provides.rst
@@ -165,7 +165,7 @@ Core
 
 ``front_model_url_resolver``
     List of functions that resolve a model instance into an object URL.
-    The first valid url returned by a provide will be used by the called.
+    The first valid url returned by a provide will be used by the caller.
 
 ``admin_model_url_resolver``
     List of functions that resolve a model instance into an object URL.

--- a/shuup/front/template_helpers/urls.py
+++ b/shuup/front/template_helpers/urls.py
@@ -14,13 +14,25 @@ from shuup.apps.provides import get_provide_objects
 
 
 @contextfunction
-def model_url(context, model, absolute=False, **kwargs):
+def model_url(context, model, absolute=False, raise_when_not_found=True, **kwargs):
+    """
+    Iterate over all `front_model_url_resolver` provides trying to find
+    some url for the given `model`. The first value returned by the resolver
+    will be used.
+
+    If no url is returned and `raise_when_not_found` is set to True (the default),
+    an exception will be raised.
+    """
     front_model_url_resolvers = get_provide_objects("front_model_url_resolver")
 
     for resolver in front_model_url_resolvers:
         url = resolver(context, model, absolute, **kwargs)
         if url:
             return url
+
+    if raise_when_not_found:
+        # no url found
+        raise ValueError("Unable to figure out `model_url` for %r" % model)
 
 
 def get_url(url, *args, **kwargs):

--- a/shuup/front/utils/urls.py
+++ b/shuup/front/utils/urls.py
@@ -24,9 +24,6 @@ def model_url(context, model, absolute=False, **kwargs):
     if hasattr(model, "pk") and model.pk and hasattr(model, "url"):
         uri = "/%s" % model.url
 
-    if not uri:  # pragma: no cover
-        raise ValueError("Unable to figure out `model_url` for %r" % model)
-
     if absolute:
         request = context.get("request")
         if not request:  # pragma: no cover


### PR DESCRIPTION
Make the caller raise exception if set to do so.

In cases where custom model url resolvers were used,
the exception inside the front resolver was preventing other
resolvers to be called as it was breaking the provides iteration.

No Refs