### PR TITLE
Admin: improve shipment creation

### DIFF
--- a/shuup/admin/modules/orders/views/shipment.py
+++ b/shuup/admin/modules/orders/views/shipment.py
@@ -77,16 +77,12 @@ class OrderCreateShipmentView(ModifiableViewMixin, UpdateView):
         form.fields["supplier"].help_text = _(
             "Select the shipment supplier. You can only ship the suppliers assigned to order lines.")
         default_field_keys.add("supplier")
-        form.product_summary = order.get_product_summary()
-        form.product_names = dict(
-            (product_id, text)
-            for (product_id, text)
-            in order.lines.exclude(product=None).values_list("product_id", "text")
-        )
-        for product_id, info in sorted(six.iteritems(form.product_summary)):
+        form.product_summary = order.get_supplier_product_summary()
+        for key, info in sorted(six.iteritems(form.product_summary)):
+            product_id = info["product_id"]
             product_name = _("%(product_name)s (%(supplier)s)") % {
-                "product_name": form.product_names.get(product_id, "Product %s" % product_id),
-                "supplier": ", ".join(info["suppliers"])
+                "product_name": info["product_name"],
+                "supplier": info["supplier_name"]
             }
 
             unshipped_count = info["unshipped"]

--- a/shuup/admin/templates/shuup/admin/orders/create_shipment.jinja
+++ b/shuup/admin/templates/shuup/admin/orders/create_shipment.jinja
@@ -39,7 +39,8 @@
                     </tr>
                     </tfoot>
                     <tbody>
-                    {% for product_id, info in form.product_summary.items() %}
+                    {% for key, info in form.product_summary.items() %}
+                        {% set product_id = info["product_id"] %}
                         {% set field = form["q_" ~ product_id] %}
                         <tr>
                             <td>{{ field.label }}</td>


### PR DESCRIPTION
Improve shipment creation for situation when same product is ordered by multiple supplier. Shipments are still created per supplier and this just adjusts the form to be more clear what is shipped/unshipped for each supplier.