### PR TITLE
Updated admin shop title to use shops public name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ List all changes after the last release here (newer on top). Each change on a se
 ### Fixed
 
 - Admin: add `model` attribute to `BaseAdminObjectSelector`
+- Admin: Title to use the shop's `requst.shop.public_name` value or `Shuup` as default
 
 ## [2.14.0] - 2021-08-03
 

--- a/shuup/admin/templates/shuup/admin/base.jinja
+++ b/shuup/admin/templates/shuup/admin/base.jinja
@@ -2,7 +2,8 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>Shuup &dash; {% block title -%}
+        {% set shop_name = request.shop.public_name if request.shop.public_name else "Shuup" %}
+        <title>{{ shop_name }} &dash; {% block title -%}
             {% if title %}{{ title }}
             {% elif view and view.title %}{{ view.title }}{% endif %}
         {%- endblock %}


### PR DESCRIPTION
### Fixed

- Admin title to use the shop's `requst.shup.public_name` value or `Shuup` as default