### PR TITLE
Save and memorise options selected by the user

### DIFF
--- a/shuup/front/templates/shuup/front/macros/checkout.jinja
+++ b/shuup/front/templates/shuup/front/macros/checkout.jinja
@@ -277,8 +277,9 @@
         </div>
         <hr>
         <input type="hidden" name="product_ids" value="{{ product_ids }}" />
-        {{ render_field(form.marketing) }}
-
+        {% if form.marketing %}
+            {{ render_field(form.marketing) }}
+        {% endif %}
         {% for field in form %}
             {% if field.name.startswith("accept_") %}
                 {{ render_field(field) }}


### PR DESCRIPTION
### Front: only show marketing permissions check on the first checkout
Save a configuration for each customer inside the options field and make sure it is not asked on the checkout anymore

### GDPR: do not ask to consent documents already consented

Refs MYS-132