### PR TITLE
Simple CMS: Fix a bug with the page links plugin

### DIFF
--- a/shuup/simple_cms/plugins.py
+++ b/shuup/simple_cms/plugins.py
@@ -26,8 +26,8 @@ class OrderedModelMultipleChoiceField(forms.ModelMultipleChoiceField):
             self.queryset = order_query_by_values(self.queryset, initial)
 
     def _check_values(self, value):  # To save current choice order in DB
-        initial_q = super(OrderedModelMultipleChoiceField, self)._check_values(value)
-        return order_query_by_values(initial_q, value)
+        queryset = super(OrderedModelMultipleChoiceField, self)._check_values(value)
+        return order_query_by_values(queryset, value)
 
 
 class PageLinksConfigForm(GenericPluginForm):

--- a/shuup/simple_cms/utils.py
+++ b/shuup/simple_cms/utils.py
@@ -9,6 +9,8 @@
 from django.db.models import Case, When
 
 
-def order_query_by_values(initial_q, values):
+def order_query_by_values(queryset, values):
     order = Case(*[When(pk=pk, then=pos) for pos, pk in enumerate(values)])
-    return initial_q.order_by(order)
+    if values:
+        queryset = queryset.order_by(order)
+    return queryset


### PR DESCRIPTION
This would break if values given to the `order_query_by_values` were None. This fixes that.
No refs