### PR TITLE
Fix picotable checkboxes breaking the layout &  Improve company registration logic

### DIFF
--- a/shuup/admin/static_src/picotable/picotable.js
+++ b/shuup/admin/static_src/picotable/picotable.js
@@ -426,13 +426,7 @@ const Picotable = (function (m, storage) {
         var columnSettings = { key: col.id, className: cx(classSet), onclick: columnOnClick };
         var massActions = (ctrl.vm.data() ? ctrl.vm.data().massActions : null);
         if (massActions.length) {
-            if (columnNumber === 0) {
-                columnSettings.className += " hidden";
-            }
-            if (columnNumber === 1) {
-                columnSettings.colspan = 2;
-            }
-            if (col.id === "primary_image") {
+            if ((col.id === "primary_image") || (columnNumber === 0)) {
                 columnSettings.className += " hidden-cell";
             }
         }

--- a/shuup/front/apps/customer_information/dashboard_items.py
+++ b/shuup/front/apps/customer_information/dashboard_items.py
@@ -8,6 +8,7 @@
 from django.utils.translation import ugettext_lazy as _
 
 from shuup.core.models import CompanyContact
+from shuup.front.utils.companies import allow_company_registration
 from shuup.front.utils.dashboard import DashboardItem
 
 
@@ -36,7 +37,7 @@ class CompanyDashboardItem(DashboardItem):
 
     def show_on_menu(self):
         # Only show this on menu if customer is company
-        return isinstance(self.request.customer, CompanyContact)
+        return (isinstance(self.request.customer, CompanyContact) or allow_company_registration(self.request.shop))
 
 
 class AddressBookDashboardItem(DashboardItem):

--- a/shuup/front/apps/customer_information/views.py
+++ b/shuup/front/apps/customer_information/views.py
@@ -9,7 +9,6 @@ import six
 from django.contrib import messages
 from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.views import password_change
-from django.http import HttpResponseNotFound
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import FormView, TemplateView
@@ -86,8 +85,8 @@ class CompanyEditView(DashboardViewMixin, FormView):
     template_name = "shuup/customer_information/edit_company.jinja"
 
     def dispatch(self, request, *args, **kwargs):
-        if not allow_company_registration(request.shop):
-            return HttpResponseNotFound()
+        if not (bool(get_company_contact(self.request.user)) or allow_company_registration(self.request.shop)):
+            return redirect("shuup:customer_edit")
         return super(CompanyEditView, self).dispatch(request, *args, **kwargs)
 
     def get_form(self, form_class=None):

--- a/shuup/front/apps/registration/views.py
+++ b/shuup/front/apps/registration/views.py
@@ -8,7 +8,6 @@
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.http import HttpResponseNotFound
 from django.shortcuts import redirect
 from django.utils.http import is_safe_url
 from django.utils.translation import ugettext_lazy as _
@@ -83,7 +82,7 @@ class CompanyRegistrationView(RegistrationViewMixin, default_views.RegistrationV
 
     def dispatch(self, request, *args, **kwargs):
         if not allow_company_registration(request.shop):
-            return HttpResponseNotFound()
+            return redirect("shuup:registration_register")
         return super(CompanyRegistrationView, self).dispatch(request, *args, **kwargs)
 
     def register(self, form):

--- a/shuup_tests/front/test_customer_information.py
+++ b/shuup_tests/front/test_customer_information.py
@@ -135,9 +135,9 @@ def test_company_edit_form_links_company(regular_user, allow_company_registratio
         assert get_company_contact(regular_user)
     else:
         response = client.get(company_edit_url)
-        assert response.status_code == 404
+        assert reverse("shuup:customer_edit") in response.url
         response = client.post(company_edit_url, data)
-        assert response.status_code == 404
+        assert reverse("shuup:customer_edit") in response.url
 
 
 @pytest.mark.django_db
@@ -258,7 +258,7 @@ def test_company_tax_number_limitations(regular_user, allow_company_registration
         client.login(username=REGULAR_USER_USERNAME, password=REGULAR_USER_PASSWORD)
         company_edit_url = reverse("shuup:company_edit")
         response = client.get(company_edit_url)
-        assert response.status_code == 404
+        assert reverse("shuup:customer_edit") in response.url
 
 
 @pytest.mark.django_db

--- a/shuup_tests/front/test_registration.py
+++ b/shuup_tests/front/test_registration.py
@@ -349,7 +349,7 @@ def test_company_registration(django_user_model, client, allow_company_registrat
     )
     if not allow_company_registration:
         response = client.get(url)
-        assert response.status_code == 404
+        assert reverse("shuup:registration_register") in response.url
     else:
         response = client.post(url, data={
             'company-name': "Test company",
@@ -499,7 +499,7 @@ def test_create_company_from_customer_dashboard(allow_company_registration, comp
         # can't create company contacts from customer dashboard
         request = apply_request_middleware(rf.get("/"), user=admin_user)
         response = view_func(request)
-        assert response.status_code == 404
+        assert reverse("shuup:customer_edit") in response.url
     else:
         request = apply_request_middleware(
             rf.post("/", {

--- a/shuup_tests/functional/test_notify_on_company_created.py
+++ b/shuup_tests/functional/test_notify_on_company_created.py
@@ -81,7 +81,7 @@ def test_notify_on_company_created(regular_user, allow_company_registration):
         script.delete()
     else:
         response = client.get(company_edit_url)
-        assert response.status_code == 404
+        assert reverse("shuup:customer_edit") in response.url
         assert Notification.objects.filter(identifier="company_created").count() == 0
 
 


### PR DESCRIPTION
- Admin: Fix picotable checkboxes breaking the layout
The first `thead` had `colspan(2)` attribute which was making problems, I removed it completely since I believe that it's unnecessary.
![image](https://user-images.githubusercontent.com/40273438/51534988-91415500-1e47-11e9-9557-087e3a28363e.png)

Fixes #1654

- Front: Improve company registration logic 
Redirect  regular contact to customer information when he tries to register a company & company registration is not allowed.
No refs