### PR TITLE
Admin: Fix contact address form breaking on region copy

### DIFF
--- a/shuup/admin/templates/shuup/admin/contacts/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/contacts/edit.jinja
@@ -16,34 +16,62 @@
 {% endblock %}
 
 {% block extra_js %}
-<script>
-(function(){
-    var shouldCopyFields = false;
-
-    function copyFieldValue() {
-        if(!shouldCopyFields) {
-            return;
+<script type="text/javascript">
+    $(function(){
+        var shouldCopyFields = false;
+        function toggleAndCopyFields() {
+            shouldCopyFields = $("#billing-to-shipping").is(":checked");
+            if (shouldCopyFields) {
+                // copy all billing fields values to shipping fields
+                $(".billing-address :input").each(function (index, element) {
+                    copyFieldValue(this);
+                });
+            }
+            $(".shipping-address :input")
+                .attr("readonly", shouldCopyFields)
+                .toggleClass("disabled", shouldCopyFields)
+                .trigger("change");
+            // copy all billing fields values to shipping fields AGAIN
+            // this is required when region app is enabled
+            // as we can't guarantee the order fields are copied.
+            // the region code could be copied before the country and when country
+            // is changed, the region code field can be replaced by a select and
+            // have options created. this way, we should copy values
+            // before the `change` event trigged above and once again after
+            // all fields get changed
+            if (shouldCopyFields) {
+                $(".billing-address :input").each(function (index, element) {
+                    copyFieldValue(this);
+                });
+            }
         }
-        var targetName = $(this).attr("id").split("-")[1];
-        var $target = $("#id_shipping_address-"+targetName);
-        $target.val($(this).val());
-        if($target.is('select')) {
-            $target.select2().val($(this).select2().val())
+        function copyFieldValue(element) {
+            if(!shouldCopyFields || !element)
+                return;
+            var targetName = $(element).attr("id").split("-")[1];
+            var $target = $("#id_shipping_address-" + targetName);
+            $target.val(element.value);
+            $target.trigger("change");
         }
-    }
-
-    $('#billing-to-shipping').click(function(){
-        if($(this).is(':checked')){
-            shouldCopyFields = true;
-            $('.shipping-address :input').attr('readonly', true);
-            $('.billing-address :input').change();
-        } else {
-            shouldCopyFields = false;
-            $('.shipping-address :input').attr('readonly', false);
+        function activateCheckoutAddressCopy() {
+            $("#id_shipping-country").attr("readonly", true);
+            toggleAndCopyFields();
+            $("#billing :input").on("input change", function (evt) {
+                copyFieldValue(evt.target);
+            });
+            $("#billing-to-shipping").on("change", toggleAndCopyFields);
         }
+        activateCheckoutAddressCopy();
+        // we detectec that a field could be replaced by any other input
+        // in cases like regions module is injected
+        // this way, we must attach the event again
+        document.addEventListener("regionFieldInitialized", function (evt) {
+            if ($(evt.detail.field).attr("name").indexOf("billing") >= 0) {
+                $(evt.detail.field).on("input change", function (evt) {
+                    copyFieldValue(evt.target)
+                });
+            }
+        });
     });
-
-    $('.billing-address :input').on("input change", copyFieldValue);
-}());
 </script>
 {% endblock %}

--- a/shuup/admin/templates/shuup/admin/orders/_address_edit.jinja
+++ b/shuup/admin/templates/shuup/admin/orders/_address_edit.jinja
@@ -36,33 +36,63 @@
 {% endblock %}
 
 {% block extra_js %}
-<script>
-(function(){
-    var shouldCopyFields = false;
-
-    function copyFieldValue() {
-        if(!shouldCopyFields) {
-            return;
+<script type="text/javascript">
+    $(function(){
+        var shouldCopyFields = false;
+        function toggleAndCopyFields() {
+            shouldCopyFields = $("#billing-to-shipping").is(":checked");
+            if (shouldCopyFields) {
+                // copy all billing fields values to shipping fields
+                $(".billing-address :input").each(function (index, element) {
+                    copyFieldValue(this);
+                });
+            }
+            $(".shipping-address :input")
+                .attr("readonly", shouldCopyFields)
+                .toggleClass("disabled", shouldCopyFields)
+                .trigger("change");
+            // copy all billing fields values to shipping fields AGAIN
+            // this is required when region app is enabled
+            // as we can't guarantee the order fields are copied.
+            // the region code could be copied before the country and when country
+            // is changed, the region code field can be replaced by a select and
+            // have options created. this way, we should copy values
+            // before the `change` event trigged above and once again after
+            // all fields get changed
+            if (shouldCopyFields) {
+                $(".billing-address :input").each(function (index, element) {
+                    copyFieldValue(this);
+                });
+            }
         }
-        var targetName = $(this).attr("id").split("-")[1];
-        var $target = $("#id_shipping_address-"+targetName);
-        $target.val($(this).val());
-        if($target.is('select')) {
-            $target.select2().val($(this).select2().val())
+        function copyFieldValue(element) {
+            if(!shouldCopyFields || !element)
+                return;
+            var targetName = $(element).attr("id").split("-")[1];
+            var $target = $("#id_shipping_address-" + targetName);
+            $target.val(element.value);
+            $target.trigger("change");
         }
-    }
-
-    $('#billing-to-shipping').click(function(){
-        if($(this).is(':checked')){
-            shouldCopyFields = true;
-            $('.billing-address :input').change();
-        } else {
-            shouldCopyFields = false;
+        function activateCheckoutAddressCopy() {
+            $("#id_shipping-country").attr("readonly", true);
+            toggleAndCopyFields();
+            $("#billing :input").on("input change", function (evt) {
+                copyFieldValue(evt.target);
+            });
+            $("#billing-to-shipping").on("change", toggleAndCopyFields);
         }
+        activateCheckoutAddressCopy();
+        // we detectec that a field could be replaced by any other input
+        // in cases like regions module is injected
+        // this way, we must attach the event again
+        document.addEventListener("regionFieldInitialized", function (evt) {
+            if ($(evt.detail.field).attr("name").indexOf("billing") >= 0) {
+                $(evt.detail.field).on("input change", function (evt) {
+                    copyFieldValue(evt.target)
+                });
+            }
+        });
     });
-
-    $('.billing-address :input').on("input change", copyFieldValue);
-}());
 </script>
 {% endblock %}
 

--- a/shuup_tests/browser/admin/test_order_detail.py
+++ b/shuup_tests/browser/admin/test_order_detail.py
@@ -83,9 +83,9 @@ def change_addresses(live_server, browser, order):
     # Now update both same time
     browser.visit("%s%s" % (live_server, edit_url))
     wait_until_condition(browser, condition=lambda x: x.is_text_present(edit_address_title))
-    click_element(browser, "#billing-to-shipping")
     new_name = "%s (edited)" % order.billing_address.name
     browser.fill("billing_address-name", new_name)
+    click_element(browser, "#billing-to-shipping")
     click_element(browser, "button[form='edit-addresses']")
     check_log_entries_count(browser, order, order_edited_log_entries + 4)
     order.refresh_from_db()


### PR DESCRIPTION
Contact address form was breaking on copying billing address region to shipping address.
This prevents that.
Edited code from [checkout.jinja](https://github.com/shuup/shuup/blob/be28e6eeee099445842bd02b72e03664c0318451/shuup/front/templates/shuup/front/macros/checkout.jinja)  so that it works with admin.

Fixes #1921