### PR TITLE
Front: improve SEO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ List all changes after the last release here (newer on top). Each change on a se
 
 ### Changed
 
+- Front: improve SEO by tuning description meta tag to product, category and CMS pages
 - Importer: index product after importing it
 - BREAKING: Core: Discounts are not cumulative anymore. The best discounted price returned by discount modules is considered.
 - BREAKING: Discounts: Remove coupon code, availability exception and exclude selected contact group from the Discount model.

--- a/shuup/core/templatetags/shuup_common.py
+++ b/shuup/core/templatetags/shuup_common.py
@@ -143,8 +143,16 @@ def safe_product_description(value):
     if isinstance(value, Undefined):
         return value
     if not settings.SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION:
-        value = linebreaks(bleach.clean(value, tags=[]))
+        value = linebreaks(bleach.clean(value, tags=[], strip=True))
     return mark_safe(value)
+
+
+@library.filter
+def cleanmeta(value):
+    if isinstance(value, Undefined):
+        return value
+    prepared_content = value.replace("&nbsp;", " ").replace("</p>", " ").replace("<br>", " ").replace('"', "'")
+    return bleach.clean(prepared_content, tags=[], strip=True)
 
 
 @library.filter

--- a/shuup/front/templates/shuup/front/macros/general.jinja
+++ b/shuup/front/templates/shuup/front/macros/general.jinja
@@ -368,9 +368,12 @@
     {% endif %}
 {% endmacro %}
 
-{% macro render_metadata(object, title, text, content_type) %}
+{% macro render_metadata(object, title, text, content_type, tags="") %}
     {% if text %}
-        <meta name="description" content="{{ text|safe|striptags|truncate(160)|replace("\n", " ")|replace("\"", "'") }}">
+        <meta name="description" content="{{ text|cleanmeta|truncate(160) }}">
+    {% endif %}
+    {% if tags %}
+        <meta name="tags" content="{{ tags }}">
     {% endif %}
     {{ render_open_graph_metadata(object, title, text, content_type) }}
 {% endmacro %}
@@ -381,7 +384,7 @@
     <meta property="og:url" content="{{ shuup.urls.model_url(object, absolute=True) }}">
     <meta property="og:title" content="{{ title }}">
     {% if text %}
-        <meta property="og:description" content="{{ text|safe|striptags|truncate(160)|replace("\n", " ")|replace("\"", "'") }}">
+        <meta property="og:description" content="{{ text|cleanmeta|truncate(160) }}">
     {% endif %}
     {% if content_type == "product" %}
         {% set object_image = object.primary_image or object.media.filter(shops=request.shop, kind=2).order_by("ordering").first() %}

--- a/shuup/front/templates/shuup/front/product/detail.jinja
+++ b/shuup/front/templates/shuup/front/product/detail.jinja
@@ -1,7 +1,7 @@
 {% extends "shuup/front/base.jinja" %}
 
 {% block extrameta %}
-{{ macros.render_metadata(product, product.name, product.short_description, "product") }}
+{{ macros.render_metadata(product, product.name, product.short_description or product.description, "product", product.keywords) }}
 {% endblock %}
 
 {% block title %}{{ product.name }}{% endblock %}

--- a/shuup/front/views/category.py
+++ b/shuup/front/views/category.py
@@ -31,7 +31,6 @@ def get_context_data(context, request, category, product_filters):
             visibility=ShopProductVisibility.LISTED,
         )
     )
-
     products = (
         catalog.get_products_queryset()
         .filter(**product_filters)

--- a/shuup/simple_cms/templates/shuup/simple_cms/macros.jinja
+++ b/shuup/simple_cms/templates/shuup/simple_cms/macros.jinja
@@ -1,13 +1,13 @@
 {% macro render_open_graph(page) %}
     {% set title = (page.open_graph and page.open_graph.title) or page.title %}
-    {% set description = (page.open_graph and page.open_graph.description) or (page.content|safe|striptags|truncate(160)|replace("\n", " ")|replace("\"", "'")) %}
+    {% set description = (page.open_graph and page.open_graph.description) or page.content %}
     {% set type = (page.open_graph and page.open_graph.og_type.value) or "website" %}
 
     <meta property="og:site_name" content="{{ (request.shop.public_name or request.shop.name) }}">
     <meta property="og:url" content="{{ shuup.urls.model_url(object, absolute=True) }}">
     <meta property="og:title" content="{{ title }}" />
     <meta property="og:type" content="{{ type }}" />
-    <meta property="og:description" content="{{ description }}" />
+    <meta property="og:description" content="{{ description|cleanmeta|truncate(160) }}" />
 
     {% if (page.open_graph and page.open_graph.image) %}
         <meta property="og:image" content="{{ request.build_absolute_uri(page.open_graph.image.url) }}" />

--- a/shuup_tests/core/test_template_tags.py
+++ b/shuup_tests/core/test_template_tags.py
@@ -233,10 +233,7 @@ def test_safe_product_description():
         assert safe_product_description(text) == text
 
     with override_settings(SHUUP_ADMIN_ALLOW_HTML_IN_PRODUCT_DESCRIPTION=False):
-        assert (
-            safe_product_description(text)
-            == "<p>&lt;strong&gt;product description&lt;/strong&gt;<br>Some text here.</p>"
-        )
+        assert safe_product_description(text) == "<p>product description<br>Some text here.</p>"
 
 
 def test_safe_vendor_description():


### PR DESCRIPTION
- Create new template filter to clean text to be used in meta tags
- Use product description as a fallback of the short description
- Strip tags in product safe description template filter instead of encoding chars

Refs https://trello.com/c/uBnRqjPj/137-check-seo-issues-reported-by-the-client