### PR TITLE
Improve the way the cache is bumped when order is created and changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Changed
+
+- Improve the way the cache is bumped when order is created and changed
+
 ### Fixed
 
 - Admin: fix missing `tr` closing tags

--- a/shuup/core/__init__.py
+++ b/shuup/core/__init__.py
@@ -49,7 +49,7 @@ class ShuupCoreAppConfig(AppConfig):
             install_error_handlers()
 
         # connect signals
-        import shuup.core.signal_handers    # noqa: F401
+        import shuup.core.signal_handlers    # noqa: F401
 
 
 default_app_config = "shuup.core.ShuupCoreAppConfig"

--- a/shuup/core/basket/objects.py
+++ b/shuup/core/basket/objects.py
@@ -218,8 +218,6 @@ class BaseBasket(OrderSource):
             return
 
         self._data[field_attr] = value
-        # mark the basket as changed
-        self.dirty = True
 
     def _get_value_from_data(self, field_attr, initialize_with=None):
         self._load()

--- a/shuup/core/order_creator/_modifier.py
+++ b/shuup/core/order_creator/_modifier.py
@@ -43,7 +43,7 @@ class OrderModifier(OrderProcessor):
             module.clear_codes(order)
 
         products_to_adjust_stock = set()
-        for line in order.lines.all():
+        for line in order.lines.all().select_related("product", "supplier"):
             if line.product:
                 products_to_adjust_stock.add((line.product, line.supplier))
             line.taxes.all().delete()  # Delete all tax lines before OrderLine's

--- a/shuup/core/signals.py
+++ b/shuup/core/signals.py
@@ -20,6 +20,7 @@ get_basket_command_handler = Signal(providing_args=["command"], use_caching=True
 pre_clean = Signal(providing_args=["instance"], use_caching=True)
 post_clean = Signal(providing_args=["instance"], use_caching=True)
 context_cache_item_bumped = Signal(providing_args=["item", "shop_id"], use_caching=True)
+order_changed = Signal(providing_args=["order"], use_caching=True)
 order_status_changed = Signal(providing_args=["order", "old_status", "new_status"], use_caching=True)
 
 #: Send from supplier module after the stocks updated have

--- a/shuup/core/suppliers/base.py
+++ b/shuup/core/suppliers/base.py
@@ -8,7 +8,6 @@
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
-from shuup.core.models import Product
 from shuup.core.signals import stocks_updated
 from shuup.core.stocks import ProductStockStatus
 from shuup.core.utils import context_cache
@@ -89,7 +88,7 @@ class BaseSupplierModule(object):
         Supplier module update stock should always bump product
         cache and send `shuup.core.signals.stocks_updated` signal.
         """
-        context_cache.bump_cache_for_product(Product.objects.get(id=product_id))
+        context_cache.bump_cache_for_product(product_id)
         stocks_updated.send(
             type(self), shops=self.supplier.shops.all(), product_ids=[product_id], supplier=self.supplier)
 

--- a/shuup/core/utils/context_cache.py
+++ b/shuup/core/utils/context_cache.py
@@ -148,6 +148,8 @@ def bump_cache_for_item_ids(item_ids, namespace, object_class, shop=None):
     and shop_products use `bump_cache_for_product` and
     `bump_cache_for_shop_product` for those.
 
+    `shop` parameter is deprecated and not used
+
     :param ids: list of cached object id's
     """
     for item_id in item_ids:

--- a/shuup/simple_supplier/module.py
+++ b/shuup/simple_supplier/module.py
@@ -109,6 +109,6 @@ class SimpleSupplierModule(BaseSupplierModule):
                         ).run(shop=shop)
 
         sv.save(update_fields=("logical_count", "physical_count", "stock_value_value"))
-        context_cache.bump_cache_for_product(Product.objects.get(id=product_id))
+        context_cache.bump_cache_for_product(product_id)
         stocks_updated.send(
             type(self), shops=self.supplier.shops.all(), product_ids=[product_id], supplier=self.supplier)


### PR DESCRIPTION
- Move stock update and cache bump to signal handlers
- Select related data when possible
- Do not make basket dirty when it is loaded
- Improve cache bump using product ID instead of loading from database

Refs CS-43