### PR TITLE
See cart object in admin (TCP-24)

### DIFF
--- a/shuup/front/__init__.py
+++ b/shuup/front/__init__.py
@@ -25,7 +25,8 @@ class ShuupFrontAppConfig(AppConfig):
             "shuup.front.admin_module.sorts_and_filters.form_parts.ConfigurationShopFormPart",
             "shuup.front.admin_module.checkout.form_parts.CheckoutShopFormPart",
             "shuup.front.admin_module.companies.form_parts.RegistrationSettingsFormPart",
-            "shuup.front.admin_module.translation.form_parts.TranslationSettingsFormPart"
+            "shuup.front.admin_module.translation.form_parts.TranslationSettingsFormPart",
+            "shuup.front.admin_module.carts.form_parts.CartDelayFormPart"
         ],
         "notify_event": [
             "shuup.front.notify_events:OrderReceived",

--- a/shuup/front/admin_module/carts/form_parts.py
+++ b/shuup/front/admin_module/carts/form_parts.py
@@ -1,0 +1,50 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from shuup import configuration
+from shuup.admin.form_part import FormPart, TemplatedFormDef
+
+CART_UPDATE_DELAY_CONF_KEY = "shuup_front_cart_update_delay"
+
+class CartDelayConfigurationForm(forms.Form):
+    shuup_front_cart_update_delay = forms.IntegerField(
+        required=True,
+        initial=2,
+        min_value=0,
+        label=_("Cart Inactivity Delay (hours)"),
+        help_text=_("Set the number of hours the cart must be inactive before it's displayed in Orders > Carts")
+    )
+
+
+class CartDelayFormPart(FormPart):
+    priority = 8
+    name = "cart_delay"
+    form = CartDelayConfigurationForm
+
+    def get_form_defs(self):
+        if not self.object.pk:
+            return
+        initial = {
+            CART_UPDATE_DELAY_CONF_KEY: configuration.get(self.object, CART_UPDATE_DELAY_CONF_KEY, 0)
+        }
+        yield TemplatedFormDef(
+            name=self.name,
+            form_class=self.form,
+            template_name="shuup/front/admin/cart_delay.jinja",
+            required=False,
+            kwargs={"initial": initial}
+        )
+
+    def form_valid(self, form):
+        if self.name not in form.forms:
+            return
+        data = form.forms[self.name].cleaned_data
+        configuration.set(self.object, CART_UPDATE_DELAY_CONF_KEY, data.get(CART_UPDATE_DELAY_CONF_KEY, 2))

--- a/shuup/front/admin_module/carts/views/_list.py
+++ b/shuup/front/admin_module/carts/views/_list.py
@@ -13,6 +13,7 @@ from django.utils.html import escape
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 
+from shuup import configuration
 from shuup.admin.utils.picotable import (
     ChoicesFilter, Column, DateRangeFilter, MultiFieldTextFilter, RangeFilter
 )
@@ -21,6 +22,7 @@ from shuup.core.models import Shop
 from shuup.front.models import StoredBasket
 from shuup.utils.i18n import format_money, get_locally_formatted_datetime
 
+CART_UPDATE_DELAY_CONF_KEY = "shuup_front_cart_update_delay"
 
 class CartListView(PicotableListView):
     model = StoredBasket
@@ -58,7 +60,8 @@ class CartListView(PicotableListView):
         """
         Ignore potentially active carts, displaying only those not updated for at least 2 hours.
         """
-        cutoff = now() - datetime.timedelta(hours=2)
+        hours = configuration.get(self.request.shop, CART_UPDATE_DELAY_CONF_KEY, 2)
+        cutoff = now() - datetime.timedelta(hours=hours)
         filters = {"updated_on__lt": cutoff, "product_count__gte": 0, "persistent": False}
         return super(CartListView, self).get_queryset().filter(**filters)
 

--- a/shuup/front/templates/shuup/front/admin/cart_delay.jinja
+++ b/shuup/front/templates/shuup/front/admin/cart_delay.jinja
@@ -1,0 +1,7 @@
+{% from "shuup/admin/macros/general.jinja" import content_block %}
+{% from "shuup/admin/macros/multilanguage.jinja" import render_monolingual_fields %}
+{% set cart_delay_form = form["cart_delay"] %}
+
+{% call content_block(_("Cart Inactivity Delay"), icon="fa-th-list") %}
+    {{ render_monolingual_fields(cart_delay_form) }}
+{% endcall %}


### PR DESCRIPTION
Previously, there was an automatic 2 hour buffer between the last update of a cart and it being displayed in Orders > Carts. The idea was to prevent the active carts from being rendered. I created a form part in Shops that allows the user to select a number of hours on inactivity before the cart is displayed in the admin menu. The default is 0 which renders the carts immediately. 