### PR TITLE
Admin: return `None` when the order source was not correctly initialized in JsonOrderCreator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+### Fixed
+
+- Admin: return `None` when the order source was not correctly initialized in JsonOrderCreator
+
 ## [1.11.10] - 2020-08-04
 
 - Fix issue on arranging menu after reset which sets the configuration None
@@ -17,14 +21,14 @@ List all changes after the last release here (newer on top). Each change on a se
 ## [1.11.9] - 2020-08-04
 
 - Admin: add option to arrange menu for superuses, staff and suppliers
-  
+
   For now it was only possible to arrange menu per user which is not
   sufficient while the menu needs to be arranged for the whole group
   of people like shop staff or vendors.
-    
+
   Allow to create menu custom menu for superusers, staff or suppliers,
   but remain the possibility to still arrange the menu per user.
-    
+
   Add option to translate each menu arranged for these groups since
   not all vendors/suppliers necessary speak same language.
 

--- a/shuup/admin/modules/orders/json_order_creator.py
+++ b/shuup/admin/modules/orders/json_order_creator.py
@@ -113,7 +113,7 @@ class JsonOrderCreator(object):
         supplier_info = sline.pop("supplier", None)
 
         if not supplier_info:
-            self.add_error(ValidationError(_("Product line dose not have a supplier."), code="no_supplier"))
+            self.add_error(ValidationError(_("Product line does not have a supplier."), code="no_supplier"))
             return False
 
         if not product_info:
@@ -368,6 +368,9 @@ class JsonOrderCreator(object):
         """
         source = self.create_source_from_state(
             state, creator=creator, ip_address=ip_address, save=True)
+
+        if not source:
+            return
 
         # Then create an OrderCreator and try to get things done!
         creator = AdminOrderCreator()


### PR DESCRIPTION
No Refs