### PR TITLE
Fix getting customer groups when customer is not saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ List all changes after the last release here (newer on top). Each change on a se
 ### Fixed
 
 - Admin: Fix primary buttons, list buttons, and filter dropdowns to use css variables
+- Core: Fix getting customer groups when customer is not saved 
 
 ## [2.14.2] - 2021-08-10
 

--- a/shuup/core/models/_product_shops.py
+++ b/shuup/core/models/_product_shops.py
@@ -571,9 +571,9 @@ class ShopProduct(MoneyPropped, TranslatableModel):
             cached_customer_groups = getattr(customer, "_cached_customer_groups", None)
             if cached_customer_groups:
                 groups = customer._cached_customer_groups
-            else:
-                groups = list(customer.groups.order_by("pk").values_list("pk", flat=True))
-                customer._cached_customer_groups = groups
+        elif customer and customer.id:
+            groups = list(customer.groups.order_by("pk").values_list("pk", flat=True))
+            customer._cached_customer_groups = groups
         else:
             from shuup.core.models import AnonymousContact
 

--- a/shuup/core/utils/price_cache.py
+++ b/shuup/core/utils/price_cache.py
@@ -29,9 +29,9 @@ def _get_price_info_cache_key_params(context, item, quantity, **context_args):
         cached_customer_groups = getattr(customer, "_cached_customer_groups", None)
         if cached_customer_groups:
             groups = customer._cached_customer_groups
-        else:
-            groups = list(customer.groups.order_by("pk").values_list("pk", flat=True))
-            customer._cached_customer_groups = groups
+    elif customer and customer.id:
+        groups = list(customer.groups.order_by("pk").values_list("pk", flat=True))
+        customer._cached_customer_groups = groups
     else:
         anonymous_group_id = getattr(AnonymousContact, "_cached_default_group_id", None)
         if anonymous_group_id:


### PR DESCRIPTION
- Fixed so if the customer is not saved we don't try to get objects from m2m relation

refs https://trello.com/c/nU8aqvFQ/245-allow-company-checkouts-to-go-through