### PR TITLE
Fixed get_supported_product_kinds_for_module()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Fixed
+
+- Core: Only product kind modules that have specified supplier modules will be returned from get_supported_product_kinds_for_module
+- Admin: Display the correct error message when adding stock to a product and not only "on text"
+
 ### Changed
 
 - Admin: filter products in list and edit views according to product kind listing name

--- a/shuup/core/basket/objects.py
+++ b/shuup/core/basket/objects.py
@@ -630,7 +630,6 @@ class BaseBasket(OrderSource):
         data = None
         if not force_new_line:
             data = self._find_product_line_data(product=product, supplier=supplier, shop=shop, extra=extra)
-
         if not data:
             data = self._initialize_product_line_data(product=product, supplier=supplier, shop=shop)
 

--- a/shuup/core/excs.py
+++ b/shuup/core/excs.py
@@ -56,6 +56,10 @@ class ProductNotVisibleProblem(Problem):
     pass
 
 
+class MissingSupplierModuleException(Exception):
+    pass
+
+
 class ImpossibleProductModeException(ValueError):
     def __init__(self, message, code=None):
         super(ImpossibleProductModeException, self).__init__(message)

--- a/shuup/core/models/_suppliers.py
+++ b/shuup/core/models/_suppliers.py
@@ -194,7 +194,7 @@ class Supplier(ModuleInterface, TranslatableShuupModel):
     def get_stock_status(self, product_id, *args, **kwargs):
         for module in self.modules:
             stock_status = module.get_stock_status(product_id, *args, **kwargs)
-            if stock_status.handled:
+            if stock_status and stock_status.handled:
                 return stock_status
 
     def get_suppliable_products(self, shop, customer):

--- a/shuup/simple_supplier/templates/shuup/simple_supplier/admin/macros.jinja
+++ b/shuup/simple_supplier/templates/shuup/simple_supplier/admin/macros.jinja
@@ -18,9 +18,15 @@
                     });
                 },
                 error: function(response) {
+                    var message = gettext(
+                        "Please enable the 'product' supplier module to the stock manager."
+                    );
+                    if(response.responseJSON && response.responseJSON.message){
+                        message = response.responseJSON.message;
+                    }
                     window.Messages.enqueue({
                         tags: "error",
-                        text: response.message
+                        text: message
                     });
                 }
             });


### PR DESCRIPTION
Fixed
- Core: Only product kind modules that have specified supplier modules will be returned from get_supported_product_kinds_for_module
- Admin: Display the correct error message when adding stock to a product and not only "on text"

refs https://trello.com/c/NiJsBtIW/24-moved-to-sprint-3-original-sprint-2-custom-product-configuration-vendor-to-sell-both-services-and-products