### PR TITLE
Fix breadcrumbs for Order Status and Currencies

### DIFF
--- a/shuup/admin/modules/currencies/views/edit.py
+++ b/shuup/admin/modules/currencies/views/edit.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django import forms
-from django.utils.translation import ugettext_lazy as _
 
 from shuup.admin.utils.views import CreateOrUpdateView
 from shuup.core.models import Currency

--- a/shuup/admin/modules/currencies/views/edit.py
+++ b/shuup/admin/modules/currencies/views/edit.py
@@ -7,7 +7,6 @@
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
-from shuup.admin.breadcrumbs import BreadcrumbedView
 from shuup.admin.utils.views import CreateOrUpdateView
 from shuup.core.models import Currency
 
@@ -18,11 +17,9 @@ class CurrencyForm(forms.ModelForm):
         exclude = ()
 
 
-class CurrencyEditView(BreadcrumbedView, CreateOrUpdateView):
+class CurrencyEditView(CreateOrUpdateView):
     model = Currency
     form_class = CurrencyForm
     template_name = "shuup/admin/currencies/edit_currency.jinja"
     context_object_name = "currency"
     add_form_errors_as_messages = True
-    parent_name = _("Currencies")
-    parent_url = "shuup_admin:currency.list"

--- a/shuup/admin/modules/orders/views/status.py
+++ b/shuup/admin/modules/orders/views/status.py
@@ -9,7 +9,6 @@ from __future__ import unicode_literals
 
 from django.utils.translation import ugettext_lazy as _
 
-from shuup.admin.breadcrumbs import BreadcrumbedView
 from shuup.admin.utils.picotable import ChoicesFilter, Column, TextFilter
 from shuup.admin.utils.views import CreateOrUpdateView, PicotableListView
 from shuup.core.models import OrderStatus, OrderStatusManager, OrderStatusRole
@@ -50,13 +49,11 @@ class OrderStatusForm(MultiLanguageModelForm):
         return super(OrderStatusForm, self).save(commit)
 
 
-class OrderStatusEditView(BreadcrumbedView, CreateOrUpdateView):
+class OrderStatusEditView(CreateOrUpdateView):
     model = OrderStatus
     form_class = OrderStatusForm
     template_name = "shuup/admin/orders/status.jinja"
     context_object_name = "status"
-    parent_name = _("Order Statuses")
-    parent_url = "shuup_admin:order_status.list"
 
 
 class OrderStatusListView(PicotableListView):


### PR DESCRIPTION
Using BreadcrumbedView is useless for Order Status and Currencies list views in /sa/. Breadcrumbs generated correctly without this view. But with BreadcrumbedView they displayed with duplicated entries, please check screens:

![currency](https://user-images.githubusercontent.com/15804042/55655903-1b217d00-57fe-11e9-94f8-8fc94d198777.png)
![status](https://user-images.githubusercontent.com/15804042/55655904-1b217d00-57fe-11e9-894e-5e82df9a51b1.png)
