### PR TITLE
Update NPM packages to latest versions

### DIFF
--- a/shuup/admin/npm-shrinkwrap.json
+++ b/shuup/admin/npm-shrinkwrap.json
@@ -1049,6 +1049,14 @@
         }
       }
     },
+    "acorn5-object-spread": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn5-object-spread/-/acorn5-object-spread-4.0.0.tgz",
+      "integrity": "sha1-1XWAge7ZcSGrC+R+Mcqu8qo5lpc=",
+      "requires": {
+        "acorn": "^5.1.2"
+      }
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -11523,6 +11531,7 @@
       "resolved": "https://registry.npmjs.org/rijs.sync/-/rijs.sync-2.3.5.tgz",
       "integrity": "sha1-hyjG19cqgBcvy6MWsn0KQ/MESas=",
       "requires": {
+        "buble": "github:pemrouz/buble#4e639aeeb64712ac95dc30a52750d1ee4432c9c8",
         "express": "^4.14.0",
         "lru_map": "^0.3.3",
         "platform": "^1.3.4",
@@ -11540,7 +11549,7 @@
         },
         "buble": {
           "version": "github:pemrouz/buble#4e639aeeb64712ac95dc30a52750d1ee4432c9c8",
-          "from": "github:pemrouz/buble#4e639aeeb64712ac95dc30a52750d1ee4432c9c8",
+          "from": "github:pemrouz/buble",
           "requires": {
             "acorn": "^5.1.2",
             "acorn-jsx": "^3.0.1",
@@ -11550,16 +11559,6 @@
             "minimist": "^1.2.0",
             "os-homedir": "^1.0.1",
             "vlq": "^0.2.2"
-          },
-          "dependencies": {
-            "acorn5-object-spread": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/acorn5-object-spread/-/acorn5-object-spread-4.0.0.tgz",
-              "integrity": "sha1-1XWAge7ZcSGrC+R+Mcqu8qo5lpc=",
-              "requires": {
-                "acorn": "^5.1.2"
-              }
-            }
           }
         },
         "chalk": {

--- a/shuup/front/npm-shrinkwrap.json
+++ b/shuup/front/npm-shrinkwrap.json
@@ -936,7 +936,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "acorn": {
       "version": "5.7.3",
@@ -1633,6 +1633,23 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
@@ -1844,8 +1861,9 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "bootstrap": {
-      "version": "https://github.com/shuup/bootstrap/tarball/852c02e",
-      "integrity": "sha512-rAk6+dVzPIlTdjBoKVDAk6Hj27ybVJJZ+iA0rFF6XfIsfovJAE+IcPstDk1ytzIgu2e2xQbq7W1HPT9zmcy44A=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
     },
     "bootstrap-select": {
       "version": "1.6.3",
@@ -3079,7 +3097,7 @@
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -5523,7 +5541,7 @@
     "osenv": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -8217,7 +8235,7 @@
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/shuup/front/package.json
+++ b/shuup/front/package.json
@@ -14,8 +14,9 @@
   "license": "OSL-3.0",
   "dependencies": {
     "autoprefixer": "^8.6.4",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
-    "bootstrap": "https://github.com/shuup/bootstrap/tarball/852c02e",
+    "bootstrap": "^3.4.1",
     "bootstrap-select": "1.6.3",
     "font-awesome": "^4.7.0",
     "jquery": "^3.3.1",

--- a/shuup/front/static_src/js/index.js
+++ b/shuup/front/static_src/js/index.js
@@ -6,6 +6,7 @@
  * This source code is licensed under the OSL-3.0 license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import "babel-polyfill";
 import "./language_changer.js";
 import "./navigation.js";
 import "./category.js";

--- a/shuup/themes/classic_gray/npm-shrinkwrap.json
+++ b/shuup/themes/classic_gray/npm-shrinkwrap.json
@@ -1869,8 +1869,9 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "bootstrap": {
-      "version": "https://github.com/shuup/bootstrap/tarball/852c02e",
-      "integrity": "sha512-rAk6+dVzPIlTdjBoKVDAk6Hj27ybVJJZ+iA0rFF6XfIsfovJAE+IcPstDk1ytzIgu2e2xQbq7W1HPT9zmcy44A=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
     },
     "bootstrap-select": {
       "version": "1.6.3",

--- a/shuup/themes/classic_gray/package.json
+++ b/shuup/themes/classic_gray/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "autoprefixer": "^8.6.4",
     "babel-preset-env": "^1.7.0",
-    "bootstrap": "https://github.com/shuup/bootstrap/tarball/852c02e",
+    "bootstrap": "^3.4.1",
     "bootstrap-select": "1.6.3",
     "font-awesome": "^4.7.0",
     "jquery": "^3.3.1",

--- a/shuup/xtheme/npm-shrinkwrap.json
+++ b/shuup/xtheme/npm-shrinkwrap.json
@@ -1898,8 +1898,9 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "bootstrap": {
-      "version": "https://github.com/shuup/bootstrap/tarball/852c02e",
-      "integrity": "sha512-rAk6+dVzPIlTdjBoKVDAk6Hj27ybVJJZ+iA0rFF6XfIsfovJAE+IcPstDk1ytzIgu2e2xQbq7W1HPT9zmcy44A=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/shuup/xtheme/package.json
+++ b/shuup/xtheme/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "autoprefixer": "^8.6.4",
     "babel-preset-env": "^1.7.0",
-    "bootstrap": "https://github.com/shuup/bootstrap/tarball/852c02e",
+    "bootstrap": "^3.4.1",
     "codemirror": "^5.40.0",
     "font-awesome": "^4.7.0",
     "jquery": "^3.2.1",


### PR DESCRIPTION
Move `babel-core` to dependencies for production builds. Add `babel-polyfill` for old browsers like IE 11. Bump `parcel-bundler`.