### PR TITLE
Fix issue 'Manager isn't available; 'auth.User' has been swapped for …

### DIFF
--- a/shuup/core/telemetry.py
+++ b/shuup/core/telemetry.py
@@ -12,7 +12,7 @@ from datetime import date, datetime, time, timedelta
 
 import requests
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import Q, Sum
@@ -25,6 +25,8 @@ from shuup import configuration
 from shuup.core.models import (
     Contact, Order, Payment, PersistentCacheEntry, Product
 )
+
+User = get_user_model()
 
 OPT_OUT_KWARGS = dict(module="telemetry", key="opt_out")
 INSTALLATION_KEY_KWARGS = dict(module="telemetry", key="installation_key")

--- a/shuup_tests/admin/test_bootstrap_field_renderer.py
+++ b/shuup_tests/admin/test_bootstrap_field_renderer.py
@@ -6,12 +6,13 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 from django import forms
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.utils import translation
 from django.utils.encoding import force_text
 
 from shuup.admin.utils.bs3_renderers import AdminFieldRenderer
 
+User = get_user_model()
 
 def test_field_title_quoting():
     with translation.override("en"):

--- a/shuup_tests/api/test_basket_customer.py
+++ b/shuup_tests/api/test_basket_customer.py
@@ -12,7 +12,7 @@ from decimal import Decimal
 
 import pytest
 import six
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.test import override_settings
 from pytest_django.fixtures import django_user_model, django_username_field
 from rest_framework import status
@@ -34,6 +34,8 @@ from shuup.testing.factories import (
 from shuup_tests.campaigns.test_discount_codes import (
     Coupon, get_default_campaign
 )
+
+User = get_user_model()
 
 REQUIRED_SETTINGS = dict(
     SHUUP_ENABLE_MULTIPLE_SHOPS=True,

--- a/shuup_tests/front/test_addressbook.py
+++ b/shuup_tests/front/test_addressbook.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 
 from shuup.core.models import get_company_contact, get_person_contact, SavedAddress
@@ -14,6 +14,8 @@ from shuup_tests.utils import SmartClient
 from shuup_tests.utils.fixtures import (
     regular_user, REGULAR_USER_PASSWORD, REGULAR_USER_USERNAME
 )
+
+User = get_user_model()
 
 regular_user = regular_user  # noqa
 

--- a/shuup_tests/front/test_customer_information.py
+++ b/shuup_tests/front/test_customer_information.py
@@ -12,7 +12,6 @@ from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import check_password
-from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.shortcuts import resolve_url
 from django.test import override_settings
@@ -32,6 +31,7 @@ from shuup_tests.utils.fixtures import (
     regular_user, REGULAR_USER_PASSWORD, REGULAR_USER_USERNAME
 )
 
+User = get_user_model()
 
 def default_customer_data():
     return {

--- a/shuup_tests/front/test_registration.py
+++ b/shuup_tests/front/test_registration.py
@@ -11,7 +11,6 @@ import uuid
 import pytest
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import User
 from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
@@ -35,6 +34,8 @@ from shuup_tests.front.utils import (
     change_company_signal, change_username_signal, FieldTestProvider,
     FormDefTestProvider
 )
+
+User = get_user_model()
 
 username = "u-%d" % uuid.uuid4().time
 email = "%s@shuup.local" % username

--- a/shuup_tests/gdpr/test_forms.py
+++ b/shuup_tests/gdpr/test_forms.py
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 import pytest
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.test import override_settings
 from django.utils.translation import activate
@@ -22,6 +22,7 @@ from shuup.testing import factories
 from shuup.testing.utils import apply_request_middleware
 from shuup_tests.utils import SmartClient
 
+User = get_user_model()
 
 @pytest.mark.django_db
 def test_authenticate_form(client):


### PR DESCRIPTION
Impossible to swap django User model
 
…'users.User''. Remove all references of 'from django.contrib.auth.models import User' in shuup_tests and 'shuup.core.telemetry'.

Replacing all references to:
`from django.contrib.auth.models import User`

By:
```
from django.contrib.auth import get_user_model
User = get_user_model()
```