### PR TITLE
Xtheme: make plugin indicate whether it can be cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ List all changes after the last release here (newer on top). Each change on a se
 
 ### Changed
 
+- General: make some plugins cacheable
 - Xtheme: add attribute on every plugin to indicate whether it can be cached or not
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Changed
+
+- Xtheme: add attribute on every plugin to indicate whether it can be cached or not
+
+### Removed
+
+- Xtheme: removed the SHUUP_XTHEME_USE_PLACEHOLDER_CACHE setting and do not cache the entire placeholder content
+
 ### Fixed
 
 - Core: implement choice attribute getter and setter correctly

--- a/shuup/front/apps/carousel/plugins.py
+++ b/shuup/front/apps/carousel/plugins.py
@@ -19,6 +19,7 @@ class CarouselPlugin(TemplatedPlugin):
     identifier = "shuup.front.apps.carousel.carousel"
     name = _("Carousel Plugin")
     template_name = "shuup/carousel/carousel.jinja"
+    cacheable = True
     fields = [
         ("carousel", None),
         (
@@ -37,6 +38,11 @@ class CarouselPlugin(TemplatedPlugin):
         defaults = super(CarouselPlugin, self).get_defaults()
         defaults.update({"carousel": self.config.get("carousel", None), "active": self.config.get("active", True)})
         return defaults
+
+    def get_cache_key(self) -> str:
+        carousel_id = self.config.get("carousel")
+        active = self.config.get("active")
+        return str((carousel_id, active))
 
     def get_context_data(self, context):
         """

--- a/shuup/simple_cms/plugins.py
+++ b/shuup/simple_cms/plugins.py
@@ -77,6 +77,7 @@ class PageLinksPlugin(TemplatedPlugin):
     identifier = "simple_cms.page_links"
     name = _("CMS Page Links")
     template_name = "shuup/simple_cms/plugins/page_links.jinja"
+    cacheable = True
     editor_form_class = PageLinksConfigForm
     fields = [
         ("title", TranslatableField(label=_("Title"), required=False, initial="")),
@@ -99,6 +100,13 @@ class PageLinksPlugin(TemplatedPlugin):
         ),
         "pages",
     ]
+
+    def get_cache_key(self) -> str:
+        title = self.get_translated_value("title")
+        selected_pages = self.config.get("pages", [])
+        show_all_pages = self.config.get("show_all_pages", True)
+        hide_expired = self.config.get("hide_expired", False)
+        return str((title, selected_pages, show_all_pages, hide_expired))
 
     def get_context_data(self, context):
         """

--- a/shuup/testing/factories.py
+++ b/shuup/testing/factories.py
@@ -908,7 +908,7 @@ def create_random_product_attribute():
 def create_random_user(locale="en", **kwargs):
     user_model = get_user_model()
     faker = get_faker(["person"], locale)
-    params = {user_model.USERNAME_FIELD: slugify(faker.first_name())}
+    params = {user_model.USERNAME_FIELD: "{}-{}".format(uuid.uuid4().hex, slugify(faker.first_name()))}
     params.update(kwargs or {})
     return user_model.objects.create(**params)
 

--- a/shuup/xtheme/plugins/_base.py
+++ b/shuup/xtheme/plugins/_base.py
@@ -32,6 +32,7 @@ class Plugin(object):
     required_context_variables = set()
     name = _("Plugin")  # User-visible name
     editor_form_class = GenericPluginForm
+    cacheable = False  # Indicates whether this plugin can be cached while rendering
 
     def __init__(self, config):
         """
@@ -172,6 +173,12 @@ class Plugin(object):
                 choices.append((plugin.identifier, getattr(plugin, "name", None) or plugin.identifier))
         choices.sort()
         return choices
+
+    def get_cache_key(self) -> str:
+        """
+        Return a string that is used as the cache key when the plugin can be cached
+        """
+        return self.identifier
 
 
 class TemplatedPlugin(Plugin):

--- a/shuup/xtheme/plugins/category_links.py
+++ b/shuup/xtheme/plugins/category_links.py
@@ -46,6 +46,7 @@ class CategoryLinksPlugin(TemplatedPlugin):
     identifier = "category_links"
     name = _("Category Links")
     template_name = "shuup/xtheme/plugins/category_links.jinja"
+    cacheable = True
     editor_form_class = CategoryLinksConfigForm
     fields = [
         ("title", TranslatableField(label=_("Title"), required=False, initial="")),
@@ -60,6 +61,12 @@ class CategoryLinksPlugin(TemplatedPlugin):
         ),
         "categories",
     ]
+
+    def get_cache_key(self) -> str:
+        selected_categories = self.config.get("categories", [])
+        show_all_categories = self.config.get("show_all_categories", True)
+        title = self.get_translated_value("title")
+        return str((selected_categories, show_all_categories, title))
 
     def get_context_data(self, context):
         """

--- a/shuup/xtheme/plugins/image.py
+++ b/shuup/xtheme/plugins/image.py
@@ -49,6 +49,7 @@ class ImagePlugin(TemplatedPlugin):
     identifier = "images"
     name = _("Image")
     template_name = "shuup/xtheme/plugins/image.jinja"
+    cacheable = True
     fields = [
         ("title", TranslatableField(label=_("Title"), required=False)),
         ("image_id", ImageIDField(label=_("Image"), required=False)),
@@ -76,6 +77,15 @@ class ImagePlugin(TemplatedPlugin):
             ),
         ),
     ]
