### PR TITLE
Front: force add prefix to registration and login forms to prevent duplicates

### DIFF
--- a/shuup/front/apps/auth/views.py
+++ b/shuup/front/apps/auth/views.py
@@ -28,6 +28,7 @@ from shuup.utils.excs import Problem
 class LoginView(FormView):
     template_name = 'shuup/user/login.jinja'
     form_class = EmailAuthenticationForm
+    prefix = "auth"
 
     def get_context_data(self, **kwargs):
         context = super(LoginView, self).get_context_data(**kwargs)

--- a/shuup/front/apps/registration/views.py
+++ b/shuup/front/apps/registration/views.py
@@ -38,6 +38,7 @@ def registration_complete(request):
 
 class RegistrationViewMixin(object):
     template_name = "shuup/registration/register.jinja"
+    prefix = "registration"
 
     def get_success_url(self, *args, **kwargs):
         url = self.request.POST.get(REDIRECT_FIELD_NAME)

--- a/shuup/front/template_helpers/general.py
+++ b/shuup/front/template_helpers/general.py
@@ -28,9 +28,14 @@ from shuup.utils.mptt import get_cached_trees
 from shuup.utils.translation import cache_translations_for_tree
 
 
-def get_login_form(request):
-    # Getting the form from the Login view
-    form = cached_load("SHUUP_LOGIN_VIEW")(request=request).get_form()
+def get_login_form(request, form_prefix="login"):
+    """
+    Get a login form from the Login view. Use different prefixes when using the
+    same form in the same template to prevent duplicated fields ID
+    """
+    login_view = cached_load("SHUUP_LOGIN_VIEW")(request=request)
+    login_view.prefix = form_prefix
+    form = login_view.get_form()
     return form
 
 

--- a/shuup/front/templates/shuup/front/macros/navigation.jinja
+++ b/shuup/front/templates/shuup/front/macros/navigation.jinja
@@ -67,7 +67,7 @@
                     {% csrf_token %}
                     {% if request.resolver_match.url_name == "logout" %}{% set next="/" %}{% endif %}
                     <input type="hidden" name="next" value="{{ next or request.path }}">
-                    {% set form = shuup.general.get_login_form(request) %}
+                    {% set form = shuup.general.get_login_form(request, form_prefix="quick-auth") %}
                     {% for f in form.hidden_fields() %}{{ f }}{% endfor %}
                     {% for f in form.visible_fields() %}{{ render_field(f, show_help_text=False) }}{% endfor %}
 

--- a/shuup_tests/front/test_auth.py
+++ b/shuup_tests/front/test_auth.py
@@ -40,8 +40,8 @@ def test_login_logs_the_user_in(client, regular_user, rf):
     prepare_user(regular_user)
     redirect_target = "/redirect-success/"
     response = client.post(reverse("shuup:login"), data={
-        "username": regular_user.username,
-        "password": REGULAR_USER_PASSWORD,
+        "auth-username": regular_user.username,
+        "auth-password": REGULAR_USER_PASSWORD,
         REDIRECT_FIELD_NAME: redirect_target
     })
 
@@ -59,8 +59,8 @@ def test_login_fails_without_valid_password(client, regular_user, rf):
     prepare_user(regular_user)
     get_default_shop()
     client.post(reverse("shuup:login"), data={
-        "username": regular_user.username,
-        "password": "x%s" % REGULAR_USER_PASSWORD,
+        "auth-username": regular_user.username,
+        "auth-password": "x%s" % REGULAR_USER_PASSWORD,
     })
     request = rf.get("/")
     request.session = client.session
@@ -74,8 +74,8 @@ def test_login_with_email_1(client, regular_user, rf):
     prepare_user(regular_user)
     redirect_target = "/redirect-success/"
     response = client.post(reverse("shuup:login"), data={
-        "username": regular_user.email,
-        "password": REGULAR_USER_PASSWORD,
+        "auth-username": regular_user.email,
+        "auth-password": REGULAR_USER_PASSWORD,
         REDIRECT_FIELD_NAME: redirect_target
     })
 
