### PR TITLE
Fix multiple translations of object returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ List all changes after the last release here (newer on top). Each change on a se
 - Dashboard: Sorting of dashboard items by ordering number
 - Xtheme: add option to set a custom cell width in placeholders
 
+### Fixed
+
+- Fix multiple translations returned when using values_list on translated field
+
 ## [2.2.11] - 2020-12-08
 
 ### Fixed

--- a/shuup/admin/modules/contacts/views/list.py
+++ b/shuup/admin/modules/contacts/views/list.py
@@ -128,12 +128,12 @@ class ContactListView(PicotableListView):
             return _(u"Contact")
 
     def get_groups_display(self, instance):
-        groups = instance.groups.all_except_defaults().values_list("translations__name", flat=True)
+        groups = [group.name for group in instance.groups.all_except_defaults()]
         return ", ".join(groups) if groups else _("No group")
 
     def get_shops_display(self, instance):
         user = self.request.user
-        shops = instance.shops.get_for_user(user=user).values_list("translations__name", flat=True)
+        shops = [shop.name for shop in instance.shops.get_for_user(user=user)]
         return ", ".join(shops) if shops else _("No shops")
 
     def get_object_abstract(self, instance, item):

--- a/shuup/admin/modules/products/views/list.py
+++ b/shuup/admin/modules/products/views/list.py
@@ -130,7 +130,7 @@ class ProductListView(PicotableListView):
             suppliers_column.filter_config = get_suppliers_filter()
 
     def format_categories(self, instance):
-        return ", ".join(list(instance.categories.values_list("translations__name", flat=True)))
+        return ", ".join(category.name for category in instance.categories.all()) or "-"
 
     def format_suppliers(self, instance):
         return ", ".join(list(instance.suppliers.values_list("name", flat=True)))


### PR DESCRIPTION
when using `values_list` on translated field

As translations are separate objects, accessing translations directly through for example: `translations__name` results in an implicit join of multiple translations and multiple translations are returned.