### PR TITLE
Admin: fix select2 placeholder when field is not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ List all changes after the last release here (newer on top). Each change on a se
 - Notify: Changed the Email topology type to support comma-separated list of emails when using constants.
 
 ### Fixed
+
+- Fixed the placeholder of Select2 component in Admin
 - FileDnDUploader: Add check for the `data-kind` attribute of the drop zone. If the data-kind is
   `images`, add an attribute to the hidden input that only allows images to be uploaded.
 

--- a/shuup/admin/forms/fields.py
+++ b/shuup/admin/forms/fields.py
@@ -59,6 +59,7 @@ class Select2ModelField(Field):
         attrs.update({"data-model": model_name})
         if not self.required:
             attrs["data-allow-clear"] = "true"
+            attrs["data-placeholder"] = _("Select an option")
         return attrs
 
 

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-12-02 12:09+0000\n"
+"POT-Creation-Date: 2020-02-14 18:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -36,6 +36,9 @@ msgid "Username or email address"
 msgstr ""
 
 msgid "Create New"
+msgstr ""
+
+msgid "Select an option"
 msgstr ""
 
 msgid "Monday"

--- a/shuup/admin/static_src/base/js/select.js
+++ b/shuup/admin/static_src/base/js/select.js
@@ -61,7 +61,16 @@ export function activateSelects() {
             const model = select.data("model");
             const searchMode = select.data("search-mode");
             const noExpand = select.data("no-expand");
-            const placeholder = select.data("placeholder");
+            const placeholderText = select.data("placeholder");
+            let placeholder = null;
+
+            if (placeholderText) {
+                placeholder = {
+                    id: null,
+                    text: placeholderText
+                };
+            }
+
             // do not set clear when there is no placeholder to use
             const allowClear = placeholder ? select.data("allow-clear") : null;
             const attrs = {


### PR DESCRIPTION
In cases when the field is not required, an error was raising
because the lack of placeholder option to use.

Instead of having a simple text, use a set of id/text with a nice fallback text.

Refs MYS-75