### PR TITLE
Front: add option to render supplier link in macro

### DIFF
--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-06 17:12+0000\n"
+"POT-Creation-Date: 2019-03-15 22:12+0000\n"
 "PO-Revision-Date: 2016-08-04 10:51-0700\n"
 "Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
@@ -894,7 +894,7 @@ msgid ""
 msgstr ""
 
 #, python-format
-msgid "By %(supplier_name)s"
+msgid "By <strong>%(supplier_name)s</strong>"
 msgstr ""
 
 #, python-brace-format

--- a/shuup/front/templates/shuup/front/macros/general.jinja
+++ b/shuup/front/templates/shuup/front/macros/general.jinja
@@ -359,11 +359,11 @@
     {% endif %}
 {% endmacro %}
 
-{% macro render_supplier_info(supplier) %}
+{% macro render_supplier_info(supplier, render_link=True) %}
     {% set supplier_url = shuup.urls.model_url(supplier, raise_when_not_found=False) %}
-    {% if supplier_url %}<a class="supplier-info-link" href="{{ supplier_url }}">{% endif %}
-        <p class="supplier-info"><small>{{ _("By %(supplier_name)s", supplier_name=supplier.name) }}</small></p>
-    {% if supplier_url %}</a>{% endif %}
+    {% if supplier_url and render_link %}<a class="supplier-info-link" href="{{ supplier_url }}">{% endif %}
+        <p class="supplier-info"><small>{{ _("By <strong>%(supplier_name)s</strong>", supplier_name=supplier.name) }}</small></p>
+    {% if supplier_url and render_link %}</a>{% endif %}
 {% endmacro %}
 
 {% macro render_availability_info(shop_product) %}

--- a/shuup/front/templates/shuup/front/macros/product.jinja
+++ b/shuup/front/templates/shuup/front/macros/product.jinja
@@ -42,7 +42,7 @@ Inheritance order for product macors:
                 <div class="name">
                     {{ product.name }}
                 </div>
-                {% if show_supplier_info %}{{ render_supplier_info(supplier) }}{% endif %}
+                {% if show_supplier_info %}{{ render_supplier_info(supplier, render_link=False) }}{% endif %}
                 {% if shop_product and shop_product.available_until %}{{ render_availability_info(shop_product) }}{% endif %}
                 <div class="actions-wrap">
                     {% if show_prices() and not xtheme.get("hide_prices") %}

--- a/shuup/front/templates/shuup/front/product/product_preview.jinja
+++ b/shuup/front/templates/shuup/front/product/product_preview.jinja
@@ -36,7 +36,7 @@
                     </div>
                     <div class="preview-details">
                         <h2 class="product-name {% if show_supplier_info %}show-supplier-info{% endif %}">{{ product.name }}</h2>
-                        {% if show_supplier_info %}{{ render_supplier_info(supplier) }}{% endif %}
+                        {% if show_supplier_info %}{{ render_supplier_info(supplier, render_link=False) }}{% endif %}
                         {% if product.short_description %}
                             <p class="description">
                                 {{ product.short_description|safe }}


### PR DESCRIPTION
Do not render link in product card as <a> elements can't be inside another <a> elements.

Refs MYS-91