### PR TITLE
Fix carousel not working with Firefox & increase padding.

### DIFF
--- a/shuup/front/static_src/js/carousel.js
+++ b/shuup/front/static_src/js/carousel.js
@@ -19,9 +19,10 @@ $(function() {
             autoplayTimeout: interval,
             autoplayHoverPause: pauseOnHover,
             nav: arrowsVisible,
+            navElement: "span",
             navText: [
-                '<i class="fa fa-angle-left .carousel-control .icon-prev"></i>',
-                '<i class="fa fa-angle-right .carousel-control .icon-prev"></i>'
+                '<span type="button" role="presentation" class="owl-prev"><i class="fa carousel fa-angle-left .carousel-control .icon-prev"></i></span>',
+                '<span type="button" role="presentation" class="owl-next"><i class="fa carousel fa-angle-right .carousel-control .icon-next"></i></span>'
             ],
             dots: useDotNavigation,
             items: 1
@@ -40,9 +41,10 @@ $(function() {
         $(this).owlCarousel({
             margin: 30,
             nav: arrowsVisible,
+            navElement: "span",
             navText: [
-                '<i class="fa fa-angle-left .carousel-control .icon-prev"></i>',
-                '<i class="fa fa-angle-right .carousel-control .icon-prev"></i>'
+                '<span type="button" role="presentation" class="owl-prev"><i class="fa fa-angle-left .carousel-control .icon-prev"></i></span>',
+                '<span type="button" role="presentation" class="owl-next"><i class="fa fa-angle-right .carousel-control .icon-next"></i></span>'
             ],
             responsiveClass: true,
             responsive: (responsiveConfigure ? responsiveConfigure : {0: {items: 2}, 640: {items: 2}, 992: {items: 4}})

--- a/shuup/front/static_src/less/front/carousel.less
+++ b/shuup/front/static_src/less/front/carousel.less
@@ -133,6 +133,13 @@
         position: absolute;
         top: 50%;
         margin-top: -15px;
+
+    }
+    .carousel { // Don't add padding to carousel banners.
+        padding: 15px 20px;
+        @media (max-width: @screen-xs-max) {
+            padding: unset;
+        }
     }
     .fa-angle-left {
         left: -25px;


### PR DESCRIPTION
- Front: Fix carousel not working with Firefox
Turns out that carousel arrows weren't working with Firefox. Everything seems to work good with Ghostery.

- Front: Increase carousel arrow padding

No refs