@@ -101,8 +101,8 @@ def test_login_with_email_2(client, regular_user, rf):
     prepare_user(regular_user)
     redirect_target = "/redirect-success/"
     client.post(reverse("shuup:login"), data={
-        "username": regular_user.email,
-        "password": REGULAR_USER_PASSWORD,
+        "auth-username": regular_user.email,
+        "auth-password": REGULAR_USER_PASSWORD,
         REDIRECT_FIELD_NAME: redirect_target
     })
 
@@ -112,8 +112,8 @@ def test_login_with_email_2(client, regular_user, rf):
 
     # Login with unknown email
     client.post(reverse("shuup:login"), data={
-        "username": "unknown@example.com",
-        "password": REGULAR_USER_PASSWORD,
+        "auth-username": "unknown@example.com",
+        "auth-password": REGULAR_USER_PASSWORD,
         REDIRECT_FIELD_NAME: redirect_target
     })
 
@@ -123,8 +123,8 @@ def test_login_with_email_2(client, regular_user, rf):
 
     # Login with username should work normally
     response = client.post(reverse("shuup:login"), data={
-        "username": regular_user.username,
-        "password": REGULAR_USER_PASSWORD,
+        "auth-username": regular_user.username,
+        "auth-password": REGULAR_USER_PASSWORD,
         REDIRECT_FIELD_NAME: redirect_target
     })
 
@@ -152,8 +152,8 @@ def test_login_with_email_3(client, regular_user, rf):
 
     # Login with new_user username should work even if there is users with same email
     response = client.post(reverse("shuup:login"), data={
-        "username": regular_user.email,
-        "password": new_user_password,
+        "auth-username": regular_user.email,
+        "auth-password": new_user_password,
         REDIRECT_FIELD_NAME: redirect_target
     })
 
@@ -172,8 +172,8 @@ def test_login_inactive_user_fails(client, regular_user, rf):
     prepare_user(regular_user)
 
     client.post(reverse("shuup:login"), data={
-        "username": regular_user.username,
-        "password": REGULAR_USER_PASSWORD,
+        "auth-username": regular_user.username,
+        "auth-password": REGULAR_USER_PASSWORD,
     })
 
     request = rf.get("/")
@@ -191,8 +191,8 @@ def test_login_inactive_user_fails(client, regular_user, rf):
     user_contact.save()
 
     client.post(reverse("shuup:login"), data={
-        "username": regular_user.username,
-        "password": REGULAR_USER_PASSWORD,
+        "auth-username": regular_user.username,
+        "auth-password": REGULAR_USER_PASSWORD,
     })
 
     request = rf.get("/")
@@ -214,8 +214,8 @@ def test_email_auth_form(rf, regular_user):
     shop = get_default_shop()
     prepare_user(regular_user)
     payload = {
-        "username": regular_user.username,
-        "password": REGULAR_USER_PASSWORD,
+        "auth-username": regular_user.username,
+        "auth-password": REGULAR_USER_PASSWORD,
     }
     request = apply_request_middleware(rf.get("/"), shop=shop)
     with override_provides("front_auth_form_field_provider", ["shuup_tests.front.utils.FieldTestProvider"]):
@@ -226,8 +226,8 @@ def test_email_auth_form(rf, regular_user):
         assert form.errors[FieldTestProvider.key][0] == FieldTestProvider.error_msg
 
         # accept terms
-        payload.update({FieldTestProvider.key: True})
-        form = EmailAuthenticationForm(request=request, data=payload)
+        payload.update({"auth-%s" % FieldTestProvider.key: True})
+        form = EmailAuthenticationForm(request=request, data=payload, prefix="auth")
         assert FieldTestProvider.key in form.fields
         assert form.is_valid()
 

