### PR TITLE
Admin: Fix bug in Campaign free product effect

### DIFF
--- a/shuup/campaigns/admin_module/forms/_basket_effects.py
+++ b/shuup/campaigns/admin_module/forms/_basket_effects.py
@@ -64,8 +64,7 @@ class FreeProductLineForm(BaseEffectModelForm):
                     "product": product.name,
                     "shop": campaign.shop.name
                 })
-
-            for error in shop_product.get_quantity_errors(self.cleaned_data["quantity"]):
+            for error in shop_product.get_quantity_errors(self.cleaned_data["quantity"], False):
                 raise ValidationError({'quantity': error.message})
 
 


### PR DESCRIPTION
`for error in shop_product.get_quantity_errors(self.cleaned_data["quantity"]):`  was throwing an error because `ignore_minimum`  in `get_quantity_errors` has not been set.


Refs ENT-3006