### PR TITLE
Admin: make contact list filter out staff by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ List all changes after the last release here (newer on top). Each change on a se
 ### Fixed
 
 - Admin: Notification name when deleteing it
+- Admin: Update contact list so that it only shows customers by default
+- Front: Fix typo
 
 ### Changed
 

--- a/shuup/admin/modules/contacts/views/list.py
+++ b/shuup/admin/modules/contacts/views/list.py
@@ -26,15 +26,22 @@ from shuup.core.models import (
 
 class ContactTypeFilter(ChoicesFilter):
     def __init__(self):
-        super(ContactTypeFilter, self).__init__(choices=[("person", _("Person")), ("company", _("Company"))])
+        super(ContactTypeFilter, self).__init__(
+            choices=[("person", _("Person")), ("company", _("Company")), ("staff", _("Staff"))],
+            default="_all"
+        )
 
     def filter_queryset(self, queryset, column, value, context):
         if value == "_all":
-            return queryset
-        model_class = PersonContact
-        if value == "company":
-            model_class = CompanyContact
-        return queryset.instance_of(model_class)
+            return queryset.exclude(PersonContact___user__is_staff=True)
+        elif value == "person":
+            return queryset.exclude(PersonContact___user__is_staff=True).instance_of(PersonContact)
+        elif value == "company":
+            return queryset.instance_of(CompanyContact)
+        elif value == "staff":
+            return queryset.filter(PersonContact___user__is_staff=True)
+
+        return queryset
 
 
 class ContactListView(PicotableListView):

--- a/shuup/front/themes/__init__.py
+++ b/shuup/front/themes/__init__.py
@@ -66,7 +66,7 @@ class BaseThemeFieldsMixin(object):
                 initial=[tab[0] for tab in product_detail_tabs],
                 choices=product_detail_tabs,
                 label=_("Product detail tabs"),
-                help_text=_("Select all tabs that should be renderd in product details.")
+                help_text=_("Select all tabs that should be rendered in product details.")
             ))
         ])
         return fields

--- a/shuup_tests/admin/test_contact_module.py
+++ b/shuup_tests/admin/test_contact_module.py
@@ -168,4 +168,4 @@ def test_contact_list_multiple_shop(rf, admin_user):
     assert contact1.pk in contacts
     assert contact2.pk in contacts
     assert contact3.pk in contacts
-    assert superuser_contact.pk in contacts
+    assert superuser_contact.pk not in contacts # Superuser must edit the filter values in order to see other superuser contacts.

--- a/shuup_tests/browser/admin/test_picotable.py
+++ b/shuup_tests/browser/admin/test_picotable.py
@@ -89,27 +89,27 @@ def _test_pagination(browser):
     ellipses = u"\u22ef"
 
     items = _get_pagination_content(browser)
-    _assert_pagination_content(items, ["Previous", "1", "2", "3", ellipses, "11", "Next"])
+    _assert_pagination_content(items, ["Previous", "1", "2", "3", ellipses, "10", "Next"])
 
     _goto_page(browser, 3)
     items = _get_pagination_content(browser)
-    _assert_pagination_content(items, ["Previous", "1", "2", "3", "4", "5",  ellipses, "11", "Next"])
+    _assert_pagination_content(items, ["Previous", "1", "2", "3", "4", "5",  ellipses, "10", "Next"])
 
     _goto_page(browser, 5)
     items = _get_pagination_content(browser)
-    _assert_pagination_content(items, ["Previous", "1", ellipses, "3", "4", "5", "6", "7", ellipses, "11", "Next"])
+    _assert_pagination_content(items, ["Previous", "1", ellipses, "3", "4", "5", "6", "7", ellipses, "10", "Next"])
 
     _goto_page(browser, 7)
     items = _get_pagination_content(browser)
-    _assert_pagination_content(items, ["Previous", "1", ellipses, "5", "6", "7", "8", "9", ellipses, "11", "Next"])
+    _assert_pagination_content(items, ["Previous", "1", ellipses, "5", "6", "7", "8", "9", "10", "Next"])
 
     _goto_page(browser, 9)
     items = _get_pagination_content(browser)
-    _assert_pagination_content(items, ["Previous", "1", ellipses, "7", "8", "9", "10", "11", "Next"])
+    _assert_pagination_content(items, ["Previous", "1", ellipses, "7", "8", "9", "10", "Next"])
 
-    _goto_page(browser, 11)
+    _goto_page(browser, 10)
     items = _get_pagination_content(browser)
-    _assert_pagination_content(items, ["Previous", "1", ellipses, "9", "10", "11", "Next"])
+    _assert_pagination_content(items, ["Previous", "1", ellipses, "8", "9", "10", "Next"])
 
 
 def _get_pagination_content(browser):


### PR DESCRIPTION
Add Staff filter option to contact list and by default do not list staff since most of the time staff should be managed directly through users or some other custom admin module for exact that purpose.