### PR TITLE
Xtheme improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ List all changes after the last release here (newer on top). Each change on a se
 
 ### Changed
 
+- Add `MiddlewareMixin` to all middlewares to prepare for Django 2.x
 - Notify: Changed the Email topology type to support comma-separated list of emails when using constants.
 
 ## Older versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ List all changes after the last release here (newer on top). Each change on a se
 
 ### Changed
 
+- Xtheme: Improve template injection by checking not wasting time invoking regex for nothing
 - Add `MiddlewareMixin` to all middlewares to prepare for Django 2.x
 - Notify: Changed the Email topology type to support comma-separated list of emails when using constants.
 

--- a/shuup/admin/middleware.py
+++ b/shuup/admin/middleware.py
@@ -9,8 +9,13 @@ from __future__ import unicode_literals
 
 from shuup.admin.shop_provider import get_shop
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 
-class ShuupAdminMiddleware(object):
+
+class ShuupAdminMiddleware(MiddlewareMixin):
     """
     Handle Shuup Admin specific tasks for each request and response.
 

--- a/shuup/core/middleware.py
+++ b/shuup/core/middleware.py
@@ -16,8 +16,13 @@ from django.utils.translation import ugettext_lazy as _
 from shuup.core.shop_provider import get_shop
 from shuup.utils.excs import ExceptionalResponse, Problem
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 
-class ExceptionMiddleware(object):
+
+class ExceptionMiddleware(MiddlewareMixin):
     def process_exception(self, request, exception):
         if isinstance(exception, ExceptionalResponse):
             return exception.response
@@ -56,7 +61,7 @@ class ExceptionMiddleware(object):
         return templates
 
 
-class ShuupMiddleware(object):
+class ShuupMiddleware(MiddlewareMixin):
     """
     Handle Shuup specific tasks for each request and response.
 

--- a/shuup/front/middleware.py
+++ b/shuup/front/middleware.py
@@ -27,12 +27,18 @@ from shuup.core.utils.users import (
 from shuup.front.basket import get_basket
 from shuup.front.utils.user import is_admin_user
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
+
 __all__ = ["ProblemMiddleware", "ShuupFrontMiddleware"]
 
 ProblemMiddleware = ExceptionMiddleware  # This class is only an alias for ExceptionMiddleware.
 
 
-class ShuupFrontMiddleware(object):
+class ShuupFrontMiddleware(MiddlewareMixin):
     """
     Handle Shuup specific tasks for each request and response.
 

--- a/shuup/xtheme/middleware.py
+++ b/shuup/xtheme/middleware.py
@@ -12,10 +12,16 @@ from django.utils.translation import ugettext_lazy as _
 from shuup.core.models import Shop
 from shuup.xtheme import get_current_theme
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
+
 log = logging.getLogger(__name__)
 
 
-class XthemeMiddleware(object):
+class XthemeMiddleware(MiddlewareMixin):
     """
     Handle Shuup specific tasks for each request and response.
 

--- a/shuup/xtheme/resources.py
+++ b/shuup/xtheme/resources.py
@@ -239,11 +239,15 @@ def inject_resources(context, content, clean=True):
         return content
 
     for location_name, location in LOCATION_INFO.items():
-        match = location["regex"].search(content)
-        if not match:
+        if not rc.resources.get(location_name):
             continue
+
         injection = rc.render_resources(location_name, clean=clean)
         if not injection:
+            continue
+
+        match = location["regex"].search(content)
+        if not match:
             continue
 
         start = match.start()


### PR DESCRIPTION
### Add `MiddlewareMixin` to all middlewares to prepare for Django 2.x
This enables the use of `MIDDLEWARE_CLASSES` or `MIDDLEWARE` setting

### Xtheme: improve xtheme resource injection performance
Check whether there is rendered content for the location
before checking whether the injection tag exists inside the content.
Multiple regex call can slow down the page loads by several times.

No Refs