### PR TITLE
Remove Support ID from admin

### DIFF
--- a/shuup/admin/templates/shuup/admin/base/_navigation.jinja
+++ b/shuup/admin/templates/shuup/admin/base/_navigation.jinja
@@ -20,9 +20,6 @@
     <div id="site-search-results" class="site-search-results"></div>
 </div>
 
-{% set support_id=shuup_admin.get_support_id() %}
-{% if support_id %}<p class="nav-text d-sm-none d-md-block">{% trans %}Support ID: {% endtrans %}{{ support_id }}</p>{% endif %}
-
 <div class="site-links d-none d-lg-block mr-3">
     <a class="nav-btn shop-btn" href="{{ url("shuup_admin:home") }}" data-toggle="tooltip" data-placement="bottom" title="{% trans %}Go home{% endtrans %}"><i class="fa fa-home"></i></a>
 


### PR DESCRIPTION
Removed Support ID from the template,
but left function here in case we need it in the future, https://github.com/shuup/shuup/blob/829dfaa4fec7ead2a4992016e5a7458a63233c1c/shuup/admin/template_helpers/shuup_admin.py#L67

Refs ENT-2978