### PR TITLE
Admin: make alert messages dismissible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+### Changed
+
+- Make Admin messages dismissible
+
 ## [1.10.3] - 2020-02-21
 
 ### Fixed

--- a/shuup/admin/static_src/base/js/messages.js
+++ b/shuup/admin/static_src/base/js/messages.js
@@ -54,9 +54,21 @@ window.Messages = (function Messages(document) {
         }
         messageDiv.className = "message " + tags.join(" ");
         const textSpan = document.createElement("span");
+        textSpan.className = "content";
         const textNode = document.createTextNode(message.text || "no text");
         textSpan.appendChild(textNode);
+
+        const dismissIcon = document.createElement("span");
+        dismissIcon.className = "dimiss-icon";
+        dismissIcon.addEventListener("click", function () {
+            messageDiv.classList.add("dimissed");
+        });
+        const statucIcon = document.createElement("span");
+        statucIcon.className = "status";
+
+        messageDiv.appendChild(statucIcon);
         messageDiv.appendChild(textSpan);
+        messageDiv.appendChild(dismissIcon);
         return messageDiv;
     }
     function flush() {

--- a/shuup/admin/static_src/base/scss/shuup/messages.scss
+++ b/shuup/admin/static_src/base/scss/shuup/messages.scss
@@ -54,13 +54,38 @@
 
     .message {
         margin-top: 0.5em;
-        padding: 1em 1.2em;
+        padding: 1em;
         box-shadow: 0px 0px 3px rgba(0,0,0,0.2);
         border-radius: 3px;
         background-color: $info;
         line-height: 2rem;
 
-        &:before {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+
+        .content {
+            text-align: left;
+            flex: 1;
+            max-width: 280px;
+            line-height: 1.5;
+            margin: 0 5px;
+        }
+
+        .dimiss-icon {
+            cursor: pointer;
+            &:before {
+                display: inline-block;
+                font-family: FontAwesome;
+                margin-right: 8px;
+                font-size: 1.2rem;
+                vertical-align: bottom;
+                content: $fa-var-times; //Font Awesome "times" variable
+            }
+        }
+
+        .status:before {
             display: inline-block;
             font-family: FontAwesome;
             margin-right: 8px;
@@ -70,7 +95,7 @@
         &.success {
             background-color: $success;
 
-            &:before {
+            .status:before {
                 content: $fa-var-check; //Font Awesome "check" variable
             }
         }
@@ -78,7 +103,7 @@
         &.warning {
             background-color: $warning;
 
-            &:before {
+            .status:before {
                 content: $fa-var-warning; //Font Awesome "warning" variable
             }
         }
@@ -86,9 +111,13 @@
         &.error {
             background-color: $danger;
 
-            &:before {
-                content: $fa-var-times-circle; //Font Awesome "times-circle" variable
+            .status:before {
+                content: $fa-var-exclamation-circle; //Font Awesome "exclamation-circle" variable
             }
+        }
+
+        &.dimissed {
+            display: none;
         }
     }
 }


### PR DESCRIPTION
No users can dismiss alert messages through a dismiss icon.
It helps to remove the messages and let the user handle lots of error when
using mobile devices

## Before

![image](https://user-images.githubusercontent.com/8770370/75035429-2faa4a80-548e-11ea-92ea-10645aa5bfe1.png)

## After

![image](https://user-images.githubusercontent.com/8770370/75035453-40f35700-548e-11ea-948d-529b91d44222.png)


Refs MYS-233