### PR TITLE
Admin: set default price value to zero by default

### DIFF
--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -203,6 +203,10 @@ class ShopProductForm(MultiLanguageModelForm):
         # TODO: Revise this. Since this is shop product form then maybe we should have shop available insted of request
         self.request = kwargs.pop("request", None)
         super(ShopProductForm, self).__init__(**kwargs)
+
+        if "default_price_value" in self.fields:
+            self.initial["default_price_value"] = self.initial["default_price_value"] or 0
+
         payment_methods_qs = PaymentMethod.objects.all()
         shipping_methods_qs = ShippingMethod.objects.all()
         if self.request:


### PR DESCRIPTION
Makes the name only required field when creating product. The price is there quite down at the form and a bit annoying if you just want to quick add some product.