### PR TITLE
Fix /sa/ products mass-actions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ VERSION_FILE = os.path.join(TOPDIR, 'shuup', '_version.py')
 #      - Add ".post0.dev" suffix to VERSION variable here
 
 NAME = 'shuup'
-VERSION = '1.9.3b5'
+VERSION = '1.9.3b5.post0.dev'
 DESCRIPTION = 'E-Commerce Platform'
 AUTHOR = 'Shoop Commerce Ltd.'
 AUTHOR_EMAIL = 'shuup@shuup.com'

--- a/shuup/admin/modules/products/mass_actions.py
+++ b/shuup/admin/modules/products/mass_actions.py
@@ -32,7 +32,7 @@ class VisibleMassAction(PicotableMassAction):
         if isinstance(ids, string_types) and ids == "all":
             query = Q(shop=shop)
         else:
-            query = Q(product__pk__in=ids, shop=shop)
+            query = Q(pk__in=ids, shop=shop)
 
         ShopProduct.objects.filter(query).update(visibility=ShopProductVisibility.ALWAYS_VISIBLE)
         for shop_product in ShopProduct.objects.filter(query).iterator():
@@ -48,7 +48,7 @@ class InvisibleMassAction(PicotableMassAction):
         if isinstance(ids, string_types) and ids == "all":
             query = Q(shop=shop)
         else:
-            query = Q(product__pk__in=ids, shop=shop)
+            query = Q(pk__in=ids, shop=shop)
 
         ShopProduct.objects.filter(query).update(visibility=ShopProductVisibility.NOT_VISIBLE)
         for shop_product in ShopProduct.objects.filter(query).iterator():
@@ -64,7 +64,7 @@ class FileResponseAction(PicotableFileMassAction):
         if isinstance(ids, string_types) and ids == "all":
             query = Q(shop=shop)
         else:
-            query = Q(product__pk__in=ids, shop=shop)
+            query = Q(pk__in=ids, shop=shop)
         view_settings = ViewSettings(ShopProduct, ProductListView.default_columns, ProductListView)
         response = HttpResponse(content_type='text/csv')
         response['Content-Disposition'] = 'attachment; filename="products.csv"'

--- a/shuup_tests/admin/test_mass_actions.py
+++ b/shuup_tests/admin/test_mass_actions.py
@@ -61,6 +61,10 @@ def test_mass_action_cache(rf, admin_user):
     cache.clear()
     product = create_product(printable_gibberish(), shop=shop, default_price=50)
     product2 = create_product(printable_gibberish(), shop=shop, default_price=100)
+
+    shop_product = product.get_shop_instance(shop)
+    shop_product2 = product2.get_shop_instance(shop)
+
     set_bump_cache_for_shop_product = mock.Mock(wraps=context_cache.bump_cache_for_shop_product)
 
     def bump_cache_for_shop_product(item):
@@ -70,10 +74,10 @@ def test_mass_action_cache(rf, admin_user):
 
     with mock.patch.object(context_cache, "bump_cache_for_shop_product", new=bump_cache_for_shop_product):
         assert set_bump_cache_for_shop_product.call_count == 0
-        InvisibleMassAction().process(request, [product.id, product2.id])
+        InvisibleMassAction().process(request, [shop_product.id, shop_product2.id])
         assert set_bump_cache_for_shop_product.call_count == 2
 
-        VisibleMassAction().process(request, [product.id, product2.id])
+        VisibleMassAction().process(request, [shop_product.id, shop_product2.id])
         assert set_bump_cache_for_shop_product.call_count == 4
 
 

--- a/shuup_tests/admin/test_product_mass_edit.py
+++ b/shuup_tests/admin/test_product_mass_edit.py
@@ -62,7 +62,7 @@ def test_mass_edit_products2(rf, admin_user):
     assert shop_product2.primary_category is None
     payload = {
         "action": InvisibleMassAction().identifier,
-        "values": [product1.pk, product2.pk]
+        "values": [shop_product1.pk, shop_product2.pk]
     }
     request = apply_request_middleware(rf.post("/"), user=admin_user)
     request._body = json.dumps(payload).encode("UTF-8")


### PR DESCRIPTION
This is fixed version of https://github.com/shuup/shuup/pull/1861

Fix for very old bug, checked on 1.9.2 and 1.3.0 versions.

Operations like set visible, set invisible, export csv won't work like expected, cuz for queries used ShopProduct id to filter over Product. Accidentally will work only if shopproduct id == product id. In all other cases will do nothing or will change visibility/export for products that has similar to shopproduct id.