### PR TITLE
Add front: clean hook for admin fields in product list modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Added
+
+- Front: Add so there is a clean hook for the admin fields for product list form modifier
 
 ## [2.2.6] - 2020-11-17
 

--- a/shuup/front/admin_module/sorts_and_filters/form_parts.py
+++ b/shuup/front/admin_module/sorts_and_filters/form_parts.py
@@ -25,6 +25,12 @@ class ConfigurationForm(forms.Form):
                 self.fields[field_key] = field
                 self.form_module_map[field_key] = extend_class
 
+    def clean(self):
+        cleaned_data = super(ConfigurationForm, self).clean()
+        for extend_class in get_provide_objects(FORM_MODIFIER_PROVIDER_KEY):
+            extend_class().admin_clean_hook(self)
+        return cleaned_data
+
 
 class ConfigurationShopFormPart(FormPart):
     priority = 7

--- a/shuup/front/utils/sorts_and_filters.py
+++ b/shuup/front/utils/sorts_and_filters.py
@@ -159,6 +159,21 @@ class ProductListFormModifier(six.with_metaclass(abc.ABCMeta)):
         """
         pass
 
+    def admin_clean_hook(self, form):
+        """
+        Extra clean for configuration form.
+
+        This hook will be called in `~Django.forms.Form.clean` method of
+        the form, after calling parent clean.  Implementor of this hook
+        may call `~Django.forms.Form.add_error` to add errors to form or
+        modify the ``form.cleaned_data`` dictionary.
+
+        :param form: Form that is currently cleaned
+        :type form: ConfigurationForm
+        :rtype: None
+        """
+        pass
+
     def clean_hook(self, form):
         """
         Extra clean for product list form.


### PR DESCRIPTION
- Add so there is a clean hook for the admin fields for product list form modifier
This is so that if a admin fields value is not JSON serializable we can clean the data from that field and then it can be serializable and save as a shop config.

refs https://trello.com/c/dywdlbNj/5-product-configuration