### PR TITLE
Admin: Require media.view-all permission to see 'Root' folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ List all changes after the last release here (newer on top). Each change on a se
  `SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION` and `SHUUP_ADMIN_ALLOW_HTML_IN_VENDOR_DESCRIPTION` are `False`.
 - Importer: log errors in the importer and use specific exception classes instead of using Exception
 - Notify: make the default script language be the fallback from Parler
+- Admin: Hide the 'Root' folder from users that do not have the `"media.view-all"` permission.
 
 
 ## [2.1.10] - 2020-09-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ List all changes after the last release here (newer on top). Each change on a se
 - Core: include arbitrary refunds for max refundable amount
 - Admin: select product variation in popup window 
 - Importer: ignore None columns while importing files
+- Admin: Show more descriptive error messages in the media uploader in some situations.
 
 ### Changed
 

--- a/shuup/admin/modules/media/static_src/media/browser/BrowserView.js
+++ b/shuup/admin/modules/media/static_src/media/browser/BrowserView.js
@@ -100,7 +100,18 @@ export function controller(config={}) {
     };
     ctrl.reloadFolderTree = function() {
         remote.get({"action": "folders"}).then(function(response) {
-            ctrl.rootFolder(response.rootFolder);
+            if (response.rootFolder.name === "Root" && !response.rootFolder.canSeeRoot) {
+                // Hide the root folder if the user cannot access it.
+                // This is only a visual thing to avoid showing the empty folder.
+                // The views handles the actual permission checking and clears the whole file
+                // QueyrSet of the root folder if the user is not allowed to access it.
+                const currentFolder = response.rootFolder.children[0];
+                ctrl.rootFolder(currentFolder || {});
+                ctrl.currentFolderId(currentFolder ? currentFolder.id : null);
+                ctrl.reloadFolderContents();
+            } else {
+                ctrl.rootFolder(response.rootFolder);
+            }
             ctrl._refreshCurrentFolderPath();
         });
     };

