### PR TITLE
Fix `0068_help_text_improvements` migration file to have the correct field char size: 128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
-
 ### Changed
 
 - Admin: MultiselectAjaxView returns ordered by name choices
 
 ### Fixed
--  Fix _vertical_phases.jinja incorrectly targets all forms
+
+- Fix `0068_help_text_improvements` migration file to have the correct field char size: 128
+- Fix _vertical_phases.jinja incorrectly targets all forms
 
 ## [2.3.0] - 2020-12-16
 

--- a/shuup/core/migrations/0068_help_text_improvements.py
+++ b/shuup/core/migrations/0068_help_text_improvements.py
@@ -475,7 +475,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='supplier',
             name='name',
-            field=models.CharField(db_index=True, help_text="The product supplier's name. You can enable suppliers to manage the inventory of stocked products.", max_length=64, verbose_name='name'),
+            field=models.CharField(db_index=True, help_text="The product supplier's name. You can enable suppliers to manage the inventory of stocked products.", max_length=128, verbose_name='name'),
         ),
         migrations.AlterField(
             model_name='supplier',


### PR DESCRIPTION
The previous migration file 0067_supplier_name_max_length_to_128 changed the field to be
greater than 64 chars, but probably because of some merge issue, the field size was
reverted to have only 64 chars.

No Refs