### PR TITLE
WIP: New variation templates

### DIFF
--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-21 18:16+0000\n"
+"POT-Creation-Date: 2019-03-28 16:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -676,9 +676,6 @@ msgstr ""
 msgid "Set Paid"
 msgstr ""
 
-msgid "Create Shipment"
-msgstr ""
-
 msgid "Create Refund"
 msgstr ""
 
@@ -858,12 +855,7 @@ msgstr ""
 msgid "Create Shipment -- %s"
 msgstr ""
 
-msgid "Supplier"
-msgstr ""
-
-msgid ""
-"Select the shipment supplier. You can only ship the suppliers assigned to "
-"order lines."
+msgid "Create Shipment"
 msgstr ""
 
 #, python-format
@@ -3003,13 +2995,26 @@ msgstr ""
 msgid "There was an error adding the log entry."
 msgstr ""
 
+msgid "Unshipped"
+msgstr ""
+
+msgid "Shipped"
+msgstr ""
+
+msgid "Ordered"
+msgstr ""
+
+msgid "Refunded"
+msgstr ""
+
+#, python-format
+msgid "Create new shipment for %(supplier_name)s"
+msgstr ""
+
 msgid "Tracking Code"
 msgstr ""
 
 msgid "Created"
-msgstr ""
-
-msgid "No shipments have been created yet."
 msgstr ""
 
 msgid ""
@@ -3041,9 +3046,6 @@ msgstr ""
 msgid "Remaining"
 msgstr ""
 
-msgid "Refunded"
-msgstr ""
-
 msgid "Add Another Refund"
 msgstr ""
 
@@ -3051,15 +3053,6 @@ msgid "Order Line"
 msgstr ""
 
 msgid "To Ship"
-msgstr ""
-
-msgid "Ordered"
-msgstr ""
-
-msgid "Shipped"
-msgstr ""
-
-msgid "Unshipped"
 msgstr ""
 
 msgid "Set All Products To Ship"
@@ -3244,6 +3237,9 @@ msgid "Combination"
 msgstr ""
 
 msgid "Variables"
+msgstr ""
+
+msgid "Template"
 msgstr ""
 
 msgid "This product is not yet a variation."

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-28 16:53+0000\n"
+"POT-Creation-Date: 2019-04-30 20:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -1005,6 +1005,18 @@ msgid "Unable to link %(product)s: %(error)s"
 msgstr ""
 
 msgid "variable combination"
+msgstr ""
+
+msgid "Activate template"
+msgstr ""
+
+msgid ""
+"Check this to activate a selected template.If no template is selected "
+"variation data will be saved without checking this."
+msgstr ""
+
+#, python-format
+msgid "Unnamed %s"
 msgstr ""
 
 msgid "Set visible"
@@ -3532,10 +3544,6 @@ msgstr ""
 
 #, python-format
 msgid "New %s"
-msgstr ""
-
-#, python-format
-msgid "Unnamed %s"
 msgstr ""
 
 #, python-format

--- a/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-08 17:25+0000\n"
+"POT-Creation-Date: 2019-04-05 15:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -514,6 +514,12 @@ msgid "Show identifier fields (for advanced users)"
 msgstr ""
 
 msgid "There are no variables defined."
+msgstr ""
+
+msgid "Variation Template"
+msgstr ""
+
+msgid "Select Template"
 msgstr ""
 
 msgid "Add new variable"

--- a/shuup/admin/modules/products/views/edit_variation.py
+++ b/shuup/admin/modules/products/views/edit_variation.py
@@ -58,7 +58,7 @@ class VariationVariablesFormPart(FormPart):
             VariationVariablesDataForm,
             template_name="shuup/admin/products/variation/_variation_variables.jinja",
             required=False,
-            kwargs={"parent_product": self.object}
+            kwargs={"parent_product": self.object, "request": self.request}
         )
 
     def form_valid(self, form):

