### PR TITLE
Optimize default front calculations around variation products

### DIFF
--- a/shuup/front/settings.py
+++ b/shuup/front/settings.py
@@ -67,6 +67,13 @@ SHUUP_FRONT_DEFAULT_SORT_CONFIGURATION = {
     "sort_products_by_price_ordering": 2
 }
 
+#: Default product context for product detail view
+#:
+#: Override this configuration for quick per project optimization or for adding
+#: something extra for your custom, templates, snippets and plugins.
+SHUUP_FRONT_PRODUCT_CONTEXT_SPEC = (
+    "shuup.front.utils.product:get_default_product_context")
+
 #: Default cache duration for template helpers (in seconds).
 #:
 #: Cache duration in seconds for front template helpers. Default: 30 minutes.

--- a/shuup/front/static_src/js/update_price.js
+++ b/shuup/front/static_src/js/update_price.js
@@ -49,7 +49,7 @@ window.updatePrice = function updatePrice(productId) {
 
         // ensure images are updated
         const combinationCarouselID = "#carousel_product_" + $(priceDiv).data("product-id");
-        const combinationImages = $(combinationCarouselID).parent("div").html();
+        const combinationImages = $content.find(combinationCarouselID).parent("div").html();
 
         $(".product-image").empty();
         $(".product-image").append(combinationImages);

--- a/shuup/front/templates/shuup/front/macros/product_ordering.jinja
+++ b/shuup/front/templates/shuup/front/macros/product_ordering.jinja
@@ -36,19 +36,16 @@
                 {{ simple_variation_form(shop_product, quantity, orderable_variation_children, supplier) }}
             {% else %}
                 {{ simple_product_form(shop_product, quantity, supplier=supplier) }}
+                {% if shop_product.product.variation_parent %}
+                <div id="product-image-sections" class="hidden">
+                    <div class="variation-image-section" id="variation-images-{{ shop_product.product.id }}">
+                        {% set product_images = shop_product.public_images.all() %}
+                        {{ render_product_image_section(shop_product.product, product_images=product_images) }}
+                    </div>
+                </div>
+                {% endif %}
             {% endif %}
         </form>
-
-        <div id="product-image-sections" class="hidden">
-        {% if variation_variables or variation_children %}
-            {% for k in shop_product.product.variation_children.visible(request.shop, request.customer) %}
-                <div class="variation-image-section" id="variation-images-{{ k.id }}">
-                    {% set product_images = k.get_shop_instance(request.shop).public_images.all() %}
-                    {{ render_product_image_section(k, product_images=product_images) }}
-                </div>
-            {% endfor %}
-        {% endif %}
-        </div>
     </div>
 {% endmacro %}
 

--- a/shuup/front/utils/product.py
+++ b/shuup/front/utils/product.py
@@ -19,11 +19,16 @@ from shuup.core.models import (
 )
 from shuup.core.utils import context_cache
 from shuup.front.utils.views import cache_product_things
+from shuup.utils.importing import cached_load
 from shuup.utils.iterables import first
 from shuup.utils.numbers import get_string_sort_order
 
 
-def get_product_context(request, product, language=None, supplier=None):   # noqa (C901)
+def get_product_context(request, product, language=None, supplier=None):
+    return cached_load("SHUUP_FRONT_PRODUCT_CONTEXT_SPEC")(request, product, language, supplier)
+
+
+def get_default_product_context(request, product, language=None, supplier=None):   # noqa (C901)
     """
     Get product context.
 


### PR DESCRIPTION
- Front: optimize child product orderability checks a bit
- Front: add option to replace product detail context
- Front: optimize rendering images for variation products
- Core: optimize price range calculations

Note: the price range calculation is also huge help in listing products since the loading time wont be affected on how complex are the variation products.