### PR TITLE
Fix front app history handling and tune admin order creator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+- Core: add option to enable order edit for multiple vendors
 - Front: do not stack history on product list when filters are changed.
   Instead replace state so back-buttons works nicely.
 - Front: prevent image Lightbox touching history so you do not need

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+- Admin: fix width issue with picotable images
 - Admin: fix bugs in order edit and improve it one step closer to
   multivendor world. Now supports situation when vendors does not
   share products.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+
+- Front: prevent image Lightbox touching history so you do not need
+  to click back 6 times after you have viewed all images.
+
 ## [1.10.12] - 2020-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
-
+- Front: do not stack history on product list when filters are changed.
+  Instead replace state so back-buttons works nicely.
 - Front: prevent image Lightbox touching history so you do not need
   to click back 6 times after you have viewed all images.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+- Admin: fix bugs in order edit and improve it one step closer to
+  multivendor world. Now supports situation when vendors does not
+  share products.
+     - Add option to make shipping and payment method optional
+     - Add supplier to pricing context
+     - Show supplier name on product column
+     - Make auto add for product select false by default
+     - Fix product select2 missing URL and data handler since
+       the whole ajax method was passed as attrs.
+     - Add option to open/close collapsed content sections in mobile
 - Core: add option to enable order edit for multiple vendors
 - Front: do not stack history on product list when filters are changed.
   Instead replace state so back-buttons works nicely.

