### PR TITLE
Add tests around basket line extra data

### DIFF
--- a/shuup_tests/core/test_basket.py
+++ b/shuup_tests/core/test_basket.py
@@ -37,12 +37,15 @@ def test_set_customer_with_custom_basket_lines(rf):
 
         base_unit_price = basket.shop.create_price("10.99")
 
-        basket.add_line(text="Custom Line",
-                        type=OrderLineType.OTHER,
-                        line_id="random-you-know",
-                        shop=basket.shop,
-                        quantity=1,
-                        base_unit_price=base_unit_price)
+        basket.add_line(
+            text="Custom Line",
+            type=OrderLineType.OTHER,
+            line_id="random-you-know",
+            shop=basket.shop,
+            quantity=1,
+            base_unit_price=base_unit_price,
+            extra={"this is purely extra": "oh is it"}
+        )
 
         basket.customer = customer
         assert basket.customer_comment is None
@@ -57,6 +60,8 @@ def test_set_customer_with_custom_basket_lines(rf):
         assert basket.customer_comment == "Some comment"
         assert basket.shipping_method == shipping_method
         assert basket.payment_method == payment_method
+        assert len(basket.get_lines()) == 1
+        assert basket.get_lines()[0].data["extra"]["this is purely extra"] == "oh is it"
 
 
 @pytest.mark.django_db

--- a/shuup_tests/core/test_order_creator.py
+++ b/shuup_tests/core/test_order_creator.py
@@ -96,11 +96,16 @@ def test_order_creator(rf, admin_user):
         base_unit_price=source.create_price(10),
     )
     source.add_line(
+        accounting_identifier="strawberries",
         type=OrderLineType.OTHER,
         quantity=1,
         base_unit_price=source.create_price(10),
         require_verification=True,
+        extra={"runner": "runner"}
     )
+
+    the_line = [sl for sl in source.get_lines() if sl.accounting_identifier == "strawberries"]
+    assert the_line[0].data["extra"]["runner"] == "runner"
 
     creator = OrderCreator()
     order = creator.create_order(source)
@@ -116,6 +121,7 @@ def test_order_creator(rf, admin_user):
     assert source.payment_method == order.payment_method
     assert source.shipping_method == order.shipping_method
     assert order.pk
+    assert order.lines.filter(accounting_identifier="strawberries").first().extra_data["runner"] == "runner"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
I think also passing extra_data should work since that is what you might expect if you check the order line attribute for this. Now you need to find the order creator "hack" around this. Not sure if there is reason, but here is few extra tests to show current behavior around this.