### PR TITLE
Core: change how price and orderability are cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ List all changes after the last release here (newer on top). Each change on a se
 
 ### Changed
 
+- Cache product orderability and prices using a list of user groups instead of per contact
 - Pull translation strings from Transifex
 
 ## [2.9.1] - 2021-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Fixed
+
+- Core: use SHA-1 to hash cache keys as Python's hash() function doesn't have a stable result across processes
+
 ### Changed
 
 - Cache product orderability and prices using a list of user groups instead of per contact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ List all changes after the last release here (newer on top). Each change on a se
 
 ### Fixed
 
+- General: replace hash() with sha1() as Python's hash() function doesn't have a stable result across processes
 - Core: use SHA-1 to hash cache keys as Python's hash() function doesn't have a stable result across processes
 
 ### Changed

--- a/shuup/campaigns/models/campaigns.py
+++ b/shuup/campaigns/models/campaigns.py
@@ -4,6 +4,7 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+import hashlib
 import random
 import string
 from django.conf import settings
@@ -185,7 +186,8 @@ class CatalogCampaign(Campaign):
             customer=context.customer.pk or 0, shop=context.shop.pk, product_id=shop_product.pk
         )
         namespace = CAMPAIGNS_CACHE_NAMESPACE
-        key = "%s:%s" % (namespace, hash(frozenset(prod_ctx_cache_elements.items())))
+        sorted_items = dict(sorted(prod_ctx_cache_elements.items(), key=lambda item: item[0]))
+        key = "%s:%s" % (namespace, hashlib.sha1(str(sorted_items).encode("utf-8")).hexdigest())
         cached_matching = cache.get(key, None)
         if cached_matching is not None:
             return cached_matching

--- a/shuup/campaigns/models/matching.py
+++ b/shuup/campaigns/models/matching.py
@@ -4,6 +4,7 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+import hashlib
 from django.db.models import Q
 
 from shuup.campaigns.consts import CONTEXT_CONDITION_CACHE_NAMESPACE
@@ -16,7 +17,8 @@ from shuup.core.utils import context_cache
 def get_matching_context_conditions(context):
     namespace = CONTEXT_CONDITION_CACHE_NAMESPACE
     ctx_cache_elements = dict(customer=context.customer.pk or 0, shop=context.shop.pk)
-    conditions_cache_key = "%s:%s" % (namespace, hash(frozenset(ctx_cache_elements.items())))
+    sorted_items = dict(sorted(ctx_cache_elements.items(), key=lambda item: item[0]))
+    conditions_cache_key = "%s:%s" % (namespace, hashlib.sha1(str(sorted_items).encode("utf-8")).hexdigest())
     matching_context_conditions = cache.get(conditions_cache_key, None)
     if matching_context_conditions is None:
         matching_context_conditions = set()

--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -567,16 +567,34 @@ class ShopProduct(MoneyPropped, TranslatableModel):
         """
         Product to be orderable it needs to be visible and purchasable.
         """
+        if customer:
+            cached_customer_groups = getattr(customer, "_cached_customer_groups", None)
+            if cached_customer_groups:
+                groups = customer._cached_customer_groups
+            else:
+                groups = list(customer.groups.order_by("pk").values_list("pk", flat=True))
+                customer._cached_customer_groups = groups
+        else:
+            from shuup.core.models import AnonymousContact
+
+            anonymous_group_id = getattr(AnonymousContact, "_cached_default_group_id", None)
+            if anonymous_group_id:
+                groups = [AnonymousContact._cached_default_group_id]
+            else:
+                anonymous_group_id = AnonymousContact().default_group.pk
+                AnonymousContact._cached_default_group_id = anonymous_group_id
+                groups = [anonymous_group_id]
+
         key, val = context_cache.get_cached_value(
             identifier="is_orderable",
             item=self,
-            context={"customer": customer},
+            context={"customer_groups": groups},
             supplier=supplier,
             stock_managed=bool(supplier and supplier.stock_managed),
             quantity=quantity,
             allow_cache=allow_cache,
         )
