### PR TITLE
Simple CMS: allow page owner see invisible page

### DIFF
--- a/shuup/simple_cms/models.py
+++ b/shuup/simple_cms/models.py
@@ -34,7 +34,7 @@ class PageOpenGraphType(Enum):
 
 
 class PageQuerySet(TranslatableQuerySet):
-    def visible(self, shop, dt=None):
+    def visible(self, shop, dt=None, user=None):
         """
         Get pages that should be publicly visible.
 
@@ -52,6 +52,8 @@ class PageQuerySet(TranslatableQuerySet):
             Q(available_from__lte=dt) &
             (Q(available_to__gte=dt) | Q(available_to__isnull=True))
         )
+        if user and not user.is_anonymous():
+            q |= Q(created_by=user)
         qs = self.for_shop(shop).filter(q)
         return qs
 

--- a/shuup/simple_cms/views.py
+++ b/shuup/simple_cms/views.py
@@ -55,4 +55,4 @@ class PageView(DetailView):
         if getattr(self.request.user, 'is_superuser', False):
             # Superusers may see all pages despite their visibility status
             return self.model.objects.for_shop(self.request.shop).filter(deleted=False)
-        return self.model.objects.visible(self.request.shop)
+        return self.model.objects.visible(self.request.shop, user=self.request.user)


### PR DESCRIPTION
Allow page creator option to preview the page on site before publishing it.