### PR TITLE
shuup: Core Address model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Changed
+
+- Core: Add a RegExValidator to the `phone` field of the `Address` model and change `max_length` to be `18`.
+
 ### Added
 
 - Admin: add new provides `admin_template_injector` that allows injection snippet in admin templates

--- a/shuup/core/models/_addresses.py
+++ b/shuup/core/models/_addresses.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 
 import six
 from django.conf import settings
+from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django_countries.fields import CountryField
@@ -172,7 +173,11 @@ class Address(NameMixin, ShuupModel):
         help_text=_("The business tax number. For example, EIN in the USA or VAT code in the EU."),
     )
     phone = models.CharField(
-        verbose_name=_("phone"), max_length=64, blank=True, help_text=_("The primary phone number for the address.")
+        verbose_name=_("phone"),
+        max_length=18,
+        blank=True,
+        help_text=_("The primary phone number for the address."),
+        validators=[RegexValidator(regex=r'[ +|0-9]{1,18}')],
     )
     email = models.EmailField(
         verbose_name=_("email"), max_length=128, blank=True, help_text=_("The primary email for the address.")


### PR DESCRIPTION
Add a `RegExValidator` to the `phone` field of the `Address` model.
Change `max_length` for `phone` from `64` to `18`.

Reference: https://trello.com/c/W4jgMbdf/218-data-validation-for-phone-number-field