### PR TITLE
Add font size 16 to SummerNote text editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Added
+
+- Add font size 16 to summernote text editor
+
 ## [2.2.7] - 2020-11-20
 
 ### Fixed

--- a/shuup/admin/static_src/base/js/editor.js
+++ b/shuup/admin/static_src/base/js/editor.js
@@ -50,6 +50,7 @@ function activateEditor($editor, attrs = {}) {
     ];
 
     const $summernote = $editor.summernote($.extend(true, {
+        fontSizes: ["8", "9", "10", "11", "12", "14", "16", "18", "24", "36"],
         height: 200,
         popatmouse: false,
         disableDragAndDrop: true,


### PR DESCRIPTION
Other font sizes were there by default.

Refs MYYR-89