-        if customer and val is not None:
+        if val is not None:
             return val
 
         if not supplier:
@@ -587,8 +605,7 @@ class ShopProduct(MoneyPropped, TranslatableModel):
                 context_cache.set_cached_value(key, False)
             return False
 
-        if customer:
-            context_cache.set_cached_value(key, True)
+        context_cache.set_cached_value(key, True)
         return True
 
     def is_visible(self, customer):

--- a/shuup/core/utils/price_cache.py
+++ b/shuup/core/utils/price_cache.py
@@ -7,7 +7,7 @@
 """
 Utilities for caching price info
 """
-from shuup.core.models import ShopProduct
+from shuup.core.models import AnonymousContact, ShopProduct
 from shuup.core.pricing import PriceInfo
 from shuup.core.utils import context_cache
 from shuup.utils.dates import to_timestamp
@@ -21,10 +21,28 @@ def _get_price_info_namespace_for_shop(shop_id):
 
 def _get_price_info_cache_key_params(context, item, quantity, **context_args):
     shop_id = context.shop.pk if hasattr(context, "shop") else 0
+    customer = getattr(context, "customer", None)
+
+    if customer:
+        cached_customer_groups = getattr(customer, "_cached_customer_groups", None)
+        if cached_customer_groups:
+            groups = customer._cached_customer_groups
+        else:
+            groups = list(customer.groups.order_by("pk").values_list("pk", flat=True))
+            customer._cached_customer_groups = groups
+    else:
+        anonymous_group_id = getattr(AnonymousContact, "_cached_default_group_id", None)
+        if anonymous_group_id:
+            groups = [AnonymousContact._cached_default_group_id]
+        else:
+            anonymous_group_id = AnonymousContact().default_group.pk
+            AnonymousContact._cached_default_group_id = anonymous_group_id
+            groups = [anonymous_group_id]
+
     return dict(
         identifier="price_info_cache",
         item=_get_price_info_namespace_for_shop(shop_id),
-        context={"customer": getattr(context, "customer", None)},
+        context={"customer_groups": groups},
         quantity=quantity,
         context_item=item,
         **context_args
@@ -50,9 +68,8 @@ def cache_many_price_info(context, item, quantity, prices_infos, **context_args)
     if not all(isinstance(item, PriceInfo) for item in prices_infos):
         return
 
-    key = context_cache.get_cache_key_for_context(
-        many=True, **_get_price_info_cache_key_params(context, item, quantity, **context_args)
-    )
+    context_kwargs = _get_price_info_cache_key_params(context, item, quantity, **context_args)
+    key = context_cache.get_cache_key_for_context(many=True, **context_kwargs)
     context_cache.set_cached_value(key, prices_infos)
 
 

--- a/shuup/core/utils/price_display.py
+++ b/shuup/core/utils/price_display.py
@@ -193,7 +193,7 @@ class PriceRangeDisplayFilter(_ContextFilter):
             else None
         )
 
-        if not priced_products:
+        if priced_products is None:
             priced_children_key = PRICED_CHILDREN_CACHE_KEY % (product.id, quantity)
             priced_products = []
 

--- a/shuup/front/template_helpers/general.py
+++ b/shuup/front/template_helpers/general.py
@@ -5,6 +5,7 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+import hashlib
 import six
 from collections import defaultdict
 from django.conf import settings
@@ -119,7 +120,7 @@ def get_listed_products(context, n_products, ordering=None, filter_dict=None, or
         ordering=ordering,
         filter_dict=filter_dict,
         orderable_only=orderable_only,
-        extra_filters=hash(str(extra_filters)),
+        extra_filters=hashlib.sha1(str(extra_filters).encode("utf-8")).hexdigest(),
     )
     if products is not None:
         return products

--- a/shuup/front/templatetags/thumbnails.py
+++ b/shuup/front/templatetags/thumbnails.py
@@ -5,8 +5,7 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
-from __future__ import unicode_literals
-
+import hashlib
 import os
 import six
 from django.conf import settings
