### PR TITLE
Front: Improve  company registration logic

### DIFF
--- a/shuup/admin/modules/products/views/delete.py
+++ b/shuup/admin/modules/products/views/delete.py
@@ -15,18 +15,19 @@ from django.utils.translation import ugettext as _
 from django.views.generic import DetailView
 
 from shuup.admin.utils.urls import get_model_url
-from shuup.core.models import Product
+from shuup.core.models import ShopProduct
 
 
 class ProductDeleteView(DetailView):
-    model = Product
+    model = ShopProduct
     context_object_name = "product"
 
     def get(self, request, *args, **kwargs):
-        return HttpResponseRedirect(get_model_url(self.get_object(), shop=self.request.shop))
+        product = self.get_object().product
+        return HttpResponseRedirect(get_model_url(product, shop=self.request.shop))
 
     def post(self, request, *args, **kwargs):
-        product = self.get_object()
+        product = self.get_object().product
         product.soft_delete(user=request.user)
         messages.success(request, _(u"%s has been marked deleted.") % product)
         return HttpResponseRedirect(reverse("shuup_admin:shop_product.list"))

--- a/shuup/admin/static_src/picotable/picotable.js
+++ b/shuup/admin/static_src/picotable/picotable.js
@@ -426,13 +426,7 @@ const Picotable = (function (m, storage) {
         var columnSettings = { key: col.id, className: cx(classSet), onclick: columnOnClick };
         var massActions = (ctrl.vm.data() ? ctrl.vm.data().massActions : null);
         if (massActions.length) {
-            if (columnNumber === 0) {
-                columnSettings.className += " hidden";
-            }
-            if (columnNumber === 1) {
-                columnSettings.colspan = 2;
-            }
-            if (col.id === "primary_image") {
+            if ((col.id === "primary_image") || (columnNumber === 0)) {
                 columnSettings.className += " hidden-cell";
             }
         }

--- a/shuup/front/apps/customer_information/views.py
+++ b/shuup/front/apps/customer_information/views.py
@@ -9,7 +9,7 @@ import six
 from django.contrib import messages
 from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.views import password_change
-from django.http import HttpResponseNotFound
+from django.http import Http404
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import FormView, TemplateView
@@ -87,7 +87,7 @@ class CompanyEditView(DashboardViewMixin, FormView):
 
     def dispatch(self, request, *args, **kwargs):
         if not allow_company_registration(request.shop):
-            return HttpResponseNotFound()
+            raise Http404()
         return super(CompanyEditView, self).dispatch(request, *args, **kwargs)
 
     def get_form(self, form_class=None):

--- a/shuup_tests/core/test_categories.py
+++ b/shuup_tests/core/test_categories.py
@@ -142,3 +142,17 @@ def test_category_deletion(admin_user):
     assert Category.objects.all_visible(customer=admin).count() == 1
     assert Category.objects.all_except_deleted().count() == 1
     configuration.set(None, get_all_seeing_key(admin), False)
+
+
+@pytest.mark.django_db
+def test_category_cached_children(admin_user):
+    parent = Category.objects.create(name="Parent")
+    child1 = Category.objects.create(name="Child1", parent=parent)
+    child2 = Category.objects.create(name="Child2", parent=parent)
+    child3 = Category.objects.create(name="Child3", parent=parent)
+
+    for cache_test in range(2):
+        children = parent.get_cached_children()
+        assert children[0] == child1
+        assert children[1] == child2
+        assert children[2] == child3

--- a/shuup_tests/front/test_registration.py
+++ b/shuup_tests/front/test_registration.py
@@ -15,6 +15,7 @@ from django.contrib.auth.models import User
 from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
+from django.http.response import Http404
 
 from shuup import configuration
 from shuup.admin.modules.contacts.views import ContactDetailView
@@ -498,8 +499,8 @@ def test_create_company_from_customer_dashboard(allow_company_registration, comp
         # If company registration is not allowed,
         # can't create company contacts from customer dashboard
         request = apply_request_middleware(rf.get("/"), user=admin_user)
-        response = view_func(request)
-        assert response.status_code == 404
+        with pytest.raises(Http404):
+            response = view_func(request)
     else:
         request = apply_request_middleware(
             rf.post("/", {


### PR DESCRIPTION
The problem was that when going to Company Information, it was throwing a full 404 (not the django one),
The button was being shown despite Shop not allowing company registration, which was causing the above mentioned error.
This ensures button is shown if customer is a company contact and if company registration is allowed.
Django 404 error is thrown instead of HttpResponseNotFound.
No refs