--- a/shuup_tests/front/test_registration.py
+++ b/shuup_tests/front/test_registration.py
@@ -53,10 +53,10 @@ def test_registration(django_user_model, client, requiring_activation):
         SHUUP_REGISTRATION_REQUIRES_ACTIVATION=requiring_activation,
     ):
         client.post(reverse("shuup:registration_register"), data={
-            "username": username,
-            "email": email,
-            "password1": "password",
-            "password2": "password",
+            "registration-username": username,
+            "registration-email": email,
+            "registration-password1": "password",
+            "registration-password2": "password",
         })
         user = django_user_model.objects.get(username=username)
         if requiring_activation:
@@ -81,10 +81,10 @@ def test_registration_2(django_user_model, client, requiring_activation):
         SHUUP_REGISTRATION_REQUIRES_ACTIVATION=requiring_activation,
     ):
         response = client.post(reverse("shuup:registration_register"), data={
-            "username": username,
-            "email": email,
-            "password1": "password",
-            "password2": "password",
+            "registration-username": username,
+            "registration-email": email,
+            "registration-password1": "password",
+            "registration-password2": "password",
             "next": reverse('shuup:checkout')
         })
         user = django_user_model.objects.get(username=username)
@@ -244,10 +244,10 @@ def test_user_will_be_redirected_to_user_account_page_after_activation(client, r
         SHUUP_REGISTRATION_REQUIRES_ACTIVATION=requiring_activation,
     ):
         response = client.post(reverse("shuup:registration_register"), data={
-            "username": username,
-            "email": email,
-            "password1": "password",
-            "password2": "password",
+            "registration-username": username,
+            "registration-email": email,
+            "registration-password1": "password",
+            "registration-password2": "password",
         }, follow=True)
         user = get_user_model().objects.get(username=username)
 
@@ -353,26 +353,26 @@ def test_company_registration(django_user_model, client, allow_company_registrat
         assert reverse("shuup:registration_register") in response.url
     else:
         response = client.post(url, data={
-            'company-name': "Test company",
-            'company-name_ext': "test",
-            'company-tax_number': "12345",
-            'company-email': "test@example.com",
-            'company-phone': "123123",
-            'company-www': "",
-            'billing-street': "testa tesat",
-            'billing-street2': "",
-            'billing-postal_code': "12345",
-            'billing-city': "test test",
-            'billing-region': "",
-            'billing-region_code': "",
-            'billing-country': "FI",
-            'contact_person-first_name': "Test",
-            'contact_person-last_name': "Tester",
-            'contact_person-email': email,
-            'contact_person-phone': "123",
-            'user_account-username': username,
-            'user_account-password1': "password",
-            'user_account-password2': "password",
+            'registration_company-name': "Test company",
+            'registration_company-name_ext': "test",
+            'registration_company-tax_number': "12345",
+            'registration_company-email': "test@example.com",
+            'registration_company-phone': "123123",
+            'registration_company-www': "",
+            'registration_billing-street': "testa tesat",
+            'registration_billing-street2': "",
+            'registration_billing-postal_code': "12345",
+            'registration_billing-city': "test test",
+            'registration_billing-region': "",
+            'registration_billing-region_code': "",
+            'registration_billing-country': "FI",
+            'registration_contact_person-first_name': "Test",
+            'registration_contact_person-last_name': "Tester",
+            'registration_contact_person-email': email,
+            'registration_contact_person-phone': "123",
+            'registration_user_account-username': username,
+            'registration_user_account-password1': "password",
+            'registration_user_account-password2': "password",
         })
 
         user = django_user_model.objects.get(username=username)

--- a/shuup_tests/front/test_registration_multishop.py
+++ b/shuup_tests/front/test_registration_multishop.py
@@ -33,10 +33,10 @@ def test_registration_person_multiple_shops(django_user_model, client):
         email = "%s@shuup.local" % username
 
         client.post(reverse("shuup:registration_register"), data={
-            "username": username,
-            "email": email,
-            "password1": "password",
-            "password2": "password",
+            "registration-username": username,
+            "registration-email": email,
+            "registration-password1": "password",
+            "registration-password2": "password",
         }, HTTP_HOST="shop2.shuup.com")
 
         user = django_user_model.objects.get(username=username)
@@ -67,26 +67,26 @@ def test_registration_company_multiple_shops(django_user_model, client):
     ):
         url = reverse("shuup:registration_register_company")
         client.post(url, data={
-            'company-name': "Test company",
-            'company-name_ext': "test",
-            'company-tax_number': "12345",
-            'company-email': "test@example.com",
-            'company-phone': "123123",
-            'company-www': "",
-            'billing-street': "testa tesat",
-            'billing-street2': "",
-            'billing-postal_code': "12345",
-            'billing-city': "test test",
-            'billing-region': "",
-            'billing-region_code': "",
-            'billing-country': "FI",
-            'contact_person-first_name': "Test",
-            'contact_person-last_name': "Tester",
-            'contact_person-email': email,
-            'contact_person-phone': "123",
-            'user_account-username': username,
-            'user_account-password1': "password",
-            'user_account-password2': "password",
+            'registration_company-name': "Test company",
+            'registration_company-name_ext': "test",
+            'registration_company-tax_number': "12345",
+            'registration_company-email': "test@example.com",
+            'registration_company-phone': "123123",
+            'registration_company-www': "",
+            'registration_billing-street': "testa tesat",
+            'registration_billing-street2': "",
+            'registration_billing-postal_code': "12345",
+            'registration_billing-city': "test test",
+            'registration_billing-region': "",
+            'registration_billing-region_code': "",
+            'registration_billing-country': "FI",
+            'registration_contact_person-first_name': "Test",
+            'registration_contact_person-last_name': "Tester",
+            'registration_contact_person-email': email,
+            'registration_contact_person-phone': "123",
+            'registration_user_account-username': username,
+            'registration_user_account-password1': "password",
+            'registration_user_account-password2': "password",
         }, HTTP_HOST="shop1.shuup.com")
         user = django_user_model.objects.get(username=username)
         contact = PersonContact.objects.get(user=user)