--- a/shuup/admin/static_src/base/scss/shuup/content-blocks.scss
+++ b/shuup/admin/static_src/base/scss/shuup/content-blocks.scss
@@ -316,6 +316,7 @@
 
 .table th {
     border-top: none;
+    font-size: 1rem;
 }
 
 .table td {

--- a/shuup/admin/static_src/base/scss/shuup/custom-forms.scss
+++ b/shuup/admin/static_src/base/scss/shuup/custom-forms.scss
@@ -1,6 +1,12 @@
 $input-border-color: #D9D9D9;
 $input-bg-color: #F3F3F3;
 
+
+.variable-templates {
+    label {
+        display: block;
+    }
+}
 .form-control {
     border-color: $border-color;
     font-weight: normal;
@@ -11,6 +17,12 @@ $input-bg-color: #F3F3F3;
     &:focus {
         border-color: $primary;
         box-shadow: 0 0 0 0.2rem rgba($primary, 0.15);
+    }
+
+    &.template {
+        width: 80%;
+        display: inline-block;
+        margin-right: 10px;
     }
 }
 
@@ -247,4 +259,93 @@ fieldset[disabled] .form-control {
     input {
         margin-right: 0.2rem;
     }
+}
+
+.modal{
+    opacity: 1;
+
+   // This is modal bg
+   &:before{
+     content: "";
+     //display: none;
+     background: rgba(0,0,0,.6);
+     position: fixed;
+     top: 0; left: 0; right: 0; bottom: 0;
+     z-index: 10;
+   }
+}
+
+.template-modal-container {
+    background: #fff;
+    box-shadow: 0px 0px 10px rgba(0,0,0,0.4);
+    animation: fadeInAnim 0.6s;
+    position: relative;
+    top: 30%;
+
+    @include media-breakpoint-down(sm) {
+        border-radius: 4px;
+        margin: 15px auto;
+        height: 40%;
+    }
+
+    @include media-breakpoint-up(md) {
+        overflow: auto;
+        margin-top: 70px;
+        width: 30%;
+        margin: auto;
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+    }
+}
+
+.template-modal-header {
+    @include clearfix;
+    padding: 15px;
+    border-bottom: 1px solid $border-color;
+    background: $gray-bg;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+
+    @include media-breakpoint-up(md) {
+        padding: 15px 30px;
+        z-index: 10;
+        width: 30%;
+        margin: auto;
+        position: fixed;
+        height: 70px;
+    }
+
+    .btn + .btn {
+        margin-right: 5px;
+    }
+
+    .btn i {
+        margin-right: 5px;
+    }
+    h2 {
+        @include media-breakpoint-down(md) {
+            font-size: 1.5rem;
+        }
+
+    }
+    h4 {
+        line-height: 38px;
+        margin: 0;
+        i {
+            margin-right: 7px;
+            line-height: inherit;
+            color: $primary;
+        }
+    }
+}
+.template-form-wrapper {
+    @include media-breakpoint-up(md) {
+        padding-top:60px;
+    }
+    padding-left: 25px;
+}
+
+#save_template_name {
+    margin: 10px;
+    margin-top: 0px;
 }

--- a/shuup/admin/templates/shuup/admin/products/variation/_variation_variables.jinja
+++ b/shuup/admin/templates/shuup/admin/products/variation/_variation_variables.jinja
@@ -4,6 +4,11 @@
 {% call content_block(_("Variables"), "fa-clone", id="variables-section") %}
     <div id="variation-variable-editor"></div>
     {{ var_form["data"]|safe }}
+    <div class="product-variable">
+    <h3>{% trans %}Template{% endtrans %}</h3>
+    {{ bs3.field(var_form["save_template"]) }}
+    {{ bs3.field(var_form["template_name"]) }}
+    </div>
     <script>
     window.addEventListener("load", function() {
         VariationVariableEditor.init({{ var_form.get_editor_args()|json }});

--- a/shuup/admin/templates/shuup/admin/products/variation/_variation_variables.jinja
+++ b/shuup/admin/templates/shuup/admin/products/variation/_variation_variables.jinja
@@ -6,11 +6,38 @@
     {{ var_form["data"]|safe }}
     <div class="product-variable">
     <h3>{% trans %}Template{% endtrans %}</h3>
-    {{ bs3.field(var_form["save_template"]) }}
-    {{ bs3.field(var_form["template_name"]) }}
+    {{ bs3.field(var_form["activate_template"]) }}
     </div>
+    {% block post_content %}
+    <div class="shuup-modal-bg" id="step-item-wrapper" style="display: none;">
+
+        <div class="template-modal-container">
+            <div class="template-modal-header">
+                <h2 class="pull-left">{% trans %}New template{% endtrans %}</h2>
+                <button class="btn btn-danger pull-right" type="button" id="template-cancel-btn">
+                    <i class="fa fa-times-circle"></i>
+                    {% trans %} Cancel {% endtrans %}
+                </button>
+            </div>
+
+            <div class="template-form-wrapper">
+            <form method="POST" id="template_name" action="/#variables-section">
+                {{ bs3.field(var_form["template_name"]) }}
+                <input type="submit" placeholder="Save" id="save_template_name" class="btn btn-success" value="Save">
+                <br>
+            </form>
+            </div>
+
+        </div>
+        </div>
+    </div>
+    {% endblock %}
     <script>
     window.addEventListener("load", function() {
         VariationVariableEditor.init({{ var_form.get_editor_args()|json }});
-    }, false);</script>
+    }, false);
+
+    </script>
+
+
 {% endcall %}

