### PR TITLE
Front: bump sort & filters queryset cache

### DIFF
--- a/shuup/front/admin_module/sorts_and_filters/form_parts.py
+++ b/shuup/front/admin_module/sorts_and_filters/form_parts.py
@@ -41,7 +41,7 @@ class ConfigurationShopFormPart(FormPart):
             kwargs={"initial": get_configuration(shop=self.object)})
 
     def form_valid(self, form):
-        if self.name in form.forms:
+        if self.name in form.forms and form[self.name].has_changed():
             set_configuration(shop=self.object, data=form[self.name].cleaned_data)
 
 
@@ -61,5 +61,5 @@ class ConfigurationCategoryFormPart(FormPart):
             kwargs={"initial": get_configuration(category=self.object)})
 
     def form_valid(self, form):
-        if self.name in form.forms:
+        if self.name in form.forms and form[self.name].has_changed():
             set_configuration(category=self.object, data=form[self.name].cleaned_data)

--- a/shuup/front/signal_handlers.py
+++ b/shuup/front/signal_handlers.py
@@ -11,11 +11,12 @@ from filer.models import Image
 
 from shuup.core import cache
 from shuup.core.models import (
-    Manufacturer, ProductCrossSell, ProductMedia, Shop, ShopProduct
+    Manufacturer, Product, ProductCrossSell, ProductMedia, Shop, ShopProduct
 )
 from shuup.core.signals import context_cache_item_bumped  # noqa
 from shuup.core.utils import context_cache
 from shuup.front.utils import cache as cache_utils
+from shuup.front.utils.sorts_and_filters import bump_product_queryset_cache
 
 
 @receiver(context_cache_item_bumped, dispatch_uid="context-cache-item-bumped")
@@ -31,6 +32,10 @@ def handle_context_cache_item_bumped(sender, item, **kwargs):
         context_cache.bump_cache_for_item(cache_utils.get_newest_products_cache_item(shop))
         context_cache.bump_cache_for_item(cache_utils.get_products_for_category_cache_item(shop))
         context_cache.bump_cache_for_item(cache_utils.get_random_products_cache_item(shop))
+        bump_product_queryset_cache()
+
+    elif isinstance(item, Product):
+        bump_product_queryset_cache()
 
 
 def handle_manufacturer_post_save(sender, instance, **kwargs):


### PR DESCRIPTION
When a product is changed, the filters cache must be bumped as
products can have attributes changed.