### PR TITLE
Admin: Fix Product deletion returning 404

### DIFF
--- a/shuup/admin/modules/products/views/delete.py
+++ b/shuup/admin/modules/products/views/delete.py
@@ -15,18 +15,19 @@ from django.utils.translation import ugettext as _
 from django.views.generic import DetailView
 
 from shuup.admin.utils.urls import get_model_url
-from shuup.core.models import Product
+from shuup.core.models import ShopProduct
 
 
 class ProductDeleteView(DetailView):
-    model = Product
+    model = ShopProduct
     context_object_name = "product"
 
     def get(self, request, *args, **kwargs):
-        return HttpResponseRedirect(get_model_url(self.get_object(), shop=self.request.shop))
+        product = self.get_object().product
+        return HttpResponseRedirect(get_model_url(product, shop=self.request.shop))
 
     def post(self, request, *args, **kwargs):
-        product = self.get_object()
+        product = self.get_object().product
         product.soft_delete(user=request.user)
         messages.success(request, _(u"%s has been marked deleted.") % product)
         return HttpResponseRedirect(reverse("shuup_admin:shop_product.list"))


### PR DESCRIPTION
What was going on:
Product that was supposed to be deleted had an id that was different from it's ShopProduct's id.
Our logic sends ShopProduct object to Product delete view which was causing the problems. These changes extract Product object from received ShopProduct in ProductDeleteView.

Fixes #1699 