### PR TITLE
Fix inactive users error

### DIFF
--- a/shuup/front/apps/auth/views.py
+++ b/shuup/front/apps/auth/views.py
@@ -56,7 +56,8 @@ class LoginView(FormView):
 
     def form_valid(self, form):
         user = form.get_user()
-        login(self.request, user)
+        if user is not None:
+            login(self.request, user)
         return super(LoginView, self).form_valid(form)
 
     def get_success_url(self):


### PR DESCRIPTION
Shuup has a bug of not displaying a correct error message to users that are inactive and are trying to log in either in the front login form or in the admin login form. This is due to the confirm_login_allowed function not being called in the form validation process when inactive user is trying to log in. Thus, the default invalid login error is displayed even for inactive users trying to log in.

This can be fixed by overriding the clean method in both front and admin auth forms and manually calling the confirm_login_allowed function in case the user trying to log in is inactive similar to this:
[https://stackoverflow.com/a/46459998](url)

In the front auth view we also need to check that the user exists to pass the unit test regarding invalid login. 