### PR TITLE
Back to user page after stop impersonating

### DIFF
--- a/shuup/front/views/misc.py
+++ b/shuup/front/views/misc.py
@@ -67,6 +67,7 @@ def stop_impersonating(request):
         return HttpResponseForbidden()
 
     impersonator_user_id = request.session["impersonator_user_id"]
+    auth_user_id = request.session["_auth_user_id"]
     del request.session["impersonator_user_id"]
     logout(request)
 
@@ -77,4 +78,4 @@ def stop_impersonating(request):
             break
 
     login(request, user)
-    return HttpResponseRedirect(reverse("shuup_admin:contact.list"))
+    return HttpResponseRedirect(reverse("shuup_admin:user.detail", args=[auth_user_id]))


### PR DESCRIPTION
Hey guys,

I saw you implemented new feature to back to super/staff_user after using 'Login as' function. This option is great and was waited by many users. Thanks.

After I tested this function on my dev workbench I found this nuance:
1) It back to /sa/contacts/ page after stop impersonating. But why contacts? From contacts or contact page we can't use 'Login as'. In this case better to redirect to /users/ page.
2) From my point of view, even better to redirect to user page, where 'Login as' was used. This was done in this commit.

So, commit changes will redirect user to /sa/users/user_id/ page, where 'Login as' was used. In other words, it will redirect to last super/staff_user page in /sa/ where user was before 'Login as'