--- a/shuup_tests/gdpr/test_forms.py
+++ b/shuup_tests/gdpr/test_forms.py
@@ -45,17 +45,17 @@ def test_authenticate_form(client):
 
     # user didn't check the privacy policy agreement
     response = client.post(reverse("shuup:login"), data={
-        "username": user.email,
-        "password": "1234",
+        "auth-username": user.email,
+        "auth-password": "1234",
         REDIRECT_FIELD_NAME: redirect_target
     })
     assert response.status_code == 200
     assert "You must accept to this to authenticate." in response.content.decode("utf-8")
 
     response = client.post(reverse("shuup:login"), data={
-        "username": user.email,
-        "password": "1234",
-        "accept_%d" % privacy_policy.id: "on",
+        "auth-username": user.email,
+        "auth-password": "1234",
+        "auth-accept_%d" % privacy_policy.id: "on",
         REDIRECT_FIELD_NAME: redirect_target
     })
     assert response.status_code == 302
@@ -80,21 +80,21 @@ def test_register_form(client):
 
     # user didn't checked the privacy policy agreement
     response = client.post(reverse("shuup:registration_register"), data={
-        "username": "user",
-        "email": "user@admin.com",
-        "password1": "1234",
-        "password2": "1234",
+        "registration-username": "user",
+        "registration-email": "user@admin.com",
+        "registration-password1": "1234",
+        "registration-password2": "1234",
         REDIRECT_FIELD_NAME: redirect_target
     })
     assert response.status_code == 200
     assert "You must accept to this to register." in response.content.decode("utf-8")
 
     response = client.post(reverse("shuup:registration_register"), data={
-        "username": "user",
-        "email": "user@admin.com",
-        "password1": "1234",
-        "password2": "1234",
-        "accept_%d" % privacy_policy.id: "on",
+        "registration-username": "user",
+        "registration-email": "user@admin.com",
+        "registration-password1": "1234",
+        "registration-password2": "1234",
+        "registration-accept_%d" % privacy_policy.id: "on",
         REDIRECT_FIELD_NAME: redirect_target
     })
     assert response.status_code == 302


### PR DESCRIPTION
Prevent duplicated form field ids when using quick login along with another registration or login form in the same template

No Refs