### PR TITLE
Admin: do not add/remove shop staff member while saving a staff user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Fixed
+
+- Admin: do not add/remove shop staff member while saving a staff user
 
 ## [2.2.6] - 2020-11-17
 

--- a/shuup/admin/modules/users/views/detail.py
+++ b/shuup/admin/modules/users/views/detail.py
@@ -309,14 +309,6 @@ class UserDetailView(CreateOrUpdateView):
         self.object = form.save()
         contact = self._get_bind_contact()
 
-        # only touch in shop staff (Access to Admin Panel) member if the user is not a superuser
-        if not getattr(self.object, "is_superuser", False):
-            shop = get_shop(self.request)
-            if getattr(self.object, "is_staff", False):
-                shop.staff_members.add(self.object)
-            else:
-                shop.staff_members.remove(self.object)
-
         if contact and not contact.user:
             contact.user = self.object
             contact.save()

--- a/shuup/admin/modules/users/views/permissions.py
+++ b/shuup/admin/modules/users/views/permissions.py
@@ -18,7 +18,6 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.generic.edit import UpdateView
 
 from shuup.admin.forms.fields import Select2MultipleField
-from shuup.admin.shop_provider import get_shop
 from shuup.admin.toolbar import get_default_edit_toolbar
 from shuup.admin.utils.urls import get_model_url
 from shuup.utils.django_compat import force_text
@@ -161,14 +160,6 @@ class UserChangePermissionsView(UpdateView):
 
     def form_valid(self, form):
         form.save()
-
-        if not getattr(self.object, "is_superuser", False):
-            shop = get_shop(self.request)
-            if getattr(self.object, "is_staff", False):
-                shop.staff_members.add(self.object)
-            else:
-                shop.staff_members.remove(self.object)
-
         messages.success(self.request, _("Permissions changed for %s.") % self.object)
         return HttpResponseRedirect(self.get_success_url())
 

--- a/shuup_tests/admin/test_user_module.py
+++ b/shuup_tests/admin/test_user_module.py
@@ -186,7 +186,7 @@ def test_user_create(rf, admin_user):
     assert response.status_code == 302
     assert get_user_model().objects.count() == before_count + 2
     last_user = get_user_model().objects.last()
-    assert last_user in shop.staff_members.all()
+    assert last_user not in shop.staff_members.all()
     assert len(mail.outbox) == 1, "mail sent"
 
     user = get_user_model().objects.create(
@@ -212,14 +212,14 @@ def test_user_create(rf, admin_user):
     last_user = get_user_model().objects.last()
     assert last_user not in shop.staff_members.all()
 
-    # add again
+    # add again, the member should not be inside shop staff member list
     view_func = UserChangePermissionsView.as_view()
     response = view_func(apply_request_middleware(rf.post("/", {
         "is_staff": True
     }), user=admin_user), pk=last_user.id)
     assert response.status_code == 302
     last_user = get_user_model().objects.last()
-    assert last_user in shop.staff_members.all()
+    assert last_user not in shop.staff_members.all()
 
     # create a superuser
     view_func = UserDetailView.as_view()
@@ -505,7 +505,7 @@ def test_login_as_staff_user(rf, admin_user):
     get_default_shop()
     staff_user = UserFactory(is_staff=True)
     view_func = LoginAsStaffUserView.as_view()
-    
+
     request = apply_request_middleware(rf.post("/"), user=admin_user)
     context = dict(request=request)
     assert get_logout_url(context) == "/sa/logout/"
@@ -548,7 +548,7 @@ def test_login_as_staff_as_staff(rf):
     shop.staff_members.add(staff_user1)
 
     staff_user2 = UserFactory(is_staff=True)
-    
+
     view_func = LoginAsStaffUserView.as_view()
     request = apply_request_middleware(rf.post("/"), user=staff_user1)
     with pytest.raises(PermissionDenied):


### PR DESCRIPTION
The user can incorrectly be added to shop staff list without actually being
part of the staffs of the shop.