### PR TITLE
Front: remove excessive levels of cache

### DIFF
--- a/shuup/admin/static_src/picotable/picotable.js
+++ b/shuup/admin/static_src/picotable/picotable.js
@@ -1274,7 +1274,7 @@ const Picotable = (function (m, storage) {
                 }
 
                 $(el).datetimepicker({
-                    format: "Y-m-d H:i",
+                    format: window.ShuupAdminConfig.settings.datetimeInputFormat,
                 });
             };
         };

--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -275,7 +275,7 @@ class ShopProduct(MoneyPropped, TranslatableModel):
         if not self.visible:
             yield ValidationError(_('This product is not visible.'), code="product_not_visible")
 
-        if self.available_until and now() > self.available_until:
+        if self.available_until and self.available_until <= now():
             yield ValidationError(_('This product is not available to the current date.'), code="product_not_available")
 
         is_logged_in = (bool(customer) and not customer.is_anonymous)

--- a/shuup/front/template_helpers/product.py
+++ b/shuup/front/template_helpers/product.py
@@ -44,19 +44,8 @@ def get_products_bought_with(context, product, count=5):
 @contextfunction
 def is_visible(context, product):
     request = context["request"]
-
-    key, val = context_cache.get_cached_value(identifier="is_visible", item=product, context=request)
-    if val is not None:
-        return val
-
-    try:
-        shop_product = product.get_shop_instance(shop=request.shop, allow_cache=True)
-        visible = shop_product.is_visible(request.customer)
-    except ShopProduct.DoesNotExist:
-        visible = False
-
-    context_cache.set_cached_value(key, visible)
-    return visible
+    shop_product = product.get_shop_instance(shop=request.shop, allow_cache=True)
+    return shop_product.is_visible(request.customer)
 
 
 @contextfunction

--- a/shuup/front/views/category.py
+++ b/shuup/front/views/category.py
@@ -11,8 +11,8 @@ from django.views.generic import DetailView
 
 from shuup.core.models import Category, Product
 from shuup.front.utils.sorts_and_filters import (
-    cached_product_queryset, get_product_queryset, get_query_filters,
-    post_filter_products, ProductListForm, sort_products
+    get_product_queryset, get_query_filters, post_filter_products,
+    ProductListForm, sort_products
 )
 from shuup.front.utils.views import cache_product_things
 
@@ -55,10 +55,7 @@ class CategoryView(DetailView):
             **self.get_product_filters()
         ).filter(get_query_filters(self.request, category, data=data))
 
-        products = cached_product_queryset(
-            get_product_queryset(products, self.request, category, data).distinct(),
-            self.request, category, data
-        )
+        products = get_product_queryset(products, self.request, category, data).distinct()
         products = post_filter_products(self.request, category, products, data)
         products = cache_product_things(self.request, products)
         products = sort_products(self.request, category, products, data)


### PR DESCRIPTION
Remove some levels of cache from front. When products becomes invisible
or any other visibility rule changes products must disapear from storefront.

Refs MYS-100