### PR TITLE
Fix bug: page jumps after selecting tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+- Admin: fix page jumps after selecting tabs
+
 ## [1.10.6] - 2020-02-28
 
 ### Changed

--- a/shuup/admin/static_src/base/js/side-nav.js
+++ b/shuup/admin/static_src/base/js/side-nav.js
@@ -19,7 +19,7 @@ $(function() {
             if ( l > 0 ) {
                 while (i < l) {
                     h = (h << 5) - h + s.charCodeAt(i++) | 0;
-                }       
+                }
             }
 
             if ( h < 0 ) {
@@ -67,8 +67,8 @@ $(function() {
                             key: item.id,
                             href: "#" + item.id,
                             onclick: function() {
-                                ctrl.showSection(item);
                                 window.location.hash = "#" + item.id;
+                                ctrl.showSection(item);
                                 return false;
                             }
                         },


### PR DESCRIPTION
If the tab's content is small (fitting on one screen), then clicking on 
that tab caused the view jump to page's top. This is good.

But if the tab didn't fit on one screen, then clicking on the tab cause 
a view to jump to that tab section hashtag anchor link location 
(url/#something). This sounds good, but in practice it was inconsistent 
and caused a graphical bug (important content not being seen).

refs SHU-36