### PR TITLE
Notify: Fix toolbar button style & user serializer error

### DIFF
--- a/shuup/admin/static_src/base/scss/shuup/custom-modals.scss
+++ b/shuup/admin/static_src/base/scss/shuup/custom-modals.scss
@@ -22,6 +22,7 @@
     @include media-breakpoint-down(sm) {
         border-radius: 4px;
         margin: 15px auto;
+        height: 80%;
     }
 
     @include media-breakpoint-up(md) {

--- a/shuup/admin/static_src/base/scss/shuup/quick-add.scss
+++ b/shuup/admin/static_src/base/scss/shuup/quick-add.scss
@@ -7,7 +7,7 @@ div.container-fluid.support-nav-wrap {
 
     &.notify {
         position: static;
-        padding-top: 0;
+        padding-left: 30px;
     }
 }
 

--- a/shuup/admin/toolbar.py
+++ b/shuup/admin/toolbar.py
@@ -479,7 +479,7 @@ def get_discard_button(discard_url):
         url=discard_url,
         text=_(u"Discard Changes"),
         icon="fa fa-undo",
-        extra_css_class="dropdown-item"
+        extra_css_class="btn btn-inverse"
     )
 
 

--- a/shuup/notify/actions/email.py
+++ b/shuup/notify/actions/email.py
@@ -13,6 +13,7 @@ from django import forms
 from django.core.mail.message import EmailMessage
 from django.utils.translation import ugettext as _
 
+from shuup.admin.forms.widgets import TextEditorWidget
 from shuup.notify.base import Action, Binding
 from shuup.notify.enums import ConstantUse, TemplateUse
 from shuup.notify.typology import Email, Language, Text
@@ -28,7 +29,7 @@ class SendEmail(Action):
     template_use = TemplateUse.MULTILINGUAL
     template_fields = {
         "subject": forms.CharField(required=True, label=_(u"Subject")),
-        "body": forms.CharField(required=True, label=_(u"Email Body"), widget=forms.Textarea()),
+        "body": forms.CharField(required=True, label=_(u"Email Body"), widget=TextEditorWidget()),
         "content_type": forms.ChoiceField(required=True,
                                           label=_(u"Content type"),
                                           choices=EMAIL_CONTENT_TYPE_CHOICES,

--- a/shuup/notify/admin_module/forms.py
+++ b/shuup/notify/admin_module/forms.py
@@ -203,6 +203,8 @@ class ScriptItemEditForm(forms.Form):
 
     def save(self):
         new_data = {}
+        if "b_recipient_c" in self.cleaned_data and hasattr(self.cleaned_data["b_recipient_c"], "pk"):
+            self.cleaned_data['b_recipient_c'] = self.cleaned_data['b_recipient_c'].pk
         self._save_bindings(new_data)
         self._save_template(new_data)
         if self.errors:

--- a/shuup/notify/templates/notify/admin/generic_script_template.jinja
+++ b/shuup/notify/templates/notify/admin/generic_script_template.jinja
@@ -15,7 +15,7 @@
                 <ul class="nav nav-tabs" id="main-tabs" role="tablist">
                     {% for f in form.forms %}
                         {% if f in languages %}
-                        <li role="presentation" {% if f==default_language %}class="active" {% endif %}><a href="#lang-{{ f }}" role="tab" data-toggle="tab">{{ languages[f] }}</a></li>
+                        <li role="presentation" class="nav-item" {% if f==default_language %}class="nav-item active" {% endif %}><a href="#lang-{{ f }}" role="tab" data-toggle="tab" class="nav-link">{{ languages[f] }}</a></li>
                         {% endif %}
                     {% endfor %}
                 </ul>

--- a/shuup/notify/templates/notify/admin/script_item_editor.jinja
+++ b/shuup/notify/templates/notify/admin/script_item_editor.jinja
@@ -91,9 +91,9 @@
             {% endif %}
             <input name="init_data" type="hidden" value="{{ init_data }}">
             <ul class="nav nav-tabs" id="main-tabs">
-                <li role="presentation" class="active"><a href="#variables">{% trans %}Variables{% endtrans %}</a></li>
+                <li role="presentation" class="nav-item"><a href="#variables" class="nav-link">{% trans %}Variables{% endtrans %}</a></li>
                 {% for language_code, language_name in form.template_languages %}
-                <li role="presentation"><a href="#template-{{ language_code }}">{{ language_name }}</a></li>
+                <li role="presentation" class="nav-item"><a href="#template-{{ language_code }}" class="nav-link">{{ language_name }}</a></li>
                 {% endfor %}
             </ul>
             <div id="variables" class="tab-pane">{{ binding_view(form) }}</div>
@@ -119,6 +119,7 @@
     }
     .iframe-content-block {
         background: #fff;
+        padding-top: 0px !important;
         padding: 30px;
     }
     .iframe-title {
@@ -127,6 +128,12 @@
     }
     .title { margin-bottom: 15px; }
     .nav-tabs { margin-bottom: 30px; }
+    .summernote-wrap {
+        width: 100%;
+    }
+    .btn-success {
+        margin: 10px;
+    }
 </style>
 {% endblock %}
 {% block extra_js %}


### PR DESCRIPTION
The user serializer bug was happening because a User model was being passed to the template
instead of just model's primary key. This ensures that doesn't happen.
Replaced normal text editor for email body with summernote.

Refs #1783, #1807