### PR TITLE
Notify: fix the email template variable name

### DIFF
--- a/shuup/notify/actions/email.py
+++ b/shuup/notify/actions/email.py
@@ -35,7 +35,7 @@ class SendEmail(Action):
             label=_("Body Template"),
             help_text=_(
                 "You can use this template to wrap the HTML body with your custom static template."
-                "Mark the spot for the HTML body with %(html_body)s."
+                "Mark the spot for the HTML body with %html_body%."
             ),
             widget=forms.Textarea()
         ),
@@ -105,8 +105,8 @@ class SendEmail(Action):
         body = strings.get("body")
         body_template = strings.get("body_template")
 
-        if body_template and "%(html_body)s" in body_template:
-            body = body_template % {"html_body": body}
+        if body_template and "%html_body%" in body_template:
+            body = body_template.replace("%html_body%", body)
 
         content_type = strings.get("content_type")
         if not (subject and body):

--- a/shuup/notify/settings.py
+++ b/shuup/notify/settings.py
@@ -8,3 +8,7 @@
 
 #: The method used to run scripts
 SHUUP_NOTIFY_SCRIPT_RUNNER = "shuup.notify.runner.run_event"
+
+
+#: The method used to return the render environment for tempaltes
+SHUUP_NOTIFY_TEMPLATE_ENVIRONMENT_PROVIDER = "shuup.notify.template.get_sandboxed_template_environment"

--- a/shuup_tests/notify/test_email.py
+++ b/shuup_tests/notify/test_email.py
@@ -52,7 +52,7 @@ def test_email_action_with_template_body():
             "en": {
                 # English
                 "subject": "Hello, {{ name }}!",
-                "body_template": "<html><style>.dog-color { color: red; }</style><body>%(html_body)s</body></html>",
+                "body_template": "<html><style>.dog-color { color: red; }</style><body>%html_body%</body></html>",
                 "body": "Hi, {{ name }}. This is a test.",
                 "content_type": "plain"
             }


### PR DESCRIPTION
Do not use any kind of string formatting as HTML can contains all sorts
of characters that make it impossible to format without a break.
Use the good old find/replace instead.

Also create environment provider method set through settings
In some cases one want to allow custom template tags for using while
rendering templates in notifications. Add a setting to set the
environment provider which can allow changing the `SandboxedEnvironment`
for anything else.

Refs REAL-20