### PR TITLE
Notify: add HTML preview for email notification and template

### DIFF
--- a/shuup/admin/forms/widgets.py
+++ b/shuup/admin/forms/widgets.py
@@ -256,6 +256,16 @@ class CodeEditorWidget(Textarea):
         return super().render(name, value, attrs_for_textarea)
 
 
+class CodeEditorWithHTMLPreview(Textarea):
+    template_name = 'shuup/admin/forms/widgets/code_editor_with_preview.html'
+
+    def render(self, name, value, attrs=None, renderer=None):
+        attrs_for_textarea = attrs.copy()
+        attrs_for_textarea["id"] += "-snippet"
+        attrs_for_textarea["class"] += " code-editor-textarea code-editor-with-preview"
+        return super().render(name, value, attrs_for_textarea)
+
+
 class PersonContactChoiceWidget(ContactChoiceWidget):
 
     @property

--- a/shuup/admin/static_src/base/js/code-mirror.js
+++ b/shuup/admin/static_src/base/js/code-mirror.js
@@ -23,8 +23,26 @@ if (window.ShuupCodeMirror) {
             lineNumbers: true,
             ...attrs,
         };
-        window.ShuupCodeMirror.editors[target] = window.ShuupCodeMirror.fromTextArea(target, baseAttrs);
-        return window.ShuupCodeMirror.editors[target];
+        window.ShuupCodeMirror.editors[target.id] = window.ShuupCodeMirror.fromTextArea(target, baseAttrs);
+
+        // Refresh code mirror objects on tab-clicks to active the editor
+        $(document).on('shown.bs.tab', 'a[data-toggle="tab"]', function() {
+            this.refresh();
+        }.bind(window.ShuupCodeMirror.editors[target.id]));
+
+        if ($(target).hasClass("code-editor-with-preview")) {
+            // For code mirror objects with preview option sync editor
+            // content to HTML prview iframe which should be available
+            // through preview container
+            window.ShuupCodeMirror.editors[target.id].on("change", function(editor) {
+                $(target)
+                    .closest(".code-editor-with-preview-container")
+                    .find("iframe.html-preview")
+                    .attr("srcdoc", editor.getValue())
+            })
+        }
+
+        return window.ShuupCodeMirror.editors[target.id];
     };
 
     Array.from(document.getElementsByClassName("code-editor-textarea")).forEach(el => {

--- a/shuup/admin/static_src/base/scss/shuup/code-mirror.scss
+++ b/shuup/admin/static_src/base/scss/shuup/code-mirror.scss
@@ -3,3 +3,14 @@
     z-index: 0;
     width: 100%;
 }
+
+.code-editor-with-preview-container {
+    width: 100%;
+}
+.code-editor-with-preview-container textarea {
+    max-width: 100% !important;
+}
+.code-editor-with-preview-container iframe {
+    width: 100%;
+    height: 500px;
+}

--- a/shuup/admin/templates/shuup/admin/forms/widgets/code_editor_with_preview.html
+++ b/shuup/admin/templates/shuup/admin/forms/widgets/code_editor_with_preview.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+<div class="d-flex flex-column code-editor-with-preview-container">
+    <textarea
+        name="{{ widget.name }}"
+        {% include "django/forms/widgets/attrs.html" %}
+    >{% if widget.value %}{{ widget.value }}{% endif %}</textarea>
+    <br>
+    <h2>{% trans "HTML Preview" %}</h2>
+    <div class="preview-container">
+        <iframe class="html-preview" srcdoc="{% if widget.value %}{{ widget.value }}{% endif %}"></iframe>
+    </div>
+</div>

--- a/shuup/notify/actions/email.py
+++ b/shuup/notify/actions/email.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.core.mail.message import EmailMessage
 from django.utils.translation import ugettext as _
 
+from shuup.admin.forms.widgets import CodeEditorWithHTMLPreview
 from shuup.notify.base import Action, Binding
 from shuup.notify.enums import ConstantUse, TemplateUse
 from shuup.notify.models import EmailTemplate
@@ -26,8 +27,8 @@ from shuup.notify.typology import Email, Language, Text
 
 class SendEmail(Action):
     EMAIL_CONTENT_TYPE_CHOICES = (
-        ('plain', _('Plain text')),
-        ('html', _('HTML'))
+        ('html', _('HTML')),
+        ('plain', _('Plain text'))
     )
 
     identifier = "send_email"
@@ -39,10 +40,10 @@ class SendEmail(Action):
             label=_("Email Template"),
             required=False
         ),
-        "body": forms.CharField(required=True, label=_("Email Body"), widget=forms.Textarea),
+        "body": forms.CharField(required=True, label=_("Email Body"), widget=CodeEditorWithHTMLPreview),
         "content_type": forms.ChoiceField(
             required=True, label=_(u"Content type"),
-            choices=EMAIL_CONTENT_TYPE_CHOICES, initial=EMAIL_CONTENT_TYPE_CHOICES[1][0]
+            choices=EMAIL_CONTENT_TYPE_CHOICES, initial=EMAIL_CONTENT_TYPE_CHOICES[0][0]
         )
     }
     recipient = Binding(_("Recipient"), type=Email, constant_use=ConstantUse.VARIABLE_OR_CONSTANT, required=True)

