### PR TITLE
Admin: prevent duplicate images in product media form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ List all changes after the last release here (newer on top). Each change on a se
 ### Fixed
 
 - Prevent duplicate images in product media form
+- Do not render duplicate hidden media form field
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ List all changes after the last release here (newer on top). Each change on a se
 
 ## [2.2.1] - 2020-11-02
 
+### Fixed
+
+- Prevent duplicate images in product media form
+
 ### Changed
 
 - Update French, Finnish and Swedish translations

--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -474,7 +474,7 @@ class BaseProductMediaFormSet(BaseModelFormSet):
         qs = ProductMedia.objects.filter(product=self.product)
         if self.allowed_media_kinds:
             qs = qs.filter(kind__in=self.allowed_media_kinds)
-        return qs
+        return qs.distinct()
 
     def form(self, **kwargs):
         kwargs.setdefault("languages", self.languages)

--- a/shuup/admin/templates/shuup/admin/products/_edit_media_form.jinja
+++ b/shuup/admin/templates/shuup/admin/products/_edit_media_form.jinja
@@ -4,7 +4,10 @@
 
 {% macro render_media_form(f, media_form, idx, is_image_form) %}
     {% for h in f.hidden_fields() %}
-        {{ h|safe }}
+        {# make sure to not duplicate hidden fields #}
+        {% if h.name not in ("kind", "file", "id") %}
+            {{ h|safe }}
+        {% endif %}
     {% endfor %}
     {%- set is_primary = f.is_primary.value() if is_image_form else None %}
     <div


### PR DESCRIPTION
In some cases, instances were wrongly fetched by Django
in https://github.com/django/django/blob/2.2.16/django/forms/models.py#L613
as the index 0 and 1 were returning the same instance:

```
>> qs[0] == qs[1]
True
```

This could be reproduced locally while using PostgreSQL database only.
The bug didn't happen while forcing the evaluation of the queryset using the list() constructor:

```
>> list(qs)[0] == list(qs)[1]
False
```

Using .distinct() also fixed the issue:

```
>> qs.distinct()[0] == qs.distinct()[1]
False
```

Refs CR-84