### PR TITLE
Core: suppliers must have supplier modules to ship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 List all changes after the last release here (newer on top). Each change on a separate bullet point line
 
+### Changed
+
+- BREAKING: Suppliers with no supplier modules cannot create shipments
+
 ## [3.0.0] - 2021-08-16
 
 ### Added
 
 - Core: allow saving encrypted configurations
 - Core: add new Catalog API to index and fetch products with annotated price and discounted price
-- SupplierHasNoSupplierModules exception.
-- Suppliers with no supplier modules cannot create shipments.
-
-### Added
-
-- Add new Catalog API to index and fetch products with annotated price and discounted price
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ List all changes after the last release here (newer on top). Each change on a se
 
 - Core: allow saving encrypted configurations
 - Core: add new Catalog API to index and fetch products with annotated price and discounted price
+- SupplierHasNoSupplierModules exception.
+- Suppliers with no supplier modules cannot create shipments.
+
+### Added
+
+- Add new Catalog API to index and fetch products with annotated price and discounted price
 
 ### Fixed
 

--- a/shuup/core/excs.py
+++ b/shuup/core/excs.py
@@ -64,3 +64,7 @@ class ImpossibleProductModeException(ValueError):
     def __init__(self, message, code=None):
         super(ImpossibleProductModeException, self).__init__(message)
         self.code = code
+
+
+class SupplierHasNoSupplierModules(Exception):
+    pass

--- a/shuup/core/models/_suppliers.py
+++ b/shuup/core/models/_suppliers.py
@@ -17,6 +17,7 @@ from parler.managers import TranslatableQuerySet
 from parler.models import TranslatedFields
 from typing import TYPE_CHECKING, Union
 
+from shuup.core.excs import SupplierHasNoSupplierModules
 from shuup.core.fields import InternalIdentifierField
 from shuup.core.modules import ModuleInterface
 from shuup.utils.analog import define_log_model
@@ -229,6 +230,10 @@ class Supplier(ModuleInterface, TranslatableShuupModel):
             module.update_stocks(product_ids, *args, **kwargs)
 
     def ship_products(self, shipment, product_quantities, *args, **kwargs):
+        if not self.modules:
+            raise SupplierHasNoSupplierModules(
+                "Cannot create shipments for this supplier as it has no supplier modules."
+            )
         for module in self.modules:
             module.ship_products(shipment, product_quantities, *args, **kwargs)
 

--- a/shuup_tests/core/test_order_refund_utils.py
+++ b/shuup_tests/core/test_order_refund_utils.py
@@ -13,18 +13,21 @@ from django.test import override_settings
 
 from shuup.core.excs import RefundArbitraryRefundsNotAllowedException, RefundExceedsAmountException
 from shuup.core.models import OrderLine, OrderLineType, ShippingMode, Supplier
-from shuup.testing.factories import add_product_to_order, create_empty_order, create_product, get_default_shop
+from shuup.testing.factories import (
+    add_product_to_order,
+    create_empty_order,
+    create_product,
+    get_default_shop,
+    get_supplier,
+)
 
 
 @pytest.mark.django_db
 def test_order_refunds_with_multiple_suppliers():
     shop = get_default_shop()
-    supplier1 = Supplier.objects.create(identifier="1", name="supplier1")
-    supplier1.shops.add(shop)
-    supplier2 = Supplier.objects.create(identifier="2")
-    supplier2.shops.add(shop)
-    supplier3 = Supplier.objects.create(identifier="3", name="s")
-    supplier3.shops.add(shop)
+    supplier1 = get_supplier("simple_supplier", shop=shop, identifier="1", name="supplier1")
+    supplier2 = get_supplier("simple_supplier", shop=shop, identifier="2", name="supplier2")
+    supplier3 = get_supplier("simple_supplier", shop=shop, identifier="3", name="s")
 
     product1 = create_product("sku1", shop=shop, default_price=10)
     shop_product1 = product1.get_shop_instance(shop=shop)
@@ -132,12 +135,9 @@ def test_order_refunds_with_multiple_suppliers():
 @pytest.mark.django_db
 def test_order_arbitrary_refunds_with_multiple_suppliers():
     shop = get_default_shop()
