### PR TITLE
Improve category API

### DIFF
--- a/shuup/core/api/category.py
+++ b/shuup/core/api/category.py
@@ -14,11 +14,12 @@ from parler_rest.fields import TranslatedFieldsField
 from parler_rest.serializers import TranslatableModelSerializer
 from rest_framework import serializers, viewsets
 
-from shuup.api.fields import EnumField
+from shuup.api.fields import Base64FileField, EnumField
 from shuup.api.mixins import PermissionHelperMixin, ProtectedModelViewSetMixin
 from shuup.core.models import (
     Category, CategoryStatus, CategoryVisibility, Shop
 )
+from shuup.utils.filer import filer_image_from_upload
 
 
 class CategorySerializer(TranslatableModelSerializer):
@@ -27,13 +28,35 @@ class CategorySerializer(TranslatableModelSerializer):
     visibility = EnumField(CategoryVisibility)
     image = serializers.SerializerMethodField()
 
-    class Meta:
-        model = Category
-        fields = '__all__'
+    def __init__(self, *args, **kwargs):
+        super(CategorySerializer, self).__init__(*args, **kwargs)
+        request = self.context.get("request")
+        if request.method == "POST":
+            self.fields["image"] = Base64FileField(required=False, write_only=True)
+            self.fields["image_path"] = serializers.CharField(required=False, write_only=True)
+        elif request.method == "GET":
+            self.fields["image"] = serializers.SerializerMethodField()
+
+    def create(self, validated_data):
+        if "image_path" in validated_data:
+            validated_data.pop("image_path")
+        return super(CategorySerializer, self).create(validated_data)
+
+    def validate(self, data):
+        if data.get("image") and data.get("image_path"):
+            data["image"] = filer_image_from_upload(
+                self.context["request"], path=data["image_path"], upload_data=data["image"])
+        elif data.get("image"):
+            raise serializers.ValidationError("Path is required when sending a Category image.")
+        return data
 
     def get_image(self, category):
         if category.image:
             return self.context["request"].build_absolute_uri(category.image.url)
+
+    class Meta:
+        model = Category
+        fields = '__all__'
 
 
 class CategoryFilter(FilterSet):

--- a/shuup/core/api/category.py
+++ b/shuup/core/api/category.py
@@ -29,7 +29,7 @@ class CategorySerializer(TranslatableModelSerializer):
 
     class Meta:
         model = Category
-        exclude = ("shops",)
+        fields = '__all__'
 
     def get_image(self, category):
         if category.image:

--- a/shuup_tests/api/test_category_api.py
+++ b/shuup_tests/api/test_category_api.py
@@ -46,6 +46,7 @@ def test_category_api(admin_user):
     assert category.ordering == category_data["ordering"]
     assert category.visibility.value == category_data["visibility"]
     assert category.visible_in_menu == category_data["visible_in_menu"]
+    assert category.shops.first().pk == shop.pk
 
     category_data["translations"]["en"]["name"] = "name 2"
     category_data["ordering"] = 3

--- a/shuup_tests/api/test_category_api.py
+++ b/shuup_tests/api/test_category_api.py
@@ -8,14 +8,15 @@
 from __future__ import unicode_literals
 
 import json
-
+import base64
+import os
 from django.utils.translation import activate
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from shuup.core import cache
 from shuup.core.models import Category, CategoryStatus, CategoryVisibility
-from shuup.testing.factories import get_default_shop
+from shuup.testing.factories import get_default_shop, get_random_filer_image
 
 
 def setup_function(fn):
@@ -27,14 +28,19 @@ def test_category_api(admin_user):
     shop = get_default_shop()
     client = APIClient()
     client.force_authenticate(user=admin_user)
-
+    image = get_random_filer_image()
+    with open(image.path, 'rb') as f:
+        img_base64 = base64.b64encode(os.urandom(50)).decode()
+        uri = "data:application/octet-stream;base64,{}".format(img_base64)
     category_data = {
         "shops": [shop.pk],
         "status": CategoryStatus.VISIBLE.value,
         "ordering": 1,
         "visibility": CategoryVisibility.VISIBLE_TO_ALL.value,
         "visible_in_menu": True,
-        "translations": {"en": {"name": "Category 1"}}
+        "translations": {"en": {"name": "Category 1"}},
+        "image_path" : "/didnt/choose/path",
+        "image" : uri
     }
     response = client.post("/api/shuup/category/",
                            content_type="application/json",
@@ -47,7 +53,20 @@ def test_category_api(admin_user):
     assert category.visibility.value == category_data["visibility"]
     assert category.visible_in_menu == category_data["visible_in_menu"]
     assert category.shops.first().pk == shop.pk
+    assert category.image.folder.pretty_logical_path == category_data["image_path"]
 
+    with open(category.image.path, 'rb') as f:
+        assert img_base64 == base64.b64encode(f.read()).decode()
+
+    category_data.pop("image_path") # Test error when not sending a path
+    response = client.post("/api/shuup/category/",
+                           content_type="application/json",
+                           data=json.dumps(category_data))
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    data = json.loads(response.content.decode("utf-8"))
+    assert data["non_field_errors"][0] == "Path is required when sending a Category image."
+
+    category_data["image_path"] = "/path/chose/me"
     category_data["translations"]["en"]["name"] = "name 2"
     category_data["ordering"] = 3
 


### PR DESCRIPTION
- API: Include shops in category API
When making a category through API the category wouldn't be connected with any shops because the shops field was excluded. This fixes that.
Refs #1708

- API: Enable image upload for Categories
Refs #1717, ENT-2832, #1708
