### PR TITLE
Front: fix issue with image thumbnails

### DIFF
--- a/shuup/front/templatetags/thumbnails.py
+++ b/shuup/front/templatetags/thumbnails.py
@@ -85,7 +85,7 @@ def thumbnail(source, alias=None, generate=True, **kwargs):
         if cache_key:
             cache.set(cache_key, thumbnail_url)
         return thumbnail_url
-    except (IOError, InvalidImageFormatError):
+    except (IOError, InvalidImageFormatError, ValueError):
         return None
 
 


### PR DESCRIPTION
It is possible to have broken image in Shuup which raises ValueError while thumbnailing. It is not worth fail rendering template because of this.