### PR TITLE
Add missing labels to product category and supplier fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ List all changes after the last release here (newer on top). Each change on a se
 
 - Admin: add option to hide font selection and always paste plain text in summernote editors
 
+### Fixed
+
+- Added missing labels to product category and supplier fields
+
 ## [2.3.18] - 2021-03-01
 
 ### Added

--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -235,6 +235,7 @@ class ShopProductForm(MultiLanguageModelForm):
                     initial=initial_suppliers,
                     attrs={"data-search-mode": "enabled"}
                 ),
+                label=self.fields["suppliers"].label,
                 required=False
             )
         else:
@@ -249,12 +250,14 @@ class ShopProductForm(MultiLanguageModelForm):
                     initial=(self.instance.primary_category if self.instance.pk else None),
                     attrs={"data-placeholder": ugettext("Select a category")}
                 ),
+                label=self.fields["primary_category"].label,
                 required=False
             )
             self.fields["categories"] = Select2ModelMultipleField(
                 initial=initial_categories,
                 model=Category,
                 widget=QuickAddCategoryMultiSelect(initial=initial_categories),
+                label=self.fields["categories"].label,
                 required=False
             )
         else:


### PR DESCRIPTION
Overriding the fields caused field labels to not be translated properly