### PR TITLE
General fixes

### DIFF
--- a/shuup/admin/browser_config.py
+++ b/shuup/admin/browser_config.py
@@ -35,5 +35,8 @@ class DefaultBrowserConfigProvider(BaseBrowserConfigProvider):
     @classmethod
     def get_gettings(cls, request, **kwargs):
         return {
-            "minSearchInputLength": settings.SHUUP_ADMIN_MINIMUM_INPUT_LENGTH_SEARCH or 1
+            "minSearchInputLength": settings.SHUUP_ADMIN_MINIMUM_INPUT_LENGTH_SEARCH or 1,
+            "dateInputFormat": settings.SHUUP_ADMIN_DATE_INPUT_FORMAT,
+            "datetimeInputFormat": settings.SHUUP_ADMIN_DATETIME_INPUT_FORMAT,
+            "timeInputFormat": settings.SHUUP_ADMIN_TIME_INPUT_FORMAT
         }

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-08 17:25+0000\n"
+"POT-Creation-Date: 2019-03-21 18:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -3568,6 +3568,9 @@ msgid "Complete wizard"
 msgstr ""
 
 msgid "Complete the setup wizard"
+msgstr ""
+
+msgid "All set. Nothing to be configured"
 msgstr ""
 
 msgid ""

--- a/shuup/admin/settings.py
+++ b/shuup/admin/settings.py
@@ -41,3 +41,15 @@ SHUUP_ADMIN_MERCHANT_DOCS_PAGE = "https://shuup-guide.readthedocs.io/en/latest/"
 #: The minimum number of characters required to start a search
 #:
 SHUUP_ADMIN_MINIMUM_INPUT_LENGTH_SEARCH = 3
+
+#: The input format to be used in date pickers
+#:
+SHUUP_ADMIN_DATE_INPUT_FORMAT = "Y-m-d"
+
+#: The input format to be used in datetime pickers
+#:
+SHUUP_ADMIN_DATETIME_INPUT_FORMAT = "Y-m-d H:i"
+
+#: The input format to be used in time pickers
+#:
+SHUUP_ADMIN_TIME_INPUT_FORMAT = "H:i"

--- a/shuup/admin/static_src/base/js/datetimepicker.js
+++ b/shuup/admin/static_src/base/js/datetimepicker.js
@@ -8,16 +8,16 @@
  */
 $(function() {
     $(".form-control.datetime").datetimepicker({
-        format: "Y-m-d H:i"
+        format: window.ShuupAdminConfig.settings.datetimeInputFormat
     });
 
     $(".form-control.date").datetimepicker({
-        format: "Y-m-d",
+        format: window.ShuupAdminConfig.settings.dateInputFormat,
         timepicker: false
     });
 
     $(".form-control.time").datetimepicker({
-        format: "H:i",
+        format: window.ShuupAdminConfig.settings.timeInputFormat,
         datepicker: false
     });
 });

--- a/shuup/admin/views/home.py
+++ b/shuup/admin/views/home.py
@@ -87,18 +87,31 @@ class HomeView(TemplateView):
                     "no_redirect": True
                 })
 
