### PR TITLE
Admin: Add settings for disabling HTML in descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+### Added
+
+- Admin: Add settings for controlling allowing HTML in product and vendor descriptions
 
 ## [1.11.0] - 2020-07-02
 

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ utils.add_exclude_patters([
 
 REQUIRES = [
     'Babel==2.5.3',
+    'bleach==3.1.5',
     'Django>=1.8,<2',
     'django-bootstrap3>=6.1,<10',
     'django-countries>=3.3,<5.3',

--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -82,7 +82,9 @@ class ProductBaseForm(MultiLanguageModelForm):
             "keywords": forms.TextInput(),
             "sales_unit": QuickAddSalesUnitSelect(editable_model="shuup.SalesUnit"),
             "tax_class": QuickAddTaxClassSelect(editable_model="shuup.TaxClass"),
-            "description": TextEditorWidget(),
+            "description": (TextEditorWidget()
+                            if settings.SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION
+                            else forms.Textarea(attrs={"rows": 5})),
             "short_description": forms.TextInput(),
         }
 

--- a/shuup/admin/settings.py
+++ b/shuup/admin/settings.py
@@ -107,3 +107,13 @@ SHUUP_ADMIN_REQUIRE_SHIPPING_METHOD_AT_ORDER_CREATOR = True
 #: Whether to require payment method at admin order creator/edit
 #:
 SHUUP_ADMIN_REQUIRE_PAYMENT_METHOD_AT_ORDER_CREATOR = True
+
+#: Whether to allow vendors and staff to use a rich text editor and HTML for product descriptions.
+#: If this is False, only a allow simple text field and sanitize all HTML from it.
+#:
+SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION = True
+
+#: Whether to allow vendors to use a rich text editor and HTML for their profile descriptions.
+#: If this is False, only a allow simple text field and sanitize all HTML from it.
+#:
+SHUUP_ADMIN_ALLOW_HTML_IN_VENDOR_DESCRIPTION = True

--- a/shuup/core/templatetags/shuup_common.py
+++ b/shuup/core/templatetags/shuup_common.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 from datetime import date
 from json import dumps as json_dump
 
+import bleach
 from babel.dates import format_date, format_datetime, format_time
 from babel.numbers import format_decimal
 from django.conf import settings
@@ -26,7 +27,7 @@ from django.utils import translation
 from django.utils.safestring import mark_safe
 from django.utils.timezone import localtime
 from django_jinja import library
-from jinja2.runtime import Undefined
+from jinja2 import Undefined
 from jinja2.utils import contextfunction
 
 from shuup.utils.i18n import (
@@ -137,6 +138,24 @@ def json(value):
     if isinstance(value, Undefined):
         value = None
     return mark_safe(json_dump(value, cls=ExtendedJSONEncoder))
+
+
+@library.filter
+def safe_product_description(value):
+    if isinstance(value, Undefined):
+        return value
+    if not settings.SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION:
+        value = bleach.clean(value, tags=[])
+    return mark_safe(value)
+
+
+@library.filter
+def safe_vendor_description(value):
+    if isinstance(value, Undefined):
+        return value
+    if not settings.SHUUP_ADMIN_ALLOW_HTML_IN_VENDOR_DESCRIPTION:
+        value = bleach.clean(value, tags=[])
+    return mark_safe(value)
 
 
 @library.global_function

--- a/shuup/front/templates/shuup/front/macros/product.jinja
+++ b/shuup/front/templates/shuup/front/macros/product.jinja
@@ -53,7 +53,7 @@ Inheritance order for product macors:
                     {% endif %}
                 </div>
                 {% if show_description and product.short_description %}
-                    <p class="description">{{ product.short_description|safe }}</p>
+                    <p class="description">{{ product.short_description|safe_product_description }}</p>
                 {% endif %}
             </div>
         </a>

--- a/shuup/front/templates/shuup/front/macros/product_information.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_information.jinja
@@ -7,7 +7,7 @@
     {%  if show_supplier_info %}{{ render_supplier_info(supplier) }}{% endif %}
     <p class="text-muted product-sku"><small>{{ product.sku }}</small></p>
     {% if product.short_description %}
-        <p class="product-short-description">{{ product.short_description|safe }}</p>
+        <p class="product-short-description">{{ product.short_description|safe_product_description }}</p>
     {% endif %}
     {% if show_prices() and not xtheme.get("hide_prices") %}
         <div class="product-price">
@@ -69,7 +69,7 @@
             {% if xtheme.should_render_product_detail_tab("description") %}
                 <div role="tabpanel" class="product-description tab-pane fade in {% if active_tab == 'description' %}in active{% endif %}" id="description">
                     {% if product.description or package_children %}
-                        {{ product.description|safe }}
+                        {{ product.description|safe_product_description }}
                         {% if package_children %}
                             {% set quantity_map = product.get_package_child_to_quantity_map() %}
                             <p><strong>{% trans %}Includes these products{% endtrans %}</strong></p>

--- a/shuup/front/templates/shuup/front/product/product_preview.jinja
+++ b/shuup/front/templates/shuup/front/product/product_preview.jinja
@@ -40,7 +40,7 @@
                         {% if show_supplier_info %}{{ render_supplier_info(supplier, render_link=False) }}{% endif %}
                         {% if product.short_description %}
                             <p class="description">
-                                {{ product.short_description|safe }}
+                                {{ product.short_description|safe_product_description }}
                             </p>
                         {% endif %}
                         {% if show_prices() and not xtheme.get("hide_prices") %}

--- a/shuup_tests/core/test_template_tags.py
+++ b/shuup_tests/core/test_template_tags.py
@@ -8,6 +8,8 @@
 from __future__ import unicode_literals
 
 from decimal import Decimal
+
+from django.conf import settings
 from mock import patch
 
 from django.utils import translation
@@ -15,7 +17,7 @@ from jinja2 import Template
 
 from shuup.core.models import Shop
 from shuup.core.templatetags.shuup_common import (
-    get_global_configuration, get_shop_configuration, money, number, percent
+    get_global_configuration, get_shop_configuration, money, number, percent, safe_product_description, safe_vendor_description
 )
 from shuup.utils.money import Money
 
@@ -213,3 +215,23 @@ def test_get_global_configuration(conf_get_mock, rf):
 def test_get_global_configuration_with_default(conf_get_mock, rf):
     get_global_configuration('some_variable', 'default')
     conf_get_mock.assert_called_once_with(None, 'some_variable', 'default')
+
+
+def test_safe_product_description():
+    text = "<p>product description</p>"
+
+    settings.SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION = True
+    assert safe_product_description(text) == text
+
+    settings.SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION = False
+    assert safe_product_description(text) == "&lt;p&gt;product description&lt;/p&gt;"
+
+
+def test_safe_vendor_description():
+    text = "<p>vendor description</p>"
+
+    settings.SHUUP_ADMIN_ALLOW_HTML_IN_VENDOR_DESCRIPTION = True
+    assert safe_vendor_description(text) == text
+
+    settings.SHUUP_ADMIN_ALLOW_HTML_IN_VENDOR_DESCRIPTION = False
+    assert safe_vendor_description(text) == "&lt;p&gt;vendor description&lt;/p&gt;"


### PR DESCRIPTION
New settings:
`SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION` (default `True`)
`SHUUP_ADMIN_ALLOW_HTML_IN_VENDOR_DESCRIPTION` (default `True`)
The default values are `True` for allowing full backwards compatibility.
New projects should most probably set these to `False`.

Refs SHU-24