### PR TITLE
Front: only show carousel title when there is one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+### Fixed
+
+- Front: only show carousel title when there is one
+
+### Changed
+
 - Front: improve next parameter with registration. Check GET
   parameter first and then fallback to POST data.
 

--- a/shuup/front/apps/carousel/templates/shuup/carousel/carousel.jinja
+++ b/shuup/front/apps/carousel/templates/shuup/carousel/carousel.jinja
@@ -69,13 +69,15 @@
         {% set caption_text = slide.get_translated_field("caption_text") or "" %}
 
         {% if link %}<a href="{{ link }}" target="{{ slide.get_link_target() }}" class="col-inner" style="text-decoration: none;" data-toggle="tooltip" title="{{ caption_text }}">{% endif %}
-            <div style="background-image: url({{ cropped_slide }}); height: {{carousel.image_height}}px; color: white;" alt="{{ caption }}" title="{{ caption }}. {{ caption_text }}">
-            {% if type == "carousel" %}
-                <div class="carousel-title-text" style="">{{ caption }}</div>
-                <p class="carousel-text" style="">{{ caption_text }}</p>
-            {% elif type == "banner_box" %}
-                <div class="carousel-title-text"
-                    style="display: flex; align-items: center; height: 100%">{{ caption }}</div>
+            <div class="carousel-page" style="background-image: url({{ cropped_slide }}); height: {{carousel.image_height}}px; color: white;" alt="{{ caption }}" title="{{ caption }}{{ '. ' if caption and caption_text else '' }}{{ caption_text }}">
+            {% if render_image_text %}
+                {% if type == "carousel" %}
+                    {% if caption %}<div class="carousel-title-text">{{ caption }}</div>{% endif %}
+                    {% if caption_text %}<p class="carousel-text">{{ caption_text }}</p>{% endif %}
+                {% elif type == "banner_box" and caption %}
+                    <div class="carousel-title-text"
+                        style="display: flex; align-items: center; height: 100%">{{ caption }}</div>
+                {% endif %}
             {% endif %}
             </div>
         {% if link %}</a>{% endif %}

--- a/shuup/front/static_src/less/front/carousel.less
+++ b/shuup/front/static_src/less/front/carousel.less
@@ -141,6 +141,10 @@
             padding: unset;
         }
     }
+    .carousel-page {
+        background-repeat: no-repeat;
+        background-size: cover;
+    }
     .fa-angle-left {
         left: -25px;
         z-index: 1000;


### PR DESCRIPTION
Make use of `render_image_text` plugin configuration to render title

Refs #2169