--- a/shuup_tests/admin/test_variation_templates.py
+++ b/shuup_tests/admin/test_variation_templates.py
@@ -1,0 +1,98 @@
+import pytest
+import json
+
+from shuup.admin.modules.products.forms import VariationVariablesDataForm
+from shuup.core.models import ProductVariationVariable, ProductVariationVariableValue
+from shuup.testing.factories import create_product
+from shuup_tests.utils import printable_gibberish
+from shuup.testing.factories import get_default_shop, create_random_user
+from shuup.testing.utils import apply_request_middleware
+
+var_data = [{"pk":"$0.3","identifier":"","names":{"en":"Size"},
+"values":[{"pk":"$0.8","identifier":"","texts":{"en":"X"}},
+{"pk":"$0.1","identifier":"","texts":{"en":"S"}}]}]
+
+@pytest.mark.django_db
+def test_variation_template_creation(rf):
+    shop = get_default_shop()
+    parent = create_product(printable_gibberish())
+    user = create_random_user(is_superuser = True, is_staff = True)
+    request = apply_request_middleware(rf.get("/"), user=user, shop=shop)
+    form = VariationVariablesDataForm()
+    form.request = request
+    assert form.get_variation_templates() == []
+    form.cleaned_data = {'data': '{"variable_values": []}', 'activate_template': False, 'template_name': 'Test'}
+    form.save()
+    var_template = form.get_variation_templates()[0]
+    assert len(form.get_variation_templates()) == 1
+    template_identifier = var_template.get('identifier')
+    template_data = {'data': '{"variable_values":' + str(var_data) + '}', 'activate_template': False, 'template_name': 'Test'}
+    form.cleaned_data = {'data': json.dumps({"variable_values": var_data, 'template_identifier' : template_identifier}), 'activate_template': False, 'template_name': '' }
+    form.save()
+    assert len(form.get_variation_templates()) == 1
+    var_template = form.get_variation_templates()[0]
+    assert var_template["data"] == var_data
+
+
+def test_variation_activation(rf):
+    shop = get_default_shop()
+    parent = create_product(printable_gibberish(), shop=shop)
+    user = create_random_user(is_superuser = True, is_staff = True)
+    request = apply_request_middleware(rf.get("/"), user=user, shop=shop)
+    form = VariationVariablesDataForm(parent_product=parent, request=request)
+    assert len(ProductVariationVariable.objects.all()) == 0  # Assert no active Variations are present
+    assert form.get_variation_templates() == []  # Assert no templates exist (yet)
+    var_data_dict = {'data': json.dumps({"variable_values": var_data}), 'activate_template': True, 'template_name': ''}  # Base skeleton
+    form.cleaned_data = var_data_dict
+    form.is_valid()
+    form.save()
+
+    assert len(ProductVariationVariable.objects.filter(product=parent)) == 1 # Size
+    assert len(ProductVariationVariableValue.objects.all()) == 2  # X,S
+
+    var_data_one_value = [{"pk":"$0.3","identifier":"","names":{"en":"Size"},
+    "values":[{"pk":"$0.8","identifier":"","texts":{"en":"X"}}]}] #  Delete one value
+    var_data_dict['data'] = json.dumps({"variable_values": var_data_one_value})
+    form.cleaned_data = var_data_dict
+    form.save()
+
+    assert len(ProductVariationVariable.objects.filter(product=parent)) == 1
+    assert len(ProductVariationVariableValue.objects.all()) == 1
+    var_data_dict["template_name"] = printable_gibberish()  # Create template
+    form.save()
+
+    assert len(ProductVariationVariable.objects.filter(product=parent)) == 1
+    assert len(ProductVariationVariableValue.objects.all()) == 1
+    assert len(form.get_variation_templates()) == 1
+
+    template_identifier = form.get_variation_templates()[0].get('identifier')
+    # dict with template identifier which contains only one ProductVariationVariableValue data
+    one_value_dict = json.dumps({"variable_values": var_data_one_value, 'template_identifier' : template_identifier})
+    two_values_dict = json.dumps({"variable_values": var_data, 'template_identifier' : template_identifier})  # Has two PVVV
+    var_data_dict['data'] = two_values_dict
+    var_data_dict['template_name'] = ''
+    form.cleaned_data = var_data_dict
+    form.save()
+
+    assert len(ProductVariationVariable.objects.filter(product=parent)) == 1
+    assert len(ProductVariationVariableValue.objects.all()) == 2
+    var_template_data = form.get_variation_templates()[0].get("data")
+    assert var_template_data == var_data
+    var_data_dict['data'] = one_value_dict
+    form.cleaned_data = var_data_dict
+    form.save()
+
+    assert len(ProductVariationVariable.objects.filter(product=parent)) == 1
+    assert len(ProductVariationVariableValue.objects.all()) == 1
+    var_template_data = form.get_variation_templates()[0].get("data")
+    assert var_template_data == var_data_one_value
+
+    var_data_dict['data'] = two_values_dict
+    var_data_dict['activate_template'] = False
+    form.cleaned_data = var_data_dict
+    form.save()
+
+    assert len(ProductVariationVariable.objects.filter(product=parent)) == 1
+    assert len(ProductVariationVariableValue.objects.all()) == 1  # Assert newest template data hasn't been activated since activated_template = False
+    var_template_data = form.get_variation_templates()[0].get("data")
+    assert var_template_data == var_data

