### PR TITLE
Core: Set that contact group shop field can be empty

### DIFF
--- a/shuup/core/models/_contacts.py
+++ b/shuup/core/models/_contacts.py
@@ -115,8 +115,6 @@ class ContactGroup(TranslatableShuupModel):
         is_default = (self.identifier in PROTECTED_CONTACT_GROUP_IDENTIFIERS)
         if is_default and shop:
             raise ValidationError(_("Cannot set shop for default Contact Group."), code="contact_group_default_shop")
-        elif not is_default and not shop:
-            raise ValidationError(_("Contact Group requires a shop."), code="contact_group_no_shop")
 
     def save(self, **kwargs):
         self.clean()

--- a/shuup_tests/core/test_contact_groups.py
+++ b/shuup_tests/core/test_contact_groups.py
@@ -105,10 +105,6 @@ def test_plain_contact_group():
         ContactGroup.objects.create(identifier=AnonymousContact.default_contact_group_identifier, shop=shop)
         assert exc_info.value == "Cannot set shop for default Contact Group."
 
-    with pytest.raises(ValidationError) as exc_info:
-        ContactGroup.objects.create(identifier="derp")
-        assert exc_info.value == "Contact Group requires a shop."
-
     cg = ContactGroup.objects.create(identifier="test", shop=shop).set_price_display_options(hide_prices=True)
     assert isinstance(cg, ContactGroup)
 

--- a/shuup_tests/core/test_contacts.py
+++ b/shuup_tests/core/test_contacts.py
@@ -412,14 +412,6 @@ def test_cannot_add_shop(regular_user):
 
 
 @pytest.mark.django_db
-def test_cannot_add_without_shop(regular_user):
-    shop = get_default_shop()
-    with pytest.raises(ValidationError):
-        ContactGroup.objects.create(identifier="adsf")
-    ContactGroup.objects.create(identifier="adsf", shop=shop)
-
-
-@pytest.mark.django_db
 def test_price_displays(regular_user):
     shop = get_default_shop()
     cg = ContactGroup.objects.create(shop=shop).set_price_display_options(hide_prices=True)


### PR DESCRIPTION
Remove custom error that was being called upon Contact Group creation which was preventing
the shop field to be empty/null

Refs RO-42