### PR TITLE
General: move admin and front login forms to settings spec

### DIFF
--- a/shuup/admin/settings.py
+++ b/shuup/admin/settings.py
@@ -84,3 +84,7 @@ SHUUP_ADMIN_LOAD_SELECT_OBJECTS_ASYNC = {
     "categories": True,
     "suppliers": True
 }
+
+#: Indicates the authentication form class that should be used in login views inside Admin
+#:
+SHUUP_ADMIN_AUTH_FORM_SPEC = ("shuup.admin.forms.EmailAuthenticationForm")

--- a/shuup/admin/urls.py
+++ b/shuup/admin/urls.py
@@ -16,7 +16,6 @@ from django.contrib.auth import logout as do_logout
 from django.views.decorators.csrf import csrf_exempt
 from django.views.i18n import set_language
 
-from shuup.admin.forms import EmailAuthenticationForm
 from shuup.admin.module_registry import get_module_urls
 from shuup.admin.utils.urls import admin_url, AdminRegexURLPattern
 from shuup.admin.views.dashboard import DashboardView
@@ -29,13 +28,20 @@ from shuup.admin.views.select import MultiselectAjaxView
 from shuup.admin.views.tour import TourView
 from shuup.admin.views.wizard import WizardView
 from shuup.utils.i18n import javascript_catalog_all
+from shuup.utils.importing import cached_load
 
 
 def login(request, **kwargs):
     if not request.user.is_anonymous() and request.method == "POST":  # We're logging in, so log out first
         do_logout(request)
+
     kwargs.setdefault("extra_context", {})["error"] = request.GET.get("error")
-    return auth_views.login(request, authentication_form=EmailAuthenticationForm, **kwargs)
+
+    return auth_views.login(
+        request=request,
+        authentication_form=cached_load("SHUUP_ADMIN_AUTH_FORM_SPEC"),
+        **kwargs
+    )
 
 
 def get_urls():

--- a/shuup/front/apps/auth/settings.py
+++ b/shuup/front/apps/auth/settings.py
@@ -10,3 +10,8 @@
 #: Set `html` if your template is HTML-based
 #:
 SHUUP_AUTH_EMAIL_CONTENT_SUBTYPE = 'plain'
+
+
+#: Specify the authentication form to be used in login views
+#:
+SHUUP_AUTH_LOGIN_FORM_SPEC = 'shuup.front.apps.auth.forms.EmailAuthenticationForm'

--- a/shuup/front/apps/auth/views.py
+++ b/shuup/front/apps/auth/views.py
@@ -21,13 +21,13 @@ from django.utils.translation import ugettext as _
 from django.views.generic import FormView, TemplateView
 
 from shuup.core.utils.forms import RecoverPasswordForm
-from shuup.front.apps.auth.forms import EmailAuthenticationForm
 from shuup.utils.excs import Problem
+from shuup.utils.importing import cached_load
 
 
 class LoginView(FormView):
     template_name = 'shuup/user/login.jinja'
-    form_class = EmailAuthenticationForm
+    form_class = cached_load("SHUUP_AUTH_LOGIN_FORM_SPEC")
 
     def get_context_data(self, **kwargs):
         context = super(LoginView, self).get_context_data(**kwargs)


### PR DESCRIPTION
Make it possible to set the authentication forms through settings.

This makes it easier to replace the form in custom projects