### PR TITLE
Admin: remove the provides to allow adding extra fields to the Attribute form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
-### Changed
+### Removed
 
-- Admin: filter products in list and edit views according to product kind listing name
-- Core: suppliers don't have default supplier modules anymore
+- Admin: remove the provides to allow adding extra fields to the Attribute form
 
 ### Add
 
@@ -20,6 +19,8 @@ List all changes after the last release here (newer on top). Each change on a se
 
 ### Changed
 
+- Admin: filter products in list and edit views according to product kind listing name
+- Core: suppliers don't have default supplier modules anymore
 - Importers: enable importers to run asynchronously
 - Importers: change the admin views to show the list of import processes
 

--- a/doc/ref/provides.rst
+++ b/doc/ref/provides.rst
@@ -109,10 +109,6 @@ Core
     Allows providing extension for shipment creation in admin.
     Should implement the `~shuup.admin.form_modifier.FormModifier` interface.
 
-``admin_extend_attribute_form``
-    Allows providing extension for the product attribute form in admin.
-    Should implement the `~shuup.admin.form_modifier.FormModifier` interface.
-
 ``admin_order_information``
     Additional information rows for Order detail page. Provide objects should inherit
     from `~shuup.admin.modules.orders.utils.OrderInformation` class.

--- a/shuup/admin/modules/attributes/forms.py
+++ b/shuup/admin/modules/attributes/forms.py
@@ -8,14 +8,11 @@
 from django.conf import settings
 from django.forms import BaseModelFormSet
 
-from shuup.admin.form_modifier import ModifiableFormMixin
 from shuup.core.models import Attribute, AttributeChoiceOption, AttributeType
 from shuup.utils.multilanguage_model_form import MultiLanguageModelForm, TranslatableModelForm
 
 
-class AttributeForm(ModifiableFormMixin, MultiLanguageModelForm):
-    form_modifier_provide_key = "admin_extend_attribute_form"
-
+class AttributeForm(MultiLanguageModelForm):
     class Meta:
         model = Attribute
         fields = "__all__"


### PR DESCRIPTION
The feature was already removed in https://github.com/shuup/shuup/commit/f267a869507b7d014126c707d1c4ec0f57e0a8c3