### PR TITLE
Front: add mixin with fields for base template

### DIFF
--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-15 15:08+0000\n"
+"POT-Creation-Date: 2019-02-21 23:08+0000\n"
 "PO-Revision-Date: 2016-08-04 10:51-0700\n"
 "Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
@@ -889,6 +889,11 @@ msgstr ""
 msgid "By %(supplier_name)s"
 msgstr ""
 
+#, python-brace-format
+msgid ""
+"Available until: <span class=\"availability-date\">{date}</span></small>"
+msgstr ""
+
 msgid "Edit account details"
 msgstr ""
 
@@ -986,15 +991,6 @@ msgstr ""
 msgid "Product Information"
 msgstr ""
 
-msgid "Description"
-msgstr ""
-
-msgid "Details"
-msgstr ""
-
-msgid "Attributes"
-msgstr ""
-
 msgid "Includes these products"
 msgstr ""
 
@@ -1011,6 +1007,9 @@ msgid "Manufacturer"
 msgstr ""
 
 msgid "Package Size"
+msgstr ""
+
+msgid "Available Until"
 msgstr ""
 
 msgid "Width"
@@ -1038,6 +1037,10 @@ msgid "Select product"
 msgstr ""
 
 msgid "Add to cart"
+msgstr ""
+
+#, python-brace-format
+msgid "Available until: {date}"
 msgstr ""
 
 msgid "Maintenance mode"
@@ -1083,6 +1086,57 @@ msgid "Open product page"
 msgstr ""
 
 msgid "Newest products"
+msgstr ""
+
+msgid "Hide prices"
+msgstr ""
+
+msgid "Set shop in catalog mode"
+msgstr ""
+
+msgid "Show supplier info"
+msgstr ""
+
+msgid ""
+"Show supplier name in product-box, product-detail, basket- and order-lines"
+msgstr ""
+
+msgid "Show Product Details"
+msgstr ""
+
+msgid ""
+"If you check this, extra information will be shown on product page in "
+"frontend."
+msgstr ""
+
+msgid "Product detail extra tab title"
+msgstr ""
+
+msgid "Enter the title for the product detail extra tab."
+msgstr ""
+
+msgid "Product detail extra tab content"
+msgstr ""
+
+msgid "Enter the content for the product detail extra tab."
+msgstr ""
+
+msgid "Description"
+msgstr ""
+
+msgid "Details"
+msgstr ""
+
+msgid "Attributes"
+msgstr ""
+
+msgid "Product reviews"
+msgstr ""
+
+msgid "Product detail tabs"
+msgstr ""
+
+msgid "Select all tabs that should be renderd in product details."
 msgstr ""
 
 msgid "Tax number is not valid."

--- a/shuup/front/templates/shuup/front/macros/general.jinja
+++ b/shuup/front/templates/shuup/front/macros/general.jinja
@@ -32,7 +32,7 @@
         {% set widget_name = field.field.widget.__class__.__name__|lower %}
         {% if widget_name == "checkboxinput" %}
             <div class="custom-checkbox {{ widget_name }}{% if field.field.required %} required{% endif %}{% if field.errors %} has-error{% endif %} {{ classes }}">
-                {{ field.as_widget()|safe }}
+                {{ (field|replace_field_attrs(required=false)).as_widget()|safe }}
                 {% if render_label %}
                 <label for="{{ field.auto_id }}">
                     {{ field.label }}

--- a/shuup/front/templates/shuup/front/macros/general.jinja
+++ b/shuup/front/templates/shuup/front/macros/general.jinja
@@ -362,3 +362,9 @@
 {% macro render_supplier_info(supplier) %}
     <p class="supplier-info"><small>{{ _("By %(supplier_name)s", supplier_name=supplier.name) }}</small></p>
 {% endmacro %}
+
+{% macro render_availability_info(shop_product) %}
+    <div class="available-until">
+        <small>{{ _('Available until: <span class="availability-date">{date}</span></small>').format(date=shop_product.available_until|date) }}
+    </div>
+{% endmacro %}

--- a/shuup/front/templates/shuup/front/macros/product.jinja
+++ b/shuup/front/templates/shuup/front/macros/product.jinja
@@ -8,17 +8,16 @@ Inheritance order for product macors:
     theme/product.jinja
 #}
 {% extends "shuup/front/macros/product_image.jinja" %}
