### PR TITLE
Admin: Adjust block title and form input spacing

### DIFF
--- a/shuup/admin/static_src/base/scss/shuup/content-blocks.scss
+++ b/shuup/admin/static_src/base/scss/shuup/content-blocks.scss
@@ -26,10 +26,17 @@
                 content: '';
                 position: absolute;
                 bottom: 0;
-                left: -15px;
-                width: calc(100% + 30px);
+                left: -10px;
+                width: calc(100% + 20px);
                 height: 1px;
                 background-color: rgba($border-color, 0.5);
+            }
+        }
+
+        @include media-breakpoint-up(xl) {
+            &::after {
+                left: -15px;
+                width: calc(100% + 30px);
             }
         }
 
@@ -47,12 +54,6 @@
             }
         }
 
-        .block-title {
-            @include media-breakpoint-down(sm) {
-                font-size: $h3-font-size;
-            }
-        }
-
         .block-title,
         .block-subtitle {
             padding-bottom: 8px;
@@ -65,6 +66,10 @@
             @include media-breakpoint-down(md)  {
                 border-color: #fff;
                 padding-bottom: 0;
+            }
+
+            @include media-breakpoint-down(sm) {
+                font-size: $h3-font-size;
             }
 
             @include media-breakpoint-up(lg) {
@@ -82,6 +87,11 @@
                 align-items: center;
                 justify-content: center;
             }
+        }
+
+        .block-subtitle {
+            margin-top: 30px;
+            align-items: center;
         }
 
         .block-title i,
@@ -168,12 +178,21 @@
         &.top-line {
             &::before {
                 content: '';
-                width: calc(100% + 30px);
+                width: calc(100% + 20px);
                 height: 5px;
                 position: absolute;
-                left: -15px;
+                left: -10px;
                 top: -15px;
                 background-color: rgba($border-color, 0.4);
+
+                @include media-breakpoint-up(xl) {
+                    width: calc(100% + 30px);
+                    left: -15px;
+                }
+            }
+
+            .block-subtitle {
+                margin-top: 0;
             }
         }
 

--- a/shuup/admin/static_src/base/scss/shuup/content-blocks.scss
+++ b/shuup/admin/static_src/base/scss/shuup/content-blocks.scss
@@ -269,14 +269,19 @@
     .summernote-wrap,
     .select2-container,
     .checkbox {
-        max-width: 80%;
+        max-width: 85%;
         border-radius: $border-radius-lg;
-        margin: 3px;
         display: inline-block;
+
+        @include media-breakpoint-down(sm) {
+            max-width: 100%;
+        }
     }
 
     .select2-container {
         min-width: 200px;
+        width: 100% !important;
+        margin-right: 0;
 
         // make room to add quick add buttons
         @include media-breakpoint-down(sm) {

--- a/shuup/admin/static_src/base/scss/shuup/custom-forms.scss
+++ b/shuup/admin/static_src/base/scss/shuup/custom-forms.scss
@@ -31,12 +31,23 @@ $input-bg-color: #F3F3F3;
 }
 
 .form-content {
-    padding: 1.2rem 0.5rem;
+    padding: 1rem .5rem;
     margin-bottom: 0;
+
+    @include media-breakpoint-down(sm) {
+        padding: .8rem .25rem;
+    }
 
     label {
         color: rgba($text-color, 0.9);
         font-weight: 600;
+    }
+
+    .control-label {
+        @include media-breakpoint-down(sm) {
+            // Make room for tooltips that are positioned absolute on the right
+            padding-right: 30px;
+        }
     }
 }
 
@@ -245,7 +256,26 @@ fieldset[disabled] .form-control {
 
 .help-popover-btn {
     display: inline-block;
-    margin-top: 4px;
+}
+
+.form-input-group .help-popover-btn {
+    // Position tooltips on the right side above the fields on mobile
+    @include media-breakpoint-down(sm) {
+        position: absolute;
+        bottom: 100%;
+        right: -10px;
+    }
+}
+
+.form-input-group .checkbox {
+    & + .help-popover-btn {
+        // Don't do positioning of the tooltips for checkboxes
+        @include media-breakpoint-down(sm) {
+            position: relative;
+            bottom: auto;
+            right: auto;
+        }
+    }
 }
 
 .checkbox {

--- a/shuup/admin/static_src/base/scss/shuup/quick-add.scss
+++ b/shuup/admin/static_src/base/scss/shuup/quick-add.scss
@@ -71,21 +71,16 @@ div.container-fluid.support-nav-wrap {
             cursor: pointer;
             float: left;
             position: relative;
-            margin-top: 4px;
 
             i.fa-plus:hover {
                 color: #000;
             }
 
-            @include media-breakpoint-up(sm) {
+            @include media-breakpoint-up(md) {
                 margin-left: 5px;
             }
 
-            i.fa-plus:hover {
-                color: #000;
-            }
-
-            @include media-breakpoint-down(xs) {
+            @include media-breakpoint-down(sm) {
                 position: absolute;
                 left: 3px;
                 bottom: 0px;
@@ -96,13 +91,12 @@ div.container-fluid.support-nav-wrap {
             cursor: pointer;
             float: left;
             position: relative;
-            margin-top: 4px;
 
             i.fa-plus:hover {
                 color: #000;
             }
 
-            @include media-breakpoint-down(xs) {
+            @include media-breakpoint-down(sm) {
                 position: absolute;
                 left: 50px;
                 bottom: 0px;


### PR DESCRIPTION
Admin: Fix block title and subtitle spacing
* Also fix the border top/bottom width of the titles in different screen sizes

Admin: Adjust form field spacing
* Make the form fields a bit wider, increasing the width from 80% to 85% in desktop, and make them 100% wide in mobile
* Reduce margin between form fields
* Fix mobile styling of quick add buttons
* Position tooltips on the right side above the fields on mobile

![127 0 0 1_8000_admin_products_new_](https://user-images.githubusercontent.com/7901266/105834954-d5860380-5fd3-11eb-9947-74b427cdee55.png)
