### PR TITLE
Core: add default to order line modified on migration

### DIFF
--- a/shuup/core/migrations/0061_order_line_dates.py
+++ b/shuup/core/migrations/0061_order_line_dates.py
@@ -22,6 +22,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='orderline',
             name='modified_on',
-            field=models.DateTimeField(auto_now=True, db_index=True, verbose_name='modified on'),
+            field=models.DateTimeField(auto_now=True, db_index=True, default=django.utils.timezone.now, verbose_name='modified on'),
         ),
     ]


### PR DESCRIPTION
To avoid situations like psycopg2.IntegrityError: column "modified_on" contains null values. I have one confirmation that this indeed helps with the problem.