### PR TITLE
Fix Duplicate images being saved when creating a new product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ List all changes after the last release here (newer on top). Each change on a se
 ### Fixed
 
 - Core: Fix error that occurred when creating an order with a product which SKU was longer than 48 characters. 
+- Admin: Multiple duplicate images being saved when image is uploaded before product is saved
 
 ## [2.6.0] - 2021-03-29
 

--- a/shuup/admin/modules/products/forms/base_forms.py
+++ b/shuup/admin/modules/products/forms/base_forms.py
@@ -146,8 +146,8 @@ class ProductBaseForm(MultiLanguageModelForm):
         return sku
 
     def save(self):
-        instance = super(ProductBaseForm, self).save()
-        if self.cleaned_data.get("file"):
+        instance = super().save()
+        if self.cleaned_data.get("file") and instance.primary_image is None:
             image = ProductMedia.objects.create(
                 product=instance,
                 file_id=self.cleaned_data["file"],


### PR DESCRIPTION
Product form is saved multiple times which can lead to multiple images being created

![image](https://user-images.githubusercontent.com/50950050/113175447-17d9f400-9254-11eb-9960-88a9bc944357.png)
