### PR TITLE
Multiple minor improvements

### DIFF
--- a/shuup/core/order_creator/_creator.py
+++ b/shuup/core/order_creator/_creator.py
@@ -72,7 +72,10 @@ class OrderProcessor(object):
         order_line.verified = (not order_line.require_verification)
         order_line.source_line = source_line
         order_line.parent_source_line = source_line.parent_line
-        order_line.extra_data = {"source_line_id": source_line.line_id}
+        extra_data = source_line.data.get("extra", {}) if hasattr(source_line, "data") else {}
+        extra_data.update({"source_line_id": source_line.line_id})
+
+        order_line.extra_data = extra_data
         self._check_orderability(order_line)
 
         yield order_line

--- a/shuup/core/order_creator/_source.py
+++ b/shuup/core/order_creator/_source.py
@@ -738,7 +738,11 @@ class SourceLine(TaxableItem, Priceful, LineWithUnit):
     def get(self, key, default=None):
         if key in self._FIELDSET:
             return getattr(self, key, default)
-        return self._data.get(key, default)
+        return self.data.get(key, default)
+
+    @property
+    def data(self):
+        return self._data or {}
 
     @property
     def parent_line(self):

--- a/shuup/testing/supplier_provider.py
+++ b/shuup/testing/supplier_provider.py
@@ -12,3 +12,9 @@ class UsernameSupplierProvider(object):
     @classmethod
     def get_supplier(cls, request, **kwargs):
         return Supplier.objects.filter(identifier=request.user.username).first()
+
+
+class RequestSupplierProvider(object):
+    @classmethod
+    def get_supplier(cls, request, **kwargs):
+        return request.supplier


### PR DESCRIPTION
1) Add `RequestSupplierProvider`. This provides an easy way to test supplier related requests
2) Expose `._data` to the public from `SourceLine`. It was strange that this was hidden after all. Basically, you could use the `to_json` but it's not always what you might want.
3) Ensure data is being carried from `SourceLine` to `OrderLine` properly.