### PR TITLE
Admin: improve product media uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ List all changes after the last release here (newer on top). Each change on a se
 
 ### Added
 
+- Admin: add error message when upload fails. At media queue complete do not
+  resave product media if the file-count has not changed. This for example
+  prevents media save when the upload itself fails.
+- Admin: add option to override dropzone upload path by using data attribute
+- Admin: add upload path to browser URLs and use it to fallback on media
+  uploads when the actual media path is not available.
 - Admin: Ability to delete manufacturer
 - Admin: Ability to login as the selected contact if it's a user
 

--- a/shuup/admin/browser_config.py
+++ b/shuup/admin/browser_config.py
@@ -28,6 +28,7 @@ class DefaultBrowserConfigProvider(BaseBrowserConfigProvider):
             "edit": "shuup_admin:edit",
             "select": "shuup_admin:select",
             "media": ("shuup_admin:media.browse" if has_permission(request.user, "media.browse") else None),
+            "upload": ("shuup_admin:media.upload" if has_permission(request.user, "media.upload") else None),
             "product": "shuup_admin:shop_product.list",
             "contact": "shuup_admin:contact.list",
             "setLanguage": "shuup_admin:set-language",

--- a/shuup/admin/static_src/product/edit_media.js
+++ b/shuup/admin/static_src/product/edit_media.js
@@ -82,20 +82,39 @@ $(function() {
         $html.insertBefore($source);
     }
 
+    function getFileIds(kind) {
+        const $fileInputs = $("#product-" + kind + "-section").find(".file-control input");
+        var fileIds = [];
+        for(var i = 0; i < $fileInputs.length; i++){
+            let fileId = parseInt($($fileInputs[i]).val());
+            if(!isNaN(fileId)) {
+                fileIds.push(parseInt($($fileInputs[i]).val()));
+            }
+        }
+        return fileIds
+    }
+
+    function getFileCount(kind) {
+        return $("#product-" + kind + "-section").data("saved_file_count") || 0;
+    }
+
+    function setFileCount(kind, count) {
+        $("#product-" + kind + "-section").data("saved_file_count", count);
+    }
+
     function onDropzoneQueueComplete(dropzone, kind) {
         if(location.pathname.indexOf("new") > 0) {
             // save product media the traditional way via the save button when creating a new product
             return;
         }
         const productId = $("#product-" + kind + "-section-dropzone").data().product_id;
-        const $fileInputs = $("#product-" + kind + "-section").find(".file-control input");
-        var fileIds = [];
+        if (!productId) {
+            return;
+        }
 
-        for(var i = 0; i < $fileInputs.length; i++){
-            let fileId = parseInt($($fileInputs[i]).val());
-            if(!isNaN(fileId)) {
-                fileIds.push(parseInt($($fileInputs[i]).val()));
-            }
+        let fileIds = getFileIds(kind);
+        if (getFileCount(kind) === fileIds.length) {  // Skip add media if file count has not changed
+            return;
         }
 
         $.ajax({
@@ -152,6 +171,9 @@ $(function() {
     dropzones.forEach(function(zoneData) {
         var fieldId = "#" + zoneData.field + "-dropzone";
         if ($(fieldId).length) {
+            // Save file count so we can prevent saving product media
+            // if file count has not changed
+            setFileCount(zoneData.queueComplete, getFileIds(zoneData.queueComplete).length);
             activateDropzone($(fieldId), {
                 uploadPath: zoneData.targetPath,
                 maxFiles: zoneData.maxFiles,


### PR DESCRIPTION
- Add error message when upload fails. At media queue complete do not resave product media if the file-count has not changed. This for example prevents media save when the upload itself fails.
- Add option to override dropzone upload path by using data attribute
- Add upload path to browser URLs and use it to fallback on media uploads when the actual media path is not available.