### PR TITLE
Core: improve filtering for variation children

### DIFF
--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -418,7 +418,7 @@ class ShopProduct(MoneyPropped, TranslatableModel):
 
     def get_orderability_errors_for_simple_variation_parent(self, supplier, customer):
         sellable = False
-        for child_product in self.product.variation_children.all():
+        for child_product in self.product.variation_children.visible(shop=self.shop, customer=customer):
             try:
                 child_shop_product = child_product.get_shop_instance(self.shop)
             except ShopProduct.DoesNotExist:

--- a/shuup/front/template_helpers/product.py
+++ b/shuup/front/template_helpers/product.py
@@ -72,10 +72,11 @@ def get_product_cross_sells(
 
     # if this product is parent, then use all children instead
     if product.mode in [ProductMode.VARIABLE_VARIATION_PARENT, ProductMode.SIMPLE_VARIATION_PARENT]:
+        # Remember to exclude relations with the same parent
         cross_sell_products = ProductCrossSell.objects.filter(
-            product1__in=product.variation_children.all(),
+            product1__in=product.variation_children.visible(request.shop, customer=request.customer),
             type=rtype
-        ).exclude(product2__in=product.variation_children.all())    # exclude relations with the same parent
+        ).exclude(product2__in=product.variation_children.visible(request.shop, customer=request.customer))
     else:
         cross_sell_products = ProductCrossSell.objects.filter(product1=product, type=rtype)
 

--- a/shuup/front/templates/shuup/front/macros/product_ordering.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_ordering.jinja
@@ -41,7 +41,7 @@
 
         <div id="product-image-sections" class="hidden">
         {% if variation_variables or variation_children %}
-            {% for k in shop_product.product.variation_children.all() %}
+            {% for k in shop_product.product.variation_children.visible(request.shop, request.customer) %}
                 <div class="variation-image-section" id="variation-images-{{ k.id }}">
                     {% set product_images = k.get_shop_instance(request.shop).public_images.all() %}
                     {{ render_product_image_section(k, product_images=product_images) }}

--- a/shuup/front/utils/product.py
+++ b/shuup/front/utils/product.py
@@ -56,7 +56,9 @@ def get_product_context(request, product, language=None, supplier=None):   # noq
         context["variation_children"] = cache_product_things(
             request,
             sorted(
-                product.variation_children.language(language).all(),
+                product.variation_children.language(language).visible(
+                    shop=request.shop, customer=request.customer
+                ),
                 key=lambda p: get_string_sort_order(p.variation_name or p.name)
             )
         )


### PR DESCRIPTION
Some variation children is not available for all customers or pricing context meaning that with different shop or customer combinations might have different "cheapest price" for parent product. This also affects on orderability and few other situations.