### PR TITLE
Fix EmailTemplate settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Fixed
+
+- Notify: Fix so there is no 500 error when accessing EmailTemplate settings page
+
 ### Added
 
 - Core: add attribute in Carrier model to control whether to manage shipments using default behavior

--- a/shuup/notify/admin_module/views/email_template.py
+++ b/shuup/notify/admin_module/views/email_template.py
@@ -56,6 +56,7 @@ class EmailTemplateDeleteView(DetailView):
 
 class EmailTemplateListView(PicotableListView):
     model = EmailTemplate
+    url_identifier = "notify.email_template"
     default_columns = [
         Column(
             "name",


### PR DESCRIPTION
- Fixed so there is no 500 error when accessing EmailTemplate settings page

refs https://sentry.io/organizations/shuup/issues/1840747854/?project=5357333&query=is%3Aunresolved