### PR TITLE
Admin: save the current user menu using the current language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Fixed
+
+- Admin: save the current user menu using the current language
+
 ### Changed
 
 - Xtheme: allow async plugin to have orderable only flag set

--- a/shuup/admin/menu.py
+++ b/shuup/admin/menu.py
@@ -17,7 +17,6 @@ from shuup.admin.utils.permissions import get_missing_permissions
 from shuup.admin.views.home import QUICKLINK_ORDER
 from shuup.apps.provides import get_provide_objects
 from shuup.utils.django_compat import force_text
-from shuup.utils.iterables import first
 
 ORDERS_MENU_CATEGORY = 1
 PRODUCTS_MENU_CATEGORY = 2
@@ -133,12 +132,9 @@ def customize_menu(entries, request):  # noqa (C901)
 
     if customized_admin_menu and isinstance(customized_admin_menu, dict):
         """
-        If menu configuration is stored to dict try to find right configuration with
-        current language and fallback to first stored configuration
+        If menu configuration is stored to dict try to find right configuration with current language
         """
-        customized_admin_menu = customized_admin_menu.get(
-            get_language(), customized_admin_menu.get(first(customized_admin_menu))
-        )
+        customized_admin_menu = customized_admin_menu.get(get_language())
 
     if customized_admin_menu:
 

--- a/shuup/admin/modules/menu/views/arrange.py
+++ b/shuup/admin/modules/menu/views/arrange.py
@@ -43,7 +43,10 @@ class AdminMenuArrangeView(TemplateView):
         return context
 
     def set_configuration(self, request, menus):
-        configuration.set(None, CUSTOM_ADMIN_MENU_USER_PREFIX.format(request.user.pk), menus)
+        config_key = CUSTOM_ADMIN_MENU_USER_PREFIX.format(request.user.pk)
+        configuration_object = configuration.get(None, config_key, {}) or {}
+        configuration_object.update({get_language(): menus})
+        configuration.set(None, config_key, configuration_object)
 
     def post(self, request):
         """


### PR DESCRIPTION
This will prevent showing the incorrect menu when the user changes
the current language.

Refs BH-116