### PR TITLE
Front: add option to explicitly override shop's list sort & filter configuration

### DIFF
--- a/shuup/front/admin_module/sorts_and_filters/form_parts.py
+++ b/shuup/front/admin_module/sorts_and_filters/form_parts.py
@@ -7,6 +7,7 @@
 from __future__ import unicode_literals
 
 from django import forms
+from django.utils.translation import ugettext_lazy as _
 
 from shuup.admin.form_part import FormPart, TemplatedFormDef
 from shuup.apps.provides import get_provide_objects
@@ -45,10 +46,18 @@ class ConfigurationShopFormPart(FormPart):
             set_configuration(shop=self.object, data=form[self.name].cleaned_data)
 
 
+class ConfigurationCategoryForm(ConfigurationForm):
+    override_default_configuration = forms.BooleanField(
+        label=_("Override shop's default configuration"),
+        required=False,
+        help_text=_("If checked, this configuration will be used instead of the shop's default configuration.")
+    )
+
+
 class ConfigurationCategoryFormPart(FormPart):
     priority = 7
     name = "product_list_facets"
-    form = ConfigurationForm
+    form = ConfigurationCategoryForm
 
     def get_form_defs(self):
         if not self.object.pk:
@@ -56,9 +65,9 @@ class ConfigurationCategoryFormPart(FormPart):
         yield TemplatedFormDef(
             name=self.name,
             form_class=self.form,
-            template_name="shuup/front/admin/sorts_and_filters.jinja",
+            template_name="shuup/front/admin/sorts_and_filters_category.jinja",
             required=False,
-            kwargs={"initial": get_configuration(category=self.object)})
+            kwargs={"initial": get_configuration(category=self.object, force_category_override=True)})
 
     def form_valid(self, form):
         if self.name in form.forms and form[self.name].has_changed():

--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-21 23:08+0000\n"
+"POT-Creation-Date: 2019-03-06 17:12+0000\n"
 "PO-Revision-Date: 2016-08-04 10:51-0700\n"
 "Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
@@ -99,6 +99,14 @@ msgid "Company tax number validation"
 msgstr ""
 
 msgid "Company tax number format is validated for European countries."
+msgstr ""
+
+msgid "Override shop's default configuration"
+msgstr ""
+
+msgid ""
+"If checked, this configuration will be used instead of the shop's default "
+"configuration."
 msgstr ""
 
 msgid "Available languages in storefront"

--- a/shuup/front/templates/shuup/front/admin/macros.jinja
+++ b/shuup/front/templates/shuup/front/admin/macros.jinja
@@ -1,0 +1,20 @@
+{% macro render_sort_filters_fields(facet_form, exclude_fields=[]) %}
+    {% set current_module = none %}
+    {% for field in facet_form %}
+        {% if field.name not in exclude_fields %}
+            {% if current_module and facet_form.form_module_map[field.name] != current_module %}
+            <hr />
+            {% endif %}
+            {% if field.name not in facet_form.translated_field_names %}
+                {% if field_names and field.name not in field_names %}
+                    {% continue %}
+                {% elif exclude and field.name in exclude %}
+                    {% continue %}
+                {% else %}
+                    {{ bs3.field(field) }}
+                {% endif %}
+            {% endif %}
+            {% set current_module = facet_form.form_module_map[field.name] %}
+        {% endif %}
+    {% endfor %}
+{% endmacro %}

--- a/shuup/front/templates/shuup/front/admin/sorts_and_filters_category.jinja
+++ b/shuup/front/templates/shuup/front/admin/sorts_and_filters_category.jinja
@@ -3,5 +3,8 @@
 {% from "shuup/admin/macros/multilanguage.jinja" import render_monolingual_fields %}
 
 {% call content_block(_("Product list sorts and filters"), icon="fa-th-list") %}
-    {{ render_sort_filters_fields(form["product_list_facets"]) }}
+    {% set facets_form = form["product_list_facets"] %}
+    {{ bs3.field(facets_form.override_default_configuration) }}
+    <hr />
+    {{ render_sort_filters_fields(facets_form, ["override_default_configuration"]) }}
 {% endcall %}

--- a/shuup/front/templates/shuup/front/macros/basket.jinja
+++ b/shuup/front/templates/shuup/front/macros/basket.jinja
@@ -203,7 +203,7 @@
 {% endmacro %}
 
 {% macro render_cart_saver() %}
