### PR TITLE
Admin: setup max-width for picotable columns

### DIFF
--- a/shuup/admin/static_src/base/scss/shuup/picotable.scss
+++ b/shuup/admin/static_src/base/scss/shuup/picotable.scss
@@ -13,6 +13,9 @@
     .table th,
     .table td {
         padding: 0.65rem 1rem;
+        max-width: 500px;
+        overflow-x: hidden;
+        text-overflow: ellipsis;
     }
 
     .table th.hidden-cell {


### PR DESCRIPTION
Longs columns just don't work and 500px limit should be fair enough.