### PR TITLE
Front: add custom field ids format to prevent duplicates

### DIFF
--- a/shuup/front/apps/auth/views.py
+++ b/shuup/front/apps/auth/views.py
@@ -39,8 +39,14 @@ class LoginView(FormView):
         kwargs['request'] = self.request
         return kwargs
 
-    def get_form(self, form_class=None):
-        form = super(LoginView, self).get_form(form_class)
+    def get_form(self, form_class=None, id_prefix="auth"):
+        if form_class is None:
+            form_class = self.get_form_class()
+
+        kwargs = self.get_form_kwargs()
+        kwargs['auto_id'] = "id_{}_for_%s".format(id_prefix)
+
+        form = form_class(**kwargs)
         form.fields[REDIRECT_FIELD_NAME] = forms.CharField(
             widget=forms.HiddenInput,
             required=False,

--- a/shuup/front/apps/registration/views.py
+++ b/shuup/front/apps/registration/views.py
@@ -48,6 +48,7 @@ class RegistrationViewMixin(object):
     def get_form_kwargs(self):
         kwargs = super(RegistrationViewMixin, self).get_form_kwargs()
         kwargs["request"] = self.request
+        kwargs["auto_id"] = "id_registration_for_%s"
         return kwargs
 
     def register(self, form):

--- a/shuup/front/template_helpers/general.py
+++ b/shuup/front/template_helpers/general.py
@@ -28,9 +28,9 @@ from shuup.utils.mptt import get_cached_trees
 from shuup.utils.translation import cache_translations_for_tree
 
 
-def get_login_form(request):
+def get_login_form(request, id_prefix="quick-login"):
     # Getting the form from the Login view
-    form = cached_load("SHUUP_LOGIN_VIEW")(request=request).get_form()
+    form = cached_load("SHUUP_LOGIN_VIEW")(request=request).get_form(id_prefix=id_prefix)
     return form
 
 


### PR DESCRIPTION
When registration and login forms were in the same template, there could be fields id collision

No refs