@@ -39,7 +38,8 @@ def _get_cached_thumbnail_url(source, **kwargs):
 
     from shuup.core.models import ProductMedia
 
-    kwargs_hash = hash(frozenset(kwargs.items()))
+    sorted_items = dict(sorted(kwargs.items(), key=lambda item: item[0]))
+    kwargs_hash = hashlib.sha1(str(sorted_items).encode("utf-8")).hexdigest()
     cache_key = None
 
     if isinstance(source, (File, ProductMedia)) and source.pk:

--- a/shuup/xtheme/layout/_base.py
+++ b/shuup/xtheme/layout/_base.py
@@ -5,6 +5,7 @@
 #
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
+import hashlib
 import logging
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext, ugettext_lazy as _
@@ -98,7 +99,8 @@ class LayoutCell(object):
                     if hasattr(plugin_inst, "get_cache_key")
                     else plugin_inst.identifier
                 )
-                full_cache_key = "shuup_xtheme_cell:{}".format(hash(f"{cache_key_prefix}-{cache_key}"))
+                hash_key = hashlib.sha1(f"{cache_key_prefix}-{cache_key}".encode("utf-8")).hexdigest()
+                full_cache_key = f"shuup_xtheme_cell:{hash_key}"
                 cached_content = cache.get(full_cache_key)
                 if cached_content is not None:
                     return cached_content

--- a/shuup_tests/core/test_products_in_shops.py
+++ b/shuup_tests/core/test_products_in_shops.py
@@ -6,13 +6,11 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
-import uuid
 from datetime import timedelta
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.test import override_settings
 from django.utils.timezone import now
-from django.utils.translation import activate
 from parler.models import TranslationDoesNotExist
 
 from shuup import configuration
@@ -30,7 +28,6 @@ from shuup.core.models import (
     Supplier,
     get_person_contact,
 )
-from shuup.core.models._product_variation import hash_combination
 from shuup.testing.factories import (
     CategoryFactory,
     create_product,
@@ -63,12 +60,12 @@ def test_product_orderability():
 
     with modify(shop_product, visibility_limit=ProductVisibility.VISIBLE_TO_ALL, orderable=True):
         shop_product.raise_if_not_orderable(supplier=supplier, customer=anon_contact, quantity=1)
-        assert shop_product.is_orderable(supplier=supplier, customer=anon_contact, quantity=1)
+        assert shop_product.is_orderable(supplier=supplier, customer=anon_contact, quantity=1, allow_cache=False)
 
     with modify(shop_product, visibility_limit=ProductVisibility.VISIBLE_TO_LOGGED_IN, orderable=True):
         with pytest.raises(ProductNotOrderableProblem):
             shop_product.raise_if_not_orderable(supplier=supplier, customer=anon_contact, quantity=1)
-        assert not shop_product.is_orderable(supplier=supplier, customer=anon_contact, quantity=1)
+        assert not shop_product.is_orderable(supplier=supplier, customer=anon_contact, quantity=1, allow_cache=False)
 
 
 @pytest.mark.django_db
@@ -79,12 +76,12 @@ def test_purchasability():
     assert shop_product.purchasable
 
     shop_product.raise_if_not_orderable(supplier=supplier, customer=anon_contact, quantity=1)
-    assert shop_product.is_orderable(supplier=supplier, customer=anon_contact, quantity=1)
+    assert shop_product.is_orderable(supplier=supplier, customer=anon_contact, quantity=1, allow_cache=False)
 
     with modify(shop_product, purchasable=False):
         with pytest.raises(ProductNotOrderableProblem):
             shop_product.raise_if_not_orderable(supplier=supplier, customer=anon_contact, quantity=1)
-        assert not shop_product.is_orderable(supplier=supplier, customer=anon_contact, quantity=1)
+        assert not shop_product.is_orderable(supplier=supplier, customer=anon_contact, quantity=1, allow_cache=False)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Cache product orderability and prices using a list of user groups instead of per contact