### PR TITLE
Core: change how orders are set to be fully shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ List all changes after the last release here (newer on top). Each change on a se
 
 ### Fixed
 
+- Admin: do not break when it's not possible to create shipments
 - Admin: Fix primary buttons, list buttons, and filter dropdowns to use css variables
 - Discounts: show the `exclude_selected_category` field in admin
 
 ### Changed
 
 - Core: Block an attempt to delete a service provider that still has associated shipping or payment methods.
+- Core: consider an order fully shipped only when all out shipments are sent
 - Front: improve SEO by tuning description meta tag to product, category and CMS pages
 - Importer: index product after importing it
 - BREAKING: Core: Discounts are not cumulative anymore. The best discounted price returned by discount modules is considered.

--- a/shuup/admin/modules/orders/views/shipment.py
+++ b/shuup/admin/modules/orders/views/shipment.py
@@ -162,10 +162,10 @@ class OrderCreateShipmentView(ModifiableViewMixin, UpdateView):
                 order=order, product_quantities=products_to_quantities, shipment=unsaved_shipment
             )
         except Problem as problem:
-            messages.error(self.request, problem)
+            messages.error(self.request, str(problem))
             return self.form_invalid(form)
-        except NoProductsToShipException:
-            messages.error(self.request, _("No products to ship."))
+        except NoProductsToShipException as exc:
+            messages.error(self.request, str(exc))
             return self.form_invalid(form)
         except NoShippingAddressException:
             messages.error(self.request, _("Shipping address is not set."))

--- a/shuup/core/models/_orders.py
+++ b/shuup/core/models/_orders.py
@@ -1094,12 +1094,27 @@ class Order(MoneyPropped, models.Model):
 
     def update_shipping_status(self):
         status_before_update = self.shipping_status
-        if not self.get_unshipped_products():
-            self.shipping_status = ShippingStatus.FULLY_SHIPPED
-        elif self.shipments.all_except_deleted().count():
-            self.shipping_status = ShippingStatus.PARTIALLY_SHIPPED
+        shipments_count = self.shipments.all_except_deleted().out_only().count()
+        has_unshipped_products = bool(self.get_unshipped_products())
+
+        if shipments_count:
+            # get the number of sent shipments
+            sent_shipments_count = self.get_sent_shipments().out_only().count()
+
+            # nothing sent
+            if sent_shipments_count == 0:
+                self.shipping_status = ShippingStatus.NOT_SHIPPED
+
+            # fully sent and no unshipped products
+            elif shipments_count == sent_shipments_count and not has_unshipped_products:
+                self.shipping_status = ShippingStatus.FULLY_SHIPPED
+
+            else:
+                self.shipping_status = ShippingStatus.PARTIALLY_SHIPPED
+
         else:
             self.shipping_status = ShippingStatus.NOT_SHIPPED
+
         if status_before_update != self.shipping_status:
             self.add_log_entry(
                 _("New shipping status is set to: %(shipping_status)s." % {"shipping_status": self.shipping_status})

--- a/shuup/simple_supplier/module.py
+++ b/shuup/simple_supplier/module.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import F
 from django.utils.translation import ugettext_lazy as _
 
+from shuup.core.excs import NoProductsToShipException
 from shuup.core.models import Product
 from shuup.core.signals import stocks_updated
 from shuup.core.stocks import ProductStockStatus
@@ -19,7 +20,6 @@ from shuup.core.utils import context_cache
 from shuup.simple_supplier.utils import get_current_stock_value
 from shuup.utils.django_compat import force_text
 from shuup.utils.djangoenv import has_installed
-from shuup.utils.excs import Problem
 
 from .models import StockAdjustment, StockCount
 
@@ -183,7 +183,7 @@ class SimpleSupplierModule(BaseSupplierModule):
                     % {"name": force_text(name), "quantity": force_text(int(quantity))}
                     for (name, quantity) in insufficient_stocks.items()
                 ]
