### PR TITLE
Reports: fix max and min dates when values are set to None

### DIFF
--- a/shuup/reports/report.py
+++ b/shuup/reports/report.py
@@ -8,13 +8,13 @@
 from __future__ import unicode_literals
 
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import six
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
-from django.utils.timezone import make_aware
+from django.utils.timezone import get_current_timezone, make_aware
 
 from shuup.apps.provides import get_provide_objects
 from shuup.core.models import Shop
@@ -48,9 +48,9 @@ class ShuupReportBase(object):
             self.shop = None
 
         if self.start_date is None:
-            self.start_date = make_aware(datetime.min)
+            self.start_date = make_aware(datetime.min + timedelta(days=1), get_current_timezone())
         if self.end_date is None:
-            self.end_date = make_aware(datetime.max)
+            self.end_date = make_aware(datetime.max - timedelta(days=1), get_current_timezone())
 
         self.rendered = False
 

--- a/shuup_tests/reports/test_reports.py
+++ b/shuup_tests/reports/test_reports.py
@@ -14,6 +14,7 @@ import pytest
 import six
 from babel.dates import format_date
 from bs4 import BeautifulSoup
+from django.test.utils import override_settings
 from django.utils.encoding import force_text
 from django.utils.functional import lazy
 from django.utils.safestring import SafeText
@@ -301,14 +302,17 @@ def test_get_totals_return_correct_totals():
 @pytest.mark.django_db
 def test_none_dates(start_date, end_date):
     _, _, shop, order = initialize_report_test(10, 2, 0, 1)
-    data = {
-        "report": SalesTestReport.get_name(),
-        "shop": shop.pk,
-        "start_date": start_date,
-        "end_date": end_date,
-        "writer": "json",
-        "force_download": 1
-    }
-    report = SalesTestReport(**data)
-    data = report.get_data()
-    assert data["data"]
+
+    for timezone in ["UTC", "America/Sao_Paulo", "Etc/GMT+12", "Pacific/Kiritimati"]:
+        with override_settings(TIME_ZONE=timezone):
+            data = {
+                "report": SalesTestReport.get_name(),
+                "shop": shop.pk,
+                "start_date": start_date,
+                "end_date": end_date,
+                "writer": "json",
+                "force_download": 1
+            }
+            report = SalesTestReport(**data)
+            data = report.get_data()
+            assert data["data"]


### PR DESCRIPTION
Make the min and max support different timezones and prevent overflow and underflow