### PR TITLE
Admin: fix the product images management form part

### DIFF
--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -510,14 +510,22 @@ class ProductImageMediaFormSet(ProductMediaFormSet):
         In addition add the first saved image as primary image for the
         product if none is selected as such.
         """
+
         super(ProductImageMediaFormSet, self).save(commit)
 
-        has_primary = any(form.cleaned_data.get("is_primary") for form in (self.forms or []))
-        eligible_forms = [form for form in (self.forms or []) if
-                          (form.cleaned_data.get("file") and not form.cleaned_data.get("DELETE"))]
+        eligible_forms = [
+            form for form in (self.forms or [])
+            if (form.cleaned_data.get("file") and not form.cleaned_data.get("DELETE"))
+        ]
+        has_primary = any(form.cleaned_data.get("is_primary") for form in eligible_forms)
 
-        if eligible_forms and not has_primary and not self.forms[0].product.primary_image:
+        if eligible_forms and not has_primary:
             # make first form be the primary image as well
-            form_instance = self.forms[0]
+            form_instance = eligible_forms[0]
             form_instance.product.primary_image = form_instance.instance
             form_instance.product.save()
+
+        # removed all images, then, clear the primary image
+        if not eligible_forms and not has_primary:
+            self.product.primary_image = None
+            self.product.save()

--- a/shuup/admin/modules/products/views/edit_media.py
+++ b/shuup/admin/modules/products/views/edit_media.py
@@ -160,13 +160,28 @@ class ProductMediaBulkAdderView(View):
             if not File.objects.filter(id=file_id).exists():
                 return JsonResponse({"response": "error", "message": "invalid file id: %s" % file_id}, status=400)
 
+        added = []
+
         for file_id in ids:
             if not ProductMedia.objects.filter(
-                    product_id=shop_product.product_id, file_id=file_id, kind=kind, shops__in=[shop_id]).exists():
+                    product_id=shop_product.product_id,
+                    file_id=file_id,
+                    kind=kind,
+                    shops__in=[shop_id]).exists():
                 image = ProductMedia.objects.create(
                     product_id=shop_product.product_id,
                     file_id=file_id,
                     kind=kind,
                 )
                 image.shops.add(shop_id)
-        return JsonResponse({"response": "success", "message": force_text(_("Files added to product."))})
+                added.append({
+                    "product": image.product_id,
+                    "file": int(file_id),
+                    "kind": kind.value,
+                    "product_media": image.pk
+                })
+        return JsonResponse({
+            "response": "success",
+            "added": added,
+            "message": force_text(_("Files added to product."))
+        })

--- a/shuup/admin/templates/shuup/admin/products/_edit_media_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_media_form.jinja
@@ -7,7 +7,16 @@
         {{ h|safe }}
     {% endfor %}
     {%- set is_primary = f.is_primary.value() if is_image_form else None %}
-    <div class="panel{% if is_primary %} panel-selected{% else %} panel-default{% endif %} pt-4" data-prefix="{{ f.prefix }}">
+    <div
+        class="panel{% if is_primary %} panel-selected{% else %} panel-default{% endif %} pt-4"
+        data-prefix="{{ f.prefix }}"
+        data-idx="{{ idx }}"
+        {% if f.instance and f.instance.pk %}
+        data-media="{{ f.instance.pk }}"
+        {% else %}
+        data-file="__file_id__"
+        {% endif %}
+    >
         <div class="panel-heading d-flex align-items-center pb-1">
           <h4 class="panel-title mr-auto">
               {%- if is_image_form -%}


### PR DESCRIPTION
The main issue is that AJAX is used to add the files uploaded to the
current product media. It already generates the many-to-many relations
in the backend and the formset forms don't contain the ids of the
ProductMedia instances created.

To solve the issue, we return the ids of the ProductMedia created in the
backend and attach those to the hidden control inputs. Each ProductMedia
will have a corresponding hiden control input in the frontend.

This allows to set the primary image

Refs REAL-100 REAL-111
Fixes #1955