### PR TITLE
Implement a register-with-activation checkout phase [WIP]

### DIFF
--- a/shuup/front/checkout/checkout_method.py
+++ b/shuup/front/checkout/checkout_method.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext_lazy as _
 from enumfields import Enum
 
 from shuup.front.apps.auth.views import LoginView
-from shuup.front.apps.registration.views import RegistrationNoActivationView
+from shuup.front.apps.registration.views import RegistrationNoActivationView, RegistrationView
 from shuup.front.checkout import CheckoutPhaseViewMixin
 from shuup.utils.form_group import FormGroup
 
@@ -90,8 +90,7 @@ class CheckoutMethodPhase(CheckoutPhaseViewMixin, LoginView):
         return kwargs
 
 
-class RegisterPhase(CheckoutPhaseViewMixin, RegistrationNoActivationView):
-    identifier = "register"
+class RegisterPhaseMixin:
     title = _("Register")
     template_name = "shuup/front/checkout/register.jinja"
 
@@ -108,3 +107,11 @@ class RegisterPhase(CheckoutPhaseViewMixin, RegistrationNoActivationView):
 
     def process(self):
         return
+
+
+class RegisterPhase(RegisterPhaseMixin, CheckoutPhaseViewMixin, RegistrationNoActivationView):
+    identifier = "register"
+
+
+class RegisterWithActivationPhase(RegisterPhaseMixin, CheckoutPhaseViewMixin, RegistrationView):
+    identifier = "register_activate"


### PR DESCRIPTION
As noted in #2027, the registration within checkout is currently hard coded to simple registration without requiring activation of the account over email. In this pull request, I'm trying to work towards implementing an optional way to have a registration with mandatory activation during checkout. At this stage it is a work in progress - but I need some advice on how to move forward.

I have implemented an additional `RegisterWithActivationPhase` checkout phase (and a test for it *and* the regular `RegisterPhase`). At this stage the user is registered and the email with the activation link is sent.

It is also highly desirable to implement a continuation path of the checkout process after the user clicks the activation link. I was thinking about appending an optional `?next=` or `?continue=` parameter to the activation url generated in the [send_user_registered_notification()](https://github.com/shuup/shuup/blob/829dfaa4fec7ead2a4992016e5a7458a63233c1c/shuup/front/apps/registration/notify_events.py#L45) function if the registration took place during a checkout. This would probably mean adding an attribute to the `request` object in `RegiterWithActivationPhase` that gets passed to the `user_registered` signal and then to `send_user_registered_notification()`. Does this look like a reasonable way to implement it?