### PR TITLE
Admin: Don't require typing characters to show options in Select2 fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ List all changes after the last release here (newer on top). Each change on a se
 ### Changed
 
 - Admin: change so TaxClassEditView is a FormPartView
+- Admin: Don't require typing any characters to show all options in Select2 fields.
 
 ### Fixed
 

--- a/shuup/admin/forms/fields.py
+++ b/shuup/admin/forms/fields.py
@@ -53,7 +53,7 @@ class Select2ModelField(Field):
     def widget_attrs(self, widget):
         attrs = super(Select2ModelField, self).widget_attrs(widget)
         model_name = "%s.%s" % (self.model._meta.app_label, self.model._meta.model_name)
-        attrs.update({"data-model": model_name})
+        attrs.update({"data-model": model_name, "data-minimum-input-length": 0})
         if not self.required:
             attrs["data-allow-clear"] = "true"
             attrs["data-placeholder"] = _("Select an option")
@@ -89,7 +89,7 @@ class Select2MultipleField(Field):
     def widget_attrs(self, widget):
         attrs = super(Select2MultipleField, self).widget_attrs(widget)
         model_name = "%s.%s" % (self.model._meta.app_label, self.model._meta.model_name)
-        attrs.update({"data-model": model_name})
+        attrs.update({"data-model": model_name, "data-minimum-input-length": 0})
         if getattr(self, "search_mode", None):
             attrs.update({"data-search-mode": self.search_mode})
         if not self.required:


### PR DESCRIPTION
Previously these would require to input 3 characters before showing any
options. It made the choices they contain very undiscoverable.

It's hard to say how much this will affect performance. In theory it
shouldn't hurt it much since these choices will anyways be loaded
asynchronously only after the page has already been rendered.

Before:
![image](https://user-images.githubusercontent.com/33625218/113168983-d2b2c380-924d-11eb-88c0-c1f35c23ce5f.png)

After:
![image](https://user-images.githubusercontent.com/33625218/113169013-dc3c2b80-924d-11eb-87c3-4277acf087a6.png)
