### PR TITLE
Fix broken tests for Django 1.8

### DIFF
--- a/shuup/utils/dates.py
+++ b/shuup/utils/dates.py
@@ -8,6 +8,7 @@
 from __future__ import unicode_literals
 
 import datetime
+import django
 import itertools
 import time
 
@@ -286,7 +287,10 @@ def dst_safe_timezone_aware(dt, tz=None):
     try:
         return timezone.make_aware(dt, timezone=tz)
     except NonExistentTimeError:
-        return timezone.make_aware(dt, timezone=tz, is_dst=True)
+        if django.VERSION < (1, 9):
+            raise  # is_dst parameter not available for Django 1.8
+        else:
+            return timezone.make_aware(dt, timezone=tz, is_dst=True)
 
 
 def local_now(tz=None):

--- a/shuup_tests/utils/test_dates.py
+++ b/shuup_tests/utils/test_dates.py
@@ -5,6 +5,8 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+import django
+import pytest
 import pytz
 
 from datetime import date, datetime, time
@@ -75,13 +77,18 @@ def test_try_parse_datetime():
 def test_dst_safe_aware():
     random_date = date(2018, 11, 4)
 
-    # with dst
-    sao_paulo = to_aware(random_date, tz=pytz.timezone("America/Sao_Paulo"))
-    assert sao_paulo.hour == 0
-    assert sao_paulo.minute == 0
-    assert sao_paulo.tzinfo._dst.seconds == 3600  # 1hr
+    def _test_with_dst():
+        sao_paulo = to_aware(random_date, tz=pytz.timezone("America/Sao_Paulo"))
+        assert sao_paulo.hour == 0
+        assert sao_paulo.minute == 0
+        assert sao_paulo.tzinfo._dst.seconds == 3600  # 1hr
 
-    # without dst
+    if django.VERSION < (1, 9):
+        with pytest.raises(pytz.exceptions.NonExistentTimeError):
+            _test_with_dst()
+    else:
+        _test_with_dst()
+
     madrid = to_aware(random_date, tz=pytz.timezone("Europe/Madrid"))
     assert madrid.hour == 0
     assert madrid.minute == 0


### PR DESCRIPTION
`shuup.utils.dates.dst_safe_timezone_aware` was added but doesn't work with Django 1.8 since `timezone.make_aware` does not have "is_dst" option. Well instead worrying this too much we will raise here.

In case this becomes problem for some old projects we accept better fixes for this, but be highly suggest updating project Django version instead.