### PR TITLE
Core: include variation parents to bought with calculations

### DIFF
--- a/shuup/core/utils/product_bought_with_relations.py
+++ b/shuup/core/utils/product_bought_with_relations.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 
-from django.db.models import Sum
+from django.db.models import Q, Sum
 
 from shuup.core.models import (
     OrderLine, OrderLineType, ProductCrossSell, ProductCrossSellType
@@ -25,7 +25,8 @@ def add_bought_with_relations_for_product(product_id, max_quantity=10):
     :type max_quantity: int
     """
     order_ids_to_check = OrderLine.objects.filter(
-        product_id=product_id
+        Q(product_id=product_id) |
+        Q(product__variation_parent_id=product_id)
     ).values_list(
         "order_id", flat=True
     )
@@ -38,7 +39,8 @@ def add_bought_with_relations_for_product(product_id, max_quantity=10):
         type=OrderLineType.PRODUCT,
         order_id__in=set(order_ids_to_check)
     ).values(
-        "product_id"
+        "product_id",
+        "product__variation_parent_id"
     ).annotate(
         total_quantity=Sum("quantity")
     ).order_by(
@@ -47,9 +49,22 @@ def add_bought_with_relations_for_product(product_id, max_quantity=10):
 
     # Add the actual cross-sells products
     for product_data in related_product_ids_and_quantities:
-        ProductCrossSell.objects.create(
-            product1_id=product_id,
-            product2_id=product_data["product_id"],
-            weight=product_data["total_quantity"],
-            type=ProductCrossSellType.BOUGHT_WITH
-        )
+        # If product ordered has variation parent then link
+        # relation to to the parent since variation children
+        # is not shown on product list on default or have
+        # their own detail
+        variation_parent_id = product_data.get("product__variation_parent_id")
+        if variation_parent_id and variation_parent_id != product_id:
+            ProductCrossSell.objects.create(
+                product1_id=product_id,
+                product2_id=variation_parent_id,
+                weight=product_data["total_quantity"],
+                type=ProductCrossSellType.BOUGHT_WITH
+            )
+        elif not variation_parent_id:
+            ProductCrossSell.objects.create(
+                product1_id=product_id,
+                product2_id=product_data["product_id"],
+                weight=product_data["total_quantity"],
+                type=ProductCrossSellType.BOUGHT_WITH
+            )

--- a/shuup_tests/core/test_compute_bought_with_relations.py
+++ b/shuup_tests/core/test_compute_bought_with_relations.py
@@ -5,10 +5,12 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-
 import pytest
+import six
 
-from shuup.core.models import ProductCrossSell
+from django.core.management import call_command
+
+from shuup.core.models import Product, ProductCrossSell, ShopProduct
 from shuup.core.utils.product_bought_with_relations import (
     add_bought_with_relations_for_product
 )
@@ -65,3 +67,74 @@ def test_product_relations_max_quantity(rf):
     # Test that ordering is ok
     assert not ProductCrossSell.objects.filter(weight=1).exists()
     assert ProductCrossSell.objects.filter(weight=11).exists()
+
+
+
+def _init_test_with_variations():
+    shop = get_default_shop()
+    supplier = get_default_supplier()
+
+    product_data = {
+        "t-shirt": {
+            "colors": ["black", "yellow"],
+        },
+        "hoodie": {
+            "colors": ["black"],
+        }
+    }
+    for key, data in six.iteritems(product_data):
+        parent = create_product(key, shop=shop)
+        shop_parent_product = parent.get_shop_instance(shop)
+        for color in data["colors"]:
+            sku = "%s-%s" % (key, color)
+            shop_product = ShopProduct.objects.filter(product__sku=sku).first()
+            if shop_product:
+                shop_product.suppliers.add(supplier)
+            else:
+                child = create_product(sku, shop=shop, supplier=supplier)
+                child.link_to_parent(parent, variables={"color": color})
+
+    assert Product.objects.count()  == 5
+
+    black_t_shirt = Product.objects.filter(sku="t-shirt-black").first()
+    black_hoodie = Product.objects.filter(sku="hoodie-black").first()
+    order = create_order_with_product(black_t_shirt, supplier, quantity=1, taxless_base_unit_price=6, shop=shop)
+    add_product_to_order(order, supplier, black_hoodie, quantity=1, taxless_base_unit_price=6)
+
+    return black_t_shirt.variation_parent, black_hoodie.variation_parent
+
+
+@pytest.mark.django_db
+def test_product_relations_variation_products(rf):
+    t_shirt, hoodie = _init_test_with_variations()
+
+    add_bought_with_relations_for_product(t_shirt.pk)
+
+    # T-shirt should be related to hoodie parent product
+    assert ProductCrossSell.objects.count() == 1
+    t_shirt_relation = ProductCrossSell.objects.filter(product2=hoodie).first()
+    assert t_shirt_relation
+    assert t_shirt_relation.product1 == t_shirt
+
+    add_bought_with_relations_for_product(hoodie.pk)
+    assert ProductCrossSell.objects.count() == 2
+
+    # Hoodie should be related to t-shirt parent product
+    hoodie_relation = ProductCrossSell.objects.filter(product2=t_shirt).first()
+    assert hoodie_relation
+    assert hoodie_relation.product1 == hoodie
+
+
+@pytest.mark.django_db
+def test_product_relations_variation_products_through_management_cmd(rf):
+    t_shirt, hoodie = _init_test_with_variations()
+    call_command("compute_bought_with_relations")
+
+    assert ProductCrossSell.objects.count() == 2
+    t_shirt_relation = ProductCrossSell.objects.filter(product2=hoodie).first()
+    assert t_shirt_relation
+    assert t_shirt_relation.product1 == t_shirt
+
+    hoodie_relation = ProductCrossSell.objects.filter(product2=t_shirt).first()
+    assert hoodie_relation
+    assert hoodie_relation.product1 == hoodie


### PR DESCRIPTION
Since product card is shown for variation parent it is important that the related bought with products are also calculated for variation parents.