### PR TITLE
Front: improve front filters JS customisation

### DIFF
--- a/shuup/front/static_src/js/index.js
+++ b/shuup/front/static_src/js/index.js
@@ -14,3 +14,4 @@ import "./carousel.js";
 import "./product_preview.js";
 import "./update_price.js";
 import "./custom.js";
+import "./utils";

--- a/shuup/front/static_src/js/utils.js
+++ b/shuup/front/static_src/js/utils.js
@@ -1,0 +1,32 @@
+/**
+ * This file is part of Shuup.
+ *
+ * Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+ *
+ * This source code is licensed under the OSL-3.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// https://davidwalsh.name/javascript-debounce-function
+export const debounce = function(func, wait, immediate) {
+    let timeout;
+    return function () {
+        const context = this, args = arguments;
+        const later = function () {
+            timeout = null;
+            if (!immediate) {
+                func.apply(context, args);
+            }
+        };
+        const callNow = immediate && !timeout;
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+        if (callNow) {
+            func.apply(context, args);
+        }
+    };
+};
+// expose to the world
+window.ShuupToolbox = {
+    debounce
+};


### PR DESCRIPTION
Add the target of the scrolling after product list load into a global variable. This can be changed by 3rd party to control the scroll enabling it to even be disabled.

Add a custom event to warn when the product list is about to be loaded

Use jQuery .get() instead of .load() in ajax_content in order to be able to replace the DOM element with the content loaded

Move debounce to utils file and expose it to a global object