### PR TITLE
Admin: show picotable item choices as is

### DIFF
--- a/shuup/admin/utils/picotable.py
+++ b/shuup/admin/utils/picotable.py
@@ -93,7 +93,7 @@ class ChoicesFilter(Filter):
         if isinstance(choices, QuerySet):
             choices = [(c.pk, c) for c in choices]
         return [("_all", "---------")] + [
-            (force_text(value, strings_only=True), force_text(display).title())
+            (force_text(value, strings_only=True), force_text(display))
             for (value, display)
             in choices
         ]


### PR DESCRIPTION
Capitalizing items that is created from objects might cause some confusion at admin side. If someone decided the category name is in lowercases for some reason we should just show it as is. Same applies to items created all caps by admin.