### PR TITLE
Admin: Show a loader in place of picotable when a request is pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ object for all baskets instances in the same process
 - Update French, Finnish and Swedish translations
 - Change the Supplier.objects.enabled() filter to only return approved suppliers
 
+### Changed
+
+- Admin: Show a loader in place of picotable when a request is pending.
 
 ## [2.2.0] - 2020-10-23
 

--- a/shuup/admin/static_src/picotable/picotable.js
+++ b/shuup/admin/static_src/picotable/picotable.js
@@ -1222,6 +1222,7 @@ const Picotable = (function (m, storage) {
             var url = ctrl.vm.url();
 
             ctrl.vm.isLoading = true;
+            m.redraw();
 
             if (!url) return;
             if (!Object.keys(ctrl.vm.filterValues()).length) {


### PR DESCRIPTION
Refs OWL-11

Looks like this when waiting for a request response:

![Screenshot_2020-11-09 18 33 16](https://user-images.githubusercontent.com/33625218/98568724-16fef080-22ba-11eb-8771-3225803b05a1.png)