-{% from "shuup/front/macros/general.jinja" import render_supplier_info %}
+{% from "shuup/front/macros/general.jinja" import render_supplier_info, render_availability_info %}
 
 {% macro product_box(
         product, show_image=True, show_description=True, class="product-box",
         thumbnail_size=(500,500), supplier=None) %}
-
+    {% set shop_product = product.get_shop_instance(request.shop, allow_cache=True) %}
     {% if supplier %}
         {% set u = url("shuup:supplier-product", supplier_pk=supplier.pk, pk=product.pk, slug=product.slug) %}
     {% else %}
         {% set u = url("shuup:product", pk=product.pk, slug=product.slug) %}
-        {% set shop_product = product.get_shop_instance(request.shop, allow_cache=True) %}
         {% set supplier = shop_product.get_supplier() %}
     {% endif %}
 
@@ -42,8 +41,9 @@ Inheritance order for product macors:
             <div class="detail-wrap">
                 <div class="name">
                     {{ product.name }}
-                    {% if show_supplier_info %}{{ render_supplier_info(supplier) }}{% endif %}
                 </div>
+                {% if show_supplier_info %}{{ render_supplier_info(supplier) }}{% endif %}
+                {% if shop_product and shop_product.available_until %}{{ render_availability_info(shop_product) }}{% endif %}
                 <div class="actions-wrap">
                     {% if show_prices() and not xtheme.get("hide_prices") %}
                     <div class="price">

--- a/shuup/front/templates/shuup/front/macros/product.jinja
+++ b/shuup/front/templates/shuup/front/macros/product.jinja
@@ -100,6 +100,10 @@ Inheritance order for product macors:
     {% endif %}
 {% endmacro %}
 
+{% macro render_product_detail_top_placeholder() %}
+    {% placeholder "detail_top_placeholder" %}{% endplaceholder %}
+{% endmacro %}
+
 {% macro render_product_placeholder_section() %}
     {% placeholder "product_bottom" %}
         {% row %}

--- a/shuup/front/templates/shuup/front/macros/product_information.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_information.jinja
@@ -109,6 +109,10 @@
                             <dt>{% trans %}Package Size{% endtrans %}</dt>
                             <dd>{{ shop_product.purchase_multiple }}</dd>
                         {% endif %}
+                        {% if shop_product.available_until %}
+                            <dt>{% trans %}Available Until{% endtrans %}</dt>
+                            <dd>{{ shop_product.available_until|date }}</dd>
+                        {% endif %}
                         {% if product.width or product.height or product.depth %}
                             <dt>{% trans %}Width{% endtrans %}</dt>
                             <dd>{{ product.width|floatformat(2) }} mm</dd>

--- a/shuup/front/templates/shuup/front/macros/product_information.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_information.jinja
@@ -17,110 +17,151 @@
     {% endif %}
 {% endmacro %}
 
-{% macro render_product_information(product) %}
-    <hr>
-    <h3>{% trans %}Product Information{% endtrans %}</h3>
+
+{% macro render_product_title_tab(tab_id, icon=None) %}
+    {% set tabs = xtheme.get_product_details_tabs() %}
+    {% if tabs and tabs[0][0] == tab_id %}
+        {% set active = True %}
+    {% endif %}
+    {% for tab, label in xtheme.get_product_details_tabs() %}
+        {% if tab == tab_id %}
+            <li role="presentation"{% if active %} class="active"{% endif %}>
+                <a href="#{{ tab_id }}" aria-controls="{{ tab_id }}" role="tab" data-toggle="tab">
+                    {% if icon %}<i class="{{ icon }}"></i>{% endif %}
+                    {{ label }}
+                </a>
+            </li>
+        {% endif %}
+    {% endfor %}
+{% endmacro %}
+
+{% macro render_product_information(product, render_title=True) %}
+    {% if render_title %}
+        <hr>
+        <h3>{% trans %}Product Information{% endtrans %}</h3>
+    {% endif %}
     {% set media_files = product.get_public_media() %}
