### PR TITLE
Simple Supplier: use Django get_or_create instead of update to allow signal handling

### DIFF
--- a/shuup/simple_supplier/admin_module/views.py
+++ b/shuup/simple_supplier/admin_module/views.py
@@ -182,7 +182,10 @@ def process_stock_managed(request, supplier_id, product_id):
     stock_managed = bool(request.POST.get("stock_managed") == "True")
     supplier = Supplier.objects.get(id=supplier_id)
     product = Product.objects.get(id=product_id)
-    StockCount.objects.filter(supplier=supplier, product=product).update(stock_managed=stock_managed)
+    stock_count = StockCount.objects.get_or_create(supplier=supplier, product=product)[0]
+    stock_count.stock_managed = stock_managed
+    stock_count.save(update_fields=["stock_managed"])
+
     for shop in supplier.shops.all():
         context_cache.bump_cache_for_product(product, shop=shop)
 

--- a/shuup/simple_supplier/module.py
+++ b/shuup/simple_supplier/module.py
@@ -77,16 +77,13 @@ class SimpleSupplierModule(BaseSupplierModule):
         cache and send `shuup.core.signals.stocks_updated` signal.
         """
         supplier_id = self.supplier.pk
-        # TODO: Consider whether this should be done without a cache table
-        values = get_current_stock_value(supplier_id=supplier_id, product_id=product_id)
-        sv, _ = StockCount.objects.get_or_create(
-            supplier_id=supplier_id,
-            product_id=product_id,
-        )
+        sv, _ = StockCount.objects.get_or_create(supplier_id=supplier_id, product_id=product_id)
         if not sv.stock_managed:
             # item doesn't manage stocks
             return
 
+        # TODO: Consider whether this should be done without a cache table
+        values = get_current_stock_value(supplier_id=supplier_id, product_id=product_id)
         sv.logical_count = values["logical_count"]
         sv.physical_count = values["physical_count"]
         latest_event = (
@@ -96,7 +93,7 @@ class SimpleSupplierModule(BaseSupplierModule):
         if latest_event:
             sv.stock_value_value = latest_event.purchase_price_value * sv.logical_count
 
-        if self.supplier.stock_managed and sv.stock_managed and has_installed("shuup.notify"):
+        if self.supplier.stock_managed and has_installed("shuup.notify"):
             if sv.alert_limit and sv.physical_count < sv.alert_limit:
                 product = Product.objects.filter(id=product_id).first()
                 if product:


### PR DESCRIPTION
Use Django's save() when changing a product managed stock flag to allow
signals to be attached and behave accordingly to the new stock status.

Refs MYS-71