### PR TITLE
Front: back to old user when stop impersonating

### DIFF
--- a/shuup_tests/functional/test_stop_impersonating.py
+++ b/shuup_tests/functional/test_stop_impersonating.py
@@ -41,7 +41,8 @@ def test_stop_impersonating(rf, admin_user, regular_user):
     response = stop_impersonating(request)
     assert response.status_code in [301, 302]  # redirect
     assert "impersonator_user_id" not in request.session
-    assert not is_authenticated(get_user(request))
+    assert is_authenticated(get_user(request))
+    assert request.user == admin_user
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
After user stop impersonating, the old user is the active one again.
This prevents the user to do login again.

Refs MOOS-26