### PR TITLE
Core: use force_text in models __str__ method to make sure to return strings

### DIFF
--- a/shuup/core/models/_labels.py
+++ b/shuup/core/models/_labels.py
@@ -8,7 +8,7 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from django.utils.encoding import force_text, python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from parler.models import TranslatedFields
 
@@ -32,4 +32,4 @@ class Label(TranslatableShuupModel):
         verbose_name_plural = _('labels')
 
     def __str__(self):
-        return self.safe_translation_getter("name", default=self.identifier)
+        return force_text(self.safe_translation_getter("name", default=self.identifier))

--- a/shuup/core/models/_product_variation.py
+++ b/shuup/core/models/_product_variation.py
@@ -50,7 +50,7 @@ class ProductVariationVariable(TranslatableModel, SortableMixin):
         ordering = ('ordering', )
 
     def __str__(self):
-        return self.safe_translation_getter("name") or self.identifier or repr(self)
+        return force_text(self.safe_translation_getter("name") or self.identifier or repr(self))
 
 
 @python_2_unicode_compatible
@@ -70,7 +70,7 @@ class ProductVariationVariableValue(TranslatableModel, SortableMixin):
         ordering = ('ordering', )
 
     def __str__(self):
-        return self.safe_translation_getter("value") or self.identifier or repr(self)
+        return force_text(self.safe_translation_getter("value") or self.identifier or repr(self))
 
 
 class ProductVariationResult(models.Model):

--- a/shuup/core/models/_products.py
+++ b/shuup/core/models/_products.py
@@ -11,7 +11,7 @@ import six
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import Q
-from django.utils.encoding import python_2_unicode_compatible
+from django.utils.encoding import force_text, python_2_unicode_compatible
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 from enumfields import Enum, EnumIntegerField
@@ -128,7 +128,7 @@ class ProductType(TranslatableModel):
         verbose_name_plural = _('product types')
 
     def __str__(self):
-        return (self.safe_translation_getter("name") or self.identifier)
+        return force_text(self.safe_translation_getter("name") or self.identifier)
 
 
 class ProductQuerySet(TranslatableQuerySet):

--- a/shuup/core/models/_shops.py
+++ b/shuup/core/models/_shops.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from django.utils.encoding import force_text, python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from enumfields import Enum, EnumIntegerField
 from filer.fields.image import FilerImageField
@@ -124,7 +124,7 @@ class Shop(ChangeProtected, TranslatableShuupModel):
         verbose_name_plural = _('shops')
 
     def __str__(self):
-        return self.safe_translation_getter("name", default="Shop %d" % self.pk)
+        return force_text(self.safe_translation_getter("name", default="Shop %d" % self.pk))
 
     def create_price(self, value):
         """

--- a/shuup/core/models/_units.py
+++ b/shuup/core/models/_units.py
@@ -15,8 +15,8 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.utils.encoding import force_text, python_2_unicode_compatible
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import pgettext
+from django.utils.translation import ugettext_lazy as _
 from parler.models import (
     TranslatedField, TranslatedFields, TranslatedFieldsModel
 )
@@ -68,7 +68,7 @@ class SalesUnit(_ShortNameToSymbol, TranslatableShuupModel):
         verbose_name_plural = _('sales units')
 
     def __str__(self):
-        return self.safe_translation_getter("name", default=self.identifier) or ""
+        return force_text(self.safe_translation_getter("name", default=self.identifier) or "")
 
     @property
     def allow_fractions(self):


### PR DESCRIPTION
`__str__` should always return strings and when using `safe_translation_getter` it returns a `__proxy__` instead

No Refs