### PR TITLE
SimpleSupplier: always return products as managed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Fixed
+
+- SimpleSupplier: always return products as managed by using a different queryset
+
 ## [2.10.0] - 2021-06-07
 
 ### Removed

--- a/shuup_tests/cache/test_cache_bumping.py
+++ b/shuup_tests/cache/test_cache_bumping.py
@@ -7,17 +7,14 @@
 """
 Tests for utils.price_display and the price filters.
 """
-
 import pytest
 import pytz
 from datetime import datetime
 from mock import patch
 
-from shuup.core.models import Supplier, get_person_contact
+from shuup.core.models import get_person_contact
 from shuup.core.utils import context_cache
-from shuup.core.utils.price_cache import cache_price_info, get_cached_price_info
 from shuup.testing import factories
-from shuup.testing.utils import apply_request_middleware
 
 
 @pytest.mark.django_db
@@ -45,7 +42,7 @@ def test_bump_caches_signal(rf):
                 allow_cache=True,
             )
 
-            assert val == None
+            assert val is None
 
     with patch("django.utils.timezone.now", new=lambda: now):
         product1 = factories.create_product(

--- a/shuup_tests/core/test_addresses.py
+++ b/shuup_tests/core/test_addresses.py
@@ -121,7 +121,7 @@ def test_immutable_address():
     new_immutable = address.to_immutable()
 
     # New address should be saved
-    assert new_immutable.pk != None
+    assert new_immutable.pk is not None
     assert isinstance(new_immutable, ImmutableAddress)
     assert get_data_dict(address).items() == get_data_dict(new_immutable).items()
 
@@ -137,6 +137,6 @@ def test_new_mutable_address():
     new_mutable = address.to_mutable()
 
     # New address should be unsaved
-    assert new_mutable.pk == None
+    assert new_mutable.pk is None
     assert isinstance(new_mutable, MutableAddress)
     assert get_data_dict(address).items() == get_data_dict(new_mutable).items()

--- a/shuup_tests/front/test_carousel.py
+++ b/shuup_tests/front/test_carousel.py
@@ -57,7 +57,7 @@ def test_carousel_plugin_form_get_context():
     context = get_jinja_context()
     test_carousel = Carousel.objects.create(name="test")
     plugin = CarouselPlugin(config={"carousel": test_carousel.pk})
-    assert plugin.get_context_data(context).get("carousel") == None
+    assert plugin.get_context_data(context).get("carousel") is None
     test_carousel.shops.add(shop)
     plugin = CarouselPlugin(config={"carousel": test_carousel.pk})
     assert plugin.get_context_data(context).get("carousel") == test_carousel

--- a/shuup_tests/functional/test_shipment_delete_with_simple_supplier.py
+++ b/shuup_tests/functional/test_shipment_delete_with_simple_supplier.py
@@ -8,7 +8,7 @@
 import pytest
 import random
 
-from shuup.core.models import Shipment, ShipmentStatus
+from shuup.core.models import Shipment
 from shuup.testing.factories import create_order_with_product, create_product, get_default_shop
 from shuup_tests.simple_supplier.utils import get_simple_supplier
 
@@ -19,7 +19,7 @@ def test_simple_supplier(rf):
     shop = get_default_shop()
     product = create_product("simple-test-product", shop)
     ss = supplier.get_stock_status(product.pk)
-    assert ss == None
+    assert ss.logical_count == 0
     num = random.randint(100, 500)
     supplier.adjust_stock(product.pk, +num)
     assert supplier.get_stock_status(product.pk).logical_count == num

--- a/shuup_tests/functional/test_shipment_received_with_simple_supplier.py
+++ b/shuup_tests/functional/test_shipment_received_with_simple_supplier.py
@@ -18,7 +18,7 @@ def test_simple_supplier(rf):
     shop = get_default_shop()
     product = create_product("simple-test-product", shop)
     ss = supplier.get_stock_status(product.pk)
-    assert ss is None
+    assert ss.logical_count == 0
     supplier.adjust_stock(product.pk, 0)
     ss = supplier.get_stock_status(product.pk)
     assert ss.product == product

--- a/shuup_tests/simple_supplier/test_simple_supplier.py
+++ b/shuup_tests/simple_supplier/test_simple_supplier.py
@@ -33,7 +33,7 @@ def test_simple_supplier(rf):
     shop = get_default_shop()
     product = create_product("simple-test-product", shop)
     ss = supplier.get_stock_status(product.pk)
-    assert ss == None
+    assert ss.logical_count == 0
     num = random.randint(100, 500)
     supplier.adjust_stock(product.pk, +num)
     assert supplier.get_stock_status(product.pk).logical_count == num

--- a/shuup_tests/xtheme/test_plugins.py
+++ b/shuup_tests/xtheme/test_plugins.py
@@ -205,7 +205,7 @@ def test_image_plugin_choice_widget_get_object():
 
     # We don't want any exceptions if the image doesn't exist or else we won't be
     # able to display the form to change it
-    assert widget.get_object(1000) == None
+    assert widget.get_object(1000) is None
 
 
 @pytest.mark.django_db

--- a/shuup_tests/xtheme/test_plugins_async.py
+++ b/shuup_tests/xtheme/test_plugins_async.py
@@ -268,7 +268,7 @@ def test_cross_sell_plugin_with_invalid_type(rf):
 @pytest.mark.django_db
 def test_cross_sell_plugin_with_invalid_type_2(rf):
     plugin = ProductCrossSellsPlugin({"type": None})
-    assert plugin.config["type"] == None
+    assert plugin.config["type"] is None
 
     context = get_context(rf)
     context_data = plugin.get_context_data({"request": context["request"]})
@@ -278,7 +278,7 @@ def test_cross_sell_plugin_with_invalid_type_2(rf):
 @pytest.mark.django_db
 def test_cross_sell_plugin_with_product_that_does_not_exists(rf):
     plugin = ProductCrossSellsPlugin({"type": None})
-    assert plugin.config["type"] == None
+    assert plugin.config["type"] is None
 
     context = get_context(rf)
     plugin.config["product"] = "1111"


### PR DESCRIPTION
Use a different queryset to filter the products model and relate to stock count

Refs RM-80