### PR TITLE
fixed picotable overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ List all changes after the last release here (newer on top). Each change on a se
 ### Changed
 
 - Admin: change so TaxClassEditView is a FormPartView
+- Admin: Picotable to scroll in container on overflow rather, than entire screen scroll
 
 ## [2.6.0] - 2021-03-29
 

--- a/shuup/admin/static_src/base/scss/shuup/picotable.scss
+++ b/shuup/admin/static_src/base/scss/shuup/picotable.scss
@@ -1,4 +1,7 @@
 #picotable {
+    .table-view{
+        overflow: scroll;
+    }
     .table {
         margin-top: 1rem;
         background-color: $white;


### PR DESCRIPTION
### Changed

- Admin: Picotable to scroll in container on overflow rather, than entire screen scroll

Old version hiding the links at top:
![old_picotable](https://user-images.githubusercontent.com/71646562/113039186-ffd37900-915c-11eb-8b72-e1a2cb69e964.PNG)

New version correctly scrolling:
![new_picotable](https://user-images.githubusercontent.com/71646562/113039187-006c0f80-915d-11eb-8e91-b4b1f0ec48be.PNG)
