### PR TITLE
Admin: do not allow non-superusers manage superusers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+
 ### Added
 
 - Include products belonging to child categories of filtered category
+
+### Changed
+
+Admin: do not allow non-superusers manage superusers
+  - Do not show is_superuser field for non-superusers no matter
+    who they are editing
+  - Do not show superuser column in list since the superusers are
+    already filtered out from non-superusers who are main people
+    using the admin panel.
+
 
 ## [2.2.5] - 2020-11-12
 

--- a/shuup/admin/modules/users/views/list.py
+++ b/shuup/admin/modules/users/views/list.py
@@ -31,7 +31,6 @@ class UserListView(PicotableListView):
             filter_config=ChoicesFilter([(False, _("no")), (True, _("yes"))], default=True),
         ),
         Column("is_staff", _(u"Access to Admin Panel"), filter_config=true_or_false_filter),
-        Column("is_superuser", _(u"Superuser (Full rights)"), filter_config=true_or_false_filter),
     ]
     toolbar_buttons_provider_key = "user_list_toolbar_provider"
     mass_actions_provider_key = "user_list_mass_actions_provider"

--- a/shuup/admin/modules/users/views/permissions.py
+++ b/shuup/admin/modules/users/views/permissions.py
@@ -37,7 +37,7 @@ class PermissionChangeFormBase(forms.ModelForm):
     def __init__(self, changing_user, *args, **kwargs):
         super(PermissionChangeFormBase, self).__init__(*args, **kwargs)
         self.changing_user = changing_user
-        if getattr(self.instance, 'is_superuser', False) and not getattr(self.changing_user, 'is_superuser', False):
+        if not getattr(self.changing_user, 'is_superuser', False):
             self.fields.pop("is_superuser")
 
         if not (
@@ -47,13 +47,14 @@ class PermissionChangeFormBase(forms.ModelForm):
             # Only require old password when editing
             self.fields.pop("old_password")
 
-        self.fields["is_superuser"].label = _("Superuser (Full rights) status")
-        self.fields["is_superuser"].help_text = _(
-            "Designates whether this user has all permissions without explicitly "
-            "assigning them. Assigning Granular Permission Groups to a Superuser "
-            "will not have any effect because Granular Permission Groups are only "
-            " able to give more rights, but Superuser already has them all."
-        )
+        if "is_superuser" in self.fields:
+            self.fields["is_superuser"].label = _("Superuser (Full rights) status")
+            self.fields["is_superuser"].help_text = _(
+                "Designates whether this user has all permissions without explicitly "
+                "assigning them. Assigning Granular Permission Groups to a Superuser "
+                "will not have any effect because Granular Permission Groups are only "
+                " able to give more rights, but Superuser already has them all."
+            )
         self.fields["is_staff"].label = _("Access to Admin Panel status")
         self.fields["is_staff"].help_text = _(
             "Designates whether this user can log into this admin site. Even "


### PR DESCRIPTION
- Do not show is_superuser field for non-superusers no matter who they are editing
- Do not show superuser column in list since the superusers are already filtered out from non-superusers who are main people using the admin panel.