### PR TITLE
Improve front checkotu as compnany and fix issue with custom list view columns

### DIFF
--- a/shuup/admin/modules/orders/views/list.py
+++ b/shuup/admin/modules/orders/views/list.py
@@ -47,6 +47,11 @@ class OrderListView(PicotableListView):
             filter_config=RangeFilter(field_type="number", filter_field="taxful_total_price_value")
         ),
     ]
+    related_objects = [
+        ("shop", "shuup.core.models:Shop"),
+        ("billing_address", "shuup.core.models:ImmutableAddress"),
+        ("shipping_address", "shuup.core.models:ImmutableAddress"),
+    ]
     mass_actions = [
         "shuup.admin.modules.orders.mass_actions:CancelOrderAction",
         "shuup.admin.modules.orders.mass_actions:OrderConfirmationPdfAction",

--- a/shuup/front/checkout/addresses.py
+++ b/shuup/front/checkout/addresses.py
@@ -144,6 +144,8 @@ class AddressesPhase(CheckoutPhaseViewMixin, FormView):
         self._process_addresses(basket)
         if self.storage.get("company"):
             basket.customer = self.storage.get("company")
+
+        if isinstance(basket.customer, CompanyContact):
             for address_kind in self.address_kinds:
                 address = getattr(basket, "{}_address".format(address_kind), None)
                 if address:

--- a/shuup_tests/admin/test_view_settings.py
+++ b/shuup_tests/admin/test_view_settings.py
@@ -10,6 +10,7 @@ import pytest
 from django.utils.http import urlencode
 
 from shuup import configuration
+from shuup.admin.modules.orders.views import OrderListView
 from shuup.admin.modules.products.views import ProductListView
 from shuup.admin.modules.settings.views import ListSettingsView
 from shuup.testing.factories import get_default_shop
@@ -67,3 +68,27 @@ def test_view_saved_columns(rf):
     column_names = [c.id for c in sorted(listview.columns, key=lambda x: x.id)]
     assert len(listview.columns) == len(visible_fields)
     assert column_names == visible_fields
+
+
+@pytest.mark.django_db
+def test_product_view_columns(rf):
+    get_default_shop()
+    listview = ProductListView()
+    column_ids = [c.id for c in listview.settings.column_spec]
+    assert "product_description" in column_ids
+    column_labels = [c.title for c in listview.settings.column_spec]
+    assert "Product Description" in column_labels
+    assert "Product Keywords" in column_labels
+
+
+@pytest.mark.django_db
+def test_order_view_columns(rf):
+    get_default_shop()
+    listview = OrderListView()
+    column_ids = [c.id for c in listview.settings.column_spec]
+    assert "shop_public_name" in column_ids
+    column_labels = [c.title for c in listview.settings.column_spec]
+    assert "Shop Public Name" in column_labels
+    assert "Shop Name" in column_labels
+    assert "Shipping address Street" in column_labels
+    assert "Billing address Street" in column_labels

--- a/shuup_tests/browser/admin/test_picotable.py
+++ b/shuup_tests/browser/admin/test_picotable.py
@@ -49,7 +49,7 @@ list_view_settings = {
     "shop_product": {
         "page_header": "Shop Products",
         "default_column_count": 7,
-        "addable_fields": [(13, "Gtin"), (6, "Default Price")],
+        "addable_fields": [(21, "Product Gtin"), (3, "Default Price")],
         "creator": create_products,
         "test_pagination": False
     },


### PR DESCRIPTION
Ensure company name and tax number is set to both billing and shipping address same way as when filled through company form when customer is not logged in. Company name and tax number at order addresses seems to help with some taxation logic as well as makes things more
consistent.

Make sure related custom columns are added accrodingly. Fix issue with filtering through columns that are by default hidden