-    supplier1 = Supplier.objects.create(identifier="1", name="supplier1")
-    supplier1.shops.add(shop)
-    supplier2 = Supplier.objects.create(identifier="2")
-    supplier2.shops.add(shop)
-    supplier3 = Supplier.objects.create(identifier="3", name="s")
-    supplier3.shops.add(shop)
+    supplier1 = get_supplier("simple_supplier", identifier="1", name="supplier1", shop=shop)
+    supplier2 = get_supplier("simple_supplier", identifier="2", name="supplier2", shop=shop)
+    supplier3 = get_supplier("simple_supplier", identifier="3", name="supplier3", shop=shop)
 
     product1 = create_product("sku1", shop=shop, default_price=10)
     shop_product1 = product1.get_shop_instance(shop=shop)

--- a/shuup_tests/core/test_orders.py
+++ b/shuup_tests/core/test_orders.py
@@ -18,6 +18,7 @@ from shuup.core.excs import (
     NoProductsToShipException,
     RefundExceedsAmountException,
     RefundExceedsQuantityException,
+    SupplierHasNoSupplierModules,
 )
 from shuup.core.models import (
     AnonymousContact,
@@ -184,7 +185,7 @@ def test_basic_order():
 
 
 @pytest.mark.django_db
-def test_basic_order_without_supplier_module():
+def test_cannot_ship_basic_order_without_supplier_module():
     PRODUCTS_TO_SEND = 10
     product = get_default_product()
     supplier = get_default_supplier()
@@ -207,33 +208,8 @@ def test_basic_order_without_supplier_module():
     order.check_all_verified()
     order.save()
     assert order.taxful_total_price == TaxfulPrice(PRODUCTS_TO_SEND * (10 + 5) - 30, currency)
-    shipment = order.create_shipment_of_all_products(supplier=supplier)
-    assert shipment.total_products == 0
-    assert shipment.weight == 0
-    assert PRODUCTS_TO_SEND == int(order.get_unshipped_products()[product.id]["unshipped"])
-
-    order.create_payment(order.taxful_total_price)
-    assert order.payments.exists(), "A payment was created"
-    with pytest.raises(NoPaymentToCreateException):
-        order.create_payment(Money(6, currency))
-    assert order.is_paid(), "Order got paid"
-    assert not order.can_set_complete(), "Finalization is possible"
-
-    # Force to be complete
-    order.change_status(next_status=OrderStatus.objects.get_default_complete(), save=False)
-    assert order.is_complete(), "Finalization done"
-
-    summary = order.get_tax_summary()
-    assert len(summary) == 2
-    assert summary[0].tax_rate * 100 == 50
-    assert summary[0].based_on == Money(100, currency)
-    assert summary[0].tax_amount == Money(50, currency)
-    assert summary[0].taxful == summary[0].based_on + summary[0].tax_amount
-    assert summary[1].tax_id is None
-    assert summary[1].tax_code == ""
-    assert summary[1].tax_amount == Money(0, currency)
-    assert summary[1].tax_rate == 0
-    assert order.get_total_tax_amount() == Money(50, currency)
+    with pytest.raises(SupplierHasNoSupplierModules):
+        shipment = order.create_shipment_of_all_products(supplier=supplier)
 
 
 @pytest.mark.django_db
@@ -559,25 +535,22 @@ def test_refund_with_shipment(restock):
 
 
 @pytest.mark.django_db
-def test_refund_entire_order_restock_shipment_no_supplier_module():
+def test_cannot_refund_entire_order_restock_shipment_no_supplier_module():
     shop = get_default_shop()
     supplier = get_default_supplier()
-    supplier.supplier_modules.clear()
     product = create_product(
         "test-sku",
         shop=get_default_shop(),
         default_price=10,
     )
-    assert not supplier.get_stock_statuses([product.id])
     order = create_order_with_product(product, supplier, 2, 200, shop=shop)
     product_line = order.lines.first()
     order.create_shipment({product_line.product: 2}, supplier=supplier)
-    assert not supplier.get_stock_statuses([product.id])
 
+    supplier.supplier_modules.clear()
     # Create a full refund with `restock_products` set to True
-    order.create_full_refund(restock_products=True)
-
-    assert not supplier.get_stock_statuses([product.id])
+    with pytest.raises(SupplierHasNoSupplierModules):
+        order.create_full_refund(restock_products=True)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Prevent suppliers with no supply modules from creating shipments.

Reference: https://trello.com/c/YdNmeTJ0/99-fix-bug-that-makes-it-not-possible-to-create-shipments-in-shuup-os