### PR TITLE
Admin: make mass action extendable and add non superuser visibility limitations

### DIFF
--- a/doc/ref/provides.rst
+++ b/doc/ref/provides.rst
@@ -97,6 +97,11 @@ Core
     Providers must subclass from ``shuup.admin.toolbar.BaseToolbarButtonProvider``
     and implement the ``get_buttons_for_view`` method.
 
+``admin_mass_actions_provider```
+    Object that provides mass actions to all views.
+    Providers must subclass from ``shuup.admin.utils.picotable.PicotableMassActionProvider``
+    and implement the ``get_mass_actions_for_view`` method.
+
 ``admin_contact_section``
     Additional ``Section`` subclasses for Contact detail sections.
 
@@ -339,4 +344,10 @@ of objects that have this attribute which can be overrided on a specialization:
 ``View.toolbar_buttons_provider_key``
     Adds buttons to a view's toolbar. Each view will have a custom provide key value.
     Only views that use toolbars can use this attribute, as in ``PicotableViewMixin``.
+    Check `~shuup.admin.modules.categories.views.list.CategoryListView` for an example.
+
+``View.mass_actions_provider_key``
+    Adds mass actions view. Each view will have a custom provide key value.
+    Only views that inherints from ``PicotableListView`` or ``PicotableViewMixin`` will have mass actions added.
+    All providers must inherit from `PicotableMassActionProvider` base class.
     Check `~shuup.admin.modules.categories.views.list.CategoryListView` for an example.

--- a/shuup/admin/modules/attributes/views/list.py
+++ b/shuup/admin/modules/attributes/views/list.py
@@ -32,6 +32,7 @@ class AttributeListView(PicotableListView):
         Column("n_product_types", _("Used in # Product Types")),
     ]
     toolbar_buttons_provider_key = "attribute_list_toolbar_provider"
+    mass_actions_provider_key = "attribute_list_mass_actions_provider"
 
     def get_queryset(self):
         return Attribute.objects.all().annotate(n_product_types=Count("product_types"))

--- a/shuup/admin/modules/categories/views/list.py
+++ b/shuup/admin/modules/categories/views/list.py
@@ -37,6 +37,7 @@ class CategoryListView(PicotableListView):
         Column("visibility", _(u"Visibility"), filter_config=ChoicesFilter(choices=CategoryVisibility.choices)),
     ]
     toolbar_buttons_provider_key = "category_list_toolbar_provider"
+    mass_actions_provider_key = "category_list_mass_actions_provider"
 
     def get_name_filter_choices(self):
         choices = []

--- a/shuup/admin/modules/contact_group_price_display/views/list.py
+++ b/shuup/admin/modules/contact_group_price_display/views/list.py
@@ -30,6 +30,7 @@ class ContactGroupPriceDisplayListView(PicotableListView):
         Column("display_mode", _(u"Display Mode"), display="show_display_mode")
     ]
     toolbar_buttons_provider_key = "contact_group_price_list_toolbar_provider"
+    mass_actions_provider_key = "contact_group_price_list_mass_actions_provider"
 
     def get_queryset(self):
         if getattr(self.request.user, "is_superuser", False):

--- a/shuup/admin/modules/contact_groups/views/list.py
+++ b/shuup/admin/modules/contact_groups/views/list.py
@@ -26,6 +26,7 @@ class ContactGroupListView(PicotableListView):
         Column("n_members", _(u"Number of Members")),
     ]
     toolbar_buttons_provider_key = "contact_group_list_toolbar_provider"
+    mass_actions_provider_key = "contact_group_list_mass_actions_provider"
 
     def get_queryset(self):
         return ContactGroup.objects.all_except_defaults().annotate(n_members=Count("members"))

--- a/shuup/admin/modules/contacts/__init__.py
+++ b/shuup/admin/modules/contacts/__init__.py
@@ -98,6 +98,9 @@ class ContactModule(AdminModule):
             if settings.SHUUP_ENABLE_MULTIPLE_SHOPS and settings.SHUUP_MANAGE_CONTACTS_PER_SHOP:
                 filters &= Q(shops=request.shop)
 
+            if not request.user.is_superuser:
+                filters &= ~Q(PersonContact___user__is_superuser=True)
+
             contacts = Contact.objects.filter(filters)
             for i, contact in enumerate(contacts[:10]):
                 relevance = 100 - i

--- a/shuup/admin/modules/contacts/views/list.py
+++ b/shuup/admin/modules/contacts/views/list.py
@@ -62,6 +62,7 @@ class ContactListView(PicotableListView):
         "shuup.admin.modules.contacts.mass_actions:EditContactGroupsAction",
     ]
     toolbar_buttons_provider_key = "contact_list_toolbar_provider"
+    mass_actions_provider_key = "contact_list_mass_actions_provider"
 
     def get_shops(self):
         return Shop.objects.get_for_user(self.request.user)

--- a/shuup/admin/modules/contacts/views/list.py
+++ b/shuup/admin/modules/contacts/views/list.py
@@ -87,6 +87,10 @@ class ContactListView(PicotableListView):
         groups = self.get_filter().get("groups")
         query = Q(groups__in=groups) if groups else Q()
 
+        # non superusers can't see superusers contacts
+        if not self.request.user.is_superuser:
+            qs = qs.exclude(PersonContact___user__is_superuser=True)
+
         if self.request.GET.get("shop"):
             qs = qs.filter(shops=Shop.objects.get_for_user(self.request.user).filter(pk=self.request.GET["shop"]))
 

--- a/shuup/admin/modules/currencies/views/list.py
+++ b/shuup/admin/modules/currencies/views/list.py
@@ -34,6 +34,7 @@ class CurrencyListView(PicotableListView):
         )
     ]
     toolbar_buttons_provider_key = "currency_list_toolbar_provider"
+    mass_actions_provider_key = "currency_list_mass_actions_provider"
 
     def format_decimal_places(self, instance):
         return "{0}".format(instance.decimal_places)

--- a/shuup/admin/modules/manufacturers/views/list.py
+++ b/shuup/admin/modules/manufacturers/views/list.py
@@ -39,6 +39,7 @@ class ManufacturerListView(PicotableListView):
         ),
     ]
     toolbar_buttons_provider_key = "manufacturer_list_toolbar_provider"
+    mass_actions_provider_key = "manufacturer_list_mass_actions_provider"
 
     def get_queryset(self):
         return Manufacturer.objects.filter(Q(shops=get_shop(self.request)) | Q(shops__isnull=True))

--- a/shuup/admin/modules/orders/views/list.py
+++ b/shuup/admin/modules/orders/views/list.py
@@ -52,6 +52,7 @@ class OrderListView(PicotableListView):
         "shuup.admin.modules.orders.mass_actions:OrderDeliveryPdfAction",
     ]
     toolbar_buttons_provider_key = "order_list_toolbar_provider"
+    mass_actions_provider_key = "order_list_mass_actions_provider"
 
     def get_toolbar(self):
         toolbar = Toolbar([

--- a/shuup/admin/modules/permission_groups/views/list.py
+++ b/shuup/admin/modules/permission_groups/views/list.py
@@ -27,6 +27,7 @@ class PermissionGroupListView(PicotableListView):
         ),
     ]
     toolbar_buttons_provider_key = "permission_group_list_toolbar_provider"
+    mass_actions_provider_key = "permission_group_list_mass_actions_provider"
 
     def get_context_data(self, **kwargs):
         context = super(PermissionGroupListView, self).get_context_data(**kwargs)

--- a/shuup/admin/modules/product_types/views/list.py
+++ b/shuup/admin/modules/product_types/views/list.py
@@ -27,6 +27,7 @@ class ProductTypeListView(PicotableListView):
         Column("n_attributes", _(u"Number of Attributes")),
     ]
     toolbar_buttons_provider_key = "product_type_list_toolbar_provider"
+    mass_actions_provider_key = "product_type_list_mass_actions_provider"
 
     def get_queryset(self):
         return ProductType.objects.all().annotate(n_attributes=Count("attributes"))

--- a/shuup/admin/modules/products/views/list.py
+++ b/shuup/admin/modules/products/views/list.py
@@ -100,6 +100,7 @@ class ProductListView(PicotableListView):
         "shuup.admin.modules.products.mass_actions:EditProductAttributesAction",
     ]
     toolbar_buttons_provider_key = "product_list_toolbar_provider"
+    mass_actions_provider_key = "product_list_mass_actions_provider"
 
     def format_categories(self, instance):
         return ", ".join(list(instance.categories.values_list("translations__name", flat=True)))

--- a/shuup/admin/modules/sales_units/views/list.py
+++ b/shuup/admin/modules/sales_units/views/list.py
@@ -24,6 +24,7 @@ class UnitListView(PicotableListView):
         Column("decimals", _(u"Allowed decimals")),
     ]
     toolbar_buttons_provider_key = "sales_unit_list_toolbar_provider"
+    mass_actions_provider_key = "sales_unit_list_mass_actions_provider"
 
     def get_queryset(self):
         return self.model.objects.all()

--- a/shuup/admin/modules/service_providers/views/_list.py
+++ b/shuup/admin/modules/service_providers/views/_list.py
@@ -25,6 +25,7 @@ class ServiceProviderListView(PicotableListView):
         Column("type", _(u"Type"), display="get_type_display", sortable=False),
     ]
     toolbar_buttons_provider_key = "service_provider_list_toolbar_provider"
+    mass_actions_provider_key = "service_provider_mass_actions_provider"
 
     def get_type_display(self, instance):
         return instance._meta.verbose_name.capitalize()

--- a/shuup/admin/modules/services/views/_list.py
+++ b/shuup/admin/modules/services/views/_list.py
@@ -34,6 +34,7 @@ class ServiceListView(PicotableListView):
         Column("shop", _(u"Shop"))
     ]
     toolbar_buttons_provider_key = "service_list_toolbar_provider"
+    mass_actions_provider_key = "service_list_mass_actions_provider"
 
     def get_object_abstract(self, instance, item):
         return [

--- a/shuup/admin/modules/shops/views/list.py
+++ b/shuup/admin/modules/shops/views/list.py
@@ -35,6 +35,7 @@ class ShopListView(PicotableListView):
         Column("status", _(u"Status"), filter_config=ChoicesFilter(choices=ShopStatus.choices)),
     ]
     toolbar_buttons_provider_key = "shop_list_toolbar_provider"
+    mass_actions_provider_key = "shop_list_mass_actions_provider"
 
     def get_queryset(self):
         return Shop.objects.get_for_user(self.request.user)

--- a/shuup/admin/modules/suppliers/views/list.py
+++ b/shuup/admin/modules/suppliers/views/list.py
@@ -35,6 +35,7 @@ class SupplierListView(PicotableListView):
         Column("module_identifier", _(u"Module"), display="get_module_display", sortable=True)
     ]
     toolbar_buttons_provider_key = "supplier_list_toolbar_provider"
+    mass_actions_provider_key = "supplier_list_mass_actions_provider"
 
     def get_queryset(self):
         return Supplier.objects.filter(Q(shops=get_shop(self.request)) | Q(shops__isnull=True))

--- a/shuup/admin/modules/taxes/views/list.py
+++ b/shuup/admin/modules/taxes/views/list.py
@@ -40,6 +40,7 @@ class TaxListView(PicotableListView):
         Column("enabled", _(u"Enabled"), filter_config=true_or_false_filter),
     ]
     toolbar_buttons_provider_key = "tax_list_toolbar_provider"
+    mass_actions_provider_key = "tax_list_mass_actions_provider"
 
 
 class CustomerTaxGroupListView(PicotableListView):

--- a/shuup/admin/modules/users/views/detail.py
+++ b/shuup/admin/modules/users/views/detail.py
@@ -234,6 +234,15 @@ class UserDetailView(CreateOrUpdateView):
             return Contact.objects.get(pk=contact_id)
         return None
 
+    def get_queryset(self):
+        qs = super(UserDetailView, self).get_queryset()
+
+        # non superusers can't see superusers
+        if not self.request.user.is_superuser:
+            qs = qs.filter(is_superuser=False)
+
+        return qs
+
     def get_initial(self):
         initial = super(UserDetailView, self).get_initial()
         contact = self._get_bind_contact()

--- a/shuup/admin/modules/users/views/list.py
+++ b/shuup/admin/modules/users/views/list.py
@@ -34,6 +34,7 @@ class UserListView(PicotableListView):
         Column("is_superuser", _(u"Superuser"), filter_config=true_or_false_filter),
     ]
     toolbar_buttons_provider_key = "user_list_toolbar_provider"
+    mass_actions_provider_key = "user_list_mass_actions_provider"
 
     def get_model(self):
         return get_user_model()

--- a/shuup/admin/modules/users/views/list.py
+++ b/shuup/admin/modules/users/views/list.py
@@ -44,6 +44,11 @@ class UserListView(PicotableListView):
         qs = self.get_model().objects.all()
         if "date_joined" in [f.name for f in model._meta.get_fields()]:
             qs = qs.order_by("-date_joined")
+
+        # non superusers can't see superusers
+        if not self.request.user.is_superuser:
+            qs = qs.filter(is_superuser=False)
+
         return qs
 
     def get_context_data(self, **kwargs):

--- a/shuup/campaigns/admin_module/views/_list.py
+++ b/shuup/campaigns/admin_module/views/_list.py
@@ -28,6 +28,7 @@ class CampaignListView(PicotableListView):
         Column("active", _("Active"), filter_config=ChoicesFilter(choices=[(0, _("No")), (1, _("Yes"))])),
     ]
     toolbar_buttons_provider_key = "campaign_list_toolbar_provider"
+    mass_actions_provider_key = "campaign_list_actions_provider"
 
     def get_queryset(self):
         shop = self.request.shop

--- a/shuup/discounts/admin/views/_active_list.py
+++ b/shuup/discounts/admin/views/_active_list.py
@@ -61,6 +61,7 @@ class DiscountListView(PicotableListView):
     ]
 
     toolbar_buttons_provider_key = "discount_list_toolbar_provider"
+    mass_actions_provider_key = "discount_list_actions_provider"
 
     def get_discount_effect(self, instance):
         if not (instance.discount_amount_value or instance.discounted_price_value or instance.discount_percentage):

--- a/shuup/front/admin_module/carts/views/_list.py
+++ b/shuup/front/admin_module/carts/views/_list.py
@@ -49,6 +49,7 @@ class CartListView(PicotableListView):
         ),
     ]
     toolbar_buttons_provider_key = "cart_list_toolbar_provider"
+    mass_actions_provider_key = "cart_list_actions_provider"
 
     def get_shops(self):
         return Shop.objects.get_for_user(self.request.user)

--- a/shuup/notify/admin_module/views/list.py
+++ b/shuup/notify/admin_module/views/list.py
@@ -32,6 +32,7 @@ class ScriptListView(PicotableListView):
         Column("enabled", _("Enabled"), filter_config=true_or_false_filter),
     ]
     toolbar_buttons_provider_key = "notify_list_toolbar_provider"
+    mass_actions_provider_key = "notify_list_actions_provider"
 
     def get_object_url(self, instance):
         return reverse("shuup_admin:notify.script.edit", kwargs={"pk": instance.pk})

--- a/shuup/tasks/admin_module/views/list.py
+++ b/shuup/tasks/admin_module/views/list.py
@@ -43,6 +43,7 @@ class TaskListView(PicotableListView):
         Column("comments", _("Comments"), sort_field="comments", display="get_comments_count", class_name="text-center")
     ]
     toolbar_buttons_provider_key = "task_list_toolbar_provider"
+    mass_actions_provider_key = "task_list_actions_provider"
 
     def get_comments_count(self, instance, **kwargs):
         return instance.comments.for_contact(get_person_contact(self.request.user)).count()

--- a/shuup/testing/admin_module/mass_actions.py
+++ b/shuup/testing/admin_module/mass_actions.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.admin.utils.picotable import (
+    PicotableMassAction, PicotableMassActionProvider
+)
+
+
+class DummyPicotableMassAction1(PicotableMassAction):
+    label = _("Dummy Mass Action #1")
+    identifier = "dummy_mass_action_1"
+
+
+class DummyPicotableMassAction2(PicotableMassAction):
+    label = _("Dummy Mass Action #2")
+    identifier = "dummy_mass_action_2"
+
+
+class DummyMassActionProvider(PicotableMassActionProvider):
+    @classmethod
+    def get_mass_actions_for_view(cls, view):
+        return [
+            "shuup.testing.admin_module.mass_actions:DummyPicotableMassAction1",
+            "shuup.testing.admin_module.mass_actions:DummyPicotableMassAction2"
+        ]

--- a/shuup_tests/admin/test_contact_edit.py
+++ b/shuup_tests/admin/test_contact_edit.py
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 import pytest
 from django.contrib.auth import get_user_model
-from django.core.exceptions import PermissionDenied
+from django.http.response import Http404
 from django.test.utils import override_settings
 
 from shuup.admin.forms.fields import Select2MultipleField
@@ -188,7 +188,7 @@ def test_contact_edit_multishop(rf):
         view = ContactDetailView.as_view()
 
         # contact not found for this shop
-        with pytest.raises(PermissionDenied):
+        with pytest.raises(Http404):
             response = view(request, pk=contact.id)
 
         request = apply_request_middleware(rf.get("/"), user=staff_user, shop=shop2)
@@ -222,7 +222,7 @@ def test_contact_company_edit_multishop(rf):
 
         # permission denied for contact and shop1
         request = apply_request_middleware(rf.get("/"), user=staff_user, shop=shop1)
-        with pytest.raises(PermissionDenied):
+        with pytest.raises(Http404):
             response = view(request, pk=contact.id)
         # permission granted for contact and shop2
         request = apply_request_middleware(rf.get("/"), user=staff_user, shop=shop2)
@@ -231,7 +231,7 @@ def test_contact_company_edit_multishop(rf):
 
         # permission denied for company and shop2
         request = apply_request_middleware(rf.get("/"), user=staff_user, shop=shop2)
-        with pytest.raises(PermissionDenied):
+        with pytest.raises(Http404):
             response = view(request, pk=company.id)
         # permission granted for company and shop1
         request = apply_request_middleware(rf.get("/"), user=staff_user, shop=shop1)
@@ -299,7 +299,7 @@ def test_contact_detail_multishop(rf):
 
         # contact not found for this shop
         request = apply_request_middleware(rf.get("/"), user=staff_user, shop=shop1)
-        with pytest.raises(PermissionDenied):
+        with pytest.raises(Http404):
             response = view(request, pk=contact.id)
 
         request = apply_request_middleware(rf.get("/"), user=staff_user, shop=shop2)
@@ -326,7 +326,7 @@ def test_company_contact_detail_multishop(rf):
 
         # company not found for this shop
         request = apply_request_middleware(rf.get("/"), user=staff_user, shop=shop2)
-        with pytest.raises(PermissionDenied):
+        with pytest.raises(Http404):
             response = view(request, pk=company.id)
 
         request = apply_request_middleware(rf.get("/"), user=staff_user, shop=shop1)

--- a/shuup_tests/admin/test_view_custom_mass_actions.py
+++ b/shuup_tests/admin/test_view_custom_mass_actions.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import json
+
+import pytest
+
+from shuup.admin.modules.manufacturers.views import ManufacturerListView
+from shuup.admin.modules.sales_units.views import SalesUnitListView
+from shuup.apps.provides import override_provides
+from shuup.testing import factories
+from shuup.testing.utils import apply_request_middleware
+
+
+@pytest.mark.django_db
+def test_view_custom_mass_actions(rf, admin_user):
+    factories.get_default_shop()
+    request = apply_request_middleware(rf.get("/", {"jq": json.dumps({"perPage": 100, "page": 1})}), user=admin_user)
+    list_view_func = ManufacturerListView.as_view()
+
+    # no mass actions
+    response = list_view_func(request)
+    data = json.loads(response.content.decode("utf-8"))
+    assert not data["massActions"]
+
+    # test with specific key
+    with override_provides("manufacturer_list_mass_actions_provider", [
+        "shuup.testing.admin_module.mass_actions:DummyMassActionProvider"
+    ]):
+        response = list_view_func(request)
+        data = json.loads(response.content.decode("utf-8"))
+        identifiers = [action["key"] for action in data["massActions"]]
+        assert "dummy_mass_action_1" in identifiers
+        assert "dummy_mass_action_2" in identifiers
+
+    list_view_func = SalesUnitListView.as_view()
+    # test with global
+    with override_provides("admin_mass_actions_provider", [
+        "shuup.testing.admin_module.mass_actions:DummyMassActionProvider"
+    ]):
+        response = list_view_func(request)
+        data = json.loads(response.content.decode("utf-8"))
+        identifiers = [action["key"] for action in data["massActions"]]
+        assert "dummy_mass_action_1" in identifiers
+        assert "dummy_mass_action_2" in identifiers

--- a/shuup_tests/admin/test_view_custom_toolbar.py
+++ b/shuup_tests/admin/test_view_custom_toolbar.py
@@ -16,7 +16,7 @@ from shuup.testing.utils import apply_request_middleware
 
 
 @pytest.mark.django_db
-def test_custom_view_toolbar_buuttons(rf, admin_user):
+def test_custom_view_toolbar_buttons(rf, admin_user):
     factories.get_default_shop()
     request = apply_request_middleware(rf.get("/"), user=admin_user)
     list_view_func = ContactGroupPriceDisplayListView.as_view()


### PR DESCRIPTION
- Introduce custom mass actions to picotable list views through provides.
 - Limit the contacts and users visibility for non superusers. Do not list superuser contacts and users when current user is not superuser

No Refs