### PR TITLE
Front: fix bug in product images

### DIFF
--- a/shuup/front/static_src/js/update_price.js
+++ b/shuup/front/static_src/js/update_price.js
@@ -48,11 +48,14 @@ window.updatePrice = function updatePrice(productId) {
         $(priceDiv).replaceWith($content.find(priceDiv));
 
         // ensure images are updated
-        var combinationProductId = $(priceDiv).data("product-id");
-        var id = "#carousel_product_" + combinationProductId;
+        const combinationCarouselID = "#carousel_product_" + $(priceDiv).data("product-id");
+        const combinationImages = $(combinationCarouselID).parent("div").html()
         $(".product-image").empty();
-        $(".product-image").append($(id).parent("div").html());
-        $(".product-image .product-carousel a").simpleLightbox();
+        $(".product-image").append(combinationImages);
+        const imagesSelector = ".product-image .product-carousel a";
+        if ($(imagesSelector).length > 0) {
+            $(imagesSelector).simpleLightbox();
+        }
         $(".product-image .owl-carousel.carousel-thumbnails").owlCarousel({
             margin: 10,
             nav: $(".carousel-thumbnails .thumbnail").length > 4,

--- a/shuup/front/templates/shuup/front/macros/product_image.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_image.jinja
@@ -85,9 +85,13 @@
     // Enable lightbox for products with multiple images. Uses arrows to
     // navigate through images.
     var selector_multiple = "a[data-imagelightbox='image-multiple']";
-    var instance_multiple = $(selector_multiple).simpleLightbox();
+    if ($(selector).length > 0) {
+        var instance_multiple = $(selector_multiple).simpleLightbox();
+    }
 
     // Enable lightbox for products with only one image.
     var selector = "a[data-imagelightbox='image']";
-    var instance = $(selector).simpleLightbox();
+    if ($(selector).length > 0) {
+        var instance = $(selector).simpleLightbox();
+    }
 {% endmacro %}


### PR DESCRIPTION
This should fix broken images with normal products.

Lightbox init should not be called if the images are not available. Also we can not empty the images and then expect to find some images from the container.