### PR TITLE
Admin: do not expect shop for request

### DIFF
--- a/shuup/admin/template_helpers/shuup_admin.py
+++ b/shuup/admin/template_helpers/shuup_admin.py
@@ -178,7 +178,7 @@ def get_shop_count(context):
 
 @contextfunction
 def get_admin_shop(context):
-    return context["request"].shop
+    return get_shop(context["request"])
 
 
 @contextfunction


### PR DESCRIPTION
Instead expecting request having shop use admin shop provider get shop to get current shop.

Admin middleware makes rest of the admin code work but this template helper code is called
already in login where there is no logged in user which means admin shop is not defined.