+    {% set tabs = xtheme.get_product_details_tabs() %}
+    {% if tabs %}
+        {% set active_tab = tabs[0][0] %}
+    {% endif %}
+
     <div class="product-tabs" role="tabpanel">
-        <ul class="nav nav-tabs" role="tablist">
-            <li role="presentation" class="active"><a href="#tab1" aria-controls="tab1" role="tab" data-toggle="tab">{% trans %}Description{% endtrans %}</a></li>
-            <li role="presentation"><a href="#tab2" aria-controls="tab2" role="tab" data-toggle="tab">{% trans %}Details{% endtrans %}</a></li>
+        <ul class="nav nav-tabs nav-justified" role="tablist">
+            {{ render_product_title_tab("description", "fa fa-file-text-o") }}
+            {{ render_product_title_tab("details", "fa fa-info-circle") }}
             {% if attributes %}
-                <li role="presentation"><a href="#tab3" aria-controls="tab3" role="tab" data-toggle="tab">{% trans %}Attributes{% endtrans %}</a></li>
+                {{ render_product_title_tab("attributes", "fa fa-tags") }}
             {% endif %}
             {% if media_files %}
-                <li role="presentation"><a href="#tab4" aria-controls="tab4" role="tab" data-toggle="tab">{% trans %}Files{% endtrans %}</a></li>
+                {{ render_product_title_tab("files", "fa fa-file-archive-o") }}
+            {% endif %}
+            {{ render_product_title_tab("product_reviews", "fa fa-star") }}
+            {% if xtheme.get("product_detail_extra_tab_title") %}
+                <li role="presentation">
+                    <a href="#extra" aria-controls="extra" role="tab" data-toggle="tab">
+                        {{ xtheme.get("product_detail_extra_tab_title")|safe }}
+                    </a>
+                </li>
             {% endif %}
         </ul>
         <div class="tab-content">
-            <div role="tabpanel" class="product-description tab-pane fade in active" id="tab1">
-                {% if product.description or package_children %}
-                    {{ product.description|safe }}
-                    {% if package_children %}
-                        {% set quantity_map = product.get_package_child_to_quantity_map() %}
-                        <p><strong>{% trans %}Includes these products{% endtrans %}</strong></p>
-                        <ul>
-                            {% for child in package_children %}
-                                <li>
-                                    {{ product_line(child, quantity_map[child]) }}
-                                </li>
-                            {% endfor %}
-                        </ul>
+            {% if xtheme.should_render_product_detail_tab("description") %}
+                <div role="tabpanel" class="product-description tab-pane fade in {% if active_tab == 'description' %}in active{% endif %}" id="description">
+                    {% if product.description or package_children %}
+                        {{ product.description|safe }}
+                        {% if package_children %}
+                            {% set quantity_map = product.get_package_child_to_quantity_map() %}
+                            <p><strong>{% trans %}Includes these products{% endtrans %}</strong></p>
+                            <ul>
+                                {% for child in package_children %}
+                                    <li>
+                                        {{ product_line(child, quantity_map[child]) }}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                    {% else %}
+                        {% trans %}No product description available{% endtrans %}
                     {% endif %}
