### PR TITLE
Core: fix so task don't require a identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Added
+
+- Xtheme: Add so snippets can have start of head content
+
+### Fixed
+
+- Core: fix so task don't require a identifier
+
 ## [2.10.1] - 2021-06-07
 
 ### Fixed

--- a/shuup/core/tasks.py
+++ b/shuup/core/tasks.py
@@ -49,7 +49,7 @@ class Task:
     queue = "default"  # str
     kwargs = None  # Optional[Dict[str, Any]]
 
-    def __init__(self, function, identifier, stored=False, queue="default", **kwargs):
+    def __init__(self, function, identifier=None, stored=False, queue="default", **kwargs):
         """
         :param function: A string that represents the function specification.
             It will be locaded dynamically and executed passing the given kwargs.
@@ -64,6 +64,9 @@ class Task:
 
         :type function: str
         """
+        if not identifier:
+            identifier = f"{queue}_{function}_{uuid4().hex}"
+
         assert isinstance(function, str)
 
         try:

--- a/shuup/xtheme/plugins/snippets.py
+++ b/shuup/xtheme/plugins/snippets.py
@@ -22,6 +22,10 @@ class SnippetsPlugin(Plugin):
     fields = [
         ("in_place", forms.CharField(label=_("In-Place Snippet"), widget=forms.Textarea, required=False)),
         (
+            "head_start",
+            forms.CharField(label=_("Resource snippet for start of head"), widget=forms.Textarea, required=False),
+        ),
+        (
             "head_end",
             forms.CharField(label=_("Resource snippet for end of head"), widget=forms.Textarea, required=False),
         ),


### PR DESCRIPTION
- Core: fix so task don't require a identifier
- Xtheme: Add so snippets can have start of head content

refs https://sentry.io/organizations/shuup/issues/2450343058/?project=5687395&query=is%3Aunresolved