### PR TITLE
Front: enforce setting the current customer to the basket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ List all changes after the last release here (newer on top). Each change on a se
 - Admin: add the groups field in user picotable list
 - Admin: improve the format of the user list for mobile devices
 
+### Fixed
+
+- Front: enforce setting the current customer to the basket
+
 ### Added
 
 - Admin: add warnings to the product page through provides

--- a/shuup/admin/modules/products/validators.py
+++ b/shuup/admin/modules/products/validators.py
@@ -13,6 +13,7 @@ from shuup.core.models import Shop, ShopProduct, Supplier
 
 class AdminProductValidator:
     """ Base class for validating products. """
+
     ordering = 0
 
     def get_validation_issues(

--- a/shuup/front/checkout/addresses.py
+++ b/shuup/front/checkout/addresses.py
@@ -13,7 +13,7 @@ from django.forms.models import model_to_dict
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic.edit import FormView
 
-from shuup.core.models import CompanyContact, SavedAddress, SavedAddressRole, SavedAddressStatus
+from shuup.core.models import AnonymousContact, CompanyContact, SavedAddress, SavedAddressRole, SavedAddressStatus
 from shuup.front.checkout import CheckoutPhaseViewMixin
 from shuup.front.utils.companies import TaxNumberCleanMixin, allow_company_registration
 from shuup.utils.django_compat import force_text
@@ -146,8 +146,11 @@ class AddressesPhase(CheckoutPhaseViewMixin, FormView):
     def process(self):
         basket = self.basket
         self._process_addresses(basket)
+
         if self.storage.get("company"):
             basket.customer = self.storage.get("company")
+        elif not basket.customer:
+            basket.customer = getattr(self.request, "customer") or AnonymousContact()
 
         if isinstance(basket.customer, CompanyContact):
             for address_kind in self.address_kinds:


### PR DESCRIPTION
When there is a customer and the basket still doesn't have a customer,
set it on the address phase.

There are cases when an anonymous user create a basket (adding a product)
and the checkout phases can't have access to the current basket.customer
as it was never set after the user logs is.

Only set the customer when there is no one set previously.

Refs https://trello.com/c/YnkkHRR5