### PR TITLE
Fix OrderDeliveryPdfAction when in action 1 order/shipment only

### DIFF
--- a/shuup/admin/modules/orders/mass_actions.py
+++ b/shuup/admin/modules/orders/mass_actions.py
@@ -92,8 +92,9 @@ class OrderDeliveryPdfAction(PicotableFileMassAction):
         shipment_ids = set(Shipment.objects.filter(order_id__in=ids).values_list("id", flat=True))
         if len(shipment_ids) == 1:
             try:
-                response = get_delivery_pdf(request, ids[0])
-                response['Content-Disposition'] = 'attachment; filename=shipment_%s_delivery.pdf' % ids[0]
+                shipment_id = shipment_ids.pop()
+                response = get_delivery_pdf(request, shipment_id)
+                response['Content-Disposition'] = 'attachment; filename=shipment_%s_delivery.pdf' % shipment_id
                 return response
             except Exception as e:
                 msg = e.message if hasattr(e, "message") else e


### PR DESCRIPTION
When try to make delivery pdf for 1 shipment only, it will work if order.id == shipment.id (accidentally). In all other cases get_delivery_pdf() will try to run Shipment.objects.get() query using order.id (because you used ids[0]). Also it will show success notification without any pdf to download, but in logs will show error, if Shipment.objects.get() will raise exception.

With proposed changes pdf generation works correctly for 1 order/shipment or for several orders with 1 created shipment (other orders without shipments). Nothing changed for several shipments.
