### PR TITLE
Reports: Fix shipping report breaking with taxful & taxless orders

### DIFF
--- a/shuup/default_reports/reports/shipping.py
+++ b/shuup/default_reports/reports/shipping.py
@@ -60,21 +60,23 @@ class ShippingReport(OrderReportMixin, ShuupReportBase):
 
         for key, group in itertools.groupby(self.get_objects(), get_group_func):
             orders = set()
-            zero_price = total_charged = self.shop.create_price(0)
+            zero_price = total_charged = self.shop.create_price(0).amount
 
             # keep track the last one
             order_line = None
 
             for order_line in group:
                 orders.add(order_line.order_id)
-                total_charged += order_line.taxful_price
-
+                if(order_line.order.prices_include_tax):
+                    total_charged += order_line.taxful_price.amount
+                else:
+                    total_charged += order_line.taxless_price.amount
             if total_charged > zero_price:
                 data.append({
                     "carrier": order_line.order.shipping_method.carrier.name,
                     "shipping_method": order_line.order.shipping_method_name,
                     "order_count": len(orders),
-                    "total_charged": total_charged.as_rounded().value
+                    "total_charged": total_charged.as_rounded()
                 })
 
         return self.get_return_data(data)


### PR DESCRIPTION
Hardest part about this was writing tests which I'm still not sure if they test the right thing. In tests,
taxless & taxful prices of an order seem to be equal to each other.
Also fixed old typo from `SalesTestReportForRequestTets` to `SalesTestReportForRequestTest`

Refs ENT-2973, #1731