### PR TITLE
Resolve string translation before passing it to urlencode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ List all changes after the last release here (newer on top). Each change on a se
 
 - Xtheme: use the context while generating the cache key
 - Xtheme: do not crash the whole site when a plugin fails to render
+- Admin: Use `ugettext` instead of `ugettext_lazy` in url encoded strings 
 
 ## [2.8.2] - 2021-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ List all changes after the last release here (newer on top). Each change on a se
 
 - Xtheme: use the context while generating the cache key
 - Xtheme: do not crash the whole site when a plugin fails to render
-- Admin: Use `ugettext` instead of `ugettext_lazy` in url encoded strings 
+- Admin: Force to parse reason as string before encoding the url
 
 ## [2.8.2] - 2021-05-14
 

--- a/shuup/admin/utils/urls.py
+++ b/shuup/admin/utils/urls.py
@@ -57,7 +57,7 @@ class AdminRegexURLPattern(URLPattern):
         """
         if request.is_ajax():
             return HttpResponseForbidden(json.dumps({"error": force_text(reason)}))
-        error_params = urlencode({"error": reason})
+        error_params = urlencode({"error": force_text(reason)})
         login_url = force_str(reverse("shuup_admin:login") + "?" + error_params)
         resp = redirect_to_login(next=request.path, login_url=login_url)
         if is_authenticated(request.user):


### PR DESCRIPTION
```
>>>isinstance("asd", (str, bytes))
True
>>>from django.utils.translation import ugettext as _
>>>isinstance(_("asd"), (str, bytes))
True
>>>from django.utils.translation import ugettext_lazy as _
>>>isinstance(_("asd"), (str, bytes))
False
```


![image](https://user-images.githubusercontent.com/50950050/118475794-60227800-b715-11eb-8d17-7c7ef4de51cc.png)