### PR TITLE
SimpleSupplier: add shop email and supplier email in alert limit

### DIFF
--- a/shuup/front/apps/customer_information/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/apps/customer_information/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-19 05:25+0000\n"
+"POT-Creation-Date: 2019-04-01 15:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -50,6 +50,9 @@ msgid "Address Type"
 msgstr ""
 
 msgid "Address Status"
+msgstr ""
+
+msgid "Customer Email"
 msgstr ""
 
 msgid "Home"

--- a/shuup/front/apps/customer_information/notify_events.py
+++ b/shuup/front/apps/customer_information/notify_events.py
@@ -5,6 +5,8 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+from django.utils.translation import ugettext_lazy as _
+
 from shuup.notify.base import Event, Variable
 from shuup.notify.typology import Email, Model
 
@@ -13,4 +15,4 @@ class CompanyAccountCreated(Event):
     identifier = "company_account_created"
 
     contact = Variable("CompanyContact", type=Model("shuup.CompanyContact"))
-    customer_email = Variable("Customer Email", type=Email)
+    customer_email = Variable(_("Customer Email"), type=Email)

--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-20 20:51+0000\n"
+"POT-Creation-Date: 2019-04-01 15:43+0000\n"
 "PO-Revision-Date: 2016-08-04 10:51-0700\n"
 "Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
@@ -30,6 +30,14 @@ msgid "Carts"
 msgstr ""
 
 msgid "Show carts"
+msgstr ""
+
+msgid "Cart Inactivity Delay (hours)"
+msgstr ""
+
+msgid ""
+"Set the number of hours the cart must be inactive before it's displayed in "
+"Orders > Carts"
 msgstr ""
 
 msgid "Created on"
@@ -605,6 +613,9 @@ msgid ""
 "This script will send an email to customer or to any configured email right "
 "after an order is created. The order contents can be put on email body as "
 "well as other informations like shipping method and payment method."
+msgstr ""
+
+msgid "Cart Inactivity Delay"
 msgstr ""
 
 msgid "Checkout configuration"

--- a/shuup/simple_supplier/module.py
+++ b/shuup/simple_supplier/module.py
@@ -99,7 +99,14 @@ class SimpleSupplierModule(BaseSupplierModule):
                 if product:
                     from .notify_events import AlertLimitReached
                     for shop in self.supplier.shops.all():
-                        AlertLimitReached(supplier=self.supplier, product=product).run(shop=shop)
+                        supplier_email = self.supplier.contact_address.email if self.supplier.contact_address else ""
+                        shop_email = shop.contact_address.email if shop.contact_address else ""
+                        AlertLimitReached(
+                            supplier=self.supplier,
+                            product=product,
+                            shop_email=shop_email,
+                            supplier_email=supplier_email
+                        ).run(shop=shop)
 
         sv.save(update_fields=("logical_count", "physical_count", "stock_value_value"))
         context_cache.bump_cache_for_product(Product.objects.get(id=product_id))

--- a/shuup/simple_supplier/notify_events.py
+++ b/shuup/simple_supplier/notify_events.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from shuup.core import cache
 from shuup.notify.base import Event, Variable
-from shuup.notify.typology import Boolean, Model
+from shuup.notify.typology import Boolean, Email, Model
 
 
 class AlertLimitReached(Event):
@@ -22,12 +22,20 @@ class AlertLimitReached(Event):
 
     supplier = Variable(_("Supplier"), type=Model("shuup.Supplier"))
     product = Variable(_("Product"), type=Model("shuup.Product"))
-    dispatched_last_24hs = Variable(_("Fired in the last 24 hours?"),
-                                    type=Boolean,
-                                    help_text=_("This will be True if this event was already dispatched "
-                                                "in the last 24 hours for the same product and supplier. "
-                                                "This is useful to prevent sending identical notifications in a short "
-                                                "period of time."))
+
+    supplier_email = Variable(_("Supplier Email"), type=Email, required=False)
+    shop_email = Variable(_("Shop Email"), type=Email, required=False)
+
+    dispatched_last_24hs = Variable(
+        _("Fired in the last 24 hours?"),
+        type=Boolean,
+        help_text=_(
+            "This will be True if this event was already dispatched "
+            "in the last 24 hours for the same product and supplier. "
+            "This is useful to prevent sending identical notifications in a short "
+            "period of time."
+        )
+    )
 
     def __init__(self, **variable_values):
         cache_key = self.cache_key_fmt % (variable_values["supplier"].pk, variable_values["product"].pk)

--- a/shuup_tests/simple_supplier/test_simple_supplier.py
+++ b/shuup_tests/simple_supplier/test_simple_supplier.py
@@ -264,7 +264,12 @@ def test_alert_limit_notification(rf, admin_user):
         # last run should be updated
         assert cache.get(cache_key) != last_run
 
-        event = AlertLimitReached(product=product, supplier=supplier)
+        event = AlertLimitReached(
+            product=product,
+            supplier=supplier,
+            supplier_email="supplier-no-break@email.com",
+            shop_email="shop-no-break@email.com"
+        )
         assert event.variable_values["dispatched_last_24hs"] is True
 
         # fake we have a cache with more than 24hrs


### PR DESCRIPTION
Sometimes the supplier and or the shop should be warned about low stocks and now that is possible

No Refs