### PR TITLE
Notify: always overrride the current notification data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Fixed
+
+- Notify: always overrride the current notification data with the new one
+
 ## [2.9.2] - 2021-05-26
 
 ### Fixed

--- a/shuup/notify/admin_module/forms.py
+++ b/shuup/notify/admin_module/forms.py
@@ -204,5 +204,5 @@ class ScriptItemEditForm(forms.Form):
         self._save_template(new_data)
         if self.errors:
             raise forms.ValidationError("Error! There are errors.")
-        self.script_item.data.update(new_data)
+        self.script_item.data = new_data
         return self.script_item


### PR DESCRIPTION
It is impossible to clear fields once set

Refs FD-223