### PR TITLE
SimpleCMS: Fix page filter for authenticated users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Fixed
+
+- SimpleCMS: Show all CMS pages for authenticated users when there is no group filter attached to the page
+
 ## [2.2.10] - 2020-12-04
 
 ### Fixed

--- a/shuup/simple_cms/models.py
+++ b/shuup/simple_cms/models.py
@@ -73,7 +73,9 @@ class PageQuerySet(TranslatableQuerySet):
                 user_filter = Q()
             else:
                 user_filter = Q(
-                    Q(available_permission_groups__in=user.groups.all()) | Q(created_by=user)
+                    Q(available_permission_groups__in=user.groups.all()) |
+                    Q(available_permission_groups__isnull=True) |
+                    Q(created_by=user)
                 )
         else:
             user_filter = Q(available_permission_groups__isnull=True)


### PR DESCRIPTION
Show all CMS pages for authenticated users when there is no group filter attached to the page