### PR TITLE
Xtheme: add option to set a custom cell width in placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ List all changes after the last release here (newer on top). Each change on a se
 ### Added
 
 - Dashboard: Sorting of dashboard items by ordering number
+- Xtheme: add option to set a custom cell width in placeholders
 
 ## [2.2.11] - 2020-12-08
 

--- a/shuup/xtheme/views/forms.py
+++ b/shuup/xtheme/views/forms.py
@@ -18,6 +18,7 @@ class LayoutCellGeneralInfoForm(forms.Form):
     CELL_FULL_WIDTH = 12
 
     CELL_WIDTH_CHOICES = [
+        (0, _("Custom")),
         (int(CELL_FULL_WIDTH), _("Full Width")),
         (int(CELL_FULL_WIDTH * 3 / 4), _("Three Fourths (3/4)")),
         (int(CELL_FULL_WIDTH * 2 / 3), _("Two Thirds (2/3)")),
@@ -44,9 +45,17 @@ class LayoutCellGeneralInfoForm(forms.Form):
         """
 
         if self.layout_cell.plugin_identifier:
-            initial_cell_width = self.layout_cell.sizes.get("sm") or self.CELL_FULL_WIDTH
+            if "sm" in self.layout_cell.sizes:
+                initial_cell_width = self.layout_cell.sizes.get("sm")
+            else:
+                initial_cell_width = self.CELL_FULL_WIDTH
+
             self.fields["cell_width"] = forms.ChoiceField(
-                label=_("Cell width"), choices=self.CELL_WIDTH_CHOICES, initial=initial_cell_width)
+                label=_("Cell width"),
+                choices=self.CELL_WIDTH_CHOICES,
+                initial=initial_cell_width,
+                required=False
+            )
 
             initial_cell_align = self.layout_cell.align or self.CELL_ALIGN_CHOICES[0][0]
             self.fields["cell_align"] = forms.ChoiceField(
@@ -78,7 +87,7 @@ class LayoutCellGeneralInfoForm(forms.Form):
         data = self.cleaned_data
         sizes = ["sm", "md"]  # TODO: Parametrize? Currently Bootstrap dependent.
         for size in sizes:
-            self.layout_cell.sizes[size] = int(data["cell_width"])
+            self.layout_cell.sizes[size] = int(data["cell_width"]) if data["cell_width"] else None
 
         self.layout_cell.align = data["cell_align"]
         self.layout_cell.extra_classes = data["cell_extra_classes"].strip()

--- a/shuup_tests/xtheme/test_editor_forms.py
+++ b/shuup_tests/xtheme/test_editor_forms.py
@@ -84,3 +84,29 @@ def test_lcfg(rf):
             assert cell.sizes["md"] == two_thirds
             assert cell.extra_classes == "newClass"
             assert cell.config["text"] == {FALLBACK_LANGUAGE_CODE: "Hello, world!"}
+
+
+@pytest.mark.django_db
+def test_custom_cell_size(rf):
+    with plugin_override():
+        with override_current_theme_class(None):
+            theme = get_current_theme(get_default_shop())
+
+            cell = LayoutCell(theme, "text", sizes={"md": None, "sm": None})
+            lcfg = LayoutCellFormGroup(
+                data={
+                    "general-cell_width": None,
+                    "general-cell_align": " ",
+                    "general-cell_extra_classes" : "newClass",
+                    "plugin-text_*": "Hello, world!"
+                },
+                layout_cell=cell,
+                theme=theme,
+                request=apply_request_middleware(rf.get("/"))
+            )
+            assert lcfg.is_valid()
+            lcfg.save()
+            assert cell.sizes["md"] is None
+            assert cell.sizes["sm"] is None
+            assert cell.extra_classes == "newClass"
+            assert cell.config["text"] == {FALLBACK_LANGUAGE_CODE: "Hello, world!"}


### PR DESCRIPTION
This allow the usage of more advanced plugins that should expand
to the whole screen size without the need of usage of bootstrap column sizes

Refs SH-84