### PR TITLE
Fix adding products with deleted children to basket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Fixed
+
+- Core: Adding normal products with only deleted children to basket
+
 ## [2.3.16] - 2021-02-18
 
 ### Fixed

--- a/shuup/core/basket/objects.py
+++ b/shuup/core/basket/objects.py
@@ -551,7 +551,7 @@ class BaseBasket(OrderSource):
         return self._orderable_lines_cache
 
     def _initialize_product_line_data(self, product, supplier, shop, quantity=0):
-        if product.variation_children.count():
+        if product.variation_children.filter(deleted=False).exists():
             raise ValueError("Error! Add a variation parent to the basket is not allowed.")
 
         return {


### PR DESCRIPTION
Fixes a case where Variation Parents that are turned to normal products by having all their variations removed can't be added to basked because basket is incorrectly identifying product as a parent due to it having deleted children.