+
+    def get_cache_key(self) -> str:
+        image_id = self.config.get("image_id", None)
+        title = self.get_translated_value("title", "")
+        url = self.config.get("url", None)
+        full_width = self.config.get("full_width", None)
+        width = self.config.get("width", None)
+        height = self.config.get("height", None)
+        return str((image_id, title, url, full_width, width, height))
 
     def get_context_data(self, context):
         """

--- a/shuup/xtheme/plugins/products.py
+++ b/shuup/xtheme/plugins/products.py
@@ -37,6 +37,7 @@ class ProductHighlightPlugin(TemplatedPlugin):
     identifier = "product_highlight"
     name = _("Product Highlights")
     template_name = "shuup/xtheme/plugins/highlight_plugin.jinja"
+    cacheable = True
     fields = [
         ("title", TranslatableField(label=_("Title"), required=False, initial="")),
         (
@@ -57,6 +58,13 @@ class ProductHighlightPlugin(TemplatedPlugin):
             ),
         ),
     ]
+
+    def get_cache_key(self) -> str:
+        title = self.get_translated_value("title")
+        highlight_type = self.config.get("type", HighlightType.NEWEST.value)
+        count = self.config.get("count", 4)
+        orderable_only = self.config.get("orderable_only", True)
+        return str((title, highlight_type, orderable_only, count))
 
     def get_context_data(self, context):
         highlight_type = self.config.get("type", HighlightType.NEWEST.value)
@@ -83,6 +91,7 @@ class ProductCrossSellsPlugin(TemplatedPlugin):
     identifier = "product_cross_sells"
     name = _("Product Cross Sells")
     template_name = "shuup/xtheme/plugins/cross_sells_plugin.jinja"
+    cacheable = True
     required_context_variables = ["product"]
     fields = [
         ("title", TranslatableField(label=_("Title"), required=False, initial="")),
@@ -121,6 +130,14 @@ class ProductCrossSellsPlugin(TemplatedPlugin):
                 type = ProductCrossSellType.RELATED
             config["type"] = type
         super(ProductCrossSellsPlugin, self).__init__(config)
+
+    def get_cache_key(self) -> str:
+        title = self.get_translated_value("title")
+        relation_type = self.config.get("type")
+        count = self.config.get("count", 4)
+        orderable_only = self.config.get("orderable_only", True)
+        use_variation_parents = self.config.get("use_variation_parents", False)
+        return str((title, relation_type, orderable_only, count, use_variation_parents))
 
     def get_context_data(self, context):
         count = self.config.get("count", 4)
@@ -163,6 +180,7 @@ class ProductsFromCategoryPlugin(TemplatedPlugin):
     name = _("Category Products Highlight")
     template_name = "shuup/xtheme/plugins/highlight_plugin.jinja"
     editor_form_class = ProductsFromCategoryForm
+    cacheable = True
     fields = [
         ("title", TranslatableField(label=_("Title"), required=False, initial="")),
         ("count", forms.IntegerField(label=_("Count"), min_value=1, initial=4)),
@@ -179,6 +197,13 @@ class ProductsFromCategoryPlugin(TemplatedPlugin):
             ),
         ),
     ]
+
+    def get_cache_key(self) -> str:
+        title = self.get_translated_value("title")
+        category_id = self.config.get("category")
+        count = self.config.get("count")
+        orderable_only = self.config.get("orderable_only", True)
+        return str((title, category_id, orderable_only, count))
 
     def get_context_data(self, context):
         products = []
@@ -227,7 +252,13 @@ class ProductSelectionPlugin(TemplatedPlugin):
     name = _("Product Selection")
     template_name = "shuup/xtheme/plugins/product_selection_plugin.jinja"
     editor_form_class = ProductSelectionConfigForm
+    cacheable = True
     fields = [("title", TranslatableField(label=_("Title"), required=False, initial=""))]
+
+    def get_cache_key(self) -> str:
+        title = self.get_translated_value("title")
+        products = self.config.get("products")
+        return str((title, products))
 
     def get_context_data(self, context):
         request = context["request"]

--- a/shuup/xtheme/plugins/products_async.py
+++ b/shuup/xtheme/plugins/products_async.py
@@ -38,6 +38,7 @@ class ProductHighlightPlugin(TemplatedPlugin):
     identifier = "async_product_highlight"
     name = _("Product Highlights (asynchronous)")
     template_name = "shuup/xtheme/plugins/highlight_plugin_async.jinja"
+    cacheable = True
     fields = [
         ("title", TranslatableField(label=_("Title"), required=False, initial="")),
         (
@@ -48,6 +49,14 @@ class ProductHighlightPlugin(TemplatedPlugin):
         ("cutoff_days", forms.IntegerField(label=_("Cutoff days"), min_value=1, initial=30)),
         ("cache_timeout", forms.IntegerField(label=_("Cache timeout (seconds)"), min_value=0, initial=120)),
     ]
+
+    def get_cache_key(self) -> str:
+        title = self.get_translated_value("title")
+        plugin_type = self.config.get("type", HighlightType.NEWEST.value)
+        count = self.config.get("count", 5)
+        cutoff_days = self.config.get("cutoff_days", 30)
+        cache_timeout = self.config.get("cache_timeout", 0)
+        return str((title, plugin_type, count, cutoff_days, cache_timeout))
 
     def get_context_data(self, context):
         request = context["request"]

--- a/shuup/xtheme/settings.py
+++ b/shuup/xtheme/settings.py
@@ -26,14 +26,3 @@ SHUUP_XTHEME_ADMIN_THEME_CONTEXT = "shuup.xtheme.admin_module.utils.get_theme_co
 SHUUP_XTHEME_EXCLUDE_TEMPLATES_FROM_RESOUCE_INJECTION = [
     "notify/admin/script_item_editor.jinja",
 ]
-
-#: Cache placeholders
-#:
-#: This useful when you have plugins does no depend on
-#: context which they should not.
-#:
-#: By default do not create plugins which are depended
-#: on context. Instead try to make those asynchronous
-#: so those are not rendered server side during initial
-#: page load.
-SHUUP_XTHEME_USE_PLACEHOLDER_CACHE = False

--- a/shuup_tests/notify/test_order_notifications.py
+++ b/shuup_tests/notify/test_order_notifications.py
@@ -191,6 +191,7 @@ def test_order_received(rf, regular_user):
 
     template_data = STEP_DATA[0]["actions"][0]["template_data"]
     for lang in ["en", "fi"]:
+        cache.clear()
         n_outbox_pre = len(mail.outbox)
         customer = create_random_person(locale=lang)
         create_random_order(customer)
@@ -205,6 +206,7 @@ def test_order_received_admin(rf, admin_user):
     get_test_script("test script", "order_received")
     template_data = STEP_DATA[0]["actions"][0]["template_data"]
     for lang in ["en", "fi"]:
+        cache.clear()
         get_initial_order_status()  # Needed for the API
         n_outbox_pre = len(mail.outbox)
         contact = create_random_person(locale=lang, minimum_name_comp_len=5)
@@ -233,6 +235,7 @@ def test_basic_order_flow_not_registered(with_company):
     LANG_CODE = {"en": "US", "fi": "FI"}
 
     for lang in ["en", "fi"]:
+        cache.clear()
         n_outbox_pre = len(mail.outbox)
         c = SmartClient()
         product_ids = _populate_client_basket(c)
@@ -284,6 +287,7 @@ def test_basic_order_flow_registered(regular_user):
     LANG_CODE = {"en": "US", "fi": "FI"}
 
     for lang in ["en", "fi"]:
+        cache.clear()
         n_outbox_pre = len(mail.outbox)
         contact = get_person_contact(regular_user)
         contact.language = lang


### PR DESCRIPTION
- Xtheme: add attribute on every plugin to indicate whether it can be cached or not
- Xtheme: removed the SHUUP_XTHEME_USE_PLACEHOLDER_CACHE setting and do not cache the entire placeholder content

Example of full cache key: `shuup_xtheme_cell:0_0_3_public_2021-05-11t1801573378940000_en_homepage_content_homepage_content|product_highlight`