### PR TITLE
Fix `Uncaught ReferenceError: sync is not defined` error

### DIFF
--- a/shuup/xtheme/static_src/editor/editor.js
+++ b/shuup/xtheme/static_src/editor/editor.js
@@ -75,7 +75,7 @@ function activateSelects() {
             const model = select.data("model");
             const searchMode = select.data("search-mode");
             const noExpand = select.data("no-expand");
-            activateSelect(select, model, searchMode, noExpand, sync);
+            activateSelect(select, model, searchMode, noExpand);
         }
     });
 }

--- a/shuup_tests/browser/front/test_xtheme_plugin_form.py
+++ b/shuup_tests/browser/front/test_xtheme_plugin_form.py
@@ -72,7 +72,12 @@ def test_xtheme_plugin_form_language_order(admin_user, browser, live_server, set
 
             # select the TextPlugin
             wait_until_appeared(iframe, "select[name='general-plugin']")
-            iframe.select("general-plugin", "text")
+            click_element(iframe, "#select2-id_general-plugin-container")
+            wait_until_appeared(iframe, "input.select2-search__field")
+            iframe.find_by_css("input.select2-search__field").first.value = "Text"
+            wait_until_appeared(browser, ".select2-results__option:not([aria-live='assertive'])")
+            iframe.execute_script('$($(".select2-results__option")[1]).trigger({type: "mouseup"})')
+
             time.sleep(1)
             wait_until_condition(iframe, lambda x: page_has_loaded(x), timeout=20)
             wait_until_appeared(iframe, "ul.editor-tabs")
@@ -123,7 +128,11 @@ def test_xtheme_plugin_form_selected_language_pane(admin_user, browser, live_ser
 
         # select the TextPlugin
         wait_until_appeared(iframe, "select[name='general-plugin']")
-        iframe.select("general-plugin", "text")
+        click_element(iframe, "#select2-id_general-plugin-container")
+        wait_until_appeared(iframe, "input.select2-search__field")
+        iframe.find_by_css("input.select2-search__field").first.value = "Text"
+        wait_until_appeared(browser, ".select2-results__option:not([aria-live='assertive'])")
+        iframe.execute_script('$($(".select2-results__option")[1]).trigger({type: "mouseup"})')
         time.sleep(1)
         wait_until_condition(iframe, lambda x: page_has_loaded(x), timeout=20)
         wait_until_appeared(iframe, "ul.editor-tabs")


### PR DESCRIPTION
This was initially caught by using the `Product Selection` plugin,
because the existing customer wondered how to add entries (the
`Products` field was empty and not selectable; despite there being a lot
of products added in the back-end already) in that plugin and if some
kind of add/select button existed as he remembered.

Browser consoles gave `Uncaught ReferenceError: sync is not defined`
error.

The long story short: the error was fixed by removing reference to
`sync` that was used but wasn't used anywhere.

This tiny change also fixed a bunch of other issues we didn't even know
we had with `Select2 widget`.

This commit also simultaneously fixes:
- all other plugins that use Select2 widget like Category Products
Highlight, Product Selection, Category Links, CMS Page Links, etc.
- the plugin selection choice (now you can also type the name of the
plugin, instead of using the dropmenu)
- all other selection fields in the front-end.

Old, bugged behavior (`Product Selection` plugin):
![image](https://user-images.githubusercontent.com/2521942/69966770-bdc20500-151f-11ea-9075-8c8c1d7eae89.png)

New, fixed behavior (`Product Selection` plugin):
![image](https://user-images.githubusercontent.com/2521942/69966653-88b5b280-151f-11ea-87da-f1fb75b4392e.png)

Old, bugged behavior (Plugin selection):
![image](https://user-images.githubusercontent.com/2521942/69967063-55bfee80-1520-11ea-8b3d-d2b4be13cf25.png)

New, fixed behavior (Plugin selection):
![image](https://user-images.githubusercontent.com/2521942/69967069-59537580-1520-11ea-9bf1-b24d0e98bb92.png)

refs SHU-45