-    {% if user.is_authenticated() and shuup.urls.has_url("shuup:saved_cart.save") %}
+    {% if request.person and shuup.urls.has_url("shuup:saved_cart.save") %}
         <div class="cart-saver row">
             <div class="col-sm-6 col-sm-offset-6">
                 <div class="clearfix">

--- a/shuup/front/templates/shuup/front/macros/navigation.jinja
+++ b/shuup/front/templates/shuup/front/macros/navigation.jinja
@@ -35,26 +35,28 @@
 {% endmacro %}
 
 {% macro render_info_dropdown(show_quick_login=True) %}
-    {% if user.is_authenticated() %}
+    {% if user.is_authenticated() or request.person %}
         {% call _render_info_for_authenticated_users() %}
-            {{ _render_dropdown_item(url("shuup:customer_edit"), "fa fa-user fa-fw", _("Edit account details")) }}
-            {% if request.is_company_member %}
-                {{ _render_dropdown_item(url("shuup:company_edit"), "fa fa-users fa-fw", _("Edit company details")) }}
+            {% if request.person %}
+                {{ _render_dropdown_item(url("shuup:customer_edit"), "fa fa-user fa-fw", _("Edit account details")) }}
+                {% if request.is_company_member %}
+                    {{ _render_dropdown_item(url("shuup:company_edit"), "fa fa-users fa-fw", _("Edit company details")) }}
+                {% endif %}
+                {% if shuup.urls.has_url("shuup:personal-orders") %}
+                    {{ _render_dropdown_item(url("shuup:personal-orders"), "fa fa-list-alt fa-fw", _("My orders")) }}
+                {% endif %}
+                {% if shuup.urls.has_url("shuup:saved_cart.list") %}
+                    {{ _render_dropdown_item(url("shuup:saved_cart.list"), "fa fa-shopping-cart fa-fw", _("My saved carts")) }}
+                {% endif %}
+                {% if shuup.urls.has_url("shuup:personal_wishlists") %}
+                    {{ _render_dropdown_item(url("shuup:personal_wishlists"), "fa fa-star fa-fw", _("My wishlists")) }}
+                {% endif %}
+                {% if shuup.general.is_shop_admin() %}
+                    {{ _render_dropdown_item(url("shuup_admin:dashboard"), "fa fa-dashboard fa-fw", _("Admin panel")) }}
+                {% endif %}
             {% endif %}
