### PR TITLE
Core: fix dst_safe_timezone_aware function for Django 1.8

### DIFF
--- a/shuup/utils/dates.py
+++ b/shuup/utils/dates.py
@@ -288,9 +288,12 @@ def dst_safe_timezone_aware(dt, tz=None):
         return timezone.make_aware(dt, timezone=tz)
     except NonExistentTimeError:
         if django.VERSION < (1, 9):
-            raise  # is_dst parameter not available for Django 1.8
-        else:
-            return timezone.make_aware(dt, timezone=tz, is_dst=True)
+            # is_dst parameter not available for Django 1.8
+            if tz is None:
+                tz = timezone.get_current_timezone()
+            return tz.localize(dt, is_dst=True)
+
+        return timezone.make_aware(dt, timezone=tz, is_dst=True)
 
 
 def local_now(tz=None):

--- a/shuup_tests/utils/test_dates.py
+++ b/shuup_tests/utils/test_dates.py
@@ -5,11 +5,9 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-import django
-import pytest
-import pytz
-
 from datetime import date, datetime, time
+
+import pytz
 
 from shuup.utils.dates import (
     parse_date, parse_datetime, try_parse_date, try_parse_datetime,
@@ -77,17 +75,10 @@ def test_try_parse_datetime():
 def test_dst_safe_aware():
     random_date = date(2018, 11, 4)
 
-    def _test_with_dst():
-        sao_paulo = to_aware(random_date, tz=pytz.timezone("America/Sao_Paulo"))
-        assert sao_paulo.hour == 0
-        assert sao_paulo.minute == 0
-        assert sao_paulo.tzinfo._dst.seconds == 3600  # 1hr
-
-    if django.VERSION < (1, 9):
-        with pytest.raises(pytz.exceptions.NonExistentTimeError):
-            _test_with_dst()
-    else:
-        _test_with_dst()
+    sao_paulo = to_aware(random_date, tz=pytz.timezone("America/Sao_Paulo"))
+    assert sao_paulo.hour == 0
+    assert sao_paulo.minute == 0
+    assert sao_paulo.tzinfo._dst.seconds == 3600  # 1hr
 
     madrid = to_aware(random_date, tz=pytz.timezone("Europe/Madrid"))
     assert madrid.hour == 0


### PR DESCRIPTION
As is_dst parameter doesn't exist, we should call pytz.localize instead