### PR TITLE
Fixed boolean from being rendered in async highlights plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ List all changes after the last release here (newer on top). Each change on a se
 
 - Admin: show taxless order total column in order list
 
+### Fixed
+
+- removed orderable boolean from async highlights plugin from being rendered
+
 ## [2.10.3] - 2021-06-15
 
 ### Fixed

--- a/shuup/xtheme/templates/shuup/xtheme/plugins/highlight_plugin_async.jinja
+++ b/shuup/xtheme/templates/shuup/xtheme/plugins/highlight_plugin_async.jinja
@@ -6,7 +6,6 @@
         {{ product_box(product, show_description=False) }}
     {% endfor %}
 {% else %}
-    {{ orderable_only }}
     <section
         class="carousel-section product-highlight-plugin async-xtheme-product-carousel-plugin"
         data-url='{{ data_url }}{% if orderable_only %}?orderable_only=1{% endif %}'


### PR DESCRIPTION
### Fixed

- removed orderable boolean from async highlights plugin from being rendered