### PR TITLE
Admin: allow to use custom file_transformer

### DIFF
--- a/shuup/importer/admin_module/import_views.py
+++ b/shuup/importer/admin_module/import_views.py
@@ -52,6 +52,8 @@ class ImportProcessView(TemplateView):
                 mode = "xlsx"
             if filename.endswith("csv"):
                 mode = "csv"
+            if self.importer_cls.custom_file_transformer:
+                return self.importer_cls.transform_file(mode, filename)
             return transform_file(mode, filename)
         except (Exception, RuntimeError) as e:
             messages.error(self.request, e)

--- a/shuup/importer/importing/importing.py
+++ b/shuup/importer/importing/importing.py
@@ -44,6 +44,7 @@ class DataImporter(object):
     meta_class_getter_name = "get_import_meta"
     meta_base_class = ImportMetaBase
     extra_matches = {}
+    custom_file_transformer = False
 
     unique_fields = {}
     unmatched_fields = set()
@@ -65,6 +66,13 @@ class DataImporter(object):
         self._meta = (meta_class(self, self.model) if meta_class else None)
 
         self.field_defaults = self._meta.get_import_defaults()
+
+    @classmethod
+    def transform_file(cls, mode, filename, data=None):
+        """
+        That method will be called if `cls.custom_file_transformer` is True
+        """
+        raise NotImplementedError("Implement `transform_file` function or set `custom_file_transformer` to False")
 
     def process_data(self):
         mapping = self.create_mapping()

--- a/shuup_tests/importer/test_product_import.py
+++ b/shuup_tests/importer/test_product_import.py
@@ -7,6 +7,7 @@
 import os
 from decimal import Decimal
 
+import mock
 import pytest
 from django.conf import settings
 from django.utils.encoding import force_text
@@ -17,6 +18,7 @@ from shuup.core.models import (
     Category, Manufacturer, MediaFile, Product, ShopProduct
 )
 from shuup.default_importer.importers import ProductImporter
+from shuup.importer.importing import DataImporter
 from shuup.importer.transforms import transform_file
 from shuup.importer.utils.importer import ImportMode
 from shuup.simple_supplier.models import StockAdjustment
@@ -471,3 +473,9 @@ def test_complex_import():
 
         if data.get("manufacturer"):
             assert product.manufacturer.name == data["manufacturer"]
+
+
+def test_custom_transform_file():
+    with mock.patch.object(DataImporter, "custom_file_transformer", True):
+        with pytest.raises(NotImplementedError):
+            DataImporter.transform_file("fake", "file name")


### PR DESCRIPTION
- set `custom_file_transformer` to True into your `DataImporter` if you want to use internal `transform_file` classmethod
- fixed slug field issue, it raised `Data too long for column 'slug'`