### PR TITLE
Notify: Show more Order related variables in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+### Added
+
+- Notify: Add a new `attributes` attribute to `shuup.notify.base.Variable` for showing examples
+  of which attributes can be accessed in the script templates.
+- Notfiy: Show some `Order` related attributes in the notify templates.
+
 ### Fixed
 
 - Core: include arbitrary refunds for max refundable amount

--- a/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-15 14:39+0000\n"
+"POT-Creation-Date: 2020-10-13 11:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -737,6 +737,9 @@ msgstr ""
 
 #, javascript-format
 msgid "Filter by %s"
+msgstr ""
+
+msgid " Select"
 msgstr ""
 
 msgid "Filters"

--- a/shuup/front/locale/en/LC_MESSAGES/django.po
+++ b/shuup/front/locale/en/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-22 17:54+0000\n"
+"POT-Creation-Date: 2020-10-13 11:37+0000\n"
 "PO-Revision-Date: 2016-08-04 10:51-0700\n"
 "Last-Translator: \n"
 "Language-Team: en <LL@li.org>\n"
@@ -472,6 +472,24 @@ msgid "stored basket"
 msgstr ""
 
 msgid "stored baskets"
+msgstr ""
+
+msgid "ID"
+msgstr ""
+
+msgid "Reference Number"
+msgstr ""
+
+msgid "Currency"
+msgstr ""
+
+msgid "Customer Name"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Shipping Method"
 msgstr ""
 
 msgid "Order Received"

--- a/shuup/front/notify_events.py
+++ b/shuup/front/notify_events.py
@@ -18,12 +18,23 @@ from shuup.notify.base import Event, Variable
 from shuup.notify.models import Script
 from shuup.notify.typology import Email, Enum, Language, Model, Phone
 
+# Common attributes that can be used with orders.
+ORDER_ATTRIBUTES = (
+    (_("ID"), "id"),
+    (_("Reference Number"), "reference_number"),
+    (_("Currency"), "currency"),
+    (_("Shop"), "shop"),
+    (_("Customer Name"), "get_customer_name()"),
+    (_("Status"), "status.name"),
+    (_("Shipping Method"), "shipping_method_name"),
+)
+
 
 class OrderReceived(Event):
     identifier = "order_received"
     name = _("Order Received")
 
-    order = Variable(_("Order"), type=Model("shuup.Order"))
+    order = Variable(_("Order"), type=Model("shuup.Order"), attributes=ORDER_ATTRIBUTES)
     customer_email = Variable(_("Customer Email"), type=Email)
     customer_phone = Variable(_("Customer Phone"), type=Phone)
     shop_email = Variable(_("Shop Email"), type=Email)
@@ -35,7 +46,7 @@ class OrderStatusChanged(Event):
     identifier = "order_status_changed"
     name = _("Order Status Changed")
 
-    order = Variable(_("Order"), type=Model("shuup.Order"))
+    order = Variable(_("Order"), type=Model("shuup.Order"), attributes=ORDER_ATTRIBUTES)
     customer_email = Variable(_("Customer Email"), type=Email)
     customer_phone = Variable(_("Customer Phone"), type=Phone)
     shop_email = Variable(_("Shop Email"), type=Email)
@@ -49,7 +60,7 @@ class ShipmentCreated(Event):
     identifier = "shipment_created"
     name = _("Shipment Created")
 
-    order = Variable(_("Order"), type=Model("shuup.Order"))
+    order = Variable(_("Order"), type=Model("shuup.Order"), attributes=ORDER_ATTRIBUTES)
     customer_email = Variable(_("Customer Email"), type=Email)
     customer_phone = Variable(_("Customer Phone"), type=Phone)
     language = Variable(_("Language"), type=Language)
@@ -63,7 +74,7 @@ class ShipmentDeleted(Event):
     identifier = "shipment_deleted"
     name = _("Shipment Deleted")
 
-    order = Variable(_("Order"), type=Model("shuup.Order"))
+    order = Variable(_("Order"), type=Model("shuup.Order"), attributes=ORDER_ATTRIBUTES)
     customer_email = Variable(_("Customer Email"), type=Email)
     customer_phone = Variable(_("Customer Phone"), type=Phone)
     language = Variable(_("Language"), type=Language)
@@ -76,7 +87,7 @@ class PaymentCreated(Event):
     identifier = "payment_created"
     name = _("Payment Created")
 
-    order = Variable(_("Order"), type=Model("shuup.Order"))
+    order = Variable(_("Order"), type=Model("shuup.Order"), attributes=ORDER_ATTRIBUTES)
     customer_email = Variable(_("Customer Email"), type=Email)
     customer_phone = Variable(_("Customer Phone"), type=Phone)
     language = Variable(_("Language"), type=Language)