-                {% else %}
-                    {% trans %}No product description available{% endtrans %}
-                {% endif %}
-            </div>
-            <div role="tabpanel" class="product-attributes tab-pane fade" id="tab2">
-                <dl class="dl-horizontal">
-                    <dt>{% trans %}SKU{% endtrans %}</dt>
-                    <dd>{{ product.sku }}</dd>
-                    {% if product.barcode %}
-                        <dt>{% trans %}Barcode{% endtrans %}</dt>
-                        <dd>{{ product.barcode }}</dd>
-                    {% endif %}
-                    {% if product.manufacturer %}
-                        <dt>{% trans %}Manufacturer{% endtrans %}</dt>
-                        <dd>
-                            {% if product.manufacturer.url %}
-                                <a href="{{ product.manufacturer.url }}" target="_blank">{{ product.manufacturer.name }}</a>
-                            {% else %}
-                                {{ product.manufacturer.name }}
-                            {% endif %}
-                        </dd>
-                    {% endif %}
-                    {% if shop_product.purchase_multiple and shop_product.purchase_multiple > 1 %}
-                        <dt>{% trans %}Package Size{% endtrans %}</dt>
-                        <dd>{{ shop_product.purchase_multiple }}</dd>
-                    {% endif %}
-                    {% if product.width or product.height or product.depth %}
-                        <dt>{% trans %}Width{% endtrans %}</dt>
-                        <dd>{{ product.width|floatformat(2) }} mm</dd>
-                        <dt>{% trans %}Height{% endtrans %}</dt>
-                        <dd>{{ product.height|floatformat(2) }} mm</dd>
-                        <dt>{% trans %}Depth{% endtrans %}</dt>
-                        <dd>{{ product.depth|floatformat(2) }} mm</dd>
-                    {% endif %}
-                    {% if product.net_weight %}
-                        <dt>{% trans %}Net Weight{% endtrans %}</dt>
-                        <dd>
-                            {% if product.net_weight < 1000 %}
-                                {{ product.net_weight|floatformat(2) }} g
-                            {% else %}
-                                {{ (product.net_weight / 1000)|floatformat(2) }} kg
-                            {% endif %}
-                        </dd>
-                    {% endif %}
-                    {% if product.gross_weight %}
-                        <dt>{% trans %}Gross Weight{% endtrans %}</dt>
-                        <dd>
-                            {% if product.gross_weight < 1000 %}
-                                {{ product.gross_weight|floatformat(2) }} g
-                            {% else %}
-                                {{ (product.gross_weight / 1000)|floatformat(2) }} kg
-                            {% endif %}
-                        </dd>
-                    {% endif %}
-                    {% if product.external_link %}
-                        <dt>{% trans %}External link{% endtrans %}</dt>
-                        <dd><a href="{{ product.external_link }}" target="_blank">{{ product.external_link }}</a></dd>
-                    {% endif %}
-                </dl>
-            </div>
-            {% if attributes %}
-                <div role="tabpanel" class="product-attributes tab-pane fade" id="tab3">
+                </div>
+            {% endif %}
+            {% if xtheme.should_render_product_detail_tab("details") %}
+                <div role="tabpanel" class="product-attributes tab-pane fade {% if active_tab == 'details' %}in active{% endif %}" id="details">
                     <dl class="dl-horizontal">
-                        {% for attribute in attributes %}
-                            {% if attribute.value is not none %}
-                                <dt>{{ attribute.name }}</dt>
-                                <dd>{{ attribute.formatted_value }}</dd>
-                            {% endif %}
-                        {% endfor %}
+                        <dt>{% trans %}SKU{% endtrans %}</dt>
+                        <dd>{{ product.sku }}</dd>
+                        {% if product.barcode %}
+                            <dt>{% trans %}Barcode{% endtrans %}</dt>
+                            <dd>{{ product.barcode }}</dd>
+                        {% endif %}
+                        {% if product.manufacturer %}
+                            <dt>{% trans %}Manufacturer{% endtrans %}</dt>
+                            <dd>
+                                {% if product.manufacturer.url %}
+                                    <a href="{{ product.manufacturer.url }}" target="_blank">{{ product.manufacturer.name }}</a>
+                                {% else %}
+                                    {{ product.manufacturer.name }}
+                                {% endif %}
+                            </dd>
+                        {% endif %}
+                        {% if shop_product.purchase_multiple and shop_product.purchase_multiple > 1 %}
+                            <dt>{% trans %}Package Size{% endtrans %}</dt>
+                            <dd>{{ shop_product.purchase_multiple }}</dd>
+                        {% endif %}
+                        {% if product.width or product.height or product.depth %}
+                            <dt>{% trans %}Width{% endtrans %}</dt>
+                            <dd>{{ product.width|floatformat(2) }} mm</dd>
+                            <dt>{% trans %}Height{% endtrans %}</dt>
+                            <dd>{{ product.height|floatformat(2) }} mm</dd>
+                            <dt>{% trans %}Depth{% endtrans %}</dt>
+                            <dd>{{ product.depth|floatformat(2) }} mm</dd>
+                        {% endif %}
+                        {% if product.net_weight %}
+                            <dt>{% trans %}Net Weight{% endtrans %}</dt>
+                            <dd>
+                                {% if product.net_weight < 1000 %}
+                                    {{ product.net_weight|floatformat(2) }} g
+                                {% else %}
+                                    {{ (product.net_weight / 1000)|floatformat(2) }} kg
+                                {% endif %}
+                            </dd>
+                        {% endif %}
+                        {% if product.gross_weight %}
+                            <dt>{% trans %}Gross Weight{% endtrans %}</dt>
+                            <dd>
+                                {% if product.gross_weight < 1000 %}
+                                    {{ product.gross_weight|floatformat(2) }} g
+                                {% else %}
+                                    {{ (product.gross_weight / 1000)|floatformat(2) }} kg
+                                {% endif %}
+                            </dd>
+                        {% endif %}
+                        {% if product.external_link %}
+                            <dt>{% trans %}External link{% endtrans %}</dt>
+                            <dd><a href="{{ product.external_link }}" target="_blank">{{ product.external_link }}</a></dd>
+                        {% endif %}
                     </dl>
                 </div>
             {% endif %}
