### PR TITLE
Notify: fix boolean test when a false constant is needed

### DIFF
--- a/shuup/notify/conditions/simple.py
+++ b/shuup/notify/conditions/simple.py
@@ -62,6 +62,15 @@ class CaseInsensitiveStringEqual(Condition):
         return (value1 == value2)
 
 
+class BooleanValuesEqual(Condition):
+    identifier_suffix = "equal"
+
+    def test(self, context):
+        value1 = bool(self.get_value(context, "v1"))
+        value2 = bool(self.get_value(context, "v2"))
+        return (value1 == value2)
+
+
 def construct_simple(base, var_type):
     identifier = "%s_%s" % (var_type.identifier, base.identifier_suffix)
     class_name = str(camel_case(identifier))
@@ -79,4 +88,4 @@ def construct_simple(base, var_type):
 LanguageEqual = construct_simple(CaseInsensitiveStringEqual, Language)
 TextEqual = construct_simple(CaseInsensitiveStringEqual, Text)
 IntegerEqual = construct_simple(BaseEqual, Integer)
-BooleanEqual = construct_simple(BaseEqual, Boolean)
+BooleanEqual = construct_simple(BooleanValuesEqual, Boolean)

--- a/shuup_tests/notify/test_conditions.py
+++ b/shuup_tests/notify/test_conditions.py
@@ -8,7 +8,7 @@
 from __future__ import unicode_literals
 
 from shuup.notify.conditions.simple import (
-    Empty, IntegerEqual, NonEmpty, TextEqual
+    Empty, IntegerEqual, NonEmpty, TextEqual, BooleanEqual
 )
 from shuup.notify.script import Context
 
@@ -42,3 +42,22 @@ def test_empty():
     assert ie.test(Context.from_variables(v=()))
     assert ie.test(Context.from_variables(v=0))
     assert not ie.test(Context.from_variables(v=6))
+
+
+def test_boolean():
+    ie = BooleanEqual({"v1": {"variable": "var1"}, "v2": {"variable": "var2"}})
+    assert ie.test(Context.from_variables(var1=False, var2=False))
+    assert ie.test(Context.from_variables(var1=False, var2=None))
+    assert ie.test(Context.from_variables(var1=True, var2=True))
+    assert not ie.test(Context.from_variables(var1=True, var2=False))
+    assert not ie.test(Context.from_variables(var1=False, var2=True))
+
+    ie = BooleanEqual({"v1": {"variable": "v"}, "v2": {"constant": None}})
+    assert ie.test(Context.from_variables(v=False))
+    assert ie.test(Context.from_variables(v=None))
+    assert not ie.test(Context.from_variables(v=True))
+
+    ie = BooleanEqual({"v1": {"variable": "v"}, "v2": {"constant": True}})
+    assert not ie.test(Context.from_variables(v=False))
+    assert not ie.test(Context.from_variables(v=None))
+    assert ie.test(Context.from_variables(v=True))


### PR DESCRIPTION
A False constant implies to be a None value as the checkbox is never checked.
Converting values to bool solves the issue

Refs HEAL-30