--- a/shuup/admin/modules/media/static_src/media/browser/BrowserView.js
+++ b/shuup/admin/modules/media/static_src/media/browser/BrowserView.js
@@ -100,10 +100,10 @@ export function controller(config={}) {
     };
     ctrl.reloadFolderTree = function() {
         remote.get({"action": "folders"}).then(function(response) {
-            if (response.rootFolder.name === "Root" && !response.rootFolder.canSeeRoot) {
+            if (response.rootFolder.id === 0 && !response.rootFolder.canSeeRoot) {
                 // Hide the root folder if the user cannot access it.
                 // This is only a visual thing to avoid showing the empty folder.
-                // The views handles the actual permission checking and clears the whole file
+                // The view handles the actual permission checking and clears the whole file
                 // QueyrSet of the root folder if the user is not allowed to access it.
                 const currentFolder = response.rootFolder.children[0];
                 ctrl.rootFolder(currentFolder || {});

--- a/shuup/admin/modules/media/static_src/media/browser/FileUpload.js
+++ b/shuup/admin/modules/media/static_src/media/browser/FileUpload.js
@@ -64,8 +64,12 @@ function handleFileXhrComplete(xhr, file, error) {
     var messageText = null;
     try {
         const responseJson = JSON.parse(xhr.responseText);
-        if (responseJson && responseJson.message) {
-            messageText = responseJson.message;
+        if (responseJson) {
+            if (responseJson.message) {
+                messageText = responseJson.message;
+            } else if (responseJson.error) {
+                messageText = responseJson.error;
+            }
         }
     } catch (e) {
         // invalid JSON? pffff.

--- a/shuup/admin/modules/media/views.py
+++ b/shuup/admin/modules/media/views.py
@@ -35,8 +35,8 @@ from shuup.admin.utils.views import CreateOrUpdateView
 from shuup.core.models import MediaFile, MediaFolder
 from shuup.utils.excs import Problem
 from shuup.utils.filer import (
-    ensure_media_file, ensure_media_folder, filer_file_from_upload,
-    filer_file_to_json_dict, filer_folder_to_json_dict,
+    can_see_root_folder, ensure_media_file, ensure_media_folder,
+    filer_file_from_upload, filer_file_to_json_dict, filer_folder_to_json_dict,
     filer_image_from_upload, get_or_create_folder, subfolder_of_users_root,
     UploadFileForm, UploadImageForm
 )
@@ -183,7 +183,6 @@ class MediaBrowserView(TemplateView):
                 else:
                     in_path = False
                     for folder_on_path in folder.logical_path:
-                        print(folder_on_path)
                         if folder_on_path in all_accessed_folders:
                             ordered_folders.append(folder)
                             in_path = True
@@ -257,7 +256,11 @@ class MediaBrowserView(TemplateView):
             else:
                 folder = None
                 subfolders = _get_folder_query(shop, self.user).filter(parent=None)
-                files = _get_file_query(shop).filter(folder=None)
+                if can_see_root_folder(self.request.user):
+                    files = _get_file_query(shop).filter(folder=None)
+                else:
+                    files = File.objects.none()
+
         except ObjectDoesNotExist:
             return JsonResponse({
                 "folder": None,

--- a/shuup/admin/modules/media/views.py
+++ b/shuup/admin/modules/media/views.py
@@ -255,11 +255,12 @@ class MediaBrowserView(TemplateView):
                 files = _get_file_query(shop, folder)
             else:
                 folder = None
-                subfolders = _get_folder_query(shop, self.user).filter(parent=None)
                 if can_see_root_folder(self.request.user):
+                    subfolders = _get_folder_query(shop, self.user).filter(parent=None)
                     files = _get_file_query(shop).filter(folder=None)
                 else:
                     files = File.objects.none()
+                    subfolders = Folder.objects.none()
 
         except ObjectDoesNotExist:
             return JsonResponse({

--- a/shuup/utils/filer.py
+++ b/shuup/utils/filer.py
@@ -286,6 +286,4 @@ def can_see_root_folder(user):
     Return True if the user is allowed to see files that exists in the root folder.
     This means all files that have `folder=None`.
     """
-    if not user:
-        return False
-    return has_permission(user, "media.view-all")
+    return bool(user and has_permission(user, "media.view-all"))

--- a/shuup_tests/utils/filer.py
+++ b/shuup_tests/utils/filer.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2020, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from shuup.admin.utils.permissions import set_permissions_for_group
+from shuup.testing import factories
+from shuup.utils.filer import can_see_root_folder
+
+
+@pytest.mark.django_db
+def test_can_see_root_folder(rf, admin_user):
+    assert not can_see_root_folder(None)
+    assert can_see_root_folder(admin_user)
+
+    shop = factories.get_default_shop()
+    staff_user = factories.UserFactory(is_staff=True)
+    assert not can_see_root_folder(staff_user)
+    permission_group = factories.get_default_permission_group()
+    staff_user.groups.add(permission_group)
+    shop.staff_members.add(staff_user)
+    set_permissions_for_group(permission_group, ["media.view-all"])
+
+    assert can_see_root_folder(staff_user)


### PR DESCRIPTION
The reason for this change was that previously all of the items in
the Root folder (aka `folder=None`) were visible for all users with
media browsing permission. This could lead to the situation where
a user uploads some files to that folder and doesn't realize that it
will be visible for many other users as well.

Refs AH-30

As expected, a superuser sees the 'Root' folder in `/admin/media/`:

![Screenshot_2020-10-14 20 50 00](https://user-images.githubusercontent.com/33625218/96029352-36456200-0e63-11eb-9f14-ea42a012426a.png)

But an other kind of staff account, with no `"media.view-all"` permission, cannot see it at all:

![image](https://user-images.githubusercontent.com/33625218/96029455-62f97980-0e63-11eb-9d17-6998eb7a4cd0.png)