-                raise Problem(
+                raise NoProductsToShipException(
                     _("Insufficient physical stock count for the following products: `%(product_counts)s`.")
                     % {"product_counts": ", ".join(formatted_counts)}
                 )

--- a/shuup_tests/admin/test_order_shipments.py
+++ b/shuup_tests/admin/test_order_shipments.py
@@ -83,7 +83,7 @@ def test_order_shipments(rf, admin_user):
     order.create_shipment({product1: 10}, supplier=supplier1)
 
     assert not order.get_unshipped_products()
-    assert order.is_fully_shipped()
+    assert not order.is_fully_shipped()
 
     context = ShipmentSection.get_context_data(order, request)
     assert len(context["suppliers"]) == 2
@@ -141,6 +141,9 @@ def test_order_shipments(rf, admin_user):
     for mark_sent_url in context["set_sent_urls"].values():
         response = client.post(mark_sent_url)
         assert response.status_code == 302
+
+    order.refresh_from_db()
+    assert order.is_fully_shipped()
 
     assert order.get_sent_shipments().count() == 3
     order.shipments.filter(status=ShipmentStatus.NOT_SENT) == 0

--- a/shuup_tests/browser/admin/test_refunds.py
+++ b/shuup_tests/browser/admin/test_refunds.py
@@ -24,6 +24,7 @@ from shuup.testing.factories import (
     get_default_shop,
     get_default_supplier,
 )
+from shuup.core.models import ShipmentStatus
 from shuup.utils.django_compat import reverse
 from shuup.utils.i18n import format_money
 
@@ -83,7 +84,8 @@ def _test_create_full_refund(browser, live_server, order):
     order.refresh_from_db()
     assert not order.taxful_total_price
     assert order.is_paid()
-    assert order.is_fully_shipped()
+    assert not order.is_fully_shipped()
+    assert not order.shipments.exists()
 
 
 def _test_refund_view(browser, live_server, order):

--- a/shuup_tests/core/test_basic_order.py
+++ b/shuup_tests/core/test_basic_order.py
@@ -8,7 +8,7 @@
 import pytest
 from django.utils.timezone import now
 
-from shuup.core.models import Order, OrderLine, OrderLineTax, OrderLineType, get_person_contact
+from shuup.core.models import Order, OrderLine, OrderLineTax, OrderLineType, ShipmentStatus, get_person_contact
 from shuup.core.shortcuts import update_order_line_from_product
 from shuup.default_tax.module import DefaultTaxModule
 from shuup.testing.factories import (
@@ -92,6 +92,8 @@ def create_order(request, creator, customer, product):
 
     assert not order.is_fully_shipped()
     shipment = order.create_shipment_of_all_products(supplier=supplier)
+    order.shipments.update(status=ShipmentStatus.SENT)
+    order.update_shipping_status()
     assert order.is_fully_shipped()
 
     assert shipment.total_products == 5, "All products were shipped"

--- a/shuup_tests/core/test_order_product_summary.py
+++ b/shuup_tests/core/test_order_product_summary.py
@@ -6,10 +6,8 @@
 # This source code is licensed under the OSL-3.0 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
-import six
-from collections import defaultdict
 
-from shuup.core.models import ShippingMode, Supplier, SupplierModule
+from shuup.core.models import ShipmentStatus, ShippingMode, Supplier, SupplierModule
 from shuup.testing.factories import add_product_to_order, create_empty_order, create_product, get_default_shop
 
 
@@ -184,6 +182,8 @@ def test_order_product_summary_with_multiple_suppliers():
     order.create_refund([{"line": line_to_refund, "quantity": 1, "amount": shop.create_price("1").amount}])
 
     assert not order.get_unshipped_products()
+    order.shipments.update(status=ShipmentStatus.SENT)
+    order.update_shipping_status()
     assert order.is_fully_shipped()
 
     # Verify product summary

--- a/shuup_tests/functional/test_refunds.py
+++ b/shuup_tests/functional/test_refunds.py
@@ -13,7 +13,7 @@ from shuup.campaigns.models.basket_effects import BasketDiscountAmount
 from shuup.campaigns.models.campaigns import BasketCampaign, CatalogCampaign
 from shuup.campaigns.models.catalog_filters import CategoryFilter
 from shuup.campaigns.models.product_effects import ProductDiscountAmount
-from shuup.core.models import AnonymousContact, OrderLineType, PaymentStatus, ShippingStatus
+from shuup.core.models import AnonymousContact, OrderLineType, PaymentStatus, ShipmentStatus, ShippingStatus
 from shuup.core.order_creator import OrderCreator
 from shuup.core.pricing import get_pricing_module
 from shuup.testing.factories import (
@@ -146,7 +146,8 @@ def test_create_full_refund(prices_include_tax):
     assert not order.taxful_total_price_value
     assert not order.taxless_total_price_value
     assert order.lines.refunds().count() == num_order_lines
-    assert order.shipping_status == ShippingStatus.FULLY_SHIPPED
+
+    assert order.shipping_status == ShippingStatus.NOT_SHIPPED
     assert order.payment_status == PaymentStatus.FULLY_PAID
     assert order.get_total_refunded_amount() == original_order_total.amount
     assert not order.get_total_unrefunded_amount().value
@@ -183,7 +184,7 @@ def test_create_refund_line_by_line(prices_include_tax):
     assert not order.taxful_total_price_value
     assert not order.taxless_total_price_value
     assert order.lines.refunds().count() == num_order_lines
-    assert order.shipping_status == ShippingStatus.FULLY_SHIPPED
+    assert order.shipping_status == ShippingStatus.NOT_SHIPPED
     assert order.get_total_refunded_amount() == original_order_total.amount
     assert not order.get_total_unrefunded_amount().value
 
@@ -212,7 +213,6 @@ def test_create_refund_amount(prices_include_tax):
     assert not order.taxful_total_price_value
     assert not order.taxless_total_price_value
     assert order.lines.refunds().count() == num_order_lines
-    # we haven't refunded any quantity so the shipping status remains as-is
     assert order.shipping_status == ShippingStatus.NOT_SHIPPED
     assert order.payment_status == PaymentStatus.FULLY_PAID
     assert order.get_total_refunded_amount() == original_order_total.amount
@@ -223,4 +223,5 @@ def test_create_refund_amount(prices_include_tax):
             [{"line": line, "quantity": line.quantity, "amount": Money(0, "EUR"), "restock_products": True}]
         )
 
-    assert order.shipping_status == ShippingStatus.FULLY_SHIPPED
+    # nothing changes
+    assert order.shipping_status == ShippingStatus.NOT_SHIPPED


### PR DESCRIPTION
Consider an order fully shipped only when all out shipments are sent

Refs https://trello.com/c/AuDBi8O4/140-bug-shipping-is-set-to-fully-shipped-by-default-not-not-shipped