### PR TITLE
Admin: fix crash when deleting a label

### DIFF
--- a/shuup/admin/modules/labels/views.py
+++ b/shuup/admin/modules/labels/views.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals
 from django.contrib import messages
 from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponseRedirect
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import DetailView
 
@@ -57,6 +58,7 @@ class LabelDeleteView(DetailView):
 
     def post(self, request, *args, **kwargs):
         label = self.get_object()
+        label_name = force_text(label)
         label.delete()
-        messages.success(request, _("%s has been deleted.") % label)
+        messages.success(request, _("%s has been deleted.") % label_name)
         return HttpResponseRedirect(reverse_lazy("shuup_admin:label.list"))

--- a/shuup/reports/report.py
+++ b/shuup/reports/report.py
@@ -8,11 +8,13 @@
 from __future__ import unicode_literals
 
 from collections import OrderedDict
+from datetime import datetime
 from decimal import Decimal
 
 import six
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
+from django.utils.timezone import make_aware
 
 from shuup.apps.provides import get_provide_objects
 from shuup.core.models import Shop
@@ -44,6 +46,12 @@ class ShuupReportBase(object):
             self.shop = Shop.objects.get(pk=self.options["shop"])
         else:
             self.shop = None
+
+        if self.start_date is None:
+            self.start_date = make_aware(datetime.min)
+        if self.end_date is None:
+            self.end_date = make_aware(datetime.max)
+
         self.rendered = False
 
     def __unicode__(self):

--- a/shuup_tests/reports/test_reports.py
+++ b/shuup_tests/reports/test_reports.py
@@ -291,3 +291,24 @@ def test_get_totals_return_correct_totals():
         "taxful_total": TaxfulPrice("5", "EUR")
     }
     assert totals == expected
+
+
+@pytest.mark.parametrize("start_date,end_date", [
+    (None, None),
+    ("1990-01-01", None),
+    (None, "2100-01-01")
+])
+@pytest.mark.django_db
+def test_none_dates(start_date, end_date):
+    _, _, shop, order = initialize_report_test(10, 2, 0, 1)
+    data = {
+        "report": SalesTestReport.get_name(),
+        "shop": shop.pk,
+        "start_date": start_date,
+        "end_date": end_date,
+        "writer": "json",
+        "force_download": 1
+    }
+    report = SalesTestReport(**data)
+    data = report.get_data()
+    assert data["data"]


### PR DESCRIPTION
Django crashes when rendering the success message because the label name was invalid
as the label was deleted