### PR TITLE
Compute bought with

### DIFF
--- a/shuup/admin/templates/shuup/admin/base.jinja
+++ b/shuup/admin/templates/shuup/admin/base.jinja
@@ -11,13 +11,13 @@
         {% if request.GET.autoRefresh %}
             <meta http-equiv="refresh" content="{{ request.GET.autoRefresh }}"/>
         {% endif %}
-        <link href="{{ static("shuup_admin/img/favicon.ico") }}" rel="icon" type="image/x-icon">
-        <link href="{{ static("shuup_admin/css/base.css") }}" rel="stylesheet" type="text/css">
+        <link href="{{ shuup_static("shuup_admin/img/favicon.ico") }}" rel="icon" type="image/x-icon">
+        <link href="{{ shuup_static("shuup_admin/css/base.css") }}" rel="stylesheet" type="text/css">
         {% block extra_css %}{% endblock -%}
         {% block extra_head %}{% endblock -%}
         {% set conf = shuup_admin.get_config() %}
         <script>var ShuupAdminConfig = {{ conf|json }};</script>
-        <script type="text/javascript" src="{{ url("shuup_admin:js-catalog") }}?lang={{ LANGUAGE_CODE }}"></script>
+        <script type="text/javascript" src="{{ url("shuup_admin:js-catalog") }}?lang={{ LANGUAGE_CODE }}&v={{ get_shuup_version() }}"></script>
     </head>
     <body class="{% block body_class %}{% endblock %} {{ "popup" if request.GET.popup else "" }}{% if not conf["menuOpen"] %} desktop-menu-closed{% endif %}">
         {% if iframe_close %}
@@ -79,8 +79,8 @@
         {% endblock %}
         {% block post_content %}{% endblock %}
         {% endif %}
-        <script src="{{ static("shuup_admin/js/vendor.js") }}"></script>
-        <script src="{{ static("shuup_admin/js/base.js") }}"></script>
+        <script src="{{ shuup_static("shuup_admin/js/vendor.js") }}"></script>
+        <script src="{{ shuup_static("shuup_admin/js/base.js") }}"></script>
         {% block extra_js %}{% endblock %}
         {% if messages %}
         <script>

--- a/shuup/admin/templates/shuup/admin/base_picotable.jinja
+++ b/shuup/admin/templates/shuup/admin/base_picotable.jinja
@@ -14,5 +14,5 @@
     </div>
 {% endblock %}
 {% block extra_js %}
-<script src="{{ static("shuup_admin/js/picotable.js") }}"></script>
+<script src="{{ shuup_static("shuup_admin/js/picotable.js") }}"></script>
 {% endblock %}

--- a/shuup/admin/templates/shuup/admin/contact_groups/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/contact_groups/edit.jinja
@@ -15,5 +15,5 @@
 
 {% block extra_js %}
     {{ super() }}
-    <script src="{{ static("shuup_admin/js/contact-group.js") }}"></script>
+    <script src="{{ shuup_static("shuup_admin/js/contact-group.js") }}"></script>
 {% endblock %}

--- a/shuup/admin/templates/shuup/admin/dashboard/dashboard.jinja
+++ b/shuup/admin/templates/shuup/admin/dashboard/dashboard.jinja
@@ -110,7 +110,7 @@
 {% endblock %}
 
 {% block extra_js %}
