### PR TITLE
Add signal when an email is sent by a notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+### Added
+
+- Add signal when an email is sent by a notification
+
 ## [1.11.4] - 2020-07-06
 
 - Fix issue with browser tests

--- a/shuup/notify/actions/email.py
+++ b/shuup/notify/actions/email.py
@@ -17,6 +17,7 @@ from django.utils.translation import ugettext as _
 from shuup.admin.forms.widgets import TextEditorWidget
 from shuup.notify.base import Action, Binding
 from shuup.notify.enums import ConstantUse, TemplateUse
+from shuup.notify.signals import notification_email_sent
 from shuup.notify.typology import Email, Language, Text
 
 
@@ -138,6 +139,8 @@ class SendEmail(Action):
         message.content_subtype = content_type
         message.send()
         context.log(logging.INFO, "Info! %s: Mail sent to %s.", self.identifier, recipient)
+
+        notification_email_sent.send(sender=type(self), message=message, context=context)
 
         if send_identifier:
             context.add_log_entry_on_log_target("Info! Email sent to %s: %s" % (recipient, subject), send_identifier)

--- a/shuup/notify/signals.py
+++ b/shuup/notify/signals.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2020, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from django.dispatch import Signal
+
+notification_email_sent = Signal(providing_args=["message", "context"])

--- a/shuup_tests/notify/test_email.py
+++ b/shuup_tests/notify/test_email.py
@@ -10,6 +10,7 @@ import pytest
 from django.conf import settings
 import django.core.mail as mail
 from django.test import override_settings
+import mock
 
 from shuup.notify.actions.email import SendEmail
 from shuup.notify.script import Context
@@ -17,6 +18,7 @@ from shuup.testing import factories
 from shuup_tests.notify.fixtures import (
     get_initialized_test_event, TEST_TEMPLATE_DATA
 )
+from shuup.notify.signals import notification_email_sent
 
 
 @pytest.mark.django_db
@@ -93,19 +95,22 @@ def test_email_action_with_template_body():
 
         mail.outbox = []  # Clear the Django testing mail outbox
 
-        event = get_initialized_test_event()
-        ctx = Context.from_event(event, shop=factories.get_default_shop())
-        ctx.set("name", "Luke J. Warm")  # This variable isn't published by the event, but it's used by the template
-        se = SendEmail({
-            "template_data": SUPER_TEST_TEMPLATE_DATA,
-            "from_email": {"constant": "from@shuup.local"},
-            "recipient": {"constant": "someone@shuup.local"},
-            "language": {"constant": "ja"},
-        })
-        se.execute(ctx)  # Once
-        assert len(mail.outbox) == 1  # 'send_identifier' should ensure this is true
-        msg = mail.outbox[0]
-        assert msg.to == ['someone@shuup.local']
-        assert msg.from_email == 'from@shuup.local'
-        assert ".dog-color { color: red; }" in msg.body
-        assert "Luke J. Warm" in msg.body
+        with mock.patch.object(notification_email_sent, "send") as mocked_method:
+            event = get_initialized_test_event()
+            ctx = Context.from_event(event, shop=factories.get_default_shop())
+            ctx.set("name", "Luke J. Warm")  # This variable isn't published by the event, but it's used by the template
+            se = SendEmail({
+                "template_data": SUPER_TEST_TEMPLATE_DATA,
+                "from_email": {"constant": "from@shuup.local"},
+                "recipient": {"constant": "someone@shuup.local"},
+                "language": {"constant": "ja"},
+            })
+            se.execute(ctx)  # Once
+            assert len(mail.outbox) == 1  # 'send_identifier' should ensure this is true
+            msg = mail.outbox[0]
+            assert msg.to == ['someone@shuup.local']
+            assert msg.from_email == 'from@shuup.local'
+            assert ".dog-color { color: red; }" in msg.body
+            assert "Luke J. Warm" in msg.body
+
+        mocked_method.assert_called()


### PR DESCRIPTION
The notification can be captured to log the emails sent and presented in a list view for auditing