### PR TITLE
Admin: add option to hide font selection and paste plain text in editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Added
+
+- Admin: add option to hide font selection and always paste plain text in summernote editors
+
 ## [2.3.18] - 2021-03-01
 
 ### Added

--- a/shuup/admin/static_src/base/js/editor.js
+++ b/shuup/admin/static_src/base/js/editor.js
@@ -30,15 +30,20 @@ const getMediaButton = ($editor) => context => {
     );
 };
 
-function activateEditor($editor, attrs = {}) {
+function activateEditor($editor, attrs = {}, options = {}) {
     function cancelEvent(event) {
         event.preventDefault();
         event.stopImmediatePropagation();
     }
 
+    let fontMenu = ["font", ["fontname", "fontsize"]];
+    if (options.allowFontFamilySelection === false) {
+        fontMenu = ["font", ["fontsize"]];
+    }
+
     const toolbar = [
       ["style", ["style", "clear"]],
-      ["font", ["fontname", "fontsize"]],
+      fontMenu,
       ["style2", ["bold", "italic", "underline", "strikethrough", "superscript", "subscript"]],
       ["color", ["forecolor", "backcolor"]],
       ["para", ["ul", "ol", "paragraph", "height"]],
@@ -59,14 +64,26 @@ function activateEditor($editor, attrs = {}) {
                 $editor.parent().find("textarea.hidden").val($(this).summernote("code"));
             },
             onPaste(event) {
-                // prevent pasting files
-                const clipboardData = event.originalEvent.clipboardData;
+                const clipboardData = (event.originalEvent || event).clipboardData || window.clipboardData;
+
                 if (clipboardData) {
-                    for (let x = 0; x < clipboardData.items.length; x += 1) {
-                        if (clipboardData.items[x].kind === "file") {
-                            cancelEvent(event);
-                            return;
+                    const bufferText = clipboardData.getData("Text");
+
+                    if (!bufferText && clipboardData.items.length) {
+                        // prevent pasting files
+                        for (let x = 0; x < clipboardData.items.length; x += 1) {
+                            if (clipboardData.items[x].kind === "file") {
+                                cancelEvent(event);
+                                return;
+                            }
                         }
+                    }
+
+                    if (options.plainTextOnPaste && bufferText) {
+                        cancelEvent(event);
+                        setTimeout(function () {
+                            document.execCommand("insertText", false, bufferText);
+                        }, 10);
                     }
                 }
             },
@@ -108,24 +125,37 @@ function activateEditor($editor, attrs = {}) {
     return $summernote;
 }
 
-function activateEditors() {
-    $(".summernote-editor").each(function (idx, object) {
-        const $editor = $(object);
-        if ($editor.parent().find(".note-editor").length === 0) {
-            const textarea = $editor.parent().find("textarea");
-            const params = textarea.data() || {};
-            const attrs = {};
-            const paramKeys = Object.keys(params);
+window.ShuupAdminEditors = {
+    _instances: [],
 
-            if (paramKeys.includes("height")) {
-                attrs.height = params.height;
+    activateEditors: function(target, options = {}) {
+        const that = this;
+
+        $(target).each(function (idx, object) {
+            const $editor = $(object);
+            if ($editor.parent().find(".note-editor").length === 0) {
+                const textarea = $editor.parent().find("textarea");
+                const params = textarea.data() || {};
+                const attrs = {};
+                const paramKeys = Object.keys(params);
+
+                if (paramKeys.includes("height")) {
+                    attrs.height = params.height;
+                }
+
+                that._instances.push(activateEditor($editor, attrs, options));
+
+                if (paramKeys.includes("noresize")) {
+                    $editor.parent().find(".note-statusbar").hide();
+                }
             }
-            activateEditor($editor, attrs);
-            if (paramKeys.includes("noresize")) {
-                $editor.parent().find(".note-statusbar").hide();
-            }
+        });
+    },
+
+    destroyEditors: function() {
+        while (this._instances.length) {
+            const $instance = this._instances.pop();
+            $($instance).summernote("destroy");
         }
-    });
-}
-
-activateEditors();
+    }
+};

--- a/shuup/admin/templates/shuup/admin/base.jinja
+++ b/shuup/admin/templates/shuup/admin/base.jinja
@@ -79,20 +79,36 @@
         {% endblock %}
         {% block post_content %}{% endblock %}
         {% endif %}
-        <script src="{{ shuup_static("shuup_admin/js/vendor.js") }}"></script>
-        <script src="{{ shuup_static("shuup_admin/js/base.js") }}"></script>
-        {% block extra_js %}{% endblock %}
-        {% if messages %}
+
+        <script src="{{ shuup_static('shuup_admin/js/vendor.js') }}"></script>
+        <script src="{{ shuup_static('shuup_admin/js/base.js') }}"></script>
+
+        {% block init_scripts %}
         <script>
-            (function(){
-                if(!window.Messages) return;
-                {% for message in messages -%}Messages.enqueue({
-                    tags: {{ message.tags|json }},
-                    text: {{ (message.tags.capitalize() ~ "! " ~ message.message)|json }}
-                });{% endfor %}
-            }());
+            if (window.ShuupAdminEditors) {
+                window.ShuupAdminEditors.activateEditors(".summernote-editor");
+            }
         </script>
-        {% endif %}
-        <script>$(function() {window.runTour();});</script>
+        {% endblock %}
+
+        {% block extra_js %}{% endblock %}
+
+        {% block messages %}
+            {% if messages %}
+            <script>
+                (function(){
+                    if(!window.Messages) return;
+                    {% for message in messages -%}Messages.enqueue({
+                        tags: {{ message.tags|json }},
+                        text: {{ (message.tags.capitalize() ~ "! " ~ message.message)|json }}
+                    });{% endfor %}
+                }());
+            </script>
+            {% endif %}
+        {% endblock %}
+
+        {% block tour %}
+            <script>$(function() {window.runTour();});</script>
+        {% endblock %}
     </body>
 </html>


### PR DESCRIPTION
Convert the script functions into an object that can is called in the base template

Also add more blocks to enable more customization of the base admin template

⚠️  This will break summernote in projects that customize `base.jinja` in Admin as they miss the new initialization block script.