### PR TITLE
 Admin: add field and change widget to support multiple files upload

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,30 +1,24 @@
 include README.rst
 include LICENSE
 include VENDOR-LICENSES.md
-
 include tox.ini
 
-recursive-include shuup \
-    *.jinja *.txt *.js *.css *.json *.less *.map \
-    *.ico *.png *.svg *.jpg \
-    *.woff *.woff2 *.eot *.otf *.ttf *.po *.mo
-
+recursive-include shuup *.jinja *.txt *.po *.mo
 recursive-include shuup/default_importer *.xls *.xlsx *.csv
-
 recursive-include shuup_tests *.jinja
-
-# No extra extensions to include from shuup_workbench, but it will be
-# included still, since it's a Python package.
-# recursive-include shuup_workbench ...
-
-prune shuup/*/bower_components
-prune shuup/*/*/bower_components
-prune shuup/*/*/*/bower_components
-prune shuup/*/*/*/*/bower_components
-prune shuup/*/*/*/*/node_modules
-prune shuup/*/*/*/node_modules
-prune shuup/*/*/node_modules
-prune shuup/*/node_modules
-prune shuup/**/.cache
-
 recursive-include doc *.rst *.py *.LICENSE Makefile make.bat
+
+# Shuup static files
+recursive-include shuup/admin/static *
+recursive-include shuup/campaigns/static *
+recursive-include shuup/front/static *
+recursive-include shuup/front/apps/recently_viewed_products/static *
+recursive-include shuup/gdpr/static *
+recursive-include shuup/notify/static *
+recursive-include shuup/order_printouts/static *
+recursive-include shuup/regions/static *
+recursive-include shuup/simple_cms/static *
+recursive-include shuup/themes/classic_gray/static *
+recursive-include shuup/xtheme/static *
+
+prune shuup/**/.cache

--- a/shuup/admin/forms/fields.py
+++ b/shuup/admin/forms/fields.py
@@ -7,8 +7,10 @@
 from decimal import Decimal
 from numbers import Number
 
+import six
 from django.forms import (
-    DecimalField, Field, MultipleChoiceField, Select, SelectMultiple
+    DecimalField, Field, ModelMultipleChoiceField, MultipleChoiceField, Select,
+    SelectMultiple
 )
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
@@ -150,3 +152,22 @@ class WeekdayField(MultipleChoiceField):
 
     def clean(self, value):
         return ",".join(super(WeekdayField, self).clean(value))
+
+
+class ImageMultipleField(ModelMultipleChoiceField):
+    def __init__(self, queryset=None, required=True, widget=None,
+                 label=None, initial=None, help_text='', *args, **kwargs):
+
+        if not queryset:
+            from filer.models import Image
+            queryset = Image.objects.all()
+
+        super(ImageMultipleField, self).__init__(
+            queryset, required, widget, label, initial, help_text, *args, **kwargs
+        )
+
+    def prepare_value(self, value):
+        if (hasattr(value, '__iter__') and not isinstance(value, six.text_type) and not hasattr(value, '_meta')):
+            return [super(ImageMultipleField, self).prepare_value(v) for v in value if v]
+
+        return super(ImageMultipleField, self).prepare_value(value)

--- a/shuup/admin/forms/widgets.py
+++ b/shuup/admin/forms/widgets.py
@@ -206,7 +206,7 @@ class FileDnDUploaderWidget(Widget):
         )
 
     def value_from_datadict(self, data, files, name):
-        value = data.get(name)
+        value = data.get(name) or ""
 
         if self.multiple_mode:
             value = value.split(";")

--- a/shuup/testing/__init__.py
+++ b/shuup/testing/__init__.py
@@ -61,6 +61,9 @@ class ShuupTestingAppConfig(AppConfig):
         "pricing_module": [
             "shuup.testing.supplier_pricing.pricing:SupplierPricingModule"
         ],
