### PR TITLE
Front: set the current query string as initial state when refreshing filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+### Fixed
+
+- Front: keep the current query string parameters as the initial state
+  when refreshing product filters.
+
 ### Changed
 
 - Admin: fix page jumps after reaload
@@ -32,7 +37,7 @@ List all changes after the last release here (newer on top). Each change on a se
 
 - Admin: fix password recovery success URL
 - Picotable: render the filters button on small devices,
-even when there is no data, to allow resetting filters
+  even when there is no data, to allow resetting filters
 
 ## [1.10.4] - 2020-02-22
 

--- a/shuup/front/package.json
+++ b/shuup/front/package.json
@@ -30,7 +30,8 @@
     "sass": "^1.15.1",
     "select2": "^4.0.12",
     "shuup-static-build-tools": "^1.0.3",
-    "simplelightbox": "^1.17.0"
+    "simplelightbox": "^1.17.0",
+    "url-search-params-polyfill": "^8.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.3"

--- a/shuup/front/static_src/js/category.js
+++ b/shuup/front/static_src/js/category.js
@@ -27,8 +27,14 @@ if (typeof window.CustomEvent !== "function") {
 window.ProductListScrollTarget = ".products-wrap";
 
 window.refreshFilters = debounce(function refreshFilters(pageNumber = 1) {
-    var pagination = $("ul.pagination");
-    var state = { page: pageNumber || 1 };
+    const pagination = $("ul.pagination");
+    const state = { page: pageNumber || 1 };
+    const currentState = new URLSearchParams(window.location.search);
+
+    for (let key of currentState.keys()) {
+        state[key] = currentState.get(key);
+    }
+
     if (!window.PRODUCT_LIST_FILTERS) {
         return;
     }

--- a/shuup/front/static_src/js/index.js
+++ b/shuup/front/static_src/js/index.js
@@ -7,6 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import "babel-polyfill";
+import "url-search-params-polyfill";
 import "./language_changer.js";
 import "./navigation.js";
 import "./category.js";


### PR DESCRIPTION
keep the current query parameters as the initial state when refreshing product filters.
This way, parameters that are not part of the product filters modifiers will be preserved.

Refs MYS-340