--- a/shuup/admin/modules/orders/static_src/create/reducers/lines.js
+++ b/shuup/admin/modules/orders/static_src/create/reducers/lines.js
@@ -15,6 +15,7 @@ function newLine() {
         id: (+new Date() * 10000).toString(36),
         type: "product",
         product: null,
+        supplier: null,
         sku: null,
         text: null,
         errors: null,
@@ -104,6 +105,7 @@ function updateLineFromProduct(state, {payload}) {
     updates.step = product.purchaseMultiple;
     updates.errors = product.errors;
     updates.product = product.product;
+    updates.supplier = product.supplier;
     updates = _.merge(updates, getFormattedStockCounts(product));
     return setLineProperties(state, id, updates);
 }
@@ -119,6 +121,9 @@ function setLineProperty(state, {payload}) {
                 updates.product = product;
                 updates.type = "product";
                 break;
+            }
+            case "supplier": {
+                updates.supplier = value;
             }
             case "text": {
                 updates.text = value;

--- a/shuup/admin/modules/orders/static_src/create/reducers/quickAdd.js
+++ b/shuup/admin/modules/orders/static_src/create/reducers/quickAdd.js
@@ -15,7 +15,7 @@ export default handleActions({
     clearQuickAddProduct: ((state) => _.assign(state, {product: {id: "", text: ""}})),
     setFocusOnQuickAdd: ((state, {payload}) => _.assign(state, {focus: payload}))
 }, {
-    autoAdd: true,
+    autoAdd: false,
     focus: false,
     product: {
         id: "",

--- a/shuup/admin/modules/orders/static_src/create/view/lines.js
+++ b/shuup/admin/modules/orders/static_src/create/view/lines.js
@@ -72,6 +72,7 @@ export function renderOrderLines(store, shop, lines) {
                 }, (line.product ? [
                     line.product.text, m("br"),
                     m("small", "(" + line.sku + ")"), m("br"),
+                    m("small", line.supplier.name), m("br"),
                     m("small", gettext("Logical Count") + ": " + line.logicalCount), m("br"),
                     m("small", gettext("Physical Count") + ": " + line.physicalCount)
                 ] : gettext("Select product"))
@@ -217,7 +218,6 @@ export function renderOrderLines(store, shop, lines) {
 var ProductQuickSelect = {
     view: function(ctrl, attrs) {
         const {store} = attrs;
-
         return m.component(Select2, {
             name: "product-quick-select",
             model: "shuup.product",
@@ -225,6 +225,16 @@ var ProductQuickSelect = {
             attrs: {
                 placeholder: gettext("Search product by name, SKU, or barcode"),
                 ajax: {
+                    url: window.ShuupAdminConfig.browserUrls.select,
+                    dataType: "json",
+                    data: function (params) {
+                        const data = {
+                            model: "shuup.product",
+                            searchMode: "sellable_mode_only",
+                            search: params.term,
+                        };
+                        return data;
+                    },
                     processResults(data) {
                         if (!data) {
                             return {results: []};
@@ -298,8 +308,8 @@ export function orderLinesView(store, isCreating) {
                         type: "checkbox",
                         checked: quickAdd.autoAdd,
                         onchange: function() {
-                            store.dispatch(clearQuickAddProduct());
                             store.dispatch(setAutoAdd(this.checked));
+                            store.dispatch(clearQuickAddProduct());
                         }
                     }),
                     m("span.quick-add-check-text", " " + gettext("Automatically add selected product"))

--- a/shuup/admin/modules/orders/static_src/create/view/utils.js
+++ b/shuup/admin/modules/orders/static_src/create/view/utils.js
@@ -55,7 +55,18 @@ export function contentBlock(icon, title, view, header = "h2") {
     return m("div.content-block",
         m("div.title",
             m(header + ".block-title.d-flex.align-items-center", m(icon), " " + title),
-            m("a.toggle-contents", m("i.fa.fa-chevron-right"))
+            m("a.toggle-contents", {
+                onclick: (event) => {
+                    const $collapseElement = $(event.target).closest(".content-block").find(".content-wrap");
+                    event.preventDefault();
+
+                    // Checks if the bootstrap collapse animation is not ongoing
+                    if (!$collapseElement.hasClass("collapsing")) {
+                        $collapseElement.collapse("toggle");
+                        $(this).closest(".title").toggleClass("open");
+                    }
+                }
+            }, m("i.fa.fa-chevron-right"))
         ),
         m("div.content-wrap.collapse",
             m("div.content", view)

--- a/shuup/admin/settings.py
+++ b/shuup/admin/settings.py
@@ -97,3 +97,13 @@ SHUUP_ADMIN_LOGIN_AS_REDIRECT_VIEW = "shuup:index"
 #: To which view redirect impersonator when login as staff
 #:
 SHUUP_ADMIN_LOGIN_AS_STAFF_REDIRECT_VIEW = "shuup_admin:dashboard"
+
+
+#: Whether to require shipping method at admin order creator/edit
+#:
+SHUUP_ADMIN_REQUIRE_SHIPPING_METHOD_AT_ORDER_CREATOR = True
+
+
+#: Whether to require payment method at admin order creator/edit
+#:
+SHUUP_ADMIN_REQUIRE_PAYMENT_METHOD_AT_ORDER_CREATOR = True

--- a/shuup/admin/static_src/base/scss/shuup/picotable.scss
+++ b/shuup/admin/static_src/base/scss/shuup/picotable.scss
@@ -197,6 +197,7 @@
         }
 
         td img {
+            max-width: unset;
             width: 42px;
             height: 42px;
             padding: 4px;

--- a/shuup/core/models/_orders.py
+++ b/shuup/core/models/_orders.py
@@ -1194,7 +1194,7 @@ class Order(MoneyPropped, models.Model):
 
     def can_edit(self):
         return (
-            not settings.SHUUP_ENABLE_MULTIPLE_SUPPLIERS
+            settings.SHUUP_ALLOW_EDITING_ORDER
             and not self.has_refunds()
             and not self.is_canceled()
             and not self.is_complete()

--- a/shuup/core/settings.py
+++ b/shuup/core/settings.py
@@ -97,6 +97,13 @@ SHUUP_ENABLE_MULTIPLE_SHOPS = False
 #: Enabling this flag allows supplier creation from Admin Panel.
 SHUUP_ENABLE_MULTIPLE_SUPPLIERS = False
 
+#: Whether to allow editing order
+#: By default when multiple suppliers is enabled this option is disabled
+#: since order edit does not offer supplier select for product line.
+#: You can enable this when there is max one vendor per product.
+#:
+SHUUP_ALLOW_EDITING_ORDER = not SHUUP_ENABLE_MULTIPLE_SUPPLIERS
+
 #: Indicates whether Shuup should restrict Contact access per Shop.
 #:
 #: This is useful when multi-shop is in use and the contact shouldn't

--- a/shuup/front/static_src/js/category.js
+++ b/shuup/front/static_src/js/category.js
@@ -89,7 +89,7 @@ window.refreshFilters = debounce(function refreshFilters(pageNumber = 1) {
     });
 
     if (window.history && window.history.pushState) {
-        history.pushState(state, null, filterString);
+        history.replaceState(state, null, filterString);
     }
 
     window.dispatchEvent(new CustomEvent("Shuup.FiltersRefreshed", {

--- a/shuup/front/static_src/js/update_price.js
+++ b/shuup/front/static_src/js/update_price.js
@@ -56,7 +56,7 @@ window.updatePrice = function updatePrice(productId) {
 
         const imagesSelector = ".product-image .product-carousel a";
         if ($(imagesSelector).length > 0) {
-            $(imagesSelector).simpleLightbox();
+            $(imagesSelector).simpleLightbox({history: false});
         }
 
         $(".product-image .owl-carousel.carousel-thumbnails").owlCarousel({

--- a/shuup/front/templates/shuup/front/macros/product_image.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_image.jinja
@@ -86,12 +86,12 @@
     // navigate through images.
     var selector_multiple = "a[data-imagelightbox='image-multiple']";
     if ($(selector_multiple).length > 0) {
-        var instance_multiple = $(selector_multiple).simpleLightbox();
+        var instance_multiple = $(selector_multiple).simpleLightbox({history: false});
     }
 
     // Enable lightbox for products with only one image.
     var selector = "a[data-imagelightbox='image']";
     if ($(selector).length > 0) {
-        var instance = $(selector).simpleLightbox();
+        var instance = $(selector).simpleLightbox({history: false});
     }
 {% endmacro %}


### PR DESCRIPTION
Front: fix issues with Lightbox and app history
Front: avoid stacking app history on product list updates
Core: add option to enable order edit for multiple vendors
Admin: improve order edit tool
- Add option to make shipping and payment method optional
- Add supplier to pricing context
- Show supplier name on product column
- Make auto add for product select false by default
- Fix product select2 missing URL and data handler since the whole ajax method was passed as attrs.
- Add option to open/close collapsed content sections in mobile