-        blocks.append(
-            SimpleHelpBlock(
-                _("Complete the setup wizard"),
-                actions=wizard_actions,
-                icon_url="shuup_admin/img/configure.png",
-                priority=-1,
-                done=wizard_complete
+        if wizard_actions:
+            blocks.append(
+                SimpleHelpBlock(
+                    _("Complete the setup wizard"),
+                    actions=wizard_actions,
+                    icon_url="shuup_admin/img/configure.png",
+                    priority=-1,
+                    done=wizard_complete
+                )
             )
-        )
 
         for module in get_modules():
             if not get_missing_permissions(self.request.user, module.get_required_permissions()):
                 blocks.extend(module.get_help_blocks(request=self.request, kind="setup"))
         blocks.sort(key=lambda b: b.priority)
+
+        if not blocks:
+            blocks.append(
+                SimpleHelpBlock(
+                    _("All set. Nothing to be configured"),
+                    actions=[],
+                    icon_url="shuup_admin/img/configure.png",
+                    priority=-1,
+                    done=True
+                )
+            )
+
         return context

--- a/shuup/admin/views/search.py
+++ b/shuup/admin/views/search.py
@@ -12,6 +12,7 @@ from django.views.generic import View
 
 from shuup.admin.base import SearchResult
 from shuup.admin.module_registry import get_modules
+from shuup.admin.utils.permissions import get_missing_permissions
 from shuup.admin.utils.search import FuzzyMatcher
 
 
@@ -20,6 +21,9 @@ def get_search_results(request, query):
     normal_results = []
     menu_entry_results = []
     for module in get_modules():
+        if get_missing_permissions(request.user, module.get_required_permissions()):
+            continue
+
         normal_results.extend(module.get_search_results(request, query) or ())
         for menu_entry in module.get_menu_entries(request) or ():
             texts = (menu_entry.get_search_query_texts() or ())

--- a/shuup/core/locale/en/LC_MESSAGES/django.po
+++ b/shuup/core/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-02-12 17:40+0000\n"
+"POT-Creation-Date: 2019-03-21 18:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "This product is not visible."
 msgstr ""
 
-msgid "This product is not available."
+msgid "This product is not available to the current date."
 msgstr ""
 
 msgid "The Product is invisible to users not logged in."
@@ -1638,12 +1638,6 @@ msgid "mode"
 msgstr ""
 
 msgid "variation parent"
-msgstr ""
-
-msgid "stock"
-msgstr ""
-
-msgid "Set to stocked if inventory should be managed within Shuup."
 msgstr ""
 
 msgid "shipping mode"

--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -276,7 +276,7 @@ class ShopProduct(MoneyPropped, TranslatableModel):
             yield ValidationError(_('This product is not visible.'), code="product_not_visible")
 
         if self.available_until and now() > self.available_until:
-            yield ValidationError(_('This product is not available.'), code="product_not_available")
+            yield ValidationError(_('This product is not available to the current date.'), code="product_not_available")
 
         is_logged_in = (bool(customer) and not customer.is_anonymous)
 

--- a/shuup/simple_supplier/notify_events.py
+++ b/shuup/simple_supplier/notify_events.py
@@ -43,5 +43,11 @@ class AlertLimitReached(Event):
 
     def run(self, shop):
         cache_key = self.cache_key_fmt % (self.variable_values["supplier"].pk, self.variable_values["product"].pk)
+
+        # do not run this if the last dispatch was < 1 minute
+        last_dispatch_time = cache.get(cache_key)
+        if last_dispatch_time and time() - last_dispatch_time < 60:
+            return
+
         cache.set(cache_key, time(), timeout=(60 * 60 * 24))
         super(AlertLimitReached, self).run(shop=shop)

--- a/shuup_tests/admin/test_home.py
+++ b/shuup_tests/admin/test_home.py
@@ -38,9 +38,9 @@ def test_home_wizard_block(rf, admin_user, settings):
     get_default_shop()
     assert has_block_with_text("wizard", rf, admin_user)
 
-    # no wizard spec defined so we shouldn't see the wizard block
+    # no wizard spec defined so we should see a info block that everything is configured
     settings.SHUUP_SETUP_WIZARD_PANE_SPEC = []
-    assert has_done_block_with_text("wizard", rf, admin_user)
+    assert not has_block_with_text("wizard", rf, admin_user)
 
 
 @pytest.mark.django_db

--- a/shuup_tests/admin/test_modules.py
+++ b/shuup_tests/admin/test_modules.py
@@ -39,8 +39,8 @@ from shuup_tests.utils.templates import \
 TEMPLATES_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), "templates"))
 
 
-def test_admin_module_base(rf):
-    request = rf.get("/")
+def test_admin_module_base(rf, admin_user):
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
     am = AdminModule()
     assert empty_iterable(am.get_urls())
     assert empty_iterable(am.get_menu_entries(request))
@@ -68,8 +68,8 @@ def test_modules_in_core_admin_work(rf, admin_user):
         assert get_menu_entry_categories(request)
 
 
-def test_search(rf):
-    request = rf.get("/")
+def test_search(rf, admin_user):
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
     with replace_modules([ATestModule]):
         assert any(sr.to_json()["text"] == "yes" for sr in get_search_results(request, "yes"))
         assert any(sr.url == "/OK" for sr in get_search_results(request, "spooky"))  # Test aliases


### PR DESCRIPTION
### Admin: show help block that nothing is needed to be configured
When there is no help block to be configured, show a block telling that it is all set.

### Admin: disable the search for modules that user doesn't have permission

### Core: improve the available until orderability error message
Make it clear that the product is not available for that current date

### Admin: add setting to customize datetime pickers format

### Simple supplier: make the physical stock be equal to logical when product is not shipped

### Simple supplier: do not spam spam alert notifications inside a single minute
Prevent too much notifications inside a minute for a given product and supplier

Refs MYS-93