### PR TITLE
Admin: show help texts in permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Added
+
+- Admin: add a method in AdminModule that allows returning help texts for permissions
+
 ### Changed
 
 - Xtheme: allow async plugin to have orderable only flag set

--- a/shuup/admin/base.py
+++ b/shuup/admin/base.py
@@ -5,13 +5,11 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from __future__ import unicode_literals
-
 import hashlib
 import six
 from django.utils.encoding import force_bytes, force_text
 from django.utils.translation import override
-from typing import Dict, Optional
+from typing import Dict, Iterable, Optional
 
 from shuup.utils.django_compat import reverse
 
@@ -62,14 +60,15 @@ class AdminModule(object):
         """
         return ()
 
-    def get_required_permissions(self):
+    def get_required_permissions(self) -> Iterable[str]:
         """
+        Returns a list of required permissions for this module to be enabled
         :rtype: list[str]
         """
         with override(language="en"):
-            return ("%s" % self.name,)
+            return [force_text(self.name)]
 
-    def get_extra_permissions(self):
+    def get_extra_permissions(self) -> Iterable[str]:
         """
         Define custom extra permissions for admin module for option
         to limit certain parts of the admin module based on per user
@@ -79,6 +78,14 @@ class AdminModule(object):
         :rtype: list[str]
         """
         return ()
+
+    def get_permissions_help_texts(self) -> Dict[str, str]:
+        """
+        Returns a dictionary where the keys is the permission identifier
+        and the value is a help text that can help the user to understand
+        where the permissions is used and how it works.
+        """
+        return dict()
 
     def get_notifications(self, request):
         """

--- a/shuup/admin/locale/en/LC_MESSAGES/django.po
+++ b/shuup/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-10 20:10+0000\n"
+"POT-Creation-Date: 2021-05-19 12:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -1585,6 +1585,33 @@ msgid "Rate"
 msgstr ""
 
 msgid "Users"
+msgstr ""
+
+msgid "Allow the user to change the passwords of other users."
+msgstr ""
+
+msgid "Allow the user send the reset password email."
+msgstr ""
+
+msgid "Allow the user to change the permission groups of other users."
+msgstr ""
+
+msgid "Allow the user to see a user detail."
+msgstr ""
+
+msgid "Allow the user to create a new user."
+msgstr ""
+
+msgid "Allow the user to list the users."
+msgstr ""
+
+msgid "Allow the user to impersonate a different user."
+msgstr ""
+
+msgid "Allow the user to impersonate a staff user."
+msgstr ""
+
+msgid "Allow the user to change the user list columns."
 msgstr ""
 
 msgid "Add some users to help manage your shop"

--- a/shuup/admin/modules/permission_groups/views/edit.py
+++ b/shuup/admin/modules/permission_groups/views/edit.py
@@ -49,11 +49,15 @@ class PermissionGroupForm(forms.ModelForm):
             partial_permissions_granted = False
             admin_module.required_permissions_fields = []
             admin_module.per_view_permissions_fields = []
+            help_texts = admin_module.get_permissions_help_texts()
 
             for required_permission in admin_module.get_required_permissions():
                 field_id = "perm:{}".format(required_permission)
                 self.fields[field_id] = forms.BooleanField(
-                    required=False, label=required_permission, initial=(required_permission in initial_permissions)
+                    required=False,
+                    label=required_permission,
+                    initial=(required_permission in initial_permissions),
+                    help_text=help_texts.get(required_permission),
                 )
                 admin_module.required_permissions_fields.append(field_id)
                 if required_permission in initial_permissions:
@@ -67,7 +71,10 @@ class PermissionGroupForm(forms.ModelForm):
             for permission in extra_permissions:
                 field_id = "perm:{}".format(permission)
                 self.fields[field_id] = forms.BooleanField(
-                    required=False, label=permission, initial=(permission in initial_permissions)
+                    required=False,
+                    label=permission,
+                    initial=(permission in initial_permissions),
+                    help_text=help_texts.get(permission),
                 )
                 admin_module.per_view_permissions_fields.append(field_id)
                 if permission in initial_permissions:

--- a/shuup/admin/modules/users/__init__.py
+++ b/shuup/admin/modules/users/__init__.py
@@ -9,6 +9,7 @@ import six
 from django.contrib.auth import get_user_model
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
+from typing import Dict
 
 from shuup.admin.base import AdminModule, MenuEntry, SearchResult
 from shuup.admin.menu import SETTINGS_MENU_CATEGORY
@@ -56,6 +57,19 @@ class UserModule(AdminModule):
                 name="user.list_settings",
             ),
         ]
+
+    def get_permissions_help_texts(self) -> Dict[str, str]:
+        return {
+            "user.change-password": _("Allow the user to change the passwords of other users."),
+            "user.reset-password": _("Allow the user send the reset password email."),
+            "user.change-permissions": _("Allow the user to change the permission groups of other users."),
+            "user.detail": _("Allow the user to see a user detail."),
+            "user.new": _("Allow the user to create a new user."),
+            "user.list": _("Allow the user to list the users."),
+            "user.login-as": _("Allow the user to impersonate a different user."),
+            "user.login-as-staff": _("Allow the user to impersonate a staff user."),
+            "user.list_settings": _("Allow the user to change the user list columns."),
+        }
 
     def get_menu_entries(self, request):
         return [


### PR DESCRIPTION
Add a method in AdminModule that allows returning help texts for permissions

This will allow the developer to define the help texts for the permissions