### PR TITLE
Xtheme: Improve the test for rendering resources & Improve notify styles

### DIFF
--- a/shuup/notify/admin_module/forms.py
+++ b/shuup/notify/admin_module/forms.py
@@ -120,7 +120,7 @@ class ScriptItemEditForm(forms.Form):
                 if binding.accepts_any_type or binding.type.is_coercible_from(var.type)
             ]
             if variables:
-                choices = [("", "")] + variables
+                choices = [("", "---------")] + variables
                 field_name = "b_%s_v" % binding_identifier
                 self.fields[field_name] = forms.ChoiceField(
                     choices=choices,

--- a/shuup_tests/xtheme/test_resources.py
+++ b/shuup_tests/xtheme/test_resources.py
@@ -70,5 +70,7 @@ def test_jinja_resource():
     container.add_resource("body_end", JinjaMarkupResource("1+1={{ 1+1|float }}", context))
     container.add_resource("body_end", JinjaMarkupResource("{{ 1|thisdoesnwork }}", context))
     container.add_resource("body_end", JinjaMarkupResource("", context))
-
+    rendered_resource = container._render_resource("://example.com/js.js?random_text")
+    assert "unknown resource type" not in rendered_resource
+    assert rendered_resource == '<script src="://example.com/js.js?random_text"></script>'
     assert container.render_resources("body_end") == "1+1=2.0(Error while rendering)"


### PR DESCRIPTION
- Xtheme: Improve the test for rendering resources
Refs #1849

- Notify: Replace empty text in "Bind to variable" with lines
This makes the select field much cleaner & more visible. (Before after choosing something from select, empty value was barely visible)
Refs #1783



