### PR TITLE
GDPR: Fix order anonymization for null addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ List all changes after the last release here (newer on top). Each change on a se
 ### Fixed
 
 - Xtheme: fix social media plugin form populate
+- GDPR: Fix anonymization error when an order of a contact had no shipping or billing address.
 
 
 ## [2.1.3] - 2020-08-28

--- a/shuup/gdpr/anonymizer.py
+++ b/shuup/gdpr/anonymizer.py
@@ -139,12 +139,13 @@ class Anonymizer(object):
         assert isinstance(order, Order)
         self.anonymize_object(order)
 
-        self.anonymize_object(order.shipping_address, save=False)
-        self.anonymize_object(order.billing_address, save=False)
+        if order.shipping_address:
+            self.anonymize_object(order.shipping_address, save=False)
+            Address.save(order.shipping_address)  # bypass Protected model save() invoking super directly
 
-        # bypass Protected model save() invoking super directly
-        Address.save(order.shipping_address)
-        Address.save(order.billing_address)
+        if order.billing_address:
+            self.anonymize_object(order.billing_address, save=False)
+            Address.save(order.billing_address)
 
     def anonymize_object(self, obj, save=True):
         if not obj:


### PR DESCRIPTION
Before if an order of a contact that was about to be anonymized
had an order with a null shipping or billing address, it would result in the error:
>     AttributeError: 'NoneType' object has no attribute '_meta'`

when `Address.save()` was called.

Refs DO-190