### PR TITLE
Admin: add settings to make select2 fields to load data asynchronously

### DIFF
--- a/shuup/admin/forms/_quick_select.py
+++ b/shuup/admin/forms/_quick_select.py
@@ -14,8 +14,15 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 
+class NoModel(object):
+    def __nonzero__(self):
+        return False
+
+    __bool__ = __nonzero__
+
+
 class QuickAddRelatedObjectBaseMixin(object):
-    model = None
+    model = NoModel()
     url = None
 
     def __init__(self, attrs=None, choices=(), editable_model=None):
@@ -27,23 +34,31 @@ class QuickAddRelatedObjectBaseMixin(object):
 
 
 class QuickAddRelatedObjectSelectMixin(QuickAddRelatedObjectBaseMixin):
-    def __init__(self, attrs=None, choices=(), editable_model=None, initial=None):
+    def __init__(self, attrs=None, choices=(), editable_model=None, initial=None, model=None):
         """
         :param initial int: primary key of the object that is initially selected
         """
+        if model is not None:
+            self.model = model
+
         if self.model and initial:
             choices = [(initial.pk, force_text(initial))]
+
         super(QuickAddRelatedObjectSelectMixin, self).__init__(attrs, choices, editable_model)
 
 
 class QuickAddRelatedObjectMultipleSelectMixin(QuickAddRelatedObjectBaseMixin):
-    def __init__(self, attrs=None, choices=(), editable_model=None, initial=None):
+    def __init__(self, attrs=None, choices=(), editable_model=None, initial=None, model=None):
         """
         :param initial list[int]: list of primary keys of the objects that
             are initially selected
         """
+        if model is not None:
+            self.model = model
+
         if self.model and initial:
             choices = [(instance.pk, force_text(instance)) for instance in initial]
+
         super(QuickAddRelatedObjectMultipleSelectMixin, self).__init__(attrs, choices, editable_model)
 
 

--- a/shuup/admin/forms/quick_select.py
+++ b/shuup/admin/forms/quick_select.py
@@ -7,6 +7,8 @@
 # LICENSE file in the root directory of this source tree.
 import django
 
+from ._quick_select import NoModel
+
 if django.VERSION < (1, 11):
     from ._quick_select import (
         QuickAddRelatedObjectMultiSelectWithoutTemplate as QuickAddRelatedObjectMultiSelect,
@@ -19,6 +21,7 @@ else:
 
 
 __all__ = [
+    "NoModel",
     "QuickAddRelatedObjectMultiSelect",
     "QuickAddRelatedObjectSelect"
 ]

--- a/shuup/admin/settings.py
+++ b/shuup/admin/settings.py
@@ -72,3 +72,15 @@ SHUUP_ALWAYS_ACTIVE_MENU_CATEGORY_IDENTIFIERS = []
 #: for example for custom domain logic when admin panel is used
 #: from shared marketplace URL.
 SHUUP_ADMIN_NAVIGATION_GET_FRONT_URL_SPEC = ("shuup.admin.utils.urls.get_front_url")
+
+#: Indicates which objects select fields should load options asynchronously.
+#: When enabled, fields will load options through AJAX requests instead
+#: of generating them while rendering the page. For enviroments with huge amount of options
+#: in fields, like categories, it is best to have this enabled.
+#: When disabled, the options will be rendered on page load whenever it is possible, as
+#: in some features, the asynchronous load is not an option.
+#:
+SHUUP_ADMIN_LOAD_SELECT_OBJECTS_ASYNC = {
+    "categories": True,
+    "suppliers": True
+}

--- a/shuup/admin/static_src/base/js/select.js
+++ b/shuup/admin/static_src/base/js/select.js
@@ -17,11 +17,13 @@ export function activateSelect($select, model, searchMode, extraFilters = null, 
         $select.width("100%");
     }
 
-    if (model === undefined) {
-        return $select.select2(Object.assign({
+    if (!model) {
+        return $select.select2({
             language: "xx",
-        }, attrs));
+            ...attrs
+        });
     }
+
     return $select.select2(Object.assign({
         language: "xx",
         minimumInputLength: window.ShuupAdminConfig.settings.minSearchInputLength,

--- a/shuup/xtheme/static_src/editor/editor.js
+++ b/shuup/xtheme/static_src/editor/editor.js
@@ -26,14 +26,16 @@ function post(args) {
 }
 
 function activateSelect($select, model, searchMode, extraFilters = null, noExpand = false, attrs = {}) {
-    if (model === undefined) {
-        // for now, just select with models will be converted into select2
-        return;
-    }
-
     if (!noExpand) {
         // make sure to expand the select2 to use all the available space
         $select.width("100%");
+    }
+
+    if (!model) {
+        return $select.select2({
+            language: "xx",
+            ...attrs
+        });
     }
 
     return $select.select2(Object.assign({
@@ -73,7 +75,7 @@ function activateSelects() {
             const model = select.data("model");
             const searchMode = select.data("search-mode");
             const noExpand = select.data("no-expand");
-            activateSelect(select, model, searchMode, noExpand);
+            activateSelect(select, model, searchMode, noExpand, sync);
         }
     });
 }


### PR DESCRIPTION
It is a common request of merchants to have categories options loaded
asynchronously or on page load. To solve this issue we are introducing a
new setting `SHUUP_ADMIN_LOAD_SELECT_OBJECTS_ASYNC` that can be adjusted
per project and adjust fields according to the business model.

The setting is enabled by default and will make categories and suppliers
fields to load objects asynchronously (through AJAX requests). When
disabled, the options will be rendered on page load.

Refs HEAL-35