### PR TITLE
Admin: make the refund lines data be an object instead of an array

### DIFF
--- a/shuup/admin/modules/orders/views/refund.py
+++ b/shuup/admin/modules/orders/views/refund.py
@@ -99,7 +99,10 @@ class OrderCreateRefundView(UpdateView):
         lines = lines = self.object.lines.all()
         if supplier:
             lines = lines.filter(supplier=supplier)
-        context["json_line_data"] = [self._get_line_data(self.object, line) for line in lines]
+        context["json_line_data"] = {
+            line.ordering: self._get_line_data(self.object, line)
+            for line in lines
+        }
         return context
 
     def _get_line_data(self, order, line):


### PR DESCRIPTION
The object keys are the lines ordering and the value is the line data.

In cases when the line ordering didn't match the line data array index
the content was loaded incorrectly showing information of a different
line.

Making the line data be an object makes it possible to use the key to
directly access the data.

Refs REAL-39