### PR TITLE
Core: fix service components get cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ List all changes after the last release here (newer on top). Each change on a se
 
 ### Fixed
 
+- Core: fix service components get cost
+
+### Fixed
+
 - Utils: fix MultiLanguageModelForm so language dependent filed will only be required if the language is required
 
 ## [2.10.5] - 2021-06-21

--- a/shuup/core/models/_service_base.py
+++ b/shuup/core/models/_service_base.py
@@ -319,7 +319,7 @@ class Service(TranslatableShuupModel):
         :rtype: Iterable[ServiceCost]
         """
         for component in self.behavior_components.all():
-            for cost in component.get_costs(self, source):
+            for cost in component.get_costs(self, source.get_source_for_supplier(self.supplier)):
                 yield cost
 
     def get_lines(self, source):

--- a/shuup/core/order_creator/_source.py
+++ b/shuup/core/order_creator/_source.py
@@ -438,6 +438,12 @@ class OrderSource(object):
             return sum(count_in_line(line) for line in self.get_product_lines() if line.supplier == supplier)
         return sum(count_in_line(line) for line in self.get_product_lines())
 
+    def get_source_for_supplier(self, supplier=None):
+        """
+        Return order sources base on the supplier.
+        """
+        return self
+
     @property
     def product_line_count(self):
         """


### PR DESCRIPTION
- Core: Fixed so we can get custom order source when getting the cost of service components

refs https://trello.com/c/WmXEs8Ab/157-vynlyf-multivendor-shipping-methods-not-calculating-correctly