### PR TITLE
Small changes to Notify and GDPR apps

### DIFF
--- a/shuup/gdpr/static_src/gdpr.js
+++ b/shuup/gdpr/static_src/gdpr.js
@@ -35,17 +35,22 @@
     });
 
     function saveConsent() {
+        $(".gdpr-consent-warn-bar").hide();
+        $(".gdpr-consent-preferences").hide();
         data = $("#consent-form").serialize();
         var request = $.ajax({
             url: $("#consent-form").attr("action"),
             type: 'POST',
             data: data,
             success: function() {
+                // Remove GDPR divs and their content upon successful completion
                 $(".gdpr-consent-warn-bar").remove();
-                $(".gdpr-consent-preferences").remove(); // Remove GDPR divs and their content upon successful completion
+                $(".gdpr-consent-preferences").remove();
                 $("body").removeClass("body-noscroll");
             },
             error: function (jqXHR, textStatus, errorThrown) {
+                $(".gdpr-consent-warn-bar").show();
+                $(".gdpr-consent-preferences").show();
                 window.alert(gettext("Error! Saving the consent failed, please try again."));
             }
         });

--- a/shuup/notify/actions/email.py
+++ b/shuup/notify/actions/email.py
@@ -15,7 +15,6 @@ from django.conf import settings
 from django.core.mail.message import EmailMessage
 from django.utils.translation import ugettext as _
 
-from shuup.admin.forms.widgets import TextEditorWidget
 from shuup.notify.base import Action, Binding
 from shuup.notify.enums import ConstantUse, TemplateUse
 from shuup.notify.models import EmailTemplate
@@ -40,10 +39,10 @@ class SendEmail(Action):
             label=_("Email Template"),
             required=False
         ),
-        "body": forms.CharField(required=True, label=_("Email Body"), widget=TextEditorWidget()),
+        "body": forms.CharField(required=True, label=_("Email Body"), widget=forms.Textarea),
         "content_type": forms.ChoiceField(
             required=True, label=_(u"Content type"),
-            choices=EMAIL_CONTENT_TYPE_CHOICES, initial=EMAIL_CONTENT_TYPE_CHOICES[0][0]
+            choices=EMAIL_CONTENT_TYPE_CHOICES, initial=EMAIL_CONTENT_TYPE_CHOICES[1][0]
         )
     }
     recipient = Binding(_("Recipient"), type=Email, constant_use=ConstantUse.VARIABLE_OR_CONSTANT, required=True)


### PR DESCRIPTION
- GDPR: hide consent immediately on accept
- Notify: Remove HTML editor from notifications since summernote does not
  function Jinja syntax very well and for example for-loops and ifs
  cause easily broken notifications.
- Notify: Make HTML default format for emails

Preview option for email notifications and email templates will follow this pull request.