### PR TITLE
Improve media browser styles

### DIFF
--- a/shuup/admin/modules/media/static_src/media/browser/BrowserView.js
+++ b/shuup/admin/modules/media/static_src/media/browser/BrowserView.js
@@ -22,8 +22,8 @@ import * as remote from "./util/remote";
 export function view(ctrl) {
     return m("div.container-fluid", [
         m("div.row", [
-            m("div.col-md-3.page-inner-navigation.folder-tree", folderTree(ctrl)),
-            m("div.col-md-9.page-content", m("div.content-block", [
+            m("div.col.page-inner-navigation.folder-tree", folderTree(ctrl)),
+            m("div.col.page-content", m("div.content-block", [
                 m("div.title", folderBreadcrumbs(ctrl)),
                 m("div.content", folderView(ctrl))
             ]))

--- a/shuup/admin/modules/media/static_src/media/browser/components/gridFileView.js
+++ b/shuup/admin/modules/media/static_src/media/browser/components/gridFileView.js
@@ -17,7 +17,7 @@ import fileContextMenu from "../menus/fileContextMenu";
 
 export default function(ctrl, folders, files) {
     const folderItems = _.map(folders, function(folder) {
-        return m("div.col-xs-6.col-md-4.col-lg-3.grid-folder.fd-zone", {
+        return m("div.grid-folder.fd-zone", {
             key: "folder-" + folder.id,
             "data-folder-id": folder.id,
             config: dropzoneConfig(ctrl),
@@ -38,7 +38,7 @@ export default function(ctrl, folders, files) {
         });
 
         return m(
-            "div.col-xs-6.col-md-4.col-lg-3.grid-file",
+            "div.grid-file",
             {
                 key: file.id,
                 draggable: true,
@@ -64,10 +64,12 @@ export default function(ctrl, folders, files) {
                 }
             }, m("i.fa.fa-cog")) : null,
             wrapFileLink(file, "a.file-preview", [
-                m("img.img-responsive", {src: file.thumbnail || images.defaultThumbnail}),
+                m("div.preview-img-wrap", [
+                    m("img.img-responsive", {src: file.thumbnail || images.defaultThumbnail}),
+                ]),
                 m("div.file-name", file.name)
             ])
         );
     });
-    return m("div.row", folderItems.concat(fileItems));
+    return m("div.custom-browser-row", folderItems.concat(fileItems));
 }

--- a/shuup/admin/modules/media/static_src/media/browser/components/images.js
+++ b/shuup/admin/modules/media/static_src/media/browser/components/images.js
@@ -7,4 +7,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 export const uploadIndicator = `${window.ShuupAdminConfig.settings.staticPrefix}shuup_admin/img/file-icons.svg`;
-export const defaultThumbnail = `${window.ShuupAdminConfig.settings.staticPrefix}shuup_admin/img/default-thumbnail`;
+export const defaultThumbnail = `${window.ShuupAdminConfig.settings.staticPrefix}shuup_admin/img/default-thumbnail.svg`;

--- a/shuup/admin/modules/media/static_src/media/browser/media-browser.scss
+++ b/shuup/admin/modules/media/static_src/media/browser/media-browser.scss
@@ -8,6 +8,9 @@
 }
 
 .folder-tree {
+    flex-basis: 260px;
+    max-width: 260px;
+
     @include media-breakpoint-down(md) {
         display: none;
     }
@@ -19,22 +22,18 @@
     }
 
     ul ul {
-        padding-left: 2.5rem;
+        padding-left: 1.5rem;
     }
 
     li a {
         font-size: 0.9rem;
-        padding: 5px 10px;
+        padding: 5px 0;
         display: block;
         text-decoration: none;
         color: $text-color;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-
-        @include media-breakpoint-up(xl) {
-            font-size: 1rem;
-        }
 
         &:hover {
             text-decoration: underline;
@@ -61,8 +60,7 @@
 }
 
 .title {
-    padding-bottom: 15px;
-    margin-bottom: 30px;
+    margin-bottom: 20px;
 
     i, a {
         margin-right: 7px;
@@ -78,23 +76,34 @@
 
     .btn-toolbar {
         margin: 0;
-        margin-bottom: 50px;
+        margin-bottom: 30px;
+
+        @include media-breakpoint-down(md) {
+            margin-bottom: 20px;
+        }
 
         .btn-group {
             margin-left: 0;
             margin-right: 15px;
+            flex-wrap: wrap;
 
             @include media-breakpoint-down(md) {
                 margin-bottom: 10px;
             }
 
+            button {
+                white-space: nowrap;
+                flex-grow: 0;
+            }
+
             &.icons {
                 button {
-                    padding: 6px 10px 4px 10px;
+                    padding-top: 6px;
+                    padding-bottom: 2px;
                 }
 
                 i {
-                    font-size: 1.4rem;
+                    font-size: 1.1rem;
                 }
             }
         }
@@ -103,49 +112,70 @@
     .folder-contents {
         min-height: 350px;
 
+        .custom-browser-row {
+            display: flex;
+            flex-flow: row wrap;
+
+            @supports (display: grid) {
+                display: grid;
+                grid-gap: 25px 15px;
+                grid-template-columns: repeat(auto-fill, minmax(155px, 1fr));
+
+                @include media-breakpoint-down(xs) {
+                    grid-gap: 20px 10px;
+                }
+            }
+        }
+
         .grid-folder,
         .grid-file {
-            margin-bottom: 60px;
+            position: relative;
+            margin: 0 15px 25px 0;
+            flex-basis: 180px;
 
-            @include media-breakpoint-down(md) {
-                &:nth-child(2n+1) {
-                    clear: both;
-                }
-            }
-
-            @include media-breakpoint-between(md, lg) {
-                &:nth-child(3n+1) {
-                    clear: both;
-                }
-            }
-
-            @include media-breakpoint-up(xl) {
-                &:nth-child(4n+1) {
-                    clear: both;
-                }
+            @supports (display: grid) {
+                margin: 0;
+                flex-basis: unset;
             }
 
             a.file-preview {
                 display: block;
                 background: #fff;
                 text-align: center;
-                padding: 15px;
+                padding: 10px;
                 border: 1px solid $border-color;
-                margin-bottom: 10px;
+                border-radius: $border-radius;
                 transition: border-color 0.1s;
+                width: 100%;
 
                 &:hover,
                 &:focus {
                     border-color: $primary;
                 }
 
-                img {
+                .preview-img-wrap {
+                    max-width: 120px;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    object-fit: contain;
                     margin: auto;
+
+                    img {
+                        margin: auto;
+                    }
                 }
             }
 
             .file-name {
                 text-align: center;
+                font-size: .8rem;
+                margin-top: 5px;
+                overflow-wrap: break-word;
+
+                @include media-breakpoint-down(xs) {
+                    font-size: .75rem;
+                }
 
                 a {
                     color: $text-color;
@@ -158,8 +188,12 @@
             }
         }
 
+        .grid-file {
+            display: flex;
+        }
+
         .grid-folder {
-            .file-preview {
+            a.file-preview {
                 padding: 30px 15px;
             }
 
@@ -338,7 +372,7 @@
 .file-cog-btn {
     padding: 0;
     position: absolute;
-    right: 25px;
+    right: 10px;
     top: 10px;
     width: 20px;
 }

--- a/shuup/admin/modules/media/static_src/media/browser/menus/menuItem.js
+++ b/shuup/admin/modules/media/static_src/media/browser/menus/menuItem.js
@@ -17,7 +17,7 @@ export default function item(label, action, attrs = {}) {
         tagBits.push("disabled");
         return;
     }
-    return m(tagBits.join("."), m("a", {
+    return m(tagBits.join("."), m("a.dropdown-item", {
         href: "#", onclick: (event) => {
             event.preventDefault();
             action();

--- a/shuup/utils/filer.py
+++ b/shuup/utils/filer.py
@@ -184,8 +184,9 @@ def filer_file_to_json_dict(file, user=None):
     try:
         thumbnail = file.easy_thumbnails_thumbnailer.get_thumbnail({
             'size': (128, 128),
-            'crop': True,
+            'crop': False,
             'upscale': True,
+            'background': "#ffffff",
             'subject_location': file.subject_location
         })
     except Exception:


### PR DESCRIPTION
## Admin: Update styling for media browser
* Fix mobile styling so that more content is visible at once
* Fix overflowing sort button in mobile screen sizes
* Adjust file and folder design to be more consistent
* Add bootstrap dropdown link styles for the dropdown menu

Ensure media browser images are squares without cropping:
* Add white padding around the images so that the image won't be cropped and the users can see the whole image contents

<hr>

**Before:**

![mediabrowser-before](https://user-images.githubusercontent.com/7901266/105998275-202b7c80-60b5-11eb-922d-3da6b169f9a0.jpg)

<hr>

**After:**

![mediabrowser-after](https://user-images.githubusercontent.com/7901266/105998259-1dc92280-60b5-11eb-9089-f46cb7df95ff.jpg)
