### PR TITLE
Admin: Replace empty coupon field choice in campaigns & Xtheme: Add warning for unsaved changes when switching between cells

### DIFF
--- a/shuup/campaigns/admin_module/forms/_basket.py
+++ b/shuup/campaigns/admin_module/forms/_basket.py
@@ -30,7 +30,7 @@ class BasketCampaignForm(BaseCampaignForm):
         if supplier:
             coupons = coupons.filter(supplier=supplier)
 
-        coupon_code_choices = [('', '')] + list(coupons.values_list("pk", "code"))
+        coupon_code_choices = [('', '---------')] + list(coupons.values_list("pk", "code"))
         field_kwargs = dict(choices=coupon_code_choices, required=False)
         field_kwargs["help_text"] = _("Define the required coupon for this campaign.")
         field_kwargs["label"] = _("Coupon")

--- a/shuup/xtheme/locale/en/LC_MESSAGES/djangojs.po
+++ b/shuup/xtheme/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-20 19:05+0000\n"
+"POT-Creation-Date: 2019-12-05 00:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -21,6 +21,11 @@ msgstr ""
 
 #, javascript-format
 msgid "Edit %s"
+msgstr ""
+
+msgid ""
+"Changing plugin cells without saving will cause changes made to this cell to "
+"be lost."
 msgstr ""
 
 #, javascript-format

--- a/shuup/xtheme/static_src/editor/editor.js
+++ b/shuup/xtheme/static_src/editor/editor.js
@@ -91,6 +91,11 @@ function updateModelChoiceWidgetURL(select) {
 domready(() => {
     let changesMade = false;
     $(".layout-cell").on("click", function() {
+        if(changesMade) {
+            if(!confirm(gettext("Changing plugin cells without saving will cause changes made to this cell to be lost."))) {
+                return;
+            }
+        }
         const {x, y} = this.dataset;
         const newQs = mutate({x, y});
         location.href = "?" + newQs;


### PR DESCRIPTION
- Admin: Replace empty coupon field choice in campaigns
Replaced empty/None coupon field choice with `---------`
![image](https://user-images.githubusercontent.com/40273438/70185713-9ff4cb80-16ea-11ea-9cdc-d07bbb5eb5cd.png)

Fixes #2072 

- Xtheme: Add warning for unsaved changes when switching between cells
![image](https://user-images.githubusercontent.com/40273438/70192530-4e553c80-16fc-11ea-9cea-3d71f6d854f3.png)

Fixes #2073 