-            {% if media_files %}
-                <div role="tabpanel" class="product-files tab-pane fade" id="tab4">
+            {% if attributes and xtheme.should_render_product_detail_tab("attributes") %}
+                <div role="tabpanel" class="product-attributes tab-pane fade {% if active_tab == 'attributes' %}in active{% endif %}" id="attributes">
+                    <div class="table-responsive">
+                        <table class="table table-striped table-condensed">
+                            {% for attribute in shuup.product.get_visible_attributes(product) %}
+                                <tr>
+                                {% if attribute.value is not none %}
+                                    <td>{{ attribute.name }}</td>
+                                    <td>{{ attribute.formatted_value }}</td>
+                                {% endif %}
+                                </tr>
+                            {% endfor %}
+                        </table>
+                    </div>
+                </div>
+            {% endif %}
+            {% if media_files and xtheme.should_render_product_detail_tab("files") %}
+                <div role="tabpanel" class="product-files tab-pane fade {% if active_tab == 'files' %}in active{% endif %}" id="files">
                     <table class="table">
                         {% for file in media_files %}
                             <tr>
@@ -133,6 +174,18 @@
                             </tr>
                         {% endfor %}
                     </table>
+                </div>
+            {% endif %}
+            {% if xtheme.should_render_product_detail_tab("product_reviews") %}
+                <div role="tabpanel" class="product-reviews tab-pane fade {% if active_tab == 'product_reviews' %}in active{% endif %}" id="product_reviews">
+                    {% set review_product=shop_product.product %}
+                    {% set title=(reviews_tab_title or "") %}
+                    {% include "shuup_product_reviews/plugins/reviews_comments.jinja" with context %}
+                </div>
+            {% endif %}
+            {% if xtheme.get("product_detail_extra_tab_title") %}
+                <div role="tabpanel" class="product-extra-content tab-pane fade" id="extra">
+                    {{ xtheme.get("product_detail_extra_tab_content")|safe }}
                 </div>
             {% endif %}
         </div>

--- a/shuup/front/templates/shuup/front/macros/product_ordering.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_ordering.jinja
@@ -200,5 +200,10 @@
             <i class="fa fa-info-circle text-info"></i> {{ shop_product.status_text }}
         </p>
         {% endif %}
+        {% if shop_product.available_until %}
+        <p class="text-right">
+            <i class="fa fa-calendar text-info"></i> {{ _("Available until: {date}").format(date=shop_product.available_until|date) }}
+        </p>
+        {% endif %}
     </div>
 {% endmacro %}

--- a/shuup/front/templates/shuup/front/product/detail.jinja
+++ b/shuup/front/templates/shuup/front/product/detail.jinja
@@ -44,8 +44,10 @@
             {% placeholder "product_extra_2" %}{% endplaceholder %}
         </div>
     </div>
