### PR TITLE
Allow refunding all but refund lines

### DIFF
--- a/shuup/admin/modules/orders/views/refund.py
+++ b/shuup/admin/modules/orders/views/refund.py
@@ -157,11 +157,17 @@ class OrderCreateRefundView(UpdateView):
             line_number_choices += [("amount", _("Refund arbitrary amount"))]
         return line_number_choices + [
             (line.ordering, self._get_line_text(line)) for line in lines
-            if (line.type == OrderLineType.PRODUCT and line.max_refundable_quantity > 0) or
-            (line.type != OrderLineType.PRODUCT and
-             line.max_refundable_amount.value > 0 and
-             line.max_refundable_quantity > 0) and
-            line.type != OrderLineType.REFUND
+            if (
+                (
+                    (line.type == OrderLineType.PRODUCT and line.max_refundable_quantity > 0) or
+                    (
+                        line.type != OrderLineType.PRODUCT and
+                        line.max_refundable_amount.value > 0 and
+                        line.max_refundable_quantity > 0
+                    )
+                ) and
+                line.type != OrderLineType.REFUND
+            )
         ]
 
     def get_form(self, form_class=None):

--- a/shuup/core/models/_order_lines.py
+++ b/shuup/core/models/_order_lines.py
@@ -129,7 +129,7 @@ class AbstractOrderLine(MoneyPropped, models.Model, Priceful):
 
     @property
     def max_refundable_quantity(self):
-        if self.type != OrderLineType.PRODUCT:
+        if self.type == OrderLineType.REFUND:
             return 0
         return self.quantity - self.refunded_quantity
 

--- a/shuup_tests/admin/test_refund_creator.py
+++ b/shuup_tests/admin/test_refund_creator.py
@@ -8,16 +8,17 @@
 
 import pytest
 
+from bs4 import BeautifulSoup
 from django.test import override_settings
 from django.utils.text import force_text
 
 from shuup.admin.modules.orders.views.refund import (
     OrderCreateFullRefundView, OrderCreateRefundView
 )
-from shuup.core.models import OrderLineType
+from shuup.core.models import OrderLine, OrderLineType
 from shuup.testing.factories import (
-    create_order_with_product, create_product, get_default_shop,
-    get_default_supplier
+    add_product_to_order, create_empty_order, create_order_with_product,
+    create_product, get_default_shop, get_default_supplier
 )
 from shuup.testing.utils import apply_request_middleware
 
@@ -112,3 +113,51 @@ def test_arbitrary_refund_availability(rf, admin_user):
     assert refund_option_str in get_refund_view_content()
     with override_settings(SHUUP_ALLOW_ARBITRARY_REFUNDS=False):
         assert refund_option_str not in get_refund_view_content()
+
+
+@pytest.mark.django_db
+def test_order_refunds_with_other_lines(rf, admin_user):
+    shop = get_default_shop()
+    supplier = get_default_supplier()
+    supplier.shops.add(shop)
+
+    product = create_product("sku", shop=shop, default_price=10)
+    shop_product = product.get_shop_instance(shop=shop)
+    shop_product.suppliers = [supplier]
+
+    order = create_empty_order(shop=shop)
+    order.full_clean()
+    order.save()
+
+    add_product_to_order(order, supplier, product, 4, 5)
+
+    # Lines without quantity shouldn't affect refunds
+    other_line = OrderLine(
+        order=order, type=OrderLineType.OTHER, text="This random line for textual information", quantity=0)
+    other_line.save()
+    order.lines.add(other_line)
+
+    # Lines with quantity again should be able to be refunded normally.
+    other_line_with_quantity = OrderLine(
+        order=order, type=OrderLineType.OTHER, text="Special service 100$/h", quantity=1, base_unit_price_value=100)
+    other_line_with_quantity.save()
+    order.lines.add(other_line_with_quantity)
+
+    assert other_line_with_quantity.max_refundable_quantity == 1
+    assert other_line_with_quantity.max_refundable_amount.value == 100
+
+    order.cache_prices()
+    order.create_payment(order.taxful_total_price)
+    assert order.is_paid()
+    assert order.taxful_total_price_value == 120 # 100 + 4 * 20
+
+    def get_refund_view_content():
+        request = apply_request_middleware(rf.get("/"), user=admin_user)
+        view = OrderCreateRefundView.as_view()
+        response = view(request, pk=order.pk)
+        return BeautifulSoup(response.render().content)
+
+    refund_soup = get_refund_view_content()
+    refund_options = refund_soup.find(id="id_form-0-line_number").findAll("option")
+    assert len(refund_options) == 4  # 1 empty line, 1 for arbitrary and 2 for lines
+    assert len([option for option in refund_options if "Special service 100$/h" in force_text(option)]) == 1


### PR DESCRIPTION
Allow refunding all lines with value and quantity. There has to be option to refund shipping and payment methods as well as "other" lines as long as there is value and quantity available.