### PR TITLE
Include child categories in product category filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Added
+
+- Include products belonging to child categories of filtered category
+
 ## [2.2.5] - 2020-11-12
 
 ### Fixed

--- a/shuup/front/forms/product_list_modifiers.py
+++ b/shuup/front/forms/product_list_modifiers.py
@@ -372,7 +372,8 @@ class CategoryProductListFilter(SimpleProductListModifier):
 
         categories = [cat.strip() for cat in categories if cat]
         if categories:
-            return Q(shop_products__categories__in=categories)
+            return Q(shop_products__categories__in=Category.objects.get_queryset_descendants(
+                Category.objects.filter(pk__in=categories), include_self=True))
 
     def get_admin_fields(self):
         default_fields = super(CategoryProductListFilter, self).get_admin_fields()

--- a/shuup/front/views/category.py
+++ b/shuup/front/views/category.py
@@ -63,7 +63,7 @@ class CategoryView(DetailView):
         return {
             "shop_products__shop": self.request.shop,
             "variation_parent__isnull": True,
-            "shop_products__categories": self.object,
+            "shop_products__categories__in": self.object.get_descendants(include_self=True),
             "shop_products__suppliers__in": Supplier.objects.enabled(shop=self.request.shop)
         }
 


### PR DESCRIPTION
Refs EZI-31
Include Products belonging to Child-Categories of selected category filter(s)

eg.
Instead of giving product three categories:
- Category: Dress / Women / Clothes
- Category: Dress / Women
- Category: Dress

Only the deepest one would be needed:
- Category: Dress / Women / Clothes

Currently If product has only "Dress" category set, it would only be shown in "Dress", not in "Women" or "Clothes".