### PR TITLE
Reports: introduce report permissions and pass request

### DIFF
--- a/shuup/admin/base.py
+++ b/shuup/admin/base.py
@@ -68,6 +68,17 @@ class AdminModule(object):
         with override(language="en"):
             return ("%s" % self.name,)
 
+    def get_extra_permissions(self):
+        """
+        Define custom extra permissions for admin module for option
+        to limit certain parts of the admin module based on per user
+        permission string. Should return unique list permission strings
+        across the installation to prevent unwanted side effects.
+
+        :rtype: list[str]
+        """
+        return ()
+
     def get_notifications(self, request):
         """
         :rtype: list[shuup.admin.base.Notification]

--- a/shuup/admin/modules/permission_groups/views/edit.py
+++ b/shuup/admin/modules/permission_groups/views/edit.py
@@ -62,7 +62,11 @@ class PermissionGroupForm(forms.ModelForm):
                 else:
                     all_permissions_granted = False
 
-            for permission in get_permissions_from_urls(admin_module.get_urls()):
+            extra_permissions = (
+                list(get_permissions_from_urls(admin_module.get_urls())) +
+                list(admin_module.get_extra_permissions())
+            )
+            for permission in extra_permissions:
                 field_id = "perm:{}".format(permission)
                 self.fields[field_id] = forms.BooleanField(
                     required=False,

--- a/shuup/reports/admin_module/__init__.py
+++ b/shuup/reports/admin_module/__init__.py
@@ -12,6 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 from shuup.admin.base import AdminModule, MenuEntry
 from shuup.admin.menu import REPORTS_MENU_CATEGORY
 from shuup.admin.utils.urls import admin_url
+from shuup.reports.report import get_report_classes
 
 
 class ReportsAdminModule(AdminModule):
@@ -36,3 +37,9 @@ class ReportsAdminModule(AdminModule):
                 category=REPORTS_MENU_CATEGORY
             )
         ]
+
+    def get_extra_permissions(self):
+        report_identifiers = set()
+        for report_class in get_report_classes():
+            report_identifiers.add(report_class)
+        return report_identifiers

--- a/shuup/reports/admin_module/views.py
+++ b/shuup/reports/admin_module/views.py
@@ -20,7 +20,7 @@ class ReportView(FormView):
     add_form_errors_as_messages = True
 
     def get_form(self, form_class=None):
-        self.report_classes = get_report_classes()
+        self.report_classes = get_report_classes(self.request)
         selected_report = self.request.GET.get("report")
         if selected_report:
             return self._get_concrete_form(selected_report)
@@ -35,7 +35,7 @@ class ReportView(FormView):
         selected_report = self.request.GET.get("report")
         form_info = self.report_classes[selected_report] if selected_report else None
         if not form_info:
-            report_classes = get_report_classes()
+            report_classes = get_report_classes(self.request)
             if not report_classes:
                 return None
             form_info = six.next(six.itervalues(report_classes))
@@ -43,7 +43,7 @@ class ReportView(FormView):
         return self._get_form(form_info)
 
     def _get_choices(self):
-        return [(k, v.title) for k, v in six.iteritems(get_report_classes())]
+        return [(k, v.title) for k, v in six.iteritems(get_report_classes(self.request))]
 
     def _get_form(self, selected):
         form = self.form_class(request=self.request, **self.get_form_kwargs())
@@ -59,7 +59,7 @@ class ReportView(FormView):
 
     def form_valid(self, form):
         writer = get_writer_instance(form.cleaned_data["writer"])
-        report = form.get_report_instance()
+        report = form.get_report_instance(self.request)
         if not self.request.POST.get("force_download") and writer.writer_type in ("html", "pprint", "json"):
             output = writer.render_report(report, inline=True)
             return self.render_to_response(self.get_context_data(form=form, result=output))

--- a/shuup/reports/forms.py
+++ b/shuup/reports/forms.py
@@ -37,15 +37,8 @@ class DateRangeChoices(Enum):
         ALL_TIME = _("All Time")
 
 
-class BaseReportForm(forms.Form):
+class ShuupReportForm(forms.Form):
     report = forms.CharField(widget=HiddenInput)
-    shop = forms.ChoiceField(label=_("Shop"), help_text=_("Filter report results by shop."))
-    date_range = EnumField(DateRangeChoices).formfield(
-        form_class=ChoiceField, label=_("Date Range"), initial=DateRangeChoices.RUNNING_WEEK, help_text=_(
-            "Filter report results by a date range."
-        ))
-    start_date = DateTimeField(label=_("Start Date"), required=False, help_text=_("For a custom date range."))
-    end_date = DateTimeField(label=_("End Date"), required=False, help_text=_("For a custom date range."))
     writer = forms.ChoiceField(
         label=_("Output Format"), initial="html", choices=[(name, name.title()) for name in sorted(get_writer_names())],
         help_text=_("The format to show the report results.")
@@ -55,6 +48,34 @@ class BaseReportForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop('request')
+        super(ShuupReportForm, self).__init__(*args, **kwargs)
+
+    def get_report_instance(self, request=None):
+        """
+        :rtype: shuup.reports.reporter.base.ShuupReportBase
+        """
+        from shuup.reports.report import get_report_class
+
+        data = self.cleaned_data
+
+        report_class = get_report_class(data["report"], request)
+        writer_name = data.pop("writer")
+        if request:
+            data.update({"request": request})
+        report = report_class(writer_name=writer_name, **data)
+        return report
+
+
+class BaseReportForm(ShuupReportForm):
+    shop = forms.ChoiceField(label=_("Shop"), help_text=_("Filter report results by shop."))
+    date_range = EnumField(DateRangeChoices).formfield(
+        form_class=ChoiceField, label=_("Date Range"), initial=DateRangeChoices.RUNNING_WEEK, help_text=_(
+            "Filter report results by a date range."
+        ))
+    start_date = DateTimeField(label=_("Start Date"), required=False, help_text=_("For a custom date range."))
+    end_date = DateTimeField(label=_("End Date"), required=False, help_text=_("For a custom date range."))
+
+    def __init__(self, *args, **kwargs):
         super(BaseReportForm, self).__init__(*args, **kwargs)
         self.fields["shop"].choices = [(shop.pk, shop.name) for shop in Shop.objects.get_for_user(self.request.user)]
 
@@ -66,16 +87,3 @@ class BaseReportForm(forms.Form):
             except Exception as exc:
                 self.add_error("__all__", force_text(exc))
         return data
-
-    def get_report_instance(self):
-        """
-        :rtype: shuup.reports.reporter.base.ShuupReportBase
-        """
-        from shuup.reports.report import get_report_class
-
-        data = self.cleaned_data
-        writer_name = data.pop("writer")
-
-        report_class = get_report_class(data["report"])
-        report = report_class(writer_name=writer_name, **data)
-        return report

--- a/shuup_tests/reports/test_admin_permissions.py
+++ b/shuup_tests/reports/test_admin_permissions.py
@@ -1,0 +1,69 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from bs4 import BeautifulSoup
+from django.utils.encoding import force_text
+
+from shuup.apps.provides import override_provides
+from shuup.admin.module_registry import replace_modules
+from shuup.admin.utils.permissions import set_permissions_for_group
+from shuup.default_reports.reports.sales import SalesReport
+from shuup.default_reports.reports.total_sales import TotalSales
+from shuup.default_reports.reports.sales_per_hour import SalesPerHour
+from shuup.reports.admin_module import ReportsAdminModule
+from shuup.reports.admin_module.views import ReportView
+from shuup.testing.factories import (
+    get_default_shop, get_default_staff_user, get_default_permission_group,
+    get_default_tax_class
+)
+from shuup.testing.utils import apply_request_middleware
+from shuup_tests.admin.utils import admin_only_urls
+
+
+REPORTS = [
+    "shuup.default_reports.reports.sales:SalesReport",
+    "shuup.default_reports.reports.total_sales:TotalSales",
+    "shuup.default_reports.reports.sales_per_hour:SalesPerHour"
+]
+
+@pytest.mark.django_db
+def test_reports_admin_permissions(rf):
+    shop = get_default_shop()  # We need a shop to exists
+    staff_user = get_default_staff_user(shop)
+    permission_group = get_default_permission_group()
+    staff_user.groups = [permission_group]
+    request = apply_request_middleware(rf.get("/"), user=staff_user)
+    request.user = staff_user
+
+    with replace_modules([ReportsAdminModule]):
+        with override_provides("reports", REPORTS):
+            extra_permissions = ReportsAdminModule().get_extra_permissions()
+            assert len(extra_permissions) == 3
+            assert SalesReport.identifier in extra_permissions
+            assert TotalSales.identifier in extra_permissions
+            assert SalesPerHour.identifier in extra_permissions
+            with admin_only_urls():
+                view_func = ReportView.as_view()
+                response = view_func(request)
+                response.render()
+                response = view_func(request, pk=None)  # "new mode"
+                response.render()
+                assert response.content
+                soup = BeautifulSoup(response.content)
+                assert soup.find("div", {"class": "content-block"}).text == "No reports available"
+                expected_report_identifiers = []
+                for report_cls in [SalesReport, TotalSales, SalesPerHour]:
+                    expected_report_identifiers.append(report_cls.identifier)
+                    set_permissions_for_group(permission_group, [report_cls.identifier])
+
+                    response = view_func(request, pk=None)  # "new mode"
+                    response.render()
+                    assert response.content
+                    soup = BeautifulSoup(response.content)
+                    for option in soup.find("select", {"id": "id_report"}).findAll("option"):
+                        assert option["value"] in expected_report_identifiers

--- a/shuup_tests/reports/test_reports.py
+++ b/shuup_tests/reports/test_reports.py
@@ -106,6 +106,16 @@ class SalesTestReport(ShuupReportBase):
         return self.get_return_data(data)
 
 
+class SalesTestReportForRequestTets(SalesTestReport):
+    def get_objects(self):
+        assert self.request
+        return super(SalesTestReportForRequestTets, self).get_objects()
+
+    def get_data(self):
+        assert self.request
+        return super(SalesTestReportForRequestTets, self).get_data()
+
+
 @pytest.mark.django_db
 def test_reporting(rf, admin_user):
 
@@ -119,7 +129,7 @@ def test_reporting(rf, admin_user):
                                                                                         tax_rate,
                                                                                         line_count)
 
-    with override_provides("reports", [__name__ + ":SalesTestReport"]):
+    with override_provides("reports", [__name__ + ":SalesTestReportForRequestTets"]):
         data = {
             "report": SalesTestReport.get_name(),
             "shop": shop.pk,


### PR DESCRIPTION
Add get_extra_permissions-method for BaseAdminModule for custom permissions inside the admin module which not necessarily depend on URLs.

Use these extra permissions to define permissions for provided reports.

Pass request to ReportView for custom logic based on current user, shop or supplier.