### PR TITLE
Add so `basket.get_final_lines()` is called after MethodsPhase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Added
+
+- Front: Add so `basket.get_final_lines(with_taxes=True)` gets called after selecting shipping- and payment method.
+  Reason for this is so all the taxes gets calculated before end customers fills in their payment details
+
 ### Changed
 
 - Core: undeprecate signals for ShopProduct model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
-### Added
+### Changed
 
 - Front: Add so `basket.get_final_lines(with_taxes=True)` gets called after selecting shipping- and payment method.
   Reason for this is so all the taxes gets calculated before end customers fills in their payment details
-
-### Changed
-
 - Core: undeprecate signals for ShopProduct model
 
 ### Added

--- a/shuup/front/checkout/methods.py
+++ b/shuup/front/checkout/methods.py
@@ -125,6 +125,7 @@ class MethodsPhase(CheckoutPhaseViewMixin, FormView):
 
         # force recalculate lines
         self.basket.uncache()
+        self.basket.get_final_lines(with_taxes=True)
 
     def get_form_kwargs(self):
         kwargs = super(MethodsPhase, self).get_form_kwargs()


### PR DESCRIPTION
- Front: Add so `basket.get_final_lines(with_taxes=True)` gets called after selecting shipping- and payment method.
  Reason for this is so all the taxes gets calculated before end customers fills in their payment details

refs https://trello.com/c/mtVzzdDO/24-set-up-taxjar-integration