-    <script src="{{ static("shuup_admin/js/dashboard.js") }}"></script>
+    <script src="{{ shuup_static("shuup_admin/js/dashboard.js") }}"></script>
     <script>
         (function(){
             window.tourConfig = {
@@ -130,5 +130,5 @@
     </script>
 {% endblock %}
 {% block extra_css %}
-    <link rel="stylesheet" href="{{ static("shuup_admin/css/dashboard.css") }}">
+    <link rel="stylesheet" href="{{ shuup_static("shuup_admin/css/dashboard.css") }}">
 {% endblock %}

--- a/shuup/admin/templates/shuup/admin/media/browser.jinja
+++ b/shuup/admin/templates/shuup/admin/media/browser.jinja
@@ -22,13 +22,13 @@
     <div id="BrowserView"></div>
 {% endblock %}
 {% block extra_js %}
-    <script src="{{ static("shuup_admin/js/media-browser.js") }}"></script>
+    <script src="{{ shuup_static("shuup_admin/js/media-browser.js") }}"></script>
     <script>
     window.MediaBrowser.init({{ browser_config|json }});
     window.MediaBrowser.setupUploadButton(document.getElementById("upload-button-wrapper"));
     </script>
 {% endblock %}
 {% block extra_css %}
-    <link rel="stylesheet" href="{{ static("shuup_admin/css/media-browser.css") }}">
+    <link rel="stylesheet" href="{{ shuup_static("shuup_admin/css/media-browser.css") }}">
     <style>body.popup .support-nav {padding:0;padding-bottom: 10px}</style>
 {% endblock %}

--- a/shuup/admin/templates/shuup/admin/orders/create.jinja
+++ b/shuup/admin/templates/shuup/admin/orders/create.jinja
@@ -8,6 +8,6 @@
 {% endblock %}
 
 {% block extra_js %}
-    <script src="{{ static("shuup_admin/js/order-creator.js") }}"></script>
+    <script src="{{ shuup_static("shuup_admin/js/order-creator.js") }}"></script>
     <script>window.OrderCreator.init({{ config|json }})</script>
 {% endblock %}

--- a/shuup/admin/templates/shuup/admin/products/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/products/edit.jinja
@@ -36,7 +36,7 @@
     {% endcall %}
 {% endblock %}
 {% block extra_js %}
-    <script src="{{ static("shuup_admin/js/product.js") }}"></script>
+    <script src="{{ shuup_static("shuup_admin/js/product.js") }}"></script>
     <script>
         function saveAsACopy(){
             $("#product_form").attr("action", "{{ url('shuup_admin:shop_product.new') }}").submit();

--- a/shuup/admin/templates/shuup/admin/products/variation/edit.jinja
+++ b/shuup/admin/templates/shuup/admin/products/variation/edit.jinja
@@ -25,7 +25,7 @@
 
 {% block extra_js %}
     {{ super() }}
-    <script src="{{ static("shuup_admin/js/product-variation-variable-editor.js") }}"></script>
+    <script src="{{ shuup_static("shuup_admin/js/product-variation-variable-editor.js") }}"></script>
 {% endblock %}
 {% block extra_css %}
     {{ super() }}

--- a/shuup/admin/templates/shuup/admin/wizard/wizard.jinja
+++ b/shuup/admin/templates/shuup/admin/wizard/wizard.jinja
@@ -4,7 +4,7 @@
     {% trans %}Welcome!{% endtrans %}
 {%- endblock %}
 {% block extra_css %}
-<link href="{{ static("shuup_admin/css/wizard.css") }}" rel="stylesheet" type="text/css">
+<link href="{{ shuup_static("shuup_admin/css/wizard.css") }}" rel="stylesheet" type="text/css">
 {% endblock %}
 {% block top %}{% endblock %}
 {% block support_content %}{% endblock %}
@@ -58,7 +58,7 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="{{ static("shuup_admin/js/wizard.js") }}"></script>
+<script src="{{ shuup_static("shuup_admin/js/wizard.js") }}"></script>
 <script>
     (function(){
         $($(".help-popover-btn .btn")[0]).append(" {% trans %}Click here for help{% endtrans %}")

--- a/shuup/core/templatetags/shuup_common.py
+++ b/shuup/core/templatetags/shuup_common.py
@@ -163,3 +163,15 @@ def get_global_configuration(name, default=None):
     """
     from shuup import configuration
     return configuration.get(None, name, default)
+
+
+@library.global_function
+def get_shuup_version():
+    from shuup import __version__
+    return __version__
+
+
+@library.global_function
+def shuup_static(path):
+    from shuup.core.utils.static import get_shuup_static_url
+    return get_shuup_static_url(path)

--- a/shuup/core/utils/static.py
+++ b/shuup/core/utils/static.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+def get_shuup_static_url(path):
+    from django.contrib.staticfiles.templatetags.staticfiles import static
+    from shuup import __version__
+    return "%s?v=%s" % (static(path), __version__)

--- a/shuup/front/apps/recently_viewed_products/plugins.py
+++ b/shuup/front/apps/recently_viewed_products/plugins.py
@@ -4,10 +4,10 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from shuup.core.models import Product
+from shuup.core.utils.static import get_shuup_static_url
 from shuup.xtheme import TemplatedPlugin
 from shuup.xtheme.resources import add_resource
 
@@ -34,4 +34,4 @@ def add_resources(context, content):
         return
     view_name = getattr(view_class, "__name__", "")
     if view_name == "ProductDetailView":
-        add_resource(context, "body_end", "%sshuup/recently_viewed_products/lib.js" % settings.STATIC_URL)
+        add_resource(context, "body_end", get_shuup_static_url("shuup/recently_viewed_products/lib.js"))

--- a/shuup/front/templates/shuup/front/base.jinja
+++ b/shuup/front/templates/shuup/front/base.jinja
@@ -24,14 +24,14 @@
     {# Include Fonts #}
     {# Include Styles #}
     {% if xtheme.get("stylesheet") %}
-        <link rel="stylesheet" href="{{ STATIC_URL }}{{ xtheme.get("stylesheet") }}">
+        <link rel="stylesheet" href="{{ shuup_static(xtheme.get('stylesheet')) }}">
     {% else %}
-        <link rel="stylesheet" href="{{ static("shuup/front/css/style.css") }}">
+        <link rel="stylesheet" href="{{ shuup_static("shuup/front/css/style.css") }}">
     {% endif %}
     {% if shuup.general.is_shop_admin() %}
-        <script type="text/javascript" src="{{ url("shuup_admin:js-catalog") }}?lang={{ LANGUAGE_CODE }}"></script>
+        <script type="text/javascript" src="{{ url("shuup_admin:js-catalog") }}?lang={{ LANGUAGE_CODE }}&v={{ get_shuup_version() }}"></script>
     {% endif %}
-    <script type="text/javascript" src="{{ url("shuup:js-catalog") }}?lang={{ LANGUAGE_CODE }}"></script>
+    <script type="text/javascript" src="{{ url("shuup:js-catalog") }}?lang={{ LANGUAGE_CODE }}&v={{ get_shuup_version() }}"></script>
 </head>
 <body {% if shuup.general.is_shop_admin() %} class="admin-tools-visible" {% endif %}>
     {{ macros.render_admin_tools() }}
@@ -61,8 +61,8 @@
     {{ render_footer() }}
 
     {# Include JavaScript libraries #}
-    <script src="{{ static("shuup/front/js/vendor.js") }}"></script>
-    <script src="{{ static("shuup/front/js/scripts.js") }}"></script>
+    <script src="{{ shuup_static("shuup/front/js/vendor.js") }}"></script>
+    <script src="{{ shuup_static("shuup/front/js/scripts.js") }}"></script>
     {# Include all Extra JavaScript #}
     {% block extrajs %}{% endblock %}
     {# Enable adding products to basket with ajax #}

--- a/shuup/front/templates/shuup/front/errors/404.jinja
+++ b/shuup/front/templates/shuup/front/errors/404.jinja
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/x-icon" href="{{ STATIC_URL }}shuup/front/img/favicon.ico">
-    <link rel="stylesheet" href="{{ static("shuup/front/css/style.css") }}">
+    <link rel="stylesheet" href="{{ shuup_static("shuup/front/css/style.css") }}">
     <title>{{ _("Page Not Found") }} (404)</title>
     <style>
         body {

--- a/shuup/front/templates/shuup/front/errors/500.jinja
+++ b/shuup/front/templates/shuup/front/errors/500.jinja
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/x-icon" href="{{ STATIC_URL }}shuup/front/img/favicon.ico">
-    <link rel="stylesheet" href="{{ static("shuup/front/css/style.css") }}">
+    <link rel="stylesheet" href="{{ shuup_static("shuup/front/css/style.css") }}">
     <title>{% trans %}Internal Server Error{% endtrans %} (500)</title>
     <style>
         body {

--- a/shuup/front/templates/shuup/front/index.jinja
+++ b/shuup/front/templates/shuup/front/index.jinja
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" type="image/x-icon" href="{{ static("img/shuup.ico") }}">
-    <link rel="stylesheet" href="{{ static("shuup/front/css/style.css") }}">
+    <link rel="stylesheet" href="{{ shuup_static("shuup/front/css/style.css") }}">
     <title>{% trans %}Welcome to Shuup!{% endtrans %}</title>
     <style>
         h1 {

--- a/shuup/front/templates/shuup/front/macros/product_ordering.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_ordering.jinja
@@ -10,6 +10,7 @@
     {% if not quantity %}
         {%- set quantity = shop_product.rounded_minimum_purchase_quantity -%}
     {% endif %}
+
     <div id="product-price-section">
         {% if request.is_ajax() %}
             <script type="text/javascript">
@@ -69,7 +70,6 @@
     {% else %}
         {%- set product_id = shop_product.product.pk -%}
     {% endif %}
-
     <input type="hidden" name="command" value="add_var">
     <input type="hidden" name="product_id" id="product_id" value="{{ shop_product.product.id }}">
     <div class="product-variations">

--- a/shuup/front/templates/shuup/front/maintenance.jinja
+++ b/shuup/front/templates/shuup/front/maintenance.jinja
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" type="image/x-icon" href="{{ static("img/shuup.ico") }}">
-    <link rel="stylesheet" href="{{ static("shuup/front/css/style.css") }}">
+    <link rel="stylesheet" href="{{ shuup_static("shuup/front/css/style.css") }}">
 
     <title>{% trans %}Maintenance mode{% endtrans %}</title>
     <style>

--- a/shuup/gdpr/resources.py
+++ b/shuup/gdpr/resources.py
@@ -7,10 +7,10 @@
 # LICENSE file in the root directory of this source tree.
 from django.conf import settings
 from django.template import loader
-from django.templatetags.static import static
 from rest_framework.reverse import reverse
 
 from shuup.core.shop_provider import get_shop
+from shuup.core.utils.static import get_shuup_static_url
 from shuup.gdpr.models import GDPRCookieCategory, GDPRSettings
 from shuup.gdpr.utils import (
     get_active_consent_pages, get_privacy_policy_page,
@@ -51,7 +51,7 @@ def add_gdpr_consent_resources(context, content):
         return
 
     # always add styles
-    add_resource(context, "head_end", static("shuup-gdpr.css"))
+    add_resource(context, "head_end", get_shuup_static_url("shuup-gdpr.css"))
 
     user = request.user
     if not user.is_anonymous() and should_reconsent_privacy_policy(shop, user):
@@ -86,4 +86,4 @@ def add_gdpr_consent_resources(context, content):
         loader.render_to_string("shuup/gdpr/gdpr_consent.jinja", context=render_context)
     )
     add_resource(context, "body_end", html_resource)
-    add_resource(context, "body_end", static("shuup-gdpr.js"))
+    add_resource(context, "body_end", get_shuup_static_url("shuup-gdpr.js"))

--- a/shuup/notify/templates/notify/admin/script_content_editor.jinja
+++ b/shuup/notify/templates/notify/admin/script_content_editor.jinja
@@ -23,11 +23,11 @@
 {% endblock %}
 
 {% block extra_css %}
-<link href="{{ static("notify/admin/script-editor.css") }}" rel="stylesheet" type="text/css">
+<link href="{{ shuup_static("notify/admin/script-editor.css") }}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block extra_js %}
-<script src="{{ static("notify/admin/script-editor.js") }}"></script>
+<script src="{{ shuup_static("notify/admin/script-editor.js") }}"></script>
 <script>
 window.ScriptEditor.init({
     eventIdentifier: {{ script.event_class.identifier|json }},

--- a/shuup/notify/templates/notify/admin/script_item_editor.jinja
+++ b/shuup/notify/templates/notify/admin/script_item_editor.jinja
@@ -161,5 +161,5 @@
             window.parent.postMessage({{ post_message|json }}, "*");
         </script>
     {% endif %}
-    <script src="{{ static("notify/admin/script-item-editor.js") }}"></script>
+    <script src="{{ shuup_static("notify/admin/script-item-editor.js") }}"></script>
 {% endblock %}

--- a/shuup/order_printouts/templates/shuup/order_printouts/admin/order_base.jinja
+++ b/shuup/order_printouts/templates/shuup/order_printouts/admin/order_base.jinja
@@ -2,7 +2,7 @@
 <html>
 <head>
     {% if html_mode %}
-        <link rel="stylesheet" href="{{ static('order_printouts/css/extra.css') }}">
+        <link rel="stylesheet" href="{{ shuup_static('order_printouts/css/extra.css') }}">
     {% endif %}
     <style>
         @page {

--- a/shuup/regions/resources.py
+++ b/shuup/regions/resources.py
@@ -5,10 +5,8 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.templatetags.static import static
-
+from shuup.core.utils.static import get_shuup_static_url
 from shuup.xtheme.resources import add_resource, InlineScriptResource
-
 
 INITIALIZE_FIELDS_FUNCTION = """
 window.initializeRegionFields('%(country_code_field)s', '%(region_code_field)s', '%(region_field)s');
@@ -34,7 +32,7 @@ def add_front_resources(context, content):
 
     # For front
     if view_name in ["CheckoutMethodPhase", "CompanyRegistrationView", "CustomerEditView", "CompanyEditView"]:
-        add_resource(context, "body_end", static("shuup-regions.js"))
+        add_resource(context, "body_end", get_shuup_static_url("shuup-regions.js"))
         add_init_fields_resource(context, "#id_billing-country", "#id_billing-region_code", "#id_billing-region")
         add_init_fields_resource(context, "#id_shipping-country", "#id_shipping-region_code", "#id_shipping-region")
 
@@ -47,7 +45,7 @@ def add_front_resources(context, content):
         if request and request.is_ajax():
             placement = "content_end"
 
-        add_resource(context, placement, static("shuup-regions.js"))
+        add_resource(context, placement, get_shuup_static_url("shuup-regions.js"))
         add_init_fields_resource(
             context,
             "#id_billing-country",
@@ -65,7 +63,7 @@ def add_front_resources(context, content):
 
     # For admin views
     elif view_name in ["ContactEditView", "OrderAddressEditView"]:
-        add_resource(context, "body_end", static("shuup-regions.js"))
+        add_resource(context, "body_end", get_shuup_static_url("shuup-regions.js"))
         add_init_fields_resource(
             context,
             "#id_billing_address-country",
@@ -81,8 +79,8 @@ def add_front_resources(context, content):
 
     # For admin order editor only regions is enough
     elif view_name == "OrderEditView":
-        add_resource(context, "body_end", static("shuup-regions.js"))
+        add_resource(context, "body_end", get_shuup_static_url("shuup-regions.js"))
 
     elif view_name in ["AddressBookEditView", "WizardView", "ShopEditView", "SupplierEditView"]:
-        add_resource(context, "body_end", static("shuup-regions.js"))
+        add_resource(context, "body_end", get_shuup_static_url("shuup-regions.js"))
         add_init_fields_resource(context, "#id_address-country", "#id_address-region_code", "#id_address-region")

--- a/shuup/simple_supplier/templates/shuup/simple_supplier/admin/base_picotable.jinja
+++ b/shuup/simple_supplier/templates/shuup/simple_supplier/admin/base_picotable.jinja
@@ -2,6 +2,6 @@
 {% from "shuup/simple_supplier/admin/macros.jinja" import render_scripts %}
 
 {% block extra_js %}
-    <script src="{{ static('shuup_admin/js/picotable.js') }}"></script>
+    <script src="{{ shuup_static('shuup_admin/js/picotable.js') }}"></script>
     {{ render_scripts() }}
 {% endblock %}

--- a/shuup/xtheme/editing.py
+++ b/shuup/xtheme/editing.py
@@ -5,12 +5,12 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.urlresolvers import NoReverseMatch, reverse
 from django.middleware.csrf import get_token
 
 from shuup.front.utils.user import is_admin_user
 from shuup.xtheme.resources import add_resource, InlineScriptResource
+from shuup.core.utils.static import get_shuup_static_url
 
 from ._theme import get_current_theme
 
@@ -112,5 +112,5 @@ def add_edit_resources(context):
         "edit": is_edit_mode(request),
         "csrfToken": get_token(request),
     }))
-    add_resource(context, "head_end", staticfiles_storage.url("xtheme/editor-injection.css"))
-    add_resource(context, "body_end", staticfiles_storage.url("xtheme/editor-injection.js"))
+    add_resource(context, "head_end", get_shuup_static_url("xtheme/editor-injection.css"))
+    add_resource(context, "body_end", get_shuup_static_url("xtheme/editor-injection.js"))

--- a/shuup/xtheme/plugins/products.py
+++ b/shuup/xtheme/plugins/products.py
@@ -89,6 +89,11 @@ class ProductCrossSellsPlugin(TemplatedPlugin):
         ("title", TranslatableField(label=_("Title"), required=False, initial="")),
         ("type", ProductCrossSell.type.field.formfield()),
         ("count", forms.IntegerField(label=_("Count"), min_value=1, initial=4)),
+        ("use_variation_parents", forms.BooleanField(
+            label=_("Show variation parents"),
+            help_text=_("Render variation parents instead of the children."),
+            initial=False, required=False
+        )),
         ("orderable_only", forms.BooleanField(
             label=_("Only show in-stock and orderable items"),
             initial=True, required=False,
@@ -122,6 +127,7 @@ class ProductCrossSellsPlugin(TemplatedPlugin):
         return {
             "request": context["request"],
             "title": self.get_translated_value("title"),
+            "use_variation_parents": self.config.get("use_variation_parents", False),
             "product": product,
             "type": type,
             "count": count,

--- a/shuup/xtheme/resources.py
+++ b/shuup/xtheme/resources.py
@@ -7,6 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 
+import os
 import re
 from logging import getLogger
 
@@ -206,12 +207,14 @@ class ResourceContainer(object):
 
         resource = force_text(resource)
 
-        # TODO: should this be extensible?
+        from six.moves.urllib.parse import urlparse
+        file_path = urlparse(resource)
+        file_name = os.path.basename(file_path.path)
 
-        if resource.endswith(".js"):
+        if file_name.endswith(".js"):
             return "<script%s></script>" % get_html_attrs({"src": resource})
 
-        if resource.endswith(".css"):
+        if file_name.endswith(".css"):
             return "<link%s>" % get_html_attrs({"href": resource, "rel": "stylesheet"})
 
         return "<!-- (unknown resource type: %s) -->" % escape(resource)

--- a/shuup/xtheme/templates/shuup/xtheme/admin/config_detail.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/admin/config_detail.jinja
@@ -74,13 +74,13 @@
     {% endcall %}
 {% endblock %}
 {% block extra_css %}
-    <link rel="stylesheet" href="{{ static("xtheme/admin/xtheme_admin.css") }}">
+    <link rel="stylesheet" href="{{ shuup_static("xtheme/admin/xtheme_admin.css") }}">
     {% if theme.extra_config_extra_css %}
         {% include theme.extra_config_extra_css %}
     {% endif %}
 {% endblock %}
 {% block extra_js %}
-    <script src="{{ static("xtheme/admin/script.js") }}"></script>
+    <script src="{{ shuup_static("xtheme/admin/script.js") }}"></script>
     {% if theme.extra_config_extra_js %}
         {% include theme.extra_config_extra_js %}
     {% endif %}

--- a/shuup/xtheme/templates/shuup/xtheme/admin/snippet_edit.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/admin/snippet_edit.jinja
@@ -5,9 +5,9 @@
 {% endblock %}
 
 {% block extra_css %}
-<link rel="stylesheet" href="{{ static("xtheme/admin/snippet.css") }}">
+<link rel="stylesheet" href="{{ shuup_static("xtheme/admin/snippet.css") }}">
 {% endblock %}
 
 {% block extra_js %}
-<script src="{{ static("xtheme/admin/snippet.js") }}"></script>
+<script src="{{ shuup_static("xtheme/admin/snippet.js") }}"></script>
 {% endblock %}

--- a/shuup/xtheme/templates/shuup/xtheme/admin/wizard.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/admin/wizard.jinja
@@ -81,5 +81,5 @@ function chooseStyle(event, button) {
 
 </script>
 {% block extra_css %}
-    <link rel="stylesheet" href="{{ static("xtheme/admin/xtheme_admin.css") }}">
+    <link rel="stylesheet" href="{{ shuup_static("xtheme/admin/xtheme_admin.css") }}">
 {% endblock %}

--- a/shuup/xtheme/templates/shuup/xtheme/editor.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/editor.jinja
@@ -2,12 +2,12 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <link rel="stylesheet" href="{{ static("xtheme/editor.css") }}">
+    <link rel="stylesheet" href="{{ shuup_static("xtheme/editor.css") }}">
     <script>var CSRF_TOKEN = "{{ csrf_token_str }}";</script>
     <script>var ShuupAdminConfig = {{ shuup_admin.get_config()|json }};</script>
-    <script type="text/javascript" src="{{ url("shuup_admin:js-catalog") }}"></script>
-    <script src="{{ static('xtheme/vendor.js') }}"></script>
-    <script src="{{ static('xtheme/editor.js') }}"></script>
+    <script type="text/javascript" src="{{ url("shuup_admin:js-catalog") }}?v={{ get_shuup_version() }}"></script>
+    <script src="{{ shuup_static('xtheme/vendor.js') }}"></script>
+    <script src="{{ shuup_static('xtheme/editor.js') }}"></script>
 </head>
 <body>
 <div id="window-toolbar">

--- a/shuup/xtheme/templates/shuup/xtheme/plugins/cross_sells_plugin.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/plugins/cross_sells_plugin.jinja
@@ -1,6 +1,7 @@
 {# This template requires shuup.front static resources to setup the carousel of products using owl-carousel #}
 {%- from "shuup/front/macros/product.jinja" import product_box with context -%}
-{%- set cross_sell_products = shuup.product.get_product_cross_sells(product, type, count=count, orderable_only=orderable_only) %}
+{%- set cross_sell_products = shuup.product.get_product_cross_sells(
+    product, type, count=count, orderable_only=orderable_only, use_variation_parents=use_variation_parents) %}
 {% if cross_sell_products %}
     <hr>
     <div class="product-cross-sells-plugin carousel-section"></section>

--- a/shuup_tests/core/test_compute_bought_with_relations.py
+++ b/shuup_tests/core/test_compute_bought_with_relations.py
@@ -69,7 +69,6 @@ def test_product_relations_max_quantity(rf):
     assert ProductCrossSell.objects.filter(weight=11).exists()
 
 
-
 def _init_test_with_variations():
     shop = get_default_shop()
     supplier = get_default_supplier()
@@ -101,7 +100,7 @@ def _init_test_with_variations():
     order = create_order_with_product(black_t_shirt, supplier, quantity=1, taxless_base_unit_price=6, shop=shop)
     add_product_to_order(order, supplier, black_hoodie, quantity=1, taxless_base_unit_price=6)
 
-    return black_t_shirt.variation_parent, black_hoodie.variation_parent
+    return black_t_shirt, black_hoodie
 
 
 @pytest.mark.django_db
@@ -119,7 +118,7 @@ def test_product_relations_variation_products(rf):
     add_bought_with_relations_for_product(hoodie.pk)
     assert ProductCrossSell.objects.count() == 2
 
-    # Hoodie should be related to t-shirt parent product
+    # Hoodie should be related to t-shirt product
     hoodie_relation = ProductCrossSell.objects.filter(product2=t_shirt).first()
     assert hoodie_relation
     assert hoodie_relation.product1 == hoodie


### PR DESCRIPTION
Relate products directly and render parents in cross-sell plugins when configured to
Refs MOOS-48

Also:

### Core: add custom template tag to render static source urls
The template tag adds the Shuup version as a suffix to burst caches
