### PR TITLE
Show initial permissions groups on change-permissions user page in /sa/

### DIFF
--- a/shuup/admin/modules/users/views/permissions.py
+++ b/shuup/admin/modules/users/views/permissions.py
@@ -54,6 +54,7 @@ class PermissionChangeFormBase(forms.ModelForm):
             )
         )
         initial_groups = self._get_initial_groups()
+        permission_groups_field.initial = [group.pk for group in initial_groups]
         permission_groups_field.widget.choices = [(group.pk, force_text(group)) for group in initial_groups]
         self.fields["permission_groups"] = permission_groups_field
 


### PR DESCRIPTION
Fix to show initial permission groups for /sa/users/$user_id_here$/change-permissions/ page.
With current master code initial user groups doesn't showed in Permission Groups field. 

Firstly I tried to use initial= of Select2MultipleField, but then I found @tulimaki removed initial from Select2MultipleField in this commit due to some Select2MultipleField bug:
https://github.com/shuup/shuup/commit/1e1f8ba2abcf4d64a82ba7508e5fb7dc209e7e5b

Btwn, changes that made tulimaki works for manufactures shops: https://github.com/shuup/shuup/blob/master/shuup/admin/modules/manufacturers/views/edit.py#L33 because `super(ManufacturerForm, self).__init__(*args, **kwargs) ` return initial shops in self.initial

