### PR TITLE
Admin: bump product cache when using mass action, limit mass action changes to one shop

### DIFF
--- a/shuup/admin/modules/orders/mass_actions.py
+++ b/shuup/admin/modules/orders/mass_actions.py
@@ -14,6 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
 from six import BytesIO
 
+from shuup.admin.shop_provider import get_shop
 from shuup.admin.utils.picotable import (
     PicotableFileMassAction, PicotableMassAction
 )
@@ -28,9 +29,11 @@ class CancelOrderAction(PicotableMassAction):
     identifier = "mass_action_order_cancel"
 
     def process(self, request, ids):
-        query = Q(id__in=ids)
+        shop = get_shop(request)
         if isinstance(ids, six.string_types) and ids == "all":
-            query = Q()
+            query = Q(shop=shop)
+        else:
+            query = Q(id__in=ids, shop=shop)
         for order in Order.objects.filter(query):
             if not order.can_set_canceled():
                 continue

--- a/shuup_tests/admin/test_mass_actions.py
+++ b/shuup_tests/admin/test_mass_actions.py
@@ -4,13 +4,18 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-import csv
+import csv, mock
 
 import pytest
 from django.http import HttpResponse
+from django.core.cache import cache
 from shuup.admin.utils.picotable import PicotableMassAction, PicotableFileMassAction
-from shuup.core.models import Product
-from shuup.testing.factories import get_default_shop, get_default_supplier, create_product
+from shuup.admin.modules.products.mass_actions import InvisibleMassAction, VisibleMassAction
+
+from shuup.core.models import Product, Shop, ShopProduct, ShopStatus, ShopProductVisibility
+from shuup.core.utils import context_cache
+
+from shuup.testing.factories import get_default_shop, get_default_supplier, create_product, get_default_currency, get_default_product
 from shuup.testing.utils import apply_request_middleware
 from shuup_tests.utils import printable_gibberish
 
@@ -48,3 +53,57 @@ def test_mass_actions(rf, admin_user):
 
     mass_action_response = TestPicotableFileMassAction().process(request, ids)
     assert mass_action_response["Content-disposition"] == 'attachment; filename="products.csv"'
+
+
+@pytest.mark.django_db
+def test_mass_action_cache(rf, admin_user):
+    shop = get_default_shop()
+    cache.clear()
+    product = create_product(printable_gibberish(), shop=shop, default_price=50)
+    product2 = create_product(printable_gibberish(), shop=shop, default_price=100)
+    set_bump_cache_for_shop_product = mock.Mock(wraps=context_cache.bump_cache_for_shop_product)
+
+    def bump_cache_for_shop_product(item):
+        return set_bump_cache_for_shop_product(item)
+
+    request = apply_request_middleware(rf.get("/"), user=admin_user, shop=shop)
+
+    with mock.patch.object(context_cache, "bump_cache_for_shop_product", new=bump_cache_for_shop_product):
+        assert set_bump_cache_for_shop_product.call_count == 0
+        InvisibleMassAction().process(request, [product.id, product2.id])
+        assert set_bump_cache_for_shop_product.call_count == 2
+
+        VisibleMassAction().process(request, [product.id, product2.id])
+        assert set_bump_cache_for_shop_product.call_count == 4
+
+
+@pytest.mark.django_db
+def test_mass_action_multishop(rf, admin_user):
+    def create_shop(name):
+        return Shop.objects.create(
+            name="foobar",
+            identifier=name,
+            status=ShopStatus.ENABLED,
+            public_name=name,
+            currency=get_default_currency().code
+        )
+    shop_one = get_default_shop()
+    shop_two = create_shop("foobar")
+    product = get_default_product()
+    shop_product_one = product.get_shop_instance(shop_one)
+    shop_product_two = ShopProduct.objects.create(shop=shop_two, product=product)
+    shop_product_two.save()
+    assert shop_product_one.visibility == ShopProductVisibility.ALWAYS_VISIBLE
+    assert shop_product_two.visibility == ShopProductVisibility.ALWAYS_VISIBLE
+    request = apply_request_middleware(rf.get("/"), user=admin_user, shop=shop_one)
+    InvisibleMassAction().process(request, 'all')
+    shop_product_one.refresh_from_db()
+    shop_product_two.refresh_from_db()
+    assert shop_product_one.visibility == ShopProductVisibility.NOT_VISIBLE
+    assert shop_product_two.visibility == ShopProductVisibility.ALWAYS_VISIBLE
+    request = apply_request_middleware(rf.get("/"), user=admin_user, shop=shop_one)
+    VisibleMassAction().process(request, 'all')
+    shop_product_one.refresh_from_db()
+    shop_product_two.refresh_from_db()
+    assert shop_product_two.visibility == ShopProductVisibility.ALWAYS_VISIBLE
+    assert shop_product_one.visibility == ShopProductVisibility.ALWAYS_VISIBLE


### PR DESCRIPTION
`.update()` is a direct SQL statement so it wasn't calling save() at all, hence it didn't trigger post_save signals at all
to bump caches.
This iterates through the whole query after the update bumping caches for each shop product id

Fixes #1710