### PR TITLE
Fix z-index on the modal-dialog

### DIFF
--- a/shuup/admin/static_src/base/scss/shuup/custom-forms.scss
+++ b/shuup/admin/static_src/base/scss/shuup/custom-forms.scss
@@ -273,6 +273,9 @@ fieldset[disabled] .form-control {
      top: 0; left: 0; right: 0; bottom: 0;
      z-index: 10;
    }
+   .modal-dialog{
+       z-index: 10;
+   }
 }
 
 .template-modal-container {


### PR DESCRIPTION
modal-dialog elements are left under the modal-bg becuase of z-index
Fix this with giving the modal-dialog the same z-index value

refs SHU-35