--- a/shuup/notify/admin_module/views/email_template.py
+++ b/shuup/notify/admin_module/views/email_template.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.generic import DetailView
 
 from shuup.admin.forms import ShuupAdminFormNoTranslation
-from shuup.admin.forms.widgets import CodeEditorWidget
+from shuup.admin.forms.widgets import CodeEditorWithHTMLPreview
 from shuup.admin.toolbar import get_default_edit_toolbar
 from shuup.admin.utils.picotable import Column
 from shuup.admin.utils.views import CreateOrUpdateView, PicotableListView
@@ -24,7 +24,7 @@ class EmailTemplateForm(ShuupAdminFormNoTranslation):
         model = EmailTemplate
         fields = ("name", "template")
         widgets = {
-            "template": CodeEditorWidget()
+            "template": CodeEditorWithHTMLPreview
         }
 
 

--- a/shuup/notify/templates/notify/admin/script_content_editor.jinja
+++ b/shuup/notify/templates/notify/admin/script_content_editor.jinja
@@ -13,8 +13,8 @@
             <div class="shuup-modal-header">
                 <h2 class="pull-left">{% trans %}Edit Step{% endtrans %}</h2>
                 <button class="btn btn-success pull-right" onclick="window.ScriptEditor.hideEditModal()" type="button">
-                    <i class="fa fa-check"></i>
-                    {% trans %}Done{% endtrans %}
+                    <i class="fa fa-close"></i>
+                    {% trans %}Close{% endtrans %}
                 </button>
             </div>
             <iframe src="about:blank" frameborder="0" name="step-item-frame" id="step-item-frame"></iframe>

--- a/shuup/notify/templates/notify/admin/script_item_editor.jinja
+++ b/shuup/notify/templates/notify/admin/script_item_editor.jinja
@@ -12,15 +12,6 @@
         </div>
         {% endif %}
         <div class="support-nav">
-            {% block breadcrumbs -%}
-                {% if not iframe_mode %}
-                    {% set breadcrumbs = breadcrumbs or shuup_admin.get_breadcrumbs() %}
-                    {%- if breadcrumbs -%}
-                        {% from "shuup/admin/macros/breadcrumbs.jinja" import render_breadcrumbs with context %}
-                        {{ render_breadcrumbs(breadcrumbs) }}
-                    {%- endif -%}
-                {% endif %}
-            {%- endblock %}
             <div class="flex-wrapper">
                 <h1 class="main-header">{% block header %}{{ self.title() }}{% endblock %}</h1>
                 <div class="page-actions">
@@ -87,6 +78,9 @@
         <h2 class="iframe-title">{{ script_item.name }}</h2>
         {% if script_item.description %}<p>{{ script_item.description }}</p>{% endif %}
         <form enctype="multipart/form-data" action="" method="post" novalidate>
+            <div clas="pull-right">
+                <button class="btn btn-success" type="submit">{% trans %}Save changes{% endtrans %}</button>
+            </div>
             {% if form.errors %}
                 <div class="alert alert-dismissible alert-danger" role="alert">
                     <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>

--- a/shuup_tests/notify/test_email_template.py
+++ b/shuup_tests/notify/test_email_template.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2020, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+import pytest
+
+from bs4 import BeautifulSoup
+
+from shuup.notify.admin_module.views.email_template import EmailTemplateEditView
+from shuup.testing import factories
+from shuup.testing.utils import apply_request_middleware
+
+
+@pytest.mark.django_db
+def test_media_view_images(rf, admin_user):
+    shop = factories.get_default_shop()
+
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
+    request.user = admin_user
+
+
+    view_func = EmailTemplateEditView.as_view()
+    response = view_func(request)
+    if hasattr(response, "render"):
+        response.render()
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content)
+    assert soup.find("div", {"class": "code-editor-with-preview-container"})


### PR DESCRIPTION
Here HTML test email with multiple lines:
![Screenshot 2021-01-22 at 12 21 28](https://user-images.githubusercontent.com/4940349/105479076-b07c5280-5cac-11eb-9f77-2743fb281f17.png)

Leads to this kind of email which should be right:
![Screenshot 2021-01-22 at 12 22 33](https://user-images.githubusercontent.com/4940349/105479095-b7a36080-5cac-11eb-980d-36a9ef9e9099.png)

Here plain text test email with multiple lines
![Screenshot 2021-01-22 at 12 22 54](https://user-images.githubusercontent.com/4940349/105479129-c1c55f00-5cac-11eb-8e6a-9ae77d249ad7.png)

And the email received looks like having linebreaks correctly:
![Screenshot 2021-01-22 at 12 23 21](https://user-images.githubusercontent.com/4940349/105479150-cbe75d80-5cac-11eb-8fdf-b9a3ecfc9de5.png)

