### PR TITLE
Front: force recalculate lines in checkout phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Fixed
+
+- Front: force recalculate lines after setting the payment and shipping methods to the basket in checkout phase
+
 ### Changed
 
 - Don't display taxless price when it's equal to taxful in checkout

--- a/shuup/core/basket/objects.py
+++ b/shuup/core/basket/objects.py
@@ -218,6 +218,8 @@ class BaseBasket(OrderSource):
             return
 
         self._data[field_attr] = value
+        # mark the basket as changed
+        self.dirty = True
 
     def _get_value_from_data(self, field_attr, initialize_with=None):
         self._load()

--- a/shuup/front/checkout/methods.py
+++ b/shuup/front/checkout/methods.py
@@ -123,6 +123,9 @@ class MethodsPhase(CheckoutPhaseViewMixin, FormView):
         self.basket.shipping_method_id = shipping_method.pk if shipping_method else None
         self.basket.payment_method_id = payment_method.pk if payment_method else None
 
+        # force recalculate lines
+        self.basket.uncache()
+
     def get_form_kwargs(self):
         kwargs = super(MethodsPhase, self).get_form_kwargs()
         kwargs["request"] = self.request


### PR DESCRIPTION
After setting the payment and shipping methods, we uncache the basket to force
shipping and payment total recalculation