### PR TITLE
Add ability to delete manufacturer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ List all changes after the last release here (newer on top). Each change on a se
 
 ### Added
 
+- Admin: Ability to delete manufacturer
 - Admin: Ability to login as the selected contact if it's a user
 
 ### Fixed

--- a/shuup/admin/modules/manufacturers/__init__.py
+++ b/shuup/admin/modules/manufacturers/__init__.py
@@ -9,9 +9,9 @@ from __future__ import unicode_literals
 
 from django.utils.translation import ugettext_lazy as _
 
+from shuup.admin.utils.urls import derive_model_url, get_edit_and_list_urls, admin_url
 from shuup.admin.base import AdminModule, MenuEntry
 from shuup.admin.menu import STOREFRONT_MENU_CATEGORY
-from shuup.admin.utils.urls import derive_model_url, get_edit_and_list_urls
 from shuup.core.models import Manufacturer
 
 
@@ -20,7 +20,13 @@ class ManufacturerModule(AdminModule):
     breadcrumbs_menu_entry = MenuEntry(name, url="shuup_admin:manufacturer.list")
 
     def get_urls(self):
-        return get_edit_and_list_urls(
+        return [
+            admin_url(
+                "^manufacturer/(?P<pk>\d+)/delete/$",
+                "shuup.admin.modules.manufacturers.views.ManufacturerDeleteView",
+                name="manufacturer.delete"
+            )
+        ] + get_edit_and_list_urls(
             url_prefix="^manufacturers",
             view_template="shuup.admin.modules.manufacturers.views.Manufacturer%sView",
             name_template="manufacturer.%s"

--- a/shuup/admin/modules/manufacturers/views/__init__.py
+++ b/shuup/admin/modules/manufacturers/views/__init__.py
@@ -5,7 +5,7 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from .edit import ManufacturerEditView
+from .edit import ManufacturerEditView, ManufacturerDeleteView
 from .list import ManufacturerListView
 
-__all__ = ["ManufacturerEditView", "ManufacturerListView"]
+__all__ = ["ManufacturerEditView", "ManufacturerListView", "ManufacturerDeleteView"]


### PR DESCRIPTION
- Added ability to delete a manufacturer when editing it.
- Added the get_context function to the manufacturer edit view so if a the manufacturer dose not have a url to there site the front_url won't be "/None" but instead it will redirect you to the front page.