### PR TITLE
Language aware lru_cache

### DIFF
--- a/shuup/admin/template_helpers/shuup_admin.py
+++ b/shuup/admin/template_helpers/shuup_admin.py
@@ -11,10 +11,10 @@ This module is installed as the `shuup_admin` template function namespace.
 """
 
 import itertools
+from functools import lru_cache
 
 from django.conf import settings
 from django.middleware.csrf import get_token
-from django.utils.lru_cache import lru_cache
 from jinja2.utils import contextfunction
 
 from shuup import configuration

--- a/shuup/core/models/_contacts.py
+++ b/shuup/core/models/_contacts.py
@@ -7,13 +7,14 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 
+from functools import lru_cache
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import QuerySet
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
-from django.utils.lru_cache import lru_cache
 from django.utils.translation import ugettext_lazy as _
 from enumfields import Enum, EnumField
 from filer.fields.image import FilerImageField

--- a/shuup/core/models/_units.py
+++ b/shuup/core/models/_units.py
@@ -9,13 +9,13 @@ from __future__ import unicode_literals
 
 import warnings
 from decimal import Decimal, ROUND_HALF_UP
+from functools import lru_cache
 
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models.signals import post_save
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
-from django.utils.lru_cache import lru_cache
 from django.utils.translation import pgettext
 from django.utils.translation import ugettext_lazy as _
 from parler.models import (

--- a/shuup/core/utils/static.py
+++ b/shuup/core/utils/static.py
@@ -5,9 +5,8 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+from functools import lru_cache
 from logging import getLogger
-
-from django.utils.lru_cache import lru_cache
 
 LOGGER = getLogger(__name__)
 

--- a/shuup/front/middleware.py
+++ b/shuup/front/middleware.py
@@ -5,6 +5,8 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+from functools import lru_cache
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import logout
@@ -13,7 +15,6 @@ from django.contrib.auth.signals import user_logged_in, user_logged_out
 from django.http import HttpResponse
 from django.template import loader
 from django.utils import timezone, translation
-from django.utils.lru_cache import lru_cache
 from django.utils.translation import ugettext_lazy as _
 
 from shuup.core.middleware import ExceptionMiddleware

--- a/shuup/front/templatetags/shuup_front.py
+++ b/shuup/front/templatetags/shuup_front.py
@@ -5,10 +5,11 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+from functools import lru_cache
+
 import django_jinja
 from django.conf import settings
 from django.utils.functional import SimpleLazyObject
-from django.utils.lru_cache import lru_cache
 from django.utils.safestring import mark_safe
 from django_jinja import library
 from markdown import Markdown

--- a/shuup/gdpr/models.py
+++ b/shuup/gdpr/models.py
@@ -10,7 +10,6 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.lru_cache import lru_cache
 from django.utils.translation import activate, get_language
 from django.utils.translation import ugettext_lazy as _
 from parler.models import TranslatableModel, TranslatedFields
@@ -18,11 +17,12 @@ from reversion.models import Version
 
 from shuup.gdpr.utils import get_active_consent_pages
 from shuup.simple_cms.models import Page
+from shuup.utils.i18n import lang_lru_cache
 
 GDPR_ANONYMIZE_TASK_TYPE_IDENTIFIER = "gdpr_anonymize"
 
 
-@lru_cache()
+@lang_lru_cache
 def get_setting(shop):
     instance, created = GDPRSettings.objects.get_or_create(shop=shop)
     if created or not instance.safe_translation_getter("cookie_banner_content"):

--- a/shuup_tests/cache/test_lang_lru_cache.py
+++ b/shuup_tests/cache/test_lang_lru_cache.py
@@ -1,0 +1,32 @@
+# This file is part of Shuup.
+#
+# Copyright (c) 2012-2021, Shoop Commerce Ltd. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from random import random
+
+from django.utils.translation import activate
+
+from shuup.utils.i18n import lang_lru_cache
+
+
+def test_lang_lru_cache():
+    """Test that functions are cached on a per-language basis"""
+    @lang_lru_cache
+    def cached_random():
+        return random()
+
+    activate("en")
+    en = cached_random()
+    assert en == cached_random()
+
+    activate("fi")
+    fi = cached_random()
+    assert fi == cached_random()
+
+    activate("sv")
+    sv = cached_random()
+    assert sv == cached_random()
+
+    assert en != fi != sv


### PR DESCRIPTION
`lru_cache` is shared between everyone and every language, which means incorrect translations are returned if different language is cached than is in use by user