### PR TITLE
Importer: Ignore rows without any data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Fixed
+
+- Importer: Ignore rows without any data
 
 ## [2.4.0] - 2021-03-02
 

--- a/shuup/importer/transforms.py
+++ b/shuup/importer/transforms.py
@@ -69,6 +69,8 @@ def process_data(rows):
     data = []
     if not len(data):
         for y, row in enumerate(rows):
+            if not any(row):  # Ignore any fully cleared rows
+                continue
             if y == 0:
                 headers = [x.lower().strip() for x in row if x]
                 continue


### PR DESCRIPTION
In cases where imported file has cleared, but not deleted rows, rows with only `None` values are included.
They should be ignored, but are instead counted towards rows of imported data