--- a/shuup_tests/browser/admin/test_variation_templates.py
+++ b/shuup_tests/browser/admin/test_variation_templates.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+import json
+import pytest
+from django.core.urlresolvers import reverse
+from shuup import configuration
+from shuup.core.models import ProductVariationVariable, ProductVariationVariableValue
+
+from shuup_tests.utils import printable_gibberish
+
+from shuup.testing.browser_utils import click_element, wait_until_condition
+from shuup.testing.factories import create_product, get_default_shop
+from shuup.testing.browser_utils import initialize_admin_browser_test
+from shuup.core.models._products import ProductMode
+
+pytestmark = pytest.mark.skipif(os.environ.get("SHUUP_BROWSER_TESTS", "0") != "1", reason="No browser tests run.")
+
+
+@pytest.mark.browser
+@pytest.mark.djangodb
+def test_variation_templates(browser, admin_user, live_server, settings):
+    shop = get_default_shop()
+    configuration_key = "saved_variation_templates"
+    assert configuration.get(shop, configuration_key, []) == []
+    product = create_product("test_sku", shop, default_price=10, mode=ProductMode.VARIABLE_VARIATION_PARENT)
+    assert product.is_variation_parent()
+    initialize_admin_browser_test(browser, live_server, settings)
+    browser.driver.set_window_size(1920, 1080)
+    url = reverse("shuup_admin:shop_product.edit_variation", kwargs={"pk": product.pk})
+    browser.visit("%s%s" % (live_server, url + "#variables-section"))
+    wait_until_condition(browser, lambda x: x.is_text_present("New template"))
+
+    assert len(ProductVariationVariable.objects.filter(product=product)) == 0 # Size
+    assert len(ProductVariationVariableValue.objects.all()) == 0  # Assert no variations are active
+
+    click_element(browser, '.fa.fa-plus')
+    # variables-template_name
+    browser.fill("variables-template_name", printable_gibberish())
+    click_element(browser, '#save_template_name')
+    wait_until_condition(browser, lambda x: x.is_text_present("Add new variable"))
+
+    assert len(configuration.get(shop, configuration_key, [])) == 1
+
+    click_element(browser, "#variation-variable-editor")
+    browser.find_by_xpath('//*[@id="variation-variable-editor"]/div/div/select/option[2]').first.click()
+    wait_until_condition(browser, lambda x: x.is_text_present("Add new variable"))
+    click_element(browser, ".btn.btn-lg.btn-text")
+    browser.find_by_xpath('//*[@id="product-variable-wrap"]/div/div[2]/div[1]/table/tbody[1]/tr/td[1]/input').first.fill("Size")
+    click_element(browser, ".btn.btn-xs.btn-text")
+    browser.find_by_xpath('//*[@id="product-variable-wrap"]/div/div[2]/div[1]/table/tbody[2]/tr/td[1]/input').first.fill("S")
+    click_element(browser, "#id_variables-activate_template")  # Activate template
+    click_element(browser, ".fa.fa-check-circle")  # Save
+
+    assert len(ProductVariationVariable.objects.filter(product=product)) == 1 # Size
+    assert len(ProductVariationVariableValue.objects.all()) == 1  # S
+
+    click_element(browser, "#variation-variable-editor") # id_variables-data
+
+    assert len(configuration.get(shop, configuration_key, [])) == 1
+
+    browser.find_by_xpath('//*[@id="variation-variable-editor"]/div/div/select/option[2]').first.click()
+    template_data = configuration.get(shop, configuration_key, [])[0].get('data')[0]
+    browser_data = json.loads(browser.find_by_css("#id_variables-data").value).get('variable_values')[0]
+    assert browser_data == template_data  # assert shown template data matches template data in the db
+


### PR DESCRIPTION
Variation templates can now be created & edited. When a certain template is activated it's data is being saved in the database
as ProductVariationVariable & ProductVariationVariableValue objects. When a new template is activated (again) all PVV objects
of that parent product are removed from the database and new ones are saved in the database.
