### PR TITLE
Core: performance improvements

### DIFF
--- a/shuup_tests/core/test_categories.py
+++ b/shuup_tests/core/test_categories.py
@@ -142,3 +142,17 @@ def test_category_deletion(admin_user):
     assert Category.objects.all_visible(customer=admin).count() == 1
     assert Category.objects.all_except_deleted().count() == 1
     configuration.set(None, get_all_seeing_key(admin), False)
+
+
+@pytest.mark.django_db
+def test_category_cached_children(admin_user):
+    parent = Category.objects.create(name="Parent")
+    child1 = Category.objects.create(name="Child1", parent=parent)
+    child2 = Category.objects.create(name="Child2", parent=parent)
+    child3 = Category.objects.create(name="Child3", parent=parent)
+
+    for cache_test in range(2):
+        children = parent.get_cached_children()
+        assert children[0] == child1
+        assert children[1] == child2
+        assert children[2] == child3


### PR DESCRIPTION
### Core: add method to return cached child categories
This is useful for example in templates where it is usual to traverse the tree

### Discounts: prevent doing unnecessary joins when fetching discounts
Do not use IN operation when there is only a single item. This reduces the number of joins and makes the query faster

Refs ENT-2770