### PR TITLE
Admin: improve user and permission groups admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Changed
+
+- Admin: remove the members field from the permission groups
+- Admin: add the groups field in user picotable list
+- Admin: improve the format of the user list for mobile devices
+
 ## [2.12.0] - 2021-07-15
 
 ### Fixed

--- a/shuup_tests/admin/test_permission_groups_module.py
+++ b/shuup_tests/admin/test_permission_groups_module.py
@@ -33,7 +33,7 @@ def test_permission_group_edit_view(rf, admin_user):
 
 
 @pytest.mark.django_db
-def test_permission_group_form_updates_members(regular_user):
+def test_permission_group_form_updates_members():
     with replace_modules([ARestrictedTestModule]):
         modules = [m for m in get_modules()]
         test_module = modules[0]
@@ -49,7 +49,6 @@ def test_permission_group_form_updates_members(regular_user):
 
         data = {
             "name": "New Name",
-            "members": [force_text(regular_user.pk)],
         }
         for permission in ARestrictedTestModule().get_required_permissions():
             data["perm:%s" % permission] = permission
@@ -59,7 +58,6 @@ def test_permission_group_form_updates_members(regular_user):
 
         assert group.name == "New Name"
         assert set(module_permissions) == get_permissions_from_group(group)
-        assert regular_user in group.user_set.all()
 
         form = PermissionGroupForm(instance=group, prefix=None, data={"name": "Name"})
         form.save()


### PR DESCRIPTION
- Admin: remove the members field from the permission groups
- Admin: add the groups field in user picotable list
- Admin: improve the format of the user list for mobile devices

Refs OR-30

![image](https://user-images.githubusercontent.com/8770370/125817832-2cad7231-14ea-436c-a8da-e23d176adff8.png)
![image](https://user-images.githubusercontent.com/8770370/125817856-9d99d702-0e41-4363-9b30-165776d3205f.png)
![image](https://user-images.githubusercontent.com/8770370/125818030-eeb52445-90b4-4fbd-9cef-f43fbc0788fc.png)
