### PR TITLE
Admin: fix issue with media dropzone (HEAL-47)

### DIFF
--- a/shuup/admin/static_src/base/js/dropzone.js
+++ b/shuup/admin/static_src/base/js/dropzone.js
@@ -17,7 +17,7 @@ function activateDropzone($dropzone, attrs={}) {
     const uploadPath = attrs.uploadPath || $data.upload_path;
     const addRemoveLinks = $data.add_remove_links;
     const uploadUrl = $data.upload_url || window.ShuupAdminConfig.browserUrls.media;
-    const browsable = ($data.browsable !== "False");
+    const browsable = ($data.browsable && $data.browsable !== "False");
     const params = $.extend(true, {
         url: uploadUrl + "?action=upload&path=" + uploadPath,
         uploadUrl,


### PR DESCRIPTION
When browse is not permitted the dropzone browse should open local filesystem instead.