-            {% if shuup.urls.has_url("shuup:personal-orders") %}
-                {{ _render_dropdown_item(url("shuup:personal-orders"), "fa fa-list-alt fa-fw", _("My orders")) }}
-            {% endif %}
-            {% if shuup.urls.has_url("shuup:saved_cart.list") %}
-                {{ _render_dropdown_item(url("shuup:saved_cart.list"), "fa fa-shopping-cart fa-fw", _("My saved carts")) }}
-            {% endif %}
-            {% if shuup.urls.has_url("shuup:personal_wishlists") %}
-                {{ _render_dropdown_item(url("shuup:personal_wishlists"), "fa fa-star fa-fw", _("My wishlists")) }}
-            {% endif %}
-            {% if shuup.general.is_shop_admin() %}
-                {{ _render_dropdown_item(url("shuup_admin:dashboard"), "fa fa-dashboard fa-fw", _("Admin panel")) }}
-            {% endif %}
-            {% if shuup.urls.has_url("shuup:logout") %}
-                {{ _render_dropdown_item(url("shuup:logout"), "fa fa-sign-out fa-fw", _("Log out"), True) }}
+            {% if user.is_authenticated() and shuup.urls.has_url("shuup:logout") %}
+                {{ _render_dropdown_item(url("shuup:logout"), "fa fa-sign-out fa-fw", _("Log out"), request.person == true) }}
             {% endif %}
         {% endcall %}
     {% elif show_quick_login %} {# Checking if the login dropdown should be shown #}

--- a/shuup/front/utils/sorts_and_filters.py
+++ b/shuup/front/utils/sorts_and_filters.py
@@ -204,10 +204,16 @@ class ProductListForm(forms.Form):
         return cleaned_data
 
 
-def get_configuration(shop=None, category=None):
+def get_configuration(shop=None, category=None, force_category_override=False):
     default_configuration = configuration.get(
         shop, FACETED_DEFAULT_CONF_KEY, settings.SHUUP_FRONT_DEFAULT_SORT_CONFIGURATION)
-    return (configuration.get(None, _get_category_configuration_key(category)) or default_configuration)
+
+    category_config = configuration.get(None, _get_category_configuration_key(category))
+    # when override_default_configuration is True, we override the default configuration
+    if category_config and (category_config.get("override_default_configuration") or force_category_override):
+        return category_config
+
+    return default_configuration
 
 
 def set_configuration(shop=None, category=None, data=None):

--- a/shuup/front/views/dashboard.py
+++ b/shuup/front/views/dashboard.py
@@ -29,6 +29,14 @@ class DashboardViewMixin(object):
                 items.append(c)
         return items
 
+    def dispatch(self, request, *args, **kwargs):
+        # these views can only be visible when a contact is available
+        if not getattr(request, "person", None):
+            from django.core.urlresolvers import reverse
+            from django.http.response import HttpResponseRedirect
+            return HttpResponseRedirect(reverse("shuup:index"))
+        return super(DashboardViewMixin, self).dispatch(request, *args, **kwargs)
+
 
 class DashboardView(DashboardViewMixin, TemplateView):
     template_name = "shuup/front/dashboard/dashboard.jinja"

--- a/shuup_tests/browser/front/test_category_view.py
+++ b/shuup_tests/browser/front/test_category_view.py
@@ -149,6 +149,7 @@ def test_category_product_filters_4(browser, live_server, settings):
     set_configuration(
         category=first_cat,
         data={
+            "override_default_configuration": True,
             "sort_products_by_name": True,
             "sort_products_by_name_ordering": 1,
             "sort_products_by_price": True,
@@ -262,7 +263,7 @@ def hide_sorts_for_shop(browser, shop):
 
 
 def show_sorts_for_the_category_only(browser, category):
-    set_configuration(category=category, data={"sort_products_by_name": True})
+    set_configuration(category=category, data={"override_default_configuration": True, "sort_products_by_name": True})
     browser.reload()
     wait_until_condition(browser, lambda x: x.is_text_present("Sort"))
     wait_until_condition(browser, lambda x: len(x.find_by_css("#id_sort option")) == 2)
@@ -271,6 +272,7 @@ def show_sorts_for_the_category_only(browser, category):
     set_configuration(
         category=category,
         data={
+            "override_default_configuration": True,
             "sort_products_by_name": True,
             "sort_products_by_name_ordering": 1,
             "sort_products_by_price": True,
@@ -328,6 +330,7 @@ def manufacturer_filter_test(browser, category, manufacturer):
     set_configuration(
         category=category,
         data={
+            "override_default_configuration": True,
             "sort_products_by_name": True,
             "sort_products_by_name_ordering": 1,
             "sort_products_by_price": True,
@@ -347,6 +350,7 @@ def variations_filter_test(browser, category):
     set_configuration(
         category=category,
         data={
+            "override_default_configuration": True,
             "sort_products_by_name": True,
             "sort_products_by_name_ordering": 1,
             "sort_products_by_price": True,
@@ -406,6 +410,7 @@ def categories_filter_test(browser, first_cat, second_cat, third_cat):
     set_configuration(
         category=first_cat,
         data={
+            "override_default_configuration": True,
             "sort_products_by_name": True,
             "sort_products_by_name_ordering": 1,
             "sort_products_by_price": True,
@@ -489,6 +494,7 @@ def second_category_sort_with_price_filter(browser, category):
     set_configuration(
         category=category,
         data={
+            "override_default_configuration": True,
             "filter_products_by_price": True,
             "filter_products_by_price_range_min": 5,
             "filter_products_by_price_range_max": 12,

--- a/shuup_tests/functional/test_sorts_and_filters_admin.py
+++ b/shuup_tests/functional/test_sorts_and_filters_admin.py
@@ -94,7 +94,17 @@ def test_sorts_and_filter_in_category_edit(rf, admin_user):
             if hasattr(response, "render"):
                 response.render()
             assert response.status_code in [200, 302]
+            # not overriding
+            assert get_configuration(category=category) == settings.SHUUP_FRONT_DEFAULT_SORT_CONFIGURATION
+
+            data["product_list_facets-override_default_configuration"] = True
+            request = apply_request_middleware(rf.post("/", data=data), user=admin_user)
+            response = view(request, pk=category.pk)
+            if hasattr(response, "render"):
+                response.render()
+            assert response.status_code in [200, 302]
             expected_configurations = {
+                "override_default_configuration": True,
                 "sort_products_by_name": True,
                 "sort_products_by_name_ordering": 6,
                 "sort_products_by_price": False,


### PR DESCRIPTION
When the merchant configured some list sort & filter for a category there was no option to clear the configuration and use the shop's default again.

Added a option to category configuration that overrides the shop default configuration when checked.

Refs MYS-57