### PR TITLE
Core: fix basket attribute issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Fixed
+
+- Core: Fix basket implementation that was using the same memory
+object for all baskets instances in the same process
+
 ## [2.2.3] - 2020-11-05
 
 ### Fixed

--- a/shuup_tests/core/test_basket.py
+++ b/shuup_tests/core/test_basket.py
@@ -81,3 +81,22 @@ def test_basket_with_custom_shop(rf):
         product_shop2 = factories.create_product("product_shop2", shop2, factories.get_default_supplier(), 10)
         line = basket.add_product(factories.get_default_supplier(), shop2, product_shop2, 1)
         assert line.shop == shop2
+
+
+@pytest.mark.django_db
+def test_basket_extra_data(rf):
+    with override_settings(**CORE_BASKET_SETTINGS):
+        shop = factories.get_default_shop()
+        user = factories.create_random_user()
+        request = apply_request_middleware(rf.get("/"), user=user, shop=shop)
+        basket_class = cached_load("SHUUP_BASKET_CLASS_SPEC")
+
+        basket1 = basket_class(request, "basket", shop=shop)
+        basket1.payment_data["token"] = "qwerty"
+        basket1.extra_data["my"] = "value"
+        basket1.shipping_data["ship"] = "there"
+
+        basket2 = basket_class(request, "basket2", shop=shop)
+        assert not basket2.extra_data
+        assert not basket2.shipping_data
+        assert not basket2.payment_data

--- a/shuup_tests/core/test_basket.py
+++ b/shuup_tests/core/test_basket.py
@@ -81,22 +81,3 @@ def test_basket_with_custom_shop(rf):
         product_shop2 = factories.create_product("product_shop2", shop2, factories.get_default_supplier(), 10)
         line = basket.add_product(factories.get_default_supplier(), shop2, product_shop2, 1)
         assert line.shop == shop2
-
-
-@pytest.mark.django_db
-def test_basket_extra_data(rf):
-    with override_settings(**CORE_BASKET_SETTINGS):
-        shop = factories.get_default_shop()
-        user = factories.create_random_user()
-        request = apply_request_middleware(rf.get("/"), user=user, shop=shop)
-        basket_class = cached_load("SHUUP_BASKET_CLASS_SPEC")
-
-        basket1 = basket_class(request, "basket", shop=shop)
-        basket1.payment_data["token"] = "qwerty"
-        basket1.extra_data["my"] = "value"
-        basket1.shipping_data["ship"] = "there"
-
-        basket2 = basket_class(request, "basket2", shop=shop)
-        assert not basket2.extra_data
-        assert not basket2.shipping_data
-        assert not basket2.payment_data


### PR DESCRIPTION
Fix the implementation that was using the same memory
object for all baskets instances in the same process.

The `_DataValueProperty` was wrongly implemented while saving
the default value inside the `__init__`. The default object was a dictionary
that was always referencing to the same instance for all baskets instances,
and this object was updated by the same process every time.

The `_DataValueProperty` was replaced by an implementation in a way
that the default value is always a new dict object.