### PR TITLE
Notify: make it possible to use from_email when sending emails

### DIFF
--- a/shuup/notify/actions/email.py
+++ b/shuup/notify/actions/email.py
@@ -36,6 +36,16 @@ class SendEmail(Action):
                                           initial=EMAIL_CONTENT_TYPE_CHOICES[0][0])
     }
 
+    from_email = Binding(
+        _("From email"),
+        type=Email,
+        constant_use=ConstantUse.VARIABLE_OR_CONSTANT,
+        required=False,
+        help_text=_(
+            'The from email to be used. It can either be binded to a variable or be a constant like '
+            'support@store.com or even "Store Support" <support@store.com>.'
+        )
+    )
     recipient = Binding(_("Recipient"), type=Email, constant_use=ConstantUse.VARIABLE_OR_CONSTANT, required=True)
     reply_to_address = Binding(_("Reply-To"), type=Email, constant_use=ConstantUse.VARIABLE_OR_CONSTANT)
     language = Binding(_("Language"), type=Language, constant_use=ConstantUse.VARIABLE_OR_CONSTANT, required=True)
@@ -91,8 +101,9 @@ class SendEmail(Action):
         reply_to = self.get_value(context, "reply_to_address")
         reply_to = [reply_to] if reply_to else None  # Push email to a list, unless it is None
 
+        from_email = self.get_value(context, "from_email") or None
         subject = " ".join(subject.splitlines())  # Email headers may not contain newlines
-        message = EmailMessage(subject=subject, body=body, to=[recipient], reply_to=reply_to)
+        message = EmailMessage(subject=subject, body=body, to=[recipient], reply_to=reply_to, from_email=from_email)
         message.content_subtype = content_type
         message.send()
         context.log(logging.INFO, "%s: Mail sent to %s :)", self.identifier, recipient)

--- a/shuup/notify/base.py
+++ b/shuup/notify/base.py
@@ -20,6 +20,7 @@ from shuup.notify.enums import (
     ConstantUse, TemplateUse, UNILINGUAL_TEMPLATE_LANGUAGE
 )
 from shuup.notify.template import render_in_context, Template
+from shuup.utils.importing import cached_load
 from shuup.utils.text import snake_case, space_case
 
 from .typology import Type
@@ -176,7 +177,7 @@ class Event(Base):
                 raise ValueError("Required variable %r missing for event %s" % (name, self.identifier))
 
     def run(self, shop):
-        from .runner import run_event
+        run_event = cached_load("SHUUP_NOTIFY_SCRIPT_RUNNER")
         run_event(event=self, shop=shop)
 
 

--- a/shuup/notify/settings.py
+++ b/shuup/notify/settings.py
@@ -5,3 +5,6 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+
+#: The method used to run scripts
+SHUUP_NOTIFY_SCRIPT_RUNNER = "shuup.notify.runner.run_event"

--- a/shuup_tests/notify/test_email.py
+++ b/shuup_tests/notify/test_email.py
@@ -29,6 +29,7 @@ def test_email_action():
     ctx.set("name", "Luke Warm")  # This variable isn't published by the event, but it's used by the template
     se = SendEmail({
         "template_data": TEST_TEMPLATE_DATA,
+        "from_email": {"constant": "from@shuup.local"},
         "recipient": {"constant": "someone@shuup.local"},
         "language": {"constant": "ja"},
         "send_identifier": {"constant": "hello, hello, hello"}
@@ -38,4 +39,5 @@ def test_email_action():
     assert len(mail.outbox) == 1  # 'send_identifier' should ensure this is true
     msg = mail.outbox[0]
     assert msg.to == ['someone@shuup.local']
+    assert msg.from_email == 'from@shuup.local'
     assert ctx.get("name").upper() in msg.subject  # The Japanese template upper-cases the name


### PR DESCRIPTION
Currently the SendMail action uses the default email address from
settings all the time.

Now it is possible to change the email's sender information

Refs REAL-42