-
-    {{ product_macros.render_product_information(product) }}
+    {{ product_macros.render_product_detail_top_placeholder() }}
+    {% if xtheme.get("show_product_detail_section", True) %}
+        {{ product_macros.render_product_information(product) }}
+    {% endif %}
     {# By default this extra section contains placeholders for cross sells #}
     {{ product_macros.render_product_placeholder_section() }}
     {# By default this lists all children for package parent #}

--- a/shuup/front/templatetags/shuup_front.py
+++ b/shuup/front/templatetags/shuup_front.py
@@ -51,3 +51,10 @@ def _cached_markdown(str_value):
 @library.filter(name="markdown")
 def markdown(value):
     return mark_safe(_cached_markdown(force_text(value)))
+
+
+@library.filter(name="replace_field_attrs")
+def replace_field_attrs(field, **attrs):
+    for attr, value in attrs.items():
+        setattr(field.field, attr, value)
+    return field

--- a/shuup/front/themes/__init__.py
+++ b/shuup/front/themes/__init__.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.admin.forms.widgets import TextEditorWidget
+from shuup.utils.djangoenv import has_installed
+
+
+class BaseThemeFieldsMixin(object):
+    """
+    Default Theme mixing with fields used in Shuup Front
+
+    Add this mixing to the theme class if you want to use the same options as
+    the Shuup Front theme provides.
+    """
+    _base_fields = [
+        ("hide_prices", forms.BooleanField(required=False, initial=False, label=_("Hide prices"))),
+        ("catalog_mode", forms.BooleanField(required=False, initial=False, label=_("Set shop in catalog mode"))),
+        ("show_supplier_info", forms.BooleanField(
+            required=False, initial=False, label=_("Show supplier info"),
+            help_text=_("Show supplier name in product-box, product-detail, basket- and order-lines")
+        )),
+        ("show_product_detail_section", forms.BooleanField(
+            required=False, initial=True, label=_("Show Product Details"),
+            help_text=_("If you check this, extra information will be shown on product page in frontend.")
+        )),
+        ("product_detail_extra_tab_title", forms.CharField(
+            required=False,
+            label=_("Product detail extra tab title"),
+            help_text=_("Enter the title for the product detail extra tab.")
+        )),
+        ("product_detail_extra_tab_content", forms.CharField(
+            widget=TextEditorWidget(),
+            required=False, label=_("Product detail extra tab content"),
+            help_text=_("Enter the content for the product detail extra tab.")
+        ))
+    ]
+
+    def get_product_tabs_options(self):
+        product_detail_tabs = [
+            ("description", _("Description")),
+            ("details", _("Details")),
+            ("attributes", _("Attributes")),
+            ("files", _("Files")),
+        ]
+        if has_installed("shuup_product_reviews"):
+            product_detail_tabs.append(("product_reviews", _("Product reviews")))
+        return product_detail_tabs
+
+    def get_base_fields(self):
+        fields = self._base_fields
+        product_detail_tabs = self.get_product_tabs_options()
+        fields.extend([
+            ("product_detail_tabs", forms.MultipleChoiceField(
+                required=False,
+                initial=[tab[0] for tab in product_detail_tabs],
+                choices=product_detail_tabs,
+                label=_("Product detail tabs"),
+                help_text=_("Select all tabs that should be renderd in product details.")
+            ))
+        ])
+        return fields
+
+    def get_product_details_tabs(self):
+        selected_options = self.get_setting("product_detail_tabs")
+        tab_options = self.get_product_tabs_options()
+
+        # nothing selected, returns everything by default
+        if not selected_options:
+            return tab_options
+
+        tabs = []
+        for selected_option in selected_options:
+            for tab_option in tab_options:
+                if selected_option == tab_option[0]:
+                    tabs.append(tab_option)
+        return tabs
+
+    def should_render_product_detail_tab(self, tab_identifier):
+        return tab_identifier in [tab[0] for tab in self.get_product_details_tabs()]

--- a/shuup/themes/classic_gray/locale/en/LC_MESSAGES/django.po
+++ b/shuup/themes/classic_gray/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-13 17:48+0000\n"
+"POT-Creation-Date: 2019-02-21 23:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,9 +16,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-msgid "Classic Gray"
-msgstr ""
 
 msgid "This theme has no special settings to configure."
 msgstr ""
@@ -36,15 +33,6 @@ msgstr ""
 msgid "Products"
 msgstr ""
 
-msgid "Show Frontpage Welcome Text"
-msgstr ""
-
-msgid "Hide prices"
-msgstr ""
-
-msgid "Set shop in catalog mode"
-msgstr ""
-
 msgid "Default"
 msgstr ""
 
@@ -52,4 +40,7 @@ msgid "Midnight Blue"
 msgstr ""
 
 msgid "Candy Pink"
+msgstr ""
+
+msgid "Show Frontpage Welcome Text"
 msgstr ""

--- a/shuup/themes/classic_gray/theme.py
+++ b/shuup/themes/classic_gray/theme.py
@@ -11,29 +11,16 @@ from django import forms
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
+from shuup.front.themes import BaseThemeFieldsMixin
 from shuup.xtheme import Theme
 
 
-class ClassicGrayTheme(Theme):
+class ClassicGrayTheme(BaseThemeFieldsMixin, Theme):
     identifier = "shuup.themes.classic_gray"
     name = "Shuup Classic Gray Theme"
     author = "Shuup Team"
     template_dir = "classic_gray"
-
-    fields = [
-        ("show_welcome_text", forms.BooleanField(required=False, initial=True, label=_("Show Frontpage Welcome Text"))),
-        ("hide_prices", forms.BooleanField(required=False, initial=False, label=_("Hide prices"))),
-        ("catalog_mode", forms.BooleanField(required=False, initial=False, label=_("Set shop in catalog mode"))),
-        (
-            "show_supplier_info",
-            forms.BooleanField(
-                required=False, initial=False, label=_("Show supplier info"),
-                help_text=_("Show supplier name in product-box, product-detail, basket- and order-lines"))
-        )
-    ]
-
     guide_template = "classic_gray/admin/guide.jinja"
-
     stylesheets = [
         {
             "identifier": "default",
@@ -54,6 +41,14 @@ class ClassicGrayTheme(Theme):
             "images": ["shuup/front/img/no_image.png"]
         },
     ]
+
+    _theme_fields = [
+        ("show_welcome_text", forms.BooleanField(required=False, initial=True, label=_("Show Frontpage Welcome Text")))
+    ]
+
+    @property
+    def fields(self):
+        return self._theme_fields + super(ClassicGrayTheme, self).get_base_fields()
 
     def get_view(self, view_name):
         import shuup.front.themes.views as views

--- a/shuup_tests/front/test_product_detail_theme_settings.py
+++ b/shuup_tests/front/test_product_detail_theme_settings.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from bs4 import BeautifulSoup
+from django.core.urlresolvers import reverse
+
+from shuup.testing import factories
+from shuup.themes.classic_gray.theme import ClassicGrayTheme
+from shuup.xtheme.models import ThemeSettings
+from shuup.xtheme.testing import override_current_theme_class
+
+
+def _get_product_detail_soup(client, product):
+    url = reverse('shuup:product', kwargs={'pk': product.pk, 'slug': product.slug})
+    response = client.get(url)
+    return BeautifulSoup(response.content)
+
+
+@pytest.mark.django_db
+def test_product_detail_theme_configs(client):
+    shop = factories.get_default_shop()
+    product = factories.create_product("sku", shop=shop, default_price=30)
+
+    # Show only product description section
+    assert ThemeSettings.objects.count() == 1
+    theme_settings = ThemeSettings.objects.first()
+    theme_settings.update_settings({"product_detail_tabs": ["description"]})
+
+    with override_current_theme_class(ClassicGrayTheme, shop):  # Ensure settings is refreshed from DB
+        soup = _get_product_detail_soup(client, product)
+        assert soup.find("div", attrs={"class": "product-tabs"})
+        tabs = soup.find_all("ul", attrs={"class": "nav-tabs"})[0].find_all("li")
+        assert len(tabs) == 1
+        assert "Description" in tabs[0].text
+
+    # disable product details completely
+    theme_settings.update_settings({"show_product_detail_section": False})
+    with override_current_theme_class(ClassicGrayTheme, shop):
+        soup = _get_product_detail_soup(client, product)
+        assert not soup.find("div", attrs={"class": "product-tabs"})


### PR DESCRIPTION
Create mixin and move classic gray fields that are expected to exist in
Front base template to it.

Improve the product detail template by allowing merchant to hide
products tabs and listing attributes using a responsive table.

Refs MYS-16