@@ -89,7 +100,7 @@ class RefundCreated(Event):
     identifier = "refund_created"
     name = _("Refund Created")
 
-    order = Variable(_("Order"), type=Model("shuup.Order"))
+    order = Variable(_("Order"), type=Model("shuup.Order"), attributes=ORDER_ATTRIBUTES)
     customer_email = Variable(_("Customer Email"), type=Email)
     customer_phone = Variable(_("Customer Phone"), type=Phone)
     language = Variable(_("Language"), type=Language)

--- a/shuup/notify/base.py
+++ b/shuup/notify/base.py
@@ -67,7 +67,22 @@ class BaseMetaclass(type):
 class Variable(object):
     _creation_counter = 0  # For sorting, incremented by `__init__`
 
-    def __init__(self, name, type=Type, required=True, help_text=""):
+    def __init__(self, name, type=Type, required=True, help_text="", attributes=()):
+        """
+        :param name: A human readable name for the variable.
+        :type name: str
+        :param type: The datatype of the variable.
+        :type type: shuup.notify.typology.Type
+        :param required: Whether the variable is required or not.
+        :type required: bool
+        :param help_text: A free-form plaintext help text for the variable.
+        :type help_text: str
+        :param attributes: A sequence of (label, accessor) pairs that will be shown
+            under the variable as guides of attributes that can be accessed from it.
+            If one would pass `[_("ID", "id")]` to this when the `name` param is "Order"
+            if would get rendered as `Order ID: {{ order.id }}` in the script editor.
+        :type attributes: typing.Sequence[tuple[str, str]]
+        """
         self.position = Variable._creation_counter
         Variable._creation_counter += 1
         if callable(type):
@@ -78,6 +93,7 @@ class Variable(object):
         self.type = type
         self.required = bool(required)
         self.help_text = help_text
+        self.attributes = attributes
 
     def get_matching_types(self, variable_dict):
         return set(

--- a/shuup/notify/templates/notify/admin/generic_script_template.jinja
+++ b/shuup/notify/templates/notify/admin/generic_script_template.jinja
@@ -1,3 +1,5 @@
+{%- from "notify/admin/macros.jinja" import render_attributes -%}
+
 {# Render monolingual fields #}
 <div class="row">
     <div class="col-md-10 col-md-offset-1">
@@ -55,6 +57,7 @@
                     <span class="text-info">{{ variable_info.name }}</span>
                     <br><code>{{ '{{ ' ~ variable_identifier ~ ' }}' }}</code>
                     <br>{{ variable_info.help_text|default("") }}
+                    {{ render_attributes(variable_identifier, variable_info) }}
                 </li>
                 {% endfor %}
             </ul>

--- a/shuup/notify/templates/notify/admin/macros.jinja
+++ b/shuup/notify/templates/notify/admin/macros.jinja
@@ -1,0 +1,18 @@
+{% macro render_attributes(variable_identifier, variable_info, onclick=None) %}
+    {% if variable_info.attributes %}
+        <br>
+    {% endif %}
+    {% for attribute in variable_info.attributes %}
+        {% set accessor = variable_identifier ~ "." ~ attribute[1] %}
+        {% set label = variable_info.name ~ " " ~ attribute[0] %}
+        <span>
+            {% if onclick %}
+                <a href="#" onclick="{{ onclick }}" data-var="{{ accessor }}">{{ label }}</a>:
+            {% else %}
+                {{ label }}:
+            {% endif %}
+            <code>{{ '{{ ' ~ accessor ~ ' }}'}}</code>
+        </span>
+        <br>
+    {% endfor %}
+{% endmacro %}

--- a/shuup/notify/templates/notify/admin/script_item_editor.jinja
+++ b/shuup/notify/templates/notify/admin/script_item_editor.jinja
@@ -1,4 +1,7 @@
 {% extends "shuup/admin/base.jinja" %}
+
+{%- from "notify/admin/macros.jinja" import render_attributes -%}
+
 {% block top %}{% endblock %}
 
 {% block support_content %}
@@ -73,6 +76,7 @@
             </a>
             <br><code>{{ '{{ ' ~ variable_identifier ~ ' }}' }}</code>
             <br>{{ variable_info.help_text|default("") }}
+            {{ render_attributes(variable_identifier, variable_info, onclick="insertTemplateVariableExpression(this.dataset.var);return false") }}
         </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
Add a new `attributes` attribute to `shuup.notify.base.Variable` for
showing examples of which attributes can be accessed in the script templates.

Refs IP-7

The new `attributes` look like this in the script editor:
**(Note that the the javascript for the variable links didn't work even before this PR, but once it gets fixed the attributes were made so that they should work just fine with that)** 

![image](https://user-images.githubusercontent.com/33625218/95858264-7f16f100-0d65-11eb-939d-f29d4c2f2ee2.png)

