### PR TITLE
Admin: add suppliers to product list by default

### DIFF
--- a/shuup/admin/modules/products/views/list.py
+++ b/shuup/admin/modules/products/views/list.py
@@ -7,6 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
@@ -17,6 +18,7 @@ from shuup.admin.utils.picotable import (
 )
 from shuup.admin.utils.views import PicotableListView
 from shuup.core.models import ProductMode, Shop, ShopProduct
+from shuup.utils.iterables import first
 
 
 class ProductPicotable(Picotable):
@@ -103,8 +105,33 @@ class ProductListView(PicotableListView):
     toolbar_buttons_provider_key = "product_list_toolbar_provider"
     mass_actions_provider_key = "product_list_mass_actions_provider"
 
+    def __init__(self):
+        def get_suppliers_column(iterable):
+            return first([col for col in iterable if col.id in ["suppliers", "shopproduct_suppliers"]], default=None)
+
+        def get_suppliers_filter():
+            return TextFilter(filter_field="suppliers__name", placeholder=_("Filter by supplier name..."))
+
+        if settings.SHUUP_ENABLE_MULTIPLE_SUPPLIERS and not get_suppliers_column(self.default_columns):
+            self.default_columns.append(
+                Column(
+                    "suppliers",
+                    _("Suppliers"),
+                    display="format_suppliers",
+                    ordering=8,
+                    filter_config=get_suppliers_filter(),
+                )
+            )
+        super(ProductListView, self).__init__()
+        suppliers_column = get_suppliers_column(self.columns)
+        if suppliers_column:
+            suppliers_column.filter_config = get_suppliers_filter()
+
     def format_categories(self, instance):
         return ", ".join(list(instance.categories.values_list("translations__name", flat=True)))
+
+    def format_suppliers(self, instance):
+        return ", ".join(list(instance.suppliers.values_list("name", flat=True)))
 
     def get_columns(self):
         for column in self.columns:

--- a/shuup_tests/admin/test_product_list_view.py
+++ b/shuup_tests/admin/test_product_list_view.py
@@ -9,8 +9,10 @@ import json
 
 import pytest
 
-from shuup.testing import factories
+from django.test import override_settings
 
+from shuup.core.settings import SHUUP_ENABLE_MULTIPLE_SUPPLIERS
+from shuup.testing import factories
 from shuup.testing.utils import apply_request_middleware
 from shuup.utils.importing import load
 
@@ -18,6 +20,7 @@ from shuup.utils.importing import load
 @pytest.mark.django_db
 def test_list_view(rf, admin_user):
     shop = factories.get_default_shop()
+
     product = factories.create_product(sku="test", shop=shop)
     shop_product = product.get_shop_instance(shop)
     shop_product.primary_category = factories.get_default_category()
@@ -35,3 +38,44 @@ def test_list_view(rf, admin_user):
     product_data = [item for item in data["items"] if item["_id"] == shop_product.pk][0]
     assert product_data["primary_category"] == factories.get_default_category().name
     assert product_data["categories"] == factories.get_default_category().name
+    assert product_data["categories"] == factories.get_default_category().name
+
+    # Suppliers not available by default since multiple suppliers is not enabled
+    assert "suppliers" not in product_data
+
+
+@pytest.mark.django_db
+def test_list_view_with_multiple_suppliers(rf, admin_user):
+    shop = factories.get_default_shop()
+
+    product = factories.create_product(sku="test", shop=shop)
+    shop_product = product.get_shop_instance(shop)
+    shop_product.primary_category = factories.get_default_category()
+    shop_product.save()
+    shop_product.categories.add(shop_product.primary_category)
+
+    # Also one product with supplier
+    supplier = factories.get_default_supplier()
+    product2 = factories.create_product(sku="test2", shop=shop, supplier=supplier)
+    shop_product2 = product2.get_shop_instance(shop)
+    shop_product2.primary_category = factories.get_default_category()
+    shop_product2.save()
+    shop_product2.categories.add(shop_product.primary_category)
+
+    with override_settings(SHUUP_ENABLE_MULTIPLE_SUPPLIERS=True):
+        view = load("shuup.admin.modules.products.views:ProductListView").as_view()
+        request = apply_request_middleware(rf.get("/", {
+            "jq": json.dumps({"perPage": 100, "page": 1})
+        }), user=admin_user)
+        response = view(request)
+        assert 200 <= response.status_code < 300
+
+        data = json.loads(response.content.decode("utf-8"))
+        product_data = [item for item in data["items"] if item["_id"] == shop_product.pk][0]
+        assert product_data["primary_category"] == factories.get_default_category().name
+        assert product_data["categories"] == factories.get_default_category().name
+        assert product_data["categories"] == factories.get_default_category().name
+        assert product_data["suppliers"] == ""
+
+        product_data2 = [item for item in data["items"] if item["_id"] == shop_product2.pk][0]
+        assert product_data2["suppliers"] == factories.get_default_supplier().name


### PR DESCRIPTION
When multiple suppliers are enabled add suppliers column to default column. Also ensure that when suppliers is used as column the filtering by name is also set for the column.