### PR TITLE
Admin: introduce extra info for items in picotable

### DIFF
--- a/shuup/admin/static_src/picotable/picotable.js
+++ b/shuup/admin/static_src/picotable/picotable.js
@@ -519,8 +519,13 @@ const Picotable = (function (m, storage) {
                     location.href = item._url;
                 }
             });
-            rowSettings.class = ctrl.isChecked(item) ? "active" : "";
-
+            rowSettings.class = "";
+            if (item._extra && item._extra.class) {
+                rowSettings.class += item._extra.class;
+            }
+            if (ctrl.isChecked(item)) {
+                rowSettings.class += " active";
+            }
             return m("tr", rowSettings, Util.map(data.columns, function (col, idx) {
                 var content;
                 if (idx === 0 && massActions.length) {
@@ -658,10 +663,14 @@ const Picotable = (function (m, storage) {
                     if (typeof line === "string") line = { text: line };
                     if (!line.text) return;
                     if (line.raw) line.text = m.trust(line.raw);
-                    var rowClass = "div.row.mobile-row." +
-                        (line.title ? "with-title" : "") +
-                        (line.class ? (line.title ? "." : "") + line.class : "");
-                    return m(rowClass, [
+
+                    const rowClasses = ["row", "mobile-row."];
+                    if (line.title) rowClasses.push("with-title");
+                    if (line.class) rowClasses.push(line.class);
+                    if (item._extra && item._extra.class) {
+                        rowClasses.push(...item._extra.class.split(" "));
+                    }
+                    return m("." + rowClasses.join("."), [
                         (line.class && massActions.length ?
                             m("div.input-checkbox", { onclick: preventSelect }, [
                                 m("input[type=checkbox]", {

--- a/shuup/admin/utils/picotable.py
+++ b/shuup/admin/utils/picotable.py
@@ -388,6 +388,7 @@ class Picotable(object):
         self.columns_by_id = dict((c.id, c) for c in self.columns)
         self.get_object_url = maybe_callable("get_object_url", context=self.context)
         self.get_object_abstract = maybe_callable("get_object_abstract", context=self.context)
+        self.get_object_extra = maybe_callable("get_object_extra", context=self.context)
         self.default_filters = self._get_default_filters()
 
     def _get_default_filter(self, column):
@@ -454,10 +455,12 @@ class Picotable(object):
 
     def process_item(self, object):
         object_url = self.get_object_url(object) if callable(self.get_object_url) else None
+        object_extra = self.get_object_extra(object) if callable(self.get_object_extra) else None
         out = {
             "_id": object.id,
             "_url": object_url,
-            "_linked_in_mobile": True if object_url else False
+            "_linked_in_mobile": True if object_url else False,
+            "_extra": object_extra
         }
         for column in self.columns:
             out[column.id] = column.get_display_value(context=self.context, object=object)
@@ -561,6 +564,18 @@ class PicotableViewMixin(object):
         :param item: The item dict so far. Useful for reusing precalculated values.
         :return: Iterable of dicts to pass through to the picotable javascript
         :rtype: Iterable[dict]
+        """
+        return None
+
+    def get_object_extra(self, instance):
+        """
+        Returns extra information as a dictionary for each object.
+
+        The following special keys are used in picotable:
+
+        * class - add the class list (space separated) to each row/item class list
+
+        :rtype: None|dict
         """
         return None
 

--- a/shuup_tests/admin/test_picotable.py
+++ b/shuup_tests/admin/test_picotable.py
@@ -31,6 +31,11 @@ class PicoContext(object):
     def __init__(self, request):
         self.request = request
 
+    def get_object_extra(self, instance):
+        return {
+            "extra": True
+        }
+
     def superuser_display(self, instance):  # Test indirect `display` callable
         return "very super" if instance.is_superuser else "-"
 
@@ -173,6 +178,12 @@ def test_picotable_no_mobile_link_for_missing_object_url(rf, admin_user, regular
     pico.get_object_url = None
     data = pico.get_data({"perPage": 100, "page": 1})
     assert not data["items"][0]["_linked_in_mobile"]
+
+
+@pytest.mark.django_db
+def test_picotable_get_object_extra(rf, admin_user):
+    pico = get_pico(rf, admin_user)
+    assert pico.get_object_extra(admin_user) == {"extra": True}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Now it is possible to return extra info for each object in picotable list.

There are some special keys like `class` that is used to change the row class list for each item.

Refs MYS-97