### PR TITLE
Front: improve logout when impersonating

### DIFF
--- a/shuup/front/template_helpers/urls.py
+++ b/shuup/front/template_helpers/urls.py
@@ -70,3 +70,15 @@ def has_url(url, *args, **kwargs):
     :rtype: bool
     """
     return bool(get_url(url, *args, **kwargs))
+
+
+@contextfunction
+def get_logout_url(context, *args, **kwargs):
+    request = context["request"]
+    if "impersonator_user_id" in request.session:
+        logout_url = get_url("shuup:stop-impersonating", *args, **kwargs)
+        if logout_url:
+                return logout_url
+
+    logout_url = get_url("shuup:logout", *args, **kwargs)
+    return (logout_url if logout_url else "/logout")

--- a/shuup/front/templates/shuup/front/macros/navigation.jinja
+++ b/shuup/front/templates/shuup/front/macros/navigation.jinja
@@ -56,7 +56,8 @@
                 {% endif %}
             {% endif %}
             {% if user.is_authenticated() and shuup.urls.has_url("shuup:logout") %}
-                {{ _render_dropdown_item(url("shuup:logout"), "fa fa-sign-out fa-fw", _("Log out"), request.person == true) }}
+
+                {{ _render_dropdown_item(shuup.urls.get_logout_url(), "fa fa-sign-out fa-fw", _("Log out"), request.person == true) }}
             {% endif %}
         {% endcall %}
     {% elif show_quick_login %} {# Checking if the login dropdown should be shown #}

--- a/shuup/front/urls.py
+++ b/shuup/front/urls.py
@@ -24,7 +24,7 @@ from .views.dashboard import DashboardView
 from .views.index import IndexView
 from .views.misc import (
     force_anonymous_contact, force_company_contact, force_person_contact,
-    toggle_all_seeing
+    stop_impersonating, toggle_all_seeing
 )
 from .views.order import OrderCompleteView
 from .views.payment import ProcessPaymentView
@@ -61,6 +61,7 @@ urlpatterns = [
     url(r'^force-anonymous-contact/$', login_required(force_anonymous_contact), name="force-anonymous-contact"),
     url(r'^force-company-contact/$', login_required(force_company_contact), name="force-company-contact"),
     url(r'^force-person-contact/$', login_required(force_person_contact), name="force-person-contact"),
+    url(r'^stop-impersonating/$', login_required(stop_impersonating), name="stop-impersonating"),
     url(r'^order/payment/(?P<pk>.+?)/(?P<key>.+?)/$',
         csrf_exempt(ProcessPaymentView.as_view()),
         kwargs={"mode": "payment"},

--- a/shuup/front/views/misc.py
+++ b/shuup/front/views/misc.py
@@ -5,7 +5,9 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.http import HttpResponseRedirect
+from django.contrib.auth import logout
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseForbidden, HttpResponseRedirect
 
 from shuup.core.models import get_company_contact_for_shop_staff
 from shuup.core.utils.users import (
@@ -57,3 +59,12 @@ def force_company_contact(request):
 
     get_company_contact_for_shop_staff(request.shop, user)
     return HttpResponseRedirect(return_url)
+
+
+def stop_impersonating(request):
+    if "impersonator_user_id" not in request.session:
+        return HttpResponseForbidden()
+
+    del request.session["impersonator_user_id"]
+    logout(request)
+    return HttpResponseRedirect(reverse("shuup_admin:contact.list"))

--- a/shuup_tests/functional/test_stop_impersonating.py
+++ b/shuup_tests/functional/test_stop_impersonating.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from django.contrib.auth import get_user
+from django.core.urlresolvers import reverse
+
+from shuup.admin.modules.users.views import LoginAsUserView
+from shuup.core.models import get_person_contact
+from shuup.front.template_helpers.urls import get_logout_url
+from shuup.front.views.misc import stop_impersonating
+from shuup.testing.factories import get_default_shop
+from shuup.testing.utils import apply_request_middleware
+from shuup_tests.utils.fixtures import regular_user
+
+
+def is_authenticated(user):
+    if callable(getattr(user, "is_authenticated")):  # Django <1.11
+        return user.is_authenticated()
+    return user.is_authenticated
+
+
+@pytest.mark.django_db
+def test_stop_impersonating(rf, admin_user, regular_user):
+    get_default_shop()
+    view_func = LoginAsUserView.as_view()
+    request = apply_request_middleware(rf.post("/"), user=admin_user)
+    assert get_logout_url({"request": request}) == reverse("shuup:logout")
+    get_person_contact(regular_user)
+    response = view_func(request, pk=regular_user.pk)
+    assert response["location"] == reverse("shuup:index")
+    assert get_user(request) == regular_user
+    assert "impersonator_user_id" in request.session
+    assert get_logout_url({"request": request}) == reverse("shuup:stop-impersonating")
+    assert is_authenticated(get_user(request))
+    response = stop_impersonating(request)
+    assert response.status_code in [301, 302]  # redirect
+    assert "impersonator_user_id" not in request.session
+    assert not is_authenticated(get_user(request))
+
+
+@pytest.mark.django_db
+def test_stop_impersonating_without_impersonating(rf, admin_user, regular_user):
+    get_default_shop()
+    request = apply_request_middleware(rf.post("/"), user=admin_user)
+    assert "impersonator_user_id" not in request.session
+    response = stop_impersonating(request)
+    assert response.status_code == 403


### PR DESCRIPTION
Make it easier to get back to admin contacts list when impersonating. Introduce `shuup.urls.get_logout_url` template helper which returns stop impersonating URL when the shop staff is impersonating users.

Stop impersonate by logging out user and redirecting to admin login with contact list as next parameter. After this simply re-login for safety and the shop staff is back at contacts list to manage contacts.