### PR TITLE
Front: add option to customize customer information forms

### DIFF
--- a/shuup/front/apps/customer_information/forms.py
+++ b/shuup/front/apps/customer_information/forms.py
@@ -5,16 +5,25 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+import six
 from django import forms
 from django.conf import settings
+from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from enumfields import EnumField
+from registration.signals import user_registered
 
 from shuup.core.fields import LanguageFormField
 from shuup.core.models import (
-    CompanyContact, PersonContact, SavedAddressRole, SavedAddressStatus
+    CompanyContact, get_company_contact, get_person_contact, MutableAddress,
+    PersonContact, SavedAddress, SavedAddressRole, SavedAddressStatus
 )
+from shuup.front.utils.companies import company_registration_requires_approval
+from shuup.utils.form_group import FormGroup
+from shuup.utils.importing import cached_load
+
+from .notify_events import CompanyAccountCreated
 
 
 class PersonContactForm(forms.ModelForm):
@@ -73,3 +82,158 @@ class SavedAddressForm(forms.Form):
     title = forms.CharField(max_length=255, label=_("Address Title"))
     role = EnumField(SavedAddressRole, default=SavedAddressRole.SHIPPING).formfield(label=_("Address Type"))
     status = EnumField(SavedAddressStatus, default=SavedAddressStatus.ENABLED).formfield(label=_("Address Status"))