+        "admin_shop_form_part": [
+            "shuup.testing.admin_module.form_parts.TestShopFormPart"
+        ]
     }
 
     def ready(self):

--- a/shuup/testing/admin_module/form_parts.py
+++ b/shuup/testing/admin_module/form_parts.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from shuup import configuration
+from shuup.admin.form_part import FormPart, TemplatedFormDef
+from shuup.admin.forms.fields import ImageMultipleField
+from shuup.admin.forms.widgets import FileDnDUploaderWidget
+
+
+class TestShopForm(forms.Form):
+    images = ImageMultipleField(
+        label=_("Multiple Images"),
+        required=False,
+        widget=FileDnDUploaderWidget(
+            kind="images",
+            upload_path="/Shop",
+            clearable=True,
+            max_files=5
+        )
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.shop = kwargs.pop("shop")
+        super(TestShopForm, self).__init__(*args, **kwargs)
+        self.fields["images"].initial = configuration.get(self.shop, "multiple_images_ids", [])
+
+    def save(self, *args, **kwargs):
+        images = [image.pk for image in self.cleaned_data.get("images", [])]
+        configuration.set(self.shop, "multiple_images_ids", images)
+
+
+class TestShopFormPart(FormPart):
+    priority = 90
+    name = "test_shop_form_part"
+
+    def get_form_defs(self):
+        yield TemplatedFormDef(
+            self.name,
+            form_class=TestShopForm,
+            template_name="shuup_testing/shuup/admin/test_form_part.jinja",
+            required=False,
+            kwargs={
+                "shop": self.object
+            }
+        )
+
+    def form_valid(self, form):
+        if form[self.name].has_changed():
+            form[self.name].save()

--- a/shuup/testing/templates/shuup_testing/shuup/admin/test_form_part.jinja
+++ b/shuup/testing/templates/shuup_testing/shuup/admin/test_form_part.jinja
@@ -1,0 +1,7 @@
+{% from "shuup/admin/macros/general.jinja" import content_block %}
+
+{% set shop_config_form = form[form_def.name] %}
+
+{% call content_block(_("Shop Extra Configuration"), "fa-info-circle") %}
+    {{ bs3.field(shop_config_form.images) }}
+{% endcall %}

--- a/shuup_tests/admin/test_shop_form_part.py
+++ b/shuup_tests/admin/test_shop_form_part.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2019, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from bs4 import BeautifulSoup
+
+from shuup import configuration
+from shuup.admin.modules.shops.views.edit import ShopEditView
+from shuup.testing import factories
+from shuup.testing.utils import apply_request_middleware
+
+
+@pytest.mark.django_db
+def test_multiple_images_shop_form_part(admin_user, rf):
+    shop = factories.get_default_shop()
+
+    get_request = apply_request_middleware(rf.get("/"), user=admin_user)
+    response = ShopEditView.as_view()(get_request, pk=shop.pk)
+    assert response.status_code == 200
+    response.render()
+    soup = BeautifulSoup(response.content)
+    assert soup.find_all("input", attrs={"id": "id_test_shop_form_part-images"})
+
+    # set inside shuup/testing/admin_module/form_parts.py
+    assert configuration.get(shop, "multiple_images_ids") is None
+
+    # save 3 images
+    image1 = factories.get_random_filer_image()
+    image2 = factories.get_random_filer_image()
+    image3 = factories.get_random_filer_image()
+
+    payload = {
+        "base-name__en": "Default",
+        "base-public_name__en": "Default",
+        "base-domain": "default.shuup.com",
+        "base-description__en": "",
+        "base-status": "1",
+        "base-currency": "EUR",
+        "base-staff_members": [],
+        "base-labels": [],
+        "address-country": [],
+        "translation_config-available_languages": "en",
+        "order_configuration-order_reference_number_length": "17",
+        "order_configuration-order_reference_number_prefix": "",
+        "test_shop_form_part-images": "{};{};{}".format(image1.pk, image2.pk, image3.pk)
+    }
+
+    post_request = apply_request_middleware(rf.post("/", data=payload), user=admin_user)
+    response = ShopEditView.as_view()(post_request, pk=shop.pk)
+    assert response.status_code == 302
+    response = ShopEditView.as_view()(get_request, pk=shop.pk)
+    assert response.status_code == 200
+    response.render()
+    soup = BeautifulSoup(response.content)
+    assert soup.find_all("input", attrs={"id": "id_test_shop_form_part-images"})[0].attrs["value"] == "{};{};{}".format(image1.pk, image2.pk, image3.pk)
+    assert configuration.get(shop, "multiple_images_ids") == [image1.pk, image2.pk, image3.pk]
+
+    # remove images
+    payload["test_shop_form_part-images"] = ""
+
+    post_request = apply_request_middleware(rf.post("/", data=payload), user=admin_user)
+    response = ShopEditView.as_view()(post_request, pk=shop.pk)
+    assert response.status_code == 302
+    response = ShopEditView.as_view()(get_request, pk=shop.pk)
+    assert response.status_code == 200
+    response.render()
+    soup = BeautifulSoup(response.content)
+    assert not soup.find_all("input", attrs={"id": "id_test_shop_form_part-images"})[0].attrs.get("value")
+    assert configuration.get(shop, "multiple_images_ids") == []

--- a/shuup_tests/admin/test_widgets.py
+++ b/shuup_tests/admin/test_widgets.py
@@ -43,6 +43,24 @@ def test_bound_file_dnd_uploader_widget():
     assert soup.select("[data-upload_path]")[0]["data-upload_path"] == "/test"
     assert soup.select("[data-dropzone]")[0]["data-dropzone"] == "true"
     assert soup.select("[data-kind]")[0]["data-kind"] == "foo"
-    assert soup.select("[data-id]")[0]["data-id"] == str(f.pk)
-    assert soup.select("[data-name]")[0]["data-name"] == f.name
-    assert not soup.select("[data-thumbnail]")
+    assert soup.select("[data-file0_id]")[0]["data-file0_id"] == str(f.pk)
+    assert soup.select("[data-file0_name]")[0]["data-file0_name"] == f.name
+    assert not soup.select("[data-file0_thumbnail]")
+
+    f2 = File.objects.create(name="file2")
+    widget_html = FileDnDUploaderWidget(upload_path="/test", kind="foo", max_files=2).render(
+        name="foo", value=[f.pk, f2.pk]
+    )
+    soup = BeautifulSoup(widget_html)
+    assert soup.select("#dropzone-dropzone"), "widget has id"
+    assert soup.select("input")[0]["name"] == "foo"
+    assert soup.select("input")[0]["value"] == str(f.pk) + ";" + str(f2.pk)
+    assert soup.select("[data-upload_path]")[0]["data-upload_path"] == "/test"
+    assert soup.select("[data-dropzone]")[0]["data-dropzone"] == "true"
+    assert soup.select("[data-kind]")[0]["data-kind"] == "foo"
+    assert soup.select("[data-file0_id]")[0]["data-file0_id"] == str(f.pk)
+    assert soup.select("[data-file0_name]")[0]["data-file0_name"] == f.name
+    assert not soup.select("[data-file0_thumbnail]")
+    assert soup.select("[data-file1_id]")[0]["data-file1_id"] == str(f2.pk)
+    assert soup.select("[data-file1_name]")[0]["data-file1_name"] == f2.name
+    assert not soup.select("[data-file1_thumbnail]")


### PR DESCRIPTION
When multiple files are added, the input value will be a list of ids separated by `;` that will be parsed by the widget when multiple files is enabled and converted into a list.

### General: add the entire static folder for each Shuup app
This makes the build a lot faster by including only the files that matter in the final package

Refs RO-24

# DO NOT MERGE :construction: 