### PR TITLE
Core: Always preserve newlines in vendor and product descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+### Changed
+
+- Preserve newlines in vendor and product descriptions even when
+ `SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION` and `SHUUP_ADMIN_ALLOW_HTML_IN_VENDOR_DESCRIPTION` are `False`.
+
 ## [2.1.10] - 2020-09-29
 
 ### Fixed

--- a/shuup/core/templatetags/shuup_common.py
+++ b/shuup/core/templatetags/shuup_common.py
@@ -23,6 +23,7 @@ import bleach
 from babel.dates import format_date, format_datetime, format_time
 from babel.numbers import format_decimal
 from django.conf import settings
+from django.template.defaultfilters import linebreaks
 from django.utils import translation
 from django.utils.safestring import mark_safe
 from django.utils.timezone import localtime
@@ -145,7 +146,7 @@ def safe_product_description(value):
     if isinstance(value, Undefined):
         return value
     if not settings.SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION:
-        value = bleach.clean(value, tags=[])
+        value = linebreaks(bleach.clean(value, tags=[]))
     return mark_safe(value)
 
 
@@ -154,7 +155,7 @@ def safe_vendor_description(value):
     if isinstance(value, Undefined):
         return value
     if not settings.SHUUP_ADMIN_ALLOW_HTML_IN_VENDOR_DESCRIPTION:
-        value = bleach.clean(value, tags=[])
+        value = linebreaks(bleach.clean(value, tags=[]))
     return mark_safe(value)
 
 

--- a/shuup_tests/core/test_template_tags.py
+++ b/shuup_tests/core/test_template_tags.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals
 from decimal import Decimal
 
 from django.conf import settings
+from django.test import override_settings
 from django.utils import translation
 from jinja2 import Template
 from mock import patch
@@ -220,23 +221,23 @@ def test_get_global_configuration_with_default(conf_get_mock, rf):
 
 
 def test_safe_product_description():
-    text = "<p>product description</p>"
+    text = "<strong>product description</strong>\nSome text here."
 
-    settings.SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION = True
-    assert safe_product_description(text) == text
+    with override_settings(SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION=True):
+        assert safe_product_description(text) == text
 
-    settings.SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION = False
-    assert safe_product_description(text) == "&lt;p&gt;product description&lt;/p&gt;"
+    with override_settings(SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION=False):
+        assert safe_product_description(text) == "<p>&lt;strong&gt;product description&lt;/strong&gt;<br>Some text here.</p>"
 
 
 def test_safe_vendor_description():
-    text = "<p>vendor description</p>"
+    text = "<strong>vendor description</strong>\nSome text here."
 
-    settings.SHUUP_ADMIN_ALLOW_HTML_IN_VENDOR_DESCRIPTION = True
-    assert safe_vendor_description(text) == text
+    with override_settings(SHUUP_ADMIN_ALLOW_HTML_IN_VENDOR_DESCRIPTION=True):
+        assert safe_vendor_description(text) == text
 
-    settings.SHUUP_ADMIN_ALLOW_HTML_IN_VENDOR_DESCRIPTION = False
-    assert safe_vendor_description(text) == "&lt;p&gt;vendor description&lt;/p&gt;"
+    with override_settings(SHUUP_ADMIN_ALLOW_HTML_IN_VENDOR_DESCRIPTION=False):
+        assert safe_vendor_description(text) == "<p>&lt;strong&gt;vendor description&lt;/strong&gt;<br>Some text here.</p>"
 
 
 def test_get_shuup_static_url():


### PR DESCRIPTION
Example description:

![Screenshot_2020-10-12 11 21 01](https://user-images.githubusercontent.com/33625218/95722963-46035180-0c7d-11eb-8c8e-42e22f32838e.png)

Before:

![Screenshot_2020-10-12 11 21 12](https://user-images.githubusercontent.com/33625218/95722978-4b609c00-0c7d-11eb-8b8a-42c1f41fbdb4.png)

After this PR:

![image](https://user-images.githubusercontent.com/33625218/95724308-e5751400-0c7e-11eb-92f9-b4150d4b86e1.png)