### PR TITLE
Campaigns: add campaign supplier to discount lines

### DIFF
--- a/shuup_tests/campaigns/test_effects.py
+++ b/shuup_tests/campaigns/test_effects.py
@@ -60,12 +60,12 @@ def test_basket_free_product(rf):
 
     effect = FreeProductLine.objects.create(campaign=campaign, quantity=2)
     effect.products.add(second_product)
-    discount_lines_count = len(effect.get_discount_lines(basket, []))
+    discount_lines_count = len(effect.get_discount_lines(basket, [], supplier))
     assert discount_lines_count == 1
 
     # do not affect as there is no shop product for the product
     effect.products.add(third_product)
-    assert len(effect.get_discount_lines(basket, [])) == discount_lines_count
+    assert len(effect.get_discount_lines(basket, [], supplier)) == discount_lines_count
 
     basket.uncache()
     final_lines = basket.get_final_lines()


### PR DESCRIPTION
When lines causes new lines to basket it is important that those discount lines are linked to correct supplier based on campaign.