### PR TITLE
Notify: Fix language bug with unilingual templates

### DIFF
--- a/shuup/notify/admin_module/forms.py
+++ b/shuup/notify/admin_module/forms.py
@@ -81,7 +81,7 @@ class ScriptItemEditForm(forms.Form):
             for language_code, language_name in settings.LANGUAGES:
                 self.template_languages.append((language_code, get_language_name(language_code)))
         elif template_use == TemplateUse.UNILINGUAL:
-            self.template_languages = [UNILINGUAL_TEMPLATE_LANGUAGE, _(u"Template")]
+            self.template_languages = [(UNILINGUAL_TEMPLATE_LANGUAGE, _(u"Template"))]
         else:  # Nothing to do
             return
 


### PR DESCRIPTION
If you tried to edit a step which has a unilingual template it would break on line 89 (the for loop) because `self.template_languages` was a list of strings, not a list of tuples as it should be.
This commit fixes this bug.

No refs