### PR TITLE
Admin: add option to impersonate staff users

### DIFF
--- a/shuup/admin/modules/users/__init__.py
+++ b/shuup/admin/modules/users/__init__.py
@@ -59,6 +59,11 @@ class UserModule(AdminModule):
                 name="user.login-as"
             ),
             admin_url(
+                "^users/(?P<pk>\d+)/login/staff/$",
+                "shuup.admin.modules.users.views.LoginAsStaffUserView",
+                name="user.login-as-staff"
+            ),
+            admin_url(
                 "^contacts/list-settings/",
                 "shuup.admin.modules.settings.views.ListSettingsView",
                 name="user.list_settings"

--- a/shuup/admin/modules/users/views/__init__.py
+++ b/shuup/admin/modules/users/views/__init__.py
@@ -4,7 +4,7 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from .detail import LoginAsUserView, UserDetailView
+from .detail import LoginAsStaffUserView, LoginAsUserView, UserDetailView
 from .list import UserListView
 from .password import UserChangePasswordView, UserResetPasswordView
 from .permissions import UserChangePermissionsView
@@ -15,5 +15,6 @@ __all__ = [
     "UserChangePasswordView",
     "UserResetPasswordView",
     "UserChangePermissionsView",
-    "LoginAsUserView"
+    "LoginAsUserView",
+    "LoginAsStaffUserView",
 ]

--- a/shuup/admin/settings.py
+++ b/shuup/admin/settings.py
@@ -88,3 +88,11 @@ SHUUP_ADMIN_LOAD_SELECT_OBJECTS_ASYNC = {
 #: Indicates the authentication form class that should be used in login views inside Admin
 #:
 SHUUP_ADMIN_AUTH_FORM_SPEC = ("shuup.admin.forms.EmailAuthenticationForm")
+
+#: To which view redirect impersonator when login as regular user
+#:
+SHUUP_ADMIN_LOGIN_AS_REDIRECT_VIEW = "shuup:index"
+
+#: To which view redirect impersonator when login as staff
+#:
+SHUUP_ADMIN_LOGIN_AS_STAFF_REDIRECT_VIEW = "shuup_admin:dashboard"

--- a/shuup/admin/template_helpers/shuup_admin.py
+++ b/shuup/admin/template_helpers/shuup_admin.py
@@ -223,3 +223,20 @@ def get_admin_supplier(context):
 @contextfunction
 def is_multiple_suppliers_enabled(context):
     return settings.SHUUP_ENABLE_MULTIPLE_SUPPLIERS is True
+
+
+@contextfunction
+def get_logout_url(context):
+    request = context["request"]
+
+    def get_url(url):
+        try:
+            return reverse(url)
+        except NoReverseMatch:
+            return None
+
+    stop_impersonate_url = None
+    if "impersonator_user_id" in request.session:
+        stop_impersonate_url = get_url("shuup_admin:stop-impersonating-staff")
+
+    return (stop_impersonate_url if stop_impersonate_url else get_url("shuup_admin:logout") or "/logout")

--- a/shuup/admin/templates/shuup/admin/base/_navigation.jinja
+++ b/shuup/admin/templates/shuup/admin/base/_navigation.jinja
@@ -50,7 +50,7 @@
         
         <a href="#" class="show-tour dropdown-item">{% trans %}Show Tour{% endtrans %}</a>
         <div class="actions">
-            <a href="{{ url("shuup_admin:logout") }}" class="btn btn-block btn-inverse">
+            <a href="{{ shuup_admin.get_logout_url() }}" class="btn btn-block btn-inverse">
                 <i class="fa fa-sign-out"></i> {% trans %}Log out{% endtrans %}
             </a>
         </div>

--- a/shuup/admin/urls.py
+++ b/shuup/admin/urls.py
@@ -21,6 +21,7 @@ from shuup.admin.utils.urls import admin_url, AdminRegexURLPattern
 from shuup.admin.views.dashboard import DashboardView
 from shuup.admin.views.edit import EditObjectView
 from shuup.admin.views.home import HomeView
+from shuup.admin.views.impersonate import stop_impersonating_staff
 from shuup.admin.views.menu import MenuToggleView, MenuView
 from shuup.admin.views.password import RequestPasswordView, ResetPasswordView
 from shuup.admin.views.search import SearchView
@@ -58,6 +59,10 @@ def get_urls():
         admin_url(r'^edit/$', EditObjectView.as_view(), name='edit', permissions=()),
         admin_url(r'^menu/$', MenuView.as_view(), name='menu', permissions=()),
         admin_url(r'^toggle-menu/$', MenuToggleView.as_view(), name='menu_toggle', permissions=()),
+        admin_url(
+            r'^stop-impersonating-staff/$', stop_impersonating_staff,
+            name="stop-impersonating-staff", permissions=()
+        ),
         admin_url(
             r'^login/$',
             login,

--- a/shuup/admin/views/impersonate.py
+++ b/shuup/admin/views/impersonate.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2020, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.conf import settings
+from django.contrib.auth import get_user_model, load_backend, login, logout
+from django.http import HttpResponseForbidden, HttpResponseRedirect
+from django.core.urlresolvers import reverse
+
+from shuup.admin.utils.permissions import has_permission
+
+
+def stop_impersonating_staff(request):
+    if "impersonator_user_id" not in request.session:
+        return HttpResponseForbidden()
+
+    impersonator_user_id = request.session["impersonator_user_id"]
+    auth_user_id = request.session["_auth_user_id"]
+    del request.session["impersonator_user_id"]
+    logout(request)
+
+    user = get_user_model().objects.get(pk=impersonator_user_id)
+    for backend in settings.AUTHENTICATION_BACKENDS:
+        if user == load_backend(backend).get_user(user.pk):
+            user.backend = backend
+            break
+
+    login(request, user)
+
+    user_url_name = "shuup_admin:user.detail"
+    if has_permission(user, user_url_name):
+        url = reverse(user_url_name, args=[auth_user_id])
+    else:
+        url = reverse(settings.SHUUP_ADMIN_LOGIN_AS_STAFF_REDIRECT_VIEW)
+
+    return HttpResponseRedirect(url)


### PR DESCRIPTION
Mostly a superuser feature but allowed to staff as long as not impersonating superuseres. Also add template helper for logout url which stops the staff user impersonation properly.