### PR TITLE
Sanitize product description on save if the setting is toggled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+### Changed
+
+- Sanitize product description on save if `SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION` is set to `False`
+
 ## [1.11.7] - 2020-07-23
 
 ### Added

--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 
 from collections import defaultdict
 
+import bleach
 from django import forms
 from django.conf import settings
 from django.contrib import messages
@@ -152,6 +153,12 @@ class ProductBaseForm(MultiLanguageModelForm):
         form_pre_clean.send(
             Product, instance=self.instance, cleaned_data=self.cleaned_data)
         super(ProductBaseForm, self).clean()
+
+        if not settings.SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION:
+            for key, value in self.cleaned_data.items():
+                if key.startswith("description__"):
+                    self.cleaned_data[key] = bleach.clean(value, tags=[])
+
         form_post_clean.send(
             Product, instance=self.instance, cleaned_data=self.cleaned_data)
 


### PR DESCRIPTION
We already did this to vendor description, so it only makes sense to do it here as well.

No refs