### PR TITLE
Fix product quantity input on enter press

### DIFF
--- a/shuup/front/templates/shuup/front/macros/basket.jinja
+++ b/shuup/front/templates/shuup/front/macros/basket.jinja
@@ -255,7 +255,22 @@
 {% endmacro %}
 
 {% macro update_quantity_js() %}
-    $("#update_basket_form .quantity :input").change(function() {
+    function checkEvent(e) {
+        return (e.which == 13 || e.keyCode == 13 || e.key == "Enter");
+    }
+
+    $("#update_basket_form .quantity :input")
+    .keydown(function(e) {
+        if (checkEvent(e)) {
+            e.preventDefault();
+        }
+    })
+    .keyup(function(e) {
+        if (checkEvent(e)) {
+            $("#update_basket_form").submit();
+        }
+    })
+    .change(function() {
         $("#update_basket_form").submit();
     });
 {% endmacro %}


### PR DESCRIPTION
Fix for https://github.com/shuup/shuup/issues/2277

In basket form all "product remove" buttons have type="submit" and when you press Enter, first "remove product" button submits the form.  That's why first product deleted from the basket.

In this fix I added additional events to track Enter keydown to prevent event, then in keyup for Enter form submitted. I supposed to add keydown and keyup, because keydown could fire several times (event attribute repeat=True) and in this case I need to check if it's initial Enter press or repeated. Decided to change this behaviour and used keyup event to release the form.