### PR TITLE
Admin: add option to extend browser urls through provides

### DIFF
--- a/doc/ref/provides.rst
+++ b/doc/ref/provides.rst
@@ -176,6 +176,13 @@ Core
     List of functions that resolve a model instance into an object URL.
     The first valid url returned by a provide will be used by the called.
 
+``browser_url_provider```
+    List of classes that implements a ``get_browser_urls(current_urls)`` class method
+    that returns a dictionary of urls names that should be exported into the browser.
+    The reversed urls can be accessed through the ``window.ShuupAdminConfig.browserUrls`` object.
+    The returned dictionary should have the url name as the value, which will be reversed when
+    rendering the templates.
+
 ``front_menu_extender``
     Additional menu items provided by addons. These should be subclassed from
     `~shuup.xtheme.extenders.FrontMenuExtender`.

--- a/shuup/admin/__init__.py
+++ b/shuup/admin/__init__.py
@@ -96,6 +96,9 @@ class ShuupAdminAppConfig(AppConfig):
         ],
         "admin_model_url_resolver": [
             "shuup.admin.utils.urls.get_model_url"
+        ],
+        "browser_url_provider": [
+            "shuup.admin.urls:DefaultBrowserUrlProvider"
         ]
     }
 

--- a/shuup/admin/template_helpers/shuup_admin.py
+++ b/shuup/admin/template_helpers/shuup_admin.py
@@ -71,27 +71,20 @@ def get_support_id(context):
     return support_id
 
 
-# TODO: Figure out a more extensible way to deal with this
-BROWSER_URL_NAMES = {
-    "edit": "shuup_admin:edit",
-    "select": "shuup_admin:select",
-    "media": "shuup_admin:media.browse",
-    "product": "shuup_admin:shop_product.list",
-    "contact": "shuup_admin:contact.list",
-    "setLanguage": "shuup_admin:set-language",
-    "tour": "shuup_admin:tour",
-    "menu_toggle": "shuup_admin:menu_toggle"
-}
-
-
 def get_browser_urls():
     browser_urls = {}
-    for name, urlname in BROWSER_URL_NAMES.items():
+
+    for browser_url_provider in get_provide_objects("browser_url_provider"):
+        browser_urls.update(browser_url_provider.get_browser_urls(browser_urls))
+
+    reversed_browser_urls = {}
+    for name, urlname in browser_urls.items():
         try:
-            browser_urls[name] = reverse(urlname)
+            reversed_browser_urls[name] = reverse(urlname)
         except NoReverseMatch:  # This may occur when a module is not available.
-            browser_urls[name] = None
-    return browser_urls
+            reversed_browser_urls[name] = None
+
+    return reversed_browser_urls
 
 
 @contextfunction

--- a/shuup/admin/urls.py
+++ b/shuup/admin/urls.py
@@ -31,6 +31,21 @@ from shuup.admin.views.wizard import WizardView
 from shuup.utils.i18n import javascript_catalog_all
 
 
+class DefaultBrowserUrlProvider(object):
+    @classmethod
+    def get_browser_urls(cls, current_urls={}):
+        return {
+            "edit": "shuup_admin:edit",
+            "select": "shuup_admin:select",
+            "media": "shuup_admin:media.browse",
+            "product": "shuup_admin:shop_product.list",
+            "contact": "shuup_admin:contact.list",
+            "setLanguage": "shuup_admin:set-language",
+            "tour": "shuup_admin:tour",
+            "menu_toggle": "shuup_admin:menu_toggle"
+        }
+
+
 def login(request, **kwargs):
     if not request.user.is_anonymous() and request.method == "POST":  # We're logging in, so log out first
         do_logout(request)

--- a/shuup_tests/admin/test_template_helpers.py
+++ b/shuup_tests/admin/test_template_helpers.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import mock
+from django.core.urlresolvers import reverse
+
+from shuup.admin.template_helpers.shuup_admin import get_config
+from shuup.testing.utils import apply_request_middleware
+from shuup.admin.urls import DefaultBrowserUrlProvider
+
+
+def test_get_config(rf, admin_user):
+    context = dict(request=apply_request_middleware(rf.get("/"), user=admin_user))
+    config = get_config(context)
+    for key, url in DefaultBrowserUrlProvider.get_browser_urls().items():
+        assert config["browserUrls"][key] == reverse(url)


### PR DESCRIPTION
One can now inject basic urls into browser using provides

Refs TCP-8