### PR TITLE
Core: fix bug with migration 0065 related to indexes

### DIFF
--- a/shuup/core/migrations/0065_add_db_indexes_to_prod_cat_and_supplier_texts.py
+++ b/shuup/core/migrations/0065_add_db_indexes_to_prod_cat_and_supplier_texts.py
@@ -19,11 +19,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterField(
             model_name='producttranslation',
-            name='keywords',
-            field=models.TextField(blank=True, db_index=True, help_text='You can enter keywords that describe your product. This will help your shoppers learn about your products. It will also help shoppers find them in the store and on the web.', verbose_name='keywords'),
-        ),
-        migrations.AlterField(
-            model_name='producttranslation',
             name='name',
             field=models.CharField(db_index=True, help_text='Enter a descriptive name for your product. This will be its title in your store.', max_length=256, verbose_name='name'),
         ),

--- a/shuup/core/models/_products.py
+++ b/shuup/core/models/_products.py
@@ -357,7 +357,7 @@ class Product(TaxableItem, AttributableMixin, TranslatableModel):
                 "A default will be created using the product name."
             )
         ),
-        keywords=models.TextField(blank=True, verbose_name=_('keywords'), db_index=True, help_text=_(
+        keywords=models.TextField(blank=True, verbose_name=_('keywords'), help_text=_(
                 "You can enter keywords that describe your product. "
                 "This will help your shoppers learn about your products. "
                 "It will also help shoppers find them in the store and on the web."


### PR DESCRIPTION
It is not good idea to add indexes to textfields. It easily results to "BLOB/TEXT column 'keywords' used in key specification without a key length".