### PR TITLE
Fix products highlights plugin not fully populating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line.
 
+### Fixed
+- Fix product highlights plugin not fully populating if not-orderable products are present
+
 ## [2.1.12] - 2020-10-21
 
 ### Fixed


### PR DESCRIPTION
If `orderable_only=True` and we have products that are not orderable and they are in in the part that doesn't get cut off by `[:n_products]` then the plugin doesn't fully populated.

Refs CR-86