### PR TITLE
Fix search results overflowing the canvas

### DIFF
--- a/shuup/admin/static_src/base/scss/shuup/site-search.scss
+++ b/shuup/admin/static_src/base/scss/shuup/site-search.scss
@@ -102,7 +102,6 @@
     position: absolute;
     top: 40px;
     padding: 15px;
-    max-height: 85vh;
     // overflow-y: auto;
     left: 30px;
     right: 30px;


### PR DESCRIPTION
Currently the search-result-canvas always has space on the bottom. But 
if there are more search results than can fit the screen, a visual bug 
happens, with results being displayed, but outside the canvas.
![2020-02-21_Screenshot_2](https://user-images.githubusercontent.com/2521942/75031133-3fd22200-54ae-11ea-825e-c8b2131ad651.png)

This change makes it so that the canvas will continue until the very 
bottom edge of the screen. Only when needed, otherwise there is still a 
space.
![2020-02-21_Screenshot_1](https://user-images.githubusercontent.com/2521942/75031125-3b0d6e00-54ae-11ea-961c-3c374da07673.png)