+
+
+class CustomerInformationFormGroup(FormGroup):
+    address_forms = ["billing", "shipping"]
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request")
+        super(CustomerInformationFormGroup, self).__init__(*args, **kwargs)
+        contact = get_person_contact(self.request.user)
+        address_form_class = cached_load("SHUUP_ADDRESS_MODEL_FORM")
+
+        for form_name in self.address_forms:
+            self.add_form_def(form_name, address_form_class, kwargs={
+                "instance": getattr(contact, "default_%s_address" % form_name)
+            })
+
+        self.add_form_def("contact", PersonContactForm, kwargs={"instance": contact})
+
+    def save(self):
+        contact = self.forms["contact"].save()
+        user = contact.user
+
+        if "billing" in self.forms:
+            billing_address = self.forms["billing"].save()
+            if billing_address.pk != contact.default_billing_address_id:  # Identity changed due to immutability
+                contact.default_billing_address = billing_address
+
+        if "shipping" in self.forms:
+            shipping_address = self.forms["shipping"].save()
+            if shipping_address.pk != contact.default_shipping_address_id:  # Identity changed due to immutability
+                contact.default_shipping_address = shipping_address
+
+        if not bool(get_company_contact(self.request.user)):  # Only update user details for non-company members
+            user.email = contact.email
+            user.first_name = contact.first_name
+            user.last_name = contact.last_name
+            user.save()
+
+        contact.save()
+        return contact
+
+
+class CompanyInformationFormGroup(FormGroup):
+    address_forms = ["billing", "shipping"]
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request")
+        super(CompanyInformationFormGroup, self).__init__(*args, **kwargs)
+
+        user = self.request.user
+        company = get_company_contact(user)
+        person = get_person_contact(user)
+        address_form_class = cached_load("SHUUP_ADDRESS_MODEL_FORM")
+
+        for form_name in self.address_forms:
+            self.add_form_def(
+                form_name,
+                address_form_class,
+                kwargs={
+                    "instance": _get_default_address_for_contact(company, "default_%s_address" % form_name, person)
+                }
+            )
+        self.add_form_def("contact", CompanyContactForm, kwargs={"instance": company})
+
+    def save(self):
+        company = self.forms["contact"].save(commit=False)
+        is_new = not bool(company.pk)
+        company.save()
+        user = self.request.user
+
+        # TODO: Should this check if contact will be created? Or should we expect create always?
+        person = get_person_contact(user)
+        person.add_to_shop(self.request.shop)
+        company.members.add(person)
+        company.add_to_shop(self.request.shop)
+
+        if "billing" in self.forms:
+            billing_address = self.forms["billing"].save()
+            if billing_address.pk != company.default_billing_address_id:  # Identity changed due to immutability
+                company.default_billing_address = billing_address
+
+        if "shipping" in self.forms:
+            shipping_address = self.forms["shipping"].save()
+            if shipping_address.pk != company.default_shipping_address_id:  # Identity changed due to immutability
+                company.default_shipping_address = shipping_address
+
+        message = _("Company information saved successfully.")
+        # If company registration requires activation,
+        # company will be created as inactive.
+        if is_new and company_registration_requires_approval(self.request.shop):
+            company.is_active = False
+            message = _("Company information saved successfully. "
+                        "Please follow the instructions sent to your email address.")
+
+        messages.success(self.request, message)
+        company.save()
+
+        if is_new:
+            user_registered.send(sender=self.__class__, user=self.request.user, request=self.request)
+            CompanyAccountCreated(contact=company, customer_email=company.email).run(shop=self.request.shop)
+
+        return company
+
+
+class AddressBookFormGroup(FormGroup):
+    saved_address_form = SavedAddressForm
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request")
+        self.instance = kwargs.pop("instance")
+        super(AddressBookFormGroup, self).__init__(*args, **kwargs)
+        address_kwargs = {}
+        saved_address_kwargs = {}
+
+        if self.instance:
+            address_kwargs["instance"] = self.instance.address
+            saved_address_kwargs["initial"] = {
+                "role": self.instance.role,
+                "status": self.instance.status,
+                "title": self.instance.title,
+            }
+
+        self.add_form_def("address", cached_load("SHUUP_ADDRESS_MODEL_FORM"), kwargs=address_kwargs)
+        self.add_form_def("saved_address", self.saved_address_form, kwargs=saved_address_kwargs)
+
+    def save(self):
+        address_form = self.forms["address"]
+        if self.instance:
+            # expect old
+            address = MutableAddress.objects.get(pk=self.instance.address.pk)
+            for k, v in six.iteritems(address_form.cleaned_data):
+                setattr(address, k, v)
+            address.save()
+        else:
+            address = address_form.save()
+        owner = self.request.customer
+        saf = self.forms["saved_address"]
+        saved_address, updated = SavedAddress.objects.update_or_create(
+            owner=owner,
+            address=address,
+            defaults={
+                "title": saf.cleaned_data.get("title"),
+                "role": saf.cleaned_data.get("role"),
+                "status": saf.cleaned_data.get("status")
+            }
+        )
+        return saved_address
+
+
+def _get_default_address_for_contact(contact, address_attr, fallback_contact):
+    if contact and getattr(contact, address_attr, None):
+        return getattr(contact, address_attr)
+    if fallback_contact and getattr(fallback_contact, address_attr, None):
+        return getattr(fallback_contact, address_attr)
+    return None

--- a/shuup/front/apps/customer_information/settings.py
+++ b/shuup/front/apps/customer_information/settings.py
@@ -1,0 +1,15 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+
+#: The default customer information edit form
+SHUUP_CUSTOMER_INFORMATION_EDIT_FORM = "shuup.front.apps.customer_information.forms:CustomerInformationFormGroup"
+
+#: The default company information edit form
+SHUUP_COMPANY_INFORMATION_EDIT_FORM = "shuup.front.apps.customer_information.forms:CompanyInformationFormGroup"
+
+#: The default address book edit form
+SHUUP_ADDRESS_BOOK_EDIT_FORM = "shuup.front.apps.customer_information.forms:AddressBookFormGroup"

--- a/shuup/front/apps/customer_information/views.py
+++ b/shuup/front/apps/customer_information/views.py
@@ -5,28 +5,17 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-import six
 from django.contrib import messages
 from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.views import password_change
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import FormView, TemplateView
-from registration.signals import user_registered
 
-from shuup.core.models import (
-    CompanyContact, get_company_contact, get_person_contact, MutableAddress,
-    SavedAddress
-)
-from shuup.front.utils.companies import (
-    allow_company_registration, company_registration_requires_approval
-)
+from shuup.core.models import CompanyContact, get_company_contact, SavedAddress
+from shuup.front.utils.companies import allow_company_registration
 from shuup.front.views.dashboard import DashboardViewMixin
-from shuup.utils.form_group import FormGroup
 from shuup.utils.importing import cached_load
-
-from .forms import CompanyContactForm, PersonContactForm, SavedAddressForm
-from .notify_events import CompanyAccountCreated
 
 
 class PasswordChangeView(DashboardViewMixin, TemplateView):
@@ -51,32 +40,16 @@ class PasswordChangeView(DashboardViewMixin, TemplateView):
 class CustomerEditView(DashboardViewMixin, FormView):
     template_name = "shuup/customer_information/edit_customer.jinja"
 
-    def get_form(self, form_class=None):
-        contact = get_person_contact(self.request.user)
-        form_group = FormGroup(**self.get_form_kwargs())
-        address_form_class = cached_load("SHUUP_ADDRESS_MODEL_FORM")
-        form_group.add_form_def("billing", address_form_class, kwargs={"instance": contact.default_billing_address})
-        form_group.add_form_def("shipping", address_form_class, kwargs={"instance": contact.default_shipping_address})
-        form_group.add_form_def("contact", PersonContactForm, kwargs={"instance": contact})
-        return form_group
+    def get_form_class(self):
+        return cached_load("SHUUP_CUSTOMER_INFORMATION_EDIT_FORM")
+
+    def get_form_kwargs(self):
+        kwargs = super(CustomerEditView, self).get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
 
     def form_valid(self, form):
-        contact = form["contact"].save()
-        user = contact.user
-        billing_address = form["billing"].save()
-        shipping_address = form["shipping"].save()
-        if billing_address.pk != contact.default_billing_address_id:  # Identity changed due to immutability
-            contact.default_billing_address = billing_address
-        if shipping_address.pk != contact.default_shipping_address_id:  # Identity changed due to immutability
-            contact.default_shipping_address = shipping_address
-
-        if not bool(get_company_contact(self.request.user)):  # Only update user details for non-company members
-            user.email = contact.email
-            user.first_name = contact.first_name
-            user.last_name = contact.last_name
-            user.save()
-
-        contact.save()
+        form.save()
         messages.success(self.request, _("Account information saved successfully."))
         return redirect("shuup:customer_edit")
 
@@ -89,62 +62,16 @@ class CompanyEditView(DashboardViewMixin, FormView):
             return redirect("shuup:customer_edit")
         return super(CompanyEditView, self).dispatch(request, *args, **kwargs)
 
-    def get_form(self, form_class=None):
-        user = self.request.user
-        company = get_company_contact(user)
-        person = get_person_contact(user)
-        form_group = FormGroup(**self.get_form_kwargs())
-        address_form_class = cached_load("SHUUP_ADDRESS_MODEL_FORM")
-        form_group.add_form_def(
-            "billing",
-            address_form_class,
-            kwargs={
-                "instance": _get_default_address_for_contact(company, "default_billing_address", person)
-            }
-        )
-        form_group.add_form_def(
-            "shipping",
-            address_form_class,
-            kwargs={
-                "instance": _get_default_address_for_contact(company, "default_shipping_address", person)
-            }
-        )
-        form_group.add_form_def("contact", CompanyContactForm, kwargs={"instance": company})
-        return form_group
+    def get_form_class(self):
+        return cached_load("SHUUP_COMPANY_INFORMATION_EDIT_FORM")
+
+    def get_form_kwargs(self):
+        kwargs = super(CompanyEditView, self).get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
 
     def form_valid(self, form):
-        company = form["contact"].save(commit=False)
-        is_new = not bool(company.pk)
-        company.save()
-        user = self.request.user
-        # TODO: Should this check if contact will be created? Or should we expect create always?
-        person = get_person_contact(user)
-        person.add_to_shop(self.request.shop)
-        company.members.add(person)
-        company.add_to_shop(self.request.shop)
-        billing_address = form["billing"].save()
-        shipping_address = form["shipping"].save()
-        if billing_address.pk != company.default_billing_address_id:  # Identity changed due to immutability
-            company.default_billing_address = billing_address
-        if shipping_address.pk != company.default_shipping_address_id:  # Identity changed due to immutability
-            company.default_shipping_address = shipping_address
-
-        message = _("Company information saved successfully.")
-        # If company registration requires activation,
-        # company will be created as inactive.
-        if is_new and company_registration_requires_approval(self.request.shop):
-            company.is_active = False
-            message = _("Company information saved successfully. "
-                        "Please follow the instructions sent to your email address.")
-
-        company.save()
-        if is_new:
-            user_registered.send(sender=self.__class__,
-                                 user=self.request.user,
-                                 request=self.request)
-            CompanyAccountCreated(contact=company, customer_email=company.email).run(shop=self.request.shop)
-
-        messages.success(self.request, message)
+        form.save()
         return redirect("shuup:company_edit")
 
     def get_context_data(self, **kwargs):
@@ -166,7 +93,6 @@ class AddressBookView(DashboardViewMixin, TemplateView):
 
 class AddressBookEditView(DashboardViewMixin, FormView):
     template_name = "shuup/customer_information/addressbook/edit.jinja"
-    form_class = SavedAddressForm
     instance = None
 
     def dispatch(self, request, *args, **kwargs):
@@ -176,47 +102,17 @@ class AddressBookEditView(DashboardViewMixin, FormView):
             self.instance = None
         return super(AddressBookEditView, self).dispatch(request, *args, **kwargs)
 
-    def get_form(self, form_class=None):
-        form_group = FormGroup(**self.get_form_kwargs())
-        address_kwargs = {}
-        saved_address_kwargs = {}
-        if self.instance:
-            address_kwargs["instance"] = self.instance.address
-            saved_address_kwargs["initial"] = {
-                "role": self.instance.role,
-                "status": self.instance.status,
-                "title": self.instance.title,
-            }
+    def get_form_class(self):
+        return cached_load("SHUUP_ADDRESS_BOOK_EDIT_FORM")
 
-        form_group.add_form_def("address", cached_load("SHUUP_ADDRESS_MODEL_FORM"), kwargs=address_kwargs)
-        form_group.add_form_def(
-            "saved_address",
-            SavedAddressForm,
-            kwargs=saved_address_kwargs
-        )
-        return form_group
+    def get_form_kwargs(self):
+        kwargs = super(AddressBookEditView, self).get_form_kwargs()
+        kwargs["request"] = self.request
+        kwargs["instance"] = self.instance
+        return kwargs
 
     def form_valid(self, form):
-        address_form = form["address"]
-        if self.instance:
-            # expect old
-            address = MutableAddress.objects.get(pk=self.instance.address.pk)
-            for k, v in six.iteritems(address_form.cleaned_data):
-                setattr(address, k, v)
-            address.save()
-        else:
-            address = address_form.save()
-        owner = self.request.customer
-        saf = form["saved_address"]
-        saved_address, updated = SavedAddress.objects.update_or_create(
-            owner=owner,
-            address=address,
-            defaults={
-                "title": saf.cleaned_data.get("title"),
-                "role": saf.cleaned_data.get("role"),
-                "status": saf.cleaned_data.get("status")
-            }
-        )
+        saved_address = form.save()
         messages.success(self.request, _("Address information saved successfully."))
         return redirect("shuup:address_book_edit", pk=saved_address.pk)
 
@@ -227,11 +123,3 @@ def delete_address(request, pk):
     except SavedAddress.DoesNotExist:
         messages.error(request, _("Cannot remove address"))
     return redirect("shuup:address_book")
-
-
-def _get_default_address_for_contact(contact, address_attr, fallback_contact):
-    if contact and getattr(contact, address_attr, None):
-        return getattr(contact, address_attr)
-    if fallback_contact and getattr(fallback_contact, address_attr, None):
-        return getattr(fallback_contact, address_attr)
-    return None

--- a/shuup/front/apps/personal_order_history/templates/shuup/personal_order_history/macros/order_detail.jinja
+++ b/shuup/front/apps/personal_order_history/templates/shuup/personal_order_history/macros/order_detail.jinja
@@ -34,23 +34,19 @@
 {% endmacro %}
 
 {% macro shipping_address() %}
-    {% if order.shipping_address_id %}
-        {% call content_block(_("Shipping Address")) %}
-            {% for line in order.shipping_address %}
-                {{ line }}<br>
-            {% endfor %}
-        {% endcall %}
-    {% endif %}
+    {% call content_block(_("Shipping Address")) %}
+        {% for line in order.shipping_address %}
+            {{ line }}<br>
+        {% endfor %}
+    {% endcall %}
 {% endmacro %}
 
 {% macro billing_address() %}
-    {% if order.billing_address_id %}
-        {% call content_block(_("Billing Address")) %}
-            {% for line in order.billing_address %}
-                {{ line }}<br>
-            {% endfor %}
-        {% endcall %}
-    {% endif %}
+    {% call content_block(_("Billing Address")) %}
+        {% for line in order.billing_address %}
+            {{ line }}<br>
+        {% endfor %}
+    {% endcall %}
 {% endmacro %}
 
 {% macro order_contents() %}

--- a/shuup/front/apps/personal_order_history/templates/shuup/personal_order_history/order_detail.jinja
+++ b/shuup/front/apps/personal_order_history/templates/shuup/personal_order_history/order_detail.jinja
@@ -18,15 +18,25 @@
 {% block dashboard_content %}
     <h2 class="page-header">{% trans identifier = order.identifier %}Order {{ identifier }}{% endtrans %}{{ render_action_buttons(order) }}</h2>
     <div class="row order-dashboard-container">
-        <div class="col-sm-12">
+        <div>
             {{ basic_info() }}
         </div>
-        <div class="col-sm-6 col-md-3">
-            {{ shipping_address() }}
-        </div>
-        <div class="col-sm-6 col-md-3">
-            {{ billing_address() }}
-        </div>
+        {% if order.shipping_address_id and order.billing_address_id %}
+            <div class="col-sm-6 col-md-3">
+                {{ shipping_address() }}
+            </div>
+            <div class="col-sm-6 col-md-3">
+                {{ billing_address() }}
+            </div>
+        {% elif order.shipping_address_id %}
+            <div class="col-md-6">
+                {{ shipping_address() }}
+            </div>
+        {% elif order.billing_address_id %}
+            <div class="col-md-6">
+                {{ billing_address() }}
+            </div>
+        {% endif %}
         <div class="col-sm-12 col-md-6">
             {{ status() }}
         </div>

--- a/shuup/front/checkout/methods.py
+++ b/shuup/front/checkout/methods.py
@@ -117,8 +117,8 @@ class MethodsPhase(CheckoutPhaseViewMixin, FormView):
         return True
 
     def process(self):
-        shipping_method = ShippingMethod.objects.filter(pk=self.storage["shipping_method_id"]).first()
-        payment_method = PaymentMethod.objects.filter(pk=self.storage["payment_method_id"]).first()
+        shipping_method = ShippingMethod.objects.filter(pk=self.storage.get("shipping_method_id")).first()
+        payment_method = PaymentMethod.objects.filter(pk=self.storage.get("payment_method_id")).first()
 
         self.basket.shipping_method_id = shipping_method.pk if shipping_method else None
         self.basket.payment_method_id = payment_method.pk if payment_method else None


### PR DESCRIPTION
Add option to change form groups for Customer Information, Company Information and Address Book forms.

This enables users to customize specially the fields which are needed for specific solutions and hide forms when not needed

Refs MOOS-46