### PR TITLE
Core: move force anons and person contacts to front (SHU-53)

### DIFF
--- a/shuup/core/models/_contacts.py
+++ b/shuup/core/models/_contacts.py
@@ -23,10 +23,7 @@ from shuup.core.fields import (
     InternalIdentifierField, LanguageField, PolymorphicJSONField
 )
 from shuup.core.pricing import PriceDisplayOptions
-from shuup.core.utils.users import (
-    is_user_all_seeing, should_force_anonymous_contact,
-    should_force_person_contact
-)
+from shuup.core.utils.users import is_user_all_seeing
 from shuup.utils.analog import define_log_model
 
 from ._base import PolymorphicShuupModel, TranslatableShuupModel
@@ -550,9 +547,6 @@ def get_person_contact(user):
     if not user or user.is_anonymous():
         return AnonymousContact()
 
-    if should_force_anonymous_contact(user):
-        return AnonymousContact()
-
     defaults = {
         'is_active': user.is_active,
         'first_name': getattr(user, 'first_name', ''),
@@ -575,9 +569,6 @@ def get_company_contact(user):
       CompanyContact (or none) of which user's PersonContact is a member
     :rtype: CompanyContact|None
     """
-    if should_force_person_contact(user):
-        return None
-
     contact = get_person_contact(user)
     if not contact:
         return None

--- a/shuup/front/middleware.py
+++ b/shuup/front/middleware.py
@@ -17,8 +17,13 @@ from django.utils.lru_cache import lru_cache
 from django.utils.translation import ugettext_lazy as _
 
 from shuup.core.middleware import ExceptionMiddleware
-from shuup.core.models import Contact, get_company_contact, get_person_contact
+from shuup.core.models import (
+    AnonymousContact, Contact, get_company_contact, get_person_contact
+)
 from shuup.core.shop_provider import get_shop
+from shuup.core.utils.users import (
+    should_force_anonymous_contact, should_force_person_contact
+)
 from shuup.front.basket import get_basket
 from shuup.front.utils.user import is_admin_user
 
@@ -78,17 +83,24 @@ class ShuupFrontMiddleware(object):
         request.shop = get_shop(request)
 
     def _set_person(self, request):
-        request.person = get_person_contact(request.user)
-        if not request.person.is_active:
-            messages.add_message(request, messages.INFO, _("Logged out since this account is inactive."))
-            logout(request)
-            # Usually logout is connected to the `refresh_on_logout`
-            # method via a signal and that already sets request.person
-            # to anonymous, but set it explicitly too, just to be sure
-            request.person = get_person_contact(None)
+        if should_force_anonymous_contact(request.user):
+            request.person = AnonymousContact()
+        else:
+            request.person = get_person_contact(request.user)
+            if not request.person.is_active:
+                messages.add_message(request, messages.INFO, _("Logged out since this account is inactive."))
+                logout(request)
+                # Usually logout is connected to the `refresh_on_logout`
+                # method via a signal and that already sets request.person
+                # to anonymous, but set it explicitly too, just to be sure
+                request.person = get_person_contact(None)
 
     def _set_customer(self, request):
-        company = get_company_contact(request.user)
+        if not request.person or should_force_person_contact(request.user):
+            company = None
+        else:
+            company = get_company_contact(request.user)
+
         request.customer = (company or request.person)
         request.is_company_member = bool(company)
         request.customer_groups = (company or request.person).groups.all()

--- a/shuup_tests/core/test_utils_users.py
+++ b/shuup_tests/core/test_utils_users.py
@@ -6,15 +6,9 @@
 # LICENSE file in the root directory of this source tree.
 import pytest
 
-from shuup.core.models import (
-    CompanyContact, get_company_contact, get_company_contact_for_shop_staff,
-    get_person_contact, PersonContact
-)
 from shuup.core.utils.users import (
-    force_anonymous_contact_for_user, force_person_contact_for_user,
     is_user_all_seeing, toggle_all_seeing_for_user
 )
-from shuup.testing import factories
 
 
 @pytest.mark.django_db
@@ -24,102 +18,3 @@ def test_is_user_all_seeing(rf, admin_user):
     assert is_user_all_seeing(admin_user)
     toggle_all_seeing_for_user(admin_user)
     assert not is_user_all_seeing(admin_user)
-
-
-@pytest.mark.django_db
-def test_forcing_to_anonymous_contact(rf, admin_user):
-    person_contact = get_person_contact(admin_user)
-    assert person_contact is not None
-    assert not get_person_contact(admin_user).is_anonymous
-
-    company_contact = get_company_contact(admin_user)
-    assert company_contact is None
-
-    force_anonymous_contact_for_user(admin_user)
-    assert get_person_contact(admin_user).is_anonymous
-
-    force_anonymous_contact_for_user(admin_user, False)
-    assert not get_person_contact(admin_user).is_anonymous
-    assert get_person_contact(admin_user).user.id == admin_user.id
-
-
-@pytest.mark.django_db
-def test_company_contact_for_shop_staff(rf, admin_user):
-    company_contact = get_company_contact(admin_user)
-    assert company_contact is None
-
-    shop = factories.get_default_shop()
-    # Let's create shop for the shop staff
-    company_contact = get_company_contact_for_shop_staff(shop, admin_user)
-
-    company_contact = get_company_contact_for_shop_staff(shop, admin_user)
-    assert company_contact is not None
-
-    # Let's create second staff member to make sure all good with
-    # creating company contact for shop staff.
-    new_staff_user = factories.create_random_user()
-    with pytest.raises(AssertionError):
-        get_company_contact_for_shop_staff(shop, new_staff_user)
-
-    new_staff_user.is_staff = True
-    new_staff_user.save()
-    
-    with pytest.raises(AssertionError):
-        # Since the new staff is not in shop members. The admin user
-        # passed since he is also superuser.
-        get_company_contact_for_shop_staff(shop, new_staff_user)
-
-    shop.staff_members.add(new_staff_user)
-    assert company_contact == get_company_contact_for_shop_staff(shop, new_staff_user)
-
-    # Make sure both user has person contact linked to the company contact
-    company_members = company_contact.members.all()
-    assert get_person_contact(admin_user) in company_members
-    assert get_person_contact(new_staff_user) in company_members
-
-
-@pytest.mark.django_db
-def test_forcing_to_person_contact(rf, admin_user):
-    company_contact = get_company_contact(admin_user)
-    assert company_contact is None
-    shop = factories.get_default_shop()
-    company_contact = get_company_contact_for_shop_staff(shop, admin_user)
-    assert isinstance(company_contact, CompanyContact)
-    assert company_contact == get_company_contact(admin_user)
-    
-    person_contact = get_person_contact(admin_user)
-    assert person_contact is not None
-
-    force_person_contact_for_user(admin_user)
-    assert get_company_contact(admin_user) is None
-
-    force_person_contact_for_user(admin_user, False)
-    assert company_contact == get_company_contact(admin_user)
-
-
-@pytest.mark.django_db
-def test_forcing_to_person_and_anonymous_contact(rf, admin_user):
-    company_contact = get_company_contact(admin_user)
-    assert company_contact is None
-    shop = factories.get_default_shop()
-    company_contact = get_company_contact_for_shop_staff(shop, admin_user)
-    assert isinstance(company_contact, CompanyContact)
-    assert company_contact == get_company_contact(admin_user)
-
-    person_contact = get_person_contact(admin_user)
-    assert person_contact is not None
-    assert not person_contact.is_anonymous
-
-    force_person_contact_for_user(admin_user)
-    assert get_company_contact(admin_user) is None
-
-    force_anonymous_contact_for_user(admin_user)
-    assert get_person_contact(admin_user).is_anonymous
-
-    force_person_contact_for_user(admin_user, False)
-    assert get_company_contact(admin_user) is None  # Since the person contact is still anonymous
-    assert get_person_contact(admin_user).is_anonymous
-
-    force_anonymous_contact_for_user(admin_user, False)
-    assert company_contact == get_company_contact(admin_user)
-    assert not get_person_contact(admin_user).is_anonymous

--- a/shuup_tests/front/test_contact_forcing_views.py
+++ b/shuup_tests/front/test_contact_forcing_views.py
@@ -29,7 +29,6 @@ def test_force_contact_views(rf):
     # Re-process middlewares so we check the force contact
     request = apply_request_middleware(rf.get("/"), user=user)
     assert request.customer.is_anonymous
-    assert get_person_contact(user).is_anonymous
     assert_all_good_with_random_user()
 
     # Force contact to person contact
@@ -37,7 +36,6 @@ def test_force_contact_views(rf):
 
     request = apply_request_middleware(rf.get("/"), user=user)
     assert request.customer == person_contact
-    assert get_person_contact(user) == person_contact
     assert_all_good_with_random_user()
 
     # Force contact to company contact. This also ensures
@@ -59,7 +57,6 @@ def test_force_contact_views(rf):
     request = apply_request_middleware(rf.get("/"), user=user)
     assert request.customer == person_contact
     assert get_person_contact(user) == person_contact
-    assert get_company_contact(user) is None
     assert_all_good_with_random_user()
 
 


### PR DESCRIPTION
There were some issues when some addon used this get person contact util to fetch contact to admin which in this force mode caused odd behavior.

Move force anonymous contact and person contact to front middleware since mostly only for seeing front outside the group the contact